### PR TITLE
DDF-1100: Redirected travis output to file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
-install: mvn install --quiet -DskipTests=true -B
-script: mvn test --quiet -B
+install: mvn install --quiet -DskipTests=true -B >> ~/build.log
+script: mvn test --quiet -B >> ~/build.log
+after_failure: tail -n 300 ~/build.log
 jdk:
   - openjdk7
   - oraclejdk7


### PR DESCRIPTION
* Travis output has been redirected to ~/build.log
* After a failure travis will print the last 300 lines of build.log to help diagnose problems