### PR TITLE
ddf-266: added line to CXF config to disable address updates

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.apache.cxf.osgi.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.cxf.osgi.cfg
@@ -1,1 +1,2 @@
 org.apache.cxf.servlet.context=/services
+org.apache.cxf.servlet.disable-address-updates=true


### PR DESCRIPTION
Added additional line to fix issue with cached localhost domain in WADL URLs.
