### PR TITLE
DDF-1210: Added KarafConsole class to allow console commands to be used in Pax Exam tests

### DIFF
--- a/test/itests/pom.xml
+++ b/test/itests/pom.xml
@@ -25,6 +25,7 @@
 	<packaging>pom</packaging>
 
 	<modules>
+		<module>test-itests-common</module>
 		<module>test-itests-catalog</module>
 	</modules>
     
@@ -133,6 +134,7 @@
             <artifactId>javax.inject</artifactId>
             <scope>test</scope>
         </dependency>
+
         <!-- End of pax exam dependencies -->
     </dependencies>
 

--- a/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -110,7 +110,8 @@ public abstract class AbstractIntegrationTest {
 
     protected static final String SERVICE_ROOT = "https://localhost:" + HTTPS_PORT + "/services";
 
-    protected static final String INSECURE_SERVICE_ROOT = "http://localhost:" + HTTP_PORT + "/services";
+    protected static final String INSECURE_SERVICE_ROOT =
+            "http://localhost:" + HTTP_PORT + "/services";
 
     protected static final String REST_PATH = SERVICE_ROOT + "/catalog/";
 
@@ -169,9 +170,9 @@ public abstract class AbstractIntegrationTest {
 
     protected Option[] configureDistribution() {
         return options(karafDistributionConfiguration(
-                        maven().groupId("ddf.distribution").artifactId("ddf").type("zip")
-                                .versionAsInProject().getURL(), "ddf", KARAF_VERSION)
-                        .unpackDirectory(new File("target/exam")).useDeployFolder(false));
+                maven().groupId("ddf.distribution").artifactId("ddf").type("zip")
+                        .versionAsInProject().getURL(), "ddf", KARAF_VERSION)
+                .unpackDirectory(new File("target/exam")).useDeployFolder(false));
 
     }
 
@@ -212,9 +213,8 @@ public abstract class AbstractIntegrationTest {
                         RMI_SERVER_PORT), replaceConfigurationFile("etc/hazelcast.xml",
                         new File(this.getClass().getResource("/hazelcast.xml").toURI())),
                 replaceConfigurationFile("etc/ddf.security.sts.client.configuration.cfg", new File(
-                                this.getClass()
-                                        .getResource("/ddf.security.sts.client.configuration.cfg")
-                                        .toURI())), replaceConfigurationFile(
+                        this.getClass().getResource("/ddf.security.sts.client.configuration.cfg")
+                                .toURI())), replaceConfigurationFile(
                         "etc/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg", new File(
                                 this.getClass().getResource(
                                         "/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg")
@@ -223,15 +223,14 @@ public abstract class AbstractIntegrationTest {
 
     protected Option[] configureMavenRepos() {
         return options(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg",
-                        "org.ops4j.pax.url.mvn.repositories",
-                        "http://repo1.maven.org/maven2@id=central,"
-                                + "http://oss.sonatype.org/content/repositories/snapshots@snapshots@noreleases@id=sonatype-snapshot,"
-                                + "http://oss.sonatype.org/content/repositories/ops4j-snapshots@snapshots@noreleases@id=ops4j-snapshot,"
-                                + "http://repository.apache.org/content/groups/snapshots-group@snapshots@noreleases@id=apache,"
-                                + "http://svn.apache.org/repos/asf/servicemix/m2-repo@id=servicemix,"
-                                + "http://repository.springsource.com/maven/bundles/release@id=springsource,"
-                                + "http://repository.springsource.com/maven/bundles/external@id=springsourceext,"
-                                + "http://oss.sonatype.org/content/repositories/releases/@id=sonatype"));
+                "org.ops4j.pax.url.mvn.repositories", "http://repo1.maven.org/maven2@id=central,"
+                        + "http://oss.sonatype.org/content/repositories/snapshots@snapshots@noreleases@id=sonatype-snapshot,"
+                        + "http://oss.sonatype.org/content/repositories/ops4j-snapshots@snapshots@noreleases@id=ops4j-snapshot,"
+                        + "http://repository.apache.org/content/groups/snapshots-group@snapshots@noreleases@id=apache,"
+                        + "http://svn.apache.org/repos/asf/servicemix/m2-repo@id=servicemix,"
+                        + "http://repository.springsource.com/maven/bundles/release@id=springsource,"
+                        + "http://repository.springsource.com/maven/bundles/external@id=springsourceext,"
+                        + "http://oss.sonatype.org/content/repositories/releases/@id=sonatype"));
     }
 
     protected Option[] configureSystemSettings() {

--- a/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -271,14 +271,16 @@ public abstract class AbstractIntegrationTest {
     /**
      * Creates a Managed Service that is created from a Managed Service Factory. Waits for the
      * asynchronous call that the properties have been updated and the service can be used.
+     * <p/>
+     * For Managed Services not created from a Managed Service Factory, use
+     * {@link #startManagedService(String, Map)} instead.
      *
      * @param factoryPid the factory pid of the Managed Service Factory
      * @param properties the service properties for the Managed Service
-     * @throws IOException          if access to persistent storage fails
-     * @throws InterruptedException
+     * @throws IOException if access to persistent storage fails
      */
     public void createManagedService(String factoryPid, Map<String, Object> properties)
-            throws IOException, InterruptedException {
+            throws IOException {
 
         final Configuration sourceConfig = configAdmin.createFactoryConfiguration(factoryPid, null);
 

--- a/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -282,6 +282,29 @@ public abstract class AbstractIntegrationTest {
 
         final Configuration sourceConfig = configAdmin.createFactoryConfiguration(factoryPid, null);
 
+        startManagedService(sourceConfig, properties);
+    }
+
+    /**
+     * Starts a Managed Service. Waits for the asynchronous call that the properties have bee
+     * updated and the service can be used.
+     * <p/>
+     * For Managed Services created from a Managed Service Factory, use
+     * {@link #createManagedService(String, Map)} instead.
+     *
+     * @param servicePid persistent identifier of the Managed Service to start
+     * @param properties service configuration properties
+     * @throws IOException thrown if if access to persistent storage fails
+     */
+    public void startManagedService(String servicePid, Map<String, Object> properties)
+            throws IOException {
+        Configuration sourceConfig = configAdmin.getConfiguration(servicePid);
+
+        startManagedService(sourceConfig, properties);
+    }
+
+    private void startManagedService(Configuration sourceConfig, Map<String, Object> properties)
+            throws IOException {
         ServiceConfigurationListener listener = new ServiceConfigurationListener(
                 sourceConfig.getPid());
 

--- a/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -176,54 +176,53 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configurePaxExam() {
-        return options(
-                logLevel(LogLevelOption.LogLevel.INFO),
-                keepRuntimeFolder(),
+        return options(logLevel(LogLevelOption.LogLevel.INFO), keepRuntimeFolder(),
                 useOwnExamBundlesStartLevel(100),
                 // increase timeout for TravisCI
                 systemTimeout(TimeUnit.MINUTES.toMillis(10)));
     }
 
     protected Option[] configureAdditionalBundles() {
-        return options(
-                junitBundles(),
+        return options(junitBundles(),
                 // HACK: incorrect version exported to override hamcrest-core from exam
                 // feature which causes a split package issue for rest-assured
                 wrappedBundle(mavenBundle("org.hamcrest", "hamcrest-all").versionAsInProject())
-                        .exports("*;version=1.3.0.10"),
+                        .exports("*;version=1.3.0.10"), wrappedBundle(
+                        mavenBundle("org.apache.karaf.itests", "itests").classifier("tests")
+                                .versionAsInProject()), wrappedBundle(
+                        mavenBundle("ddf.test.itests", "test-itests-common").classifier("tests")
+                                .versionAsInProject()).bundleSymbolicName("test-itests-common"),
                 mavenBundle("ddf.test.thirdparty", "rest-assured").versionAsInProject());
     }
 
     protected Option[] configureConfigurationPorts() throws URISyntaxException {
-        return options(
-                editConfigurationFilePut("etc/system.properties", "urlScheme", "https"),
+        return options(editConfigurationFilePut("etc/system.properties", "urlScheme", "https"),
                 editConfigurationFilePut("etc/system.properties", "host", "localhost"),
                 editConfigurationFilePut("etc/system.properties", "jetty.port", HTTPS_PORT),
                 editConfigurationFilePut("etc/system.properties", "hostContext", "/solr"),
                 editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
                 editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", SSH_PORT),
                 editConfigurationFilePut("etc/ddf.platform.config.cfg", "port", HTTP_PORT),
-                editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
-                        "org.osgi.service.http.port", HTTP_PORT),
-                editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
+                editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port",
+                        HTTP_PORT), editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
                         "org.osgi.service.http.port.secure", HTTPS_PORT),
-                editConfigurationFilePut("etc/org.apache.karaf.management.cfg",
-                        "rmiRegistryPort", RMI_REG_PORT),
-                editConfigurationFilePut("etc/org.apache.karaf.management.cfg",
-                        "rmiServerPort", RMI_SERVER_PORT),
-                replaceConfigurationFile("etc/hazelcast.xml", new File(this.getClass()
-                        .getResource("/hazelcast.xml").toURI())),
-                replaceConfigurationFile("etc/ddf.security.sts.client.configuration.cfg",
-                        new File(this.getClass()
-                        .getResource("/ddf.security.sts.client.configuration.cfg").toURI())),
-                replaceConfigurationFile("etc/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg",
-                        new File(this.getClass()
-                                .getResource("/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg").toURI())));
+                editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort",
+                        RMI_REG_PORT),
+                editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort",
+                        RMI_SERVER_PORT), replaceConfigurationFile("etc/hazelcast.xml",
+                        new File(this.getClass().getResource("/hazelcast.xml").toURI())),
+                replaceConfigurationFile("etc/ddf.security.sts.client.configuration.cfg", new File(
+                                this.getClass()
+                                        .getResource("/ddf.security.sts.client.configuration.cfg")
+                                        .toURI())), replaceConfigurationFile(
+                        "etc/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg", new File(
+                                this.getClass().getResource(
+                                        "/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg")
+                                        .toURI())));
     }
 
     protected Option[] configureMavenRepos() {
-        return options(
-                editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg",
+        return options(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg",
                         "org.ops4j.pax.url.mvn.repositories",
                         "http://repo1.maven.org/maven2@id=central,"
                                 + "http://oss.sonatype.org/content/repositories/snapshots@snapshots@noreleases@id=sonatype-snapshot,"
@@ -236,8 +235,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configureSystemSettings() {
-        return options(
-                when(System.getProperty(TEST_LOGLEVEL_PROPERTY) != null).useOptions(
+        return options(when(System.getProperty(TEST_LOGLEVEL_PROPERTY) != null).useOptions(
                         systemProperty(TEST_LOGLEVEL_PROPERTY)
                                 .value(System.getProperty(TEST_LOGLEVEL_PROPERTY, ""))),
                 when(Boolean.getBoolean("isDebugEnabled")).useOptions(
@@ -248,9 +246,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configureVmOptions() {
-        return options(
-                vmOption("-Xmx2048M"),
-                vmOption("-XX:PermSize=128M"),
+        return options(vmOption("-Xmx2048M"), vmOption("-XX:PermSize=128M"),
                 vmOption("-XX:MaxPermSize=512M"),
                 // avoid integration tests stealing focus on OS X
                 vmOption("-Djava.awt.headless=true"));
@@ -282,8 +278,8 @@ public abstract class AbstractIntegrationTest {
      * @throws IOException          if access to persistent storage fails
      * @throws InterruptedException
      */
-    public void createManagedService(String factoryPid, Map<String,
-            Object> properties) throws IOException, InterruptedException {
+    public void createManagedService(String factoryPid, Map<String, Object> properties)
+            throws IOException, InterruptedException {
 
         final Configuration sourceConfig = configAdmin.createFactoryConfiguration(factoryPid, null);
 
@@ -359,8 +355,8 @@ public abstract class AbstractIntegrationTest {
                     }
 
                     if (!((bundle.getHeaders().get("Fragment-Host") != null
-                            && bundle.getState() == Bundle.RESOLVED) || bundle
-                            .getState() == Bundle.ACTIVE)) {
+                            && bundle.getState() == Bundle.RESOLVED)
+                            || bundle.getState() == Bundle.ACTIVE)) {
                         LOGGER.info("{} bundle not ready yet", bundleName);
                         ready = false;
                     }
@@ -408,8 +404,8 @@ public abstract class AbstractIntegrationTest {
         return provider;
     }
 
-    protected FederatedSource waitForFederatedSource(String id) throws InterruptedException,
-            InvalidSyntaxException {
+    protected FederatedSource waitForFederatedSource(String id)
+            throws InterruptedException, InvalidSyntaxException {
         LOGGER.info("Waiting for FederatedSource {} to become available.", id);
 
         FederatedSource source = null;
@@ -475,9 +471,8 @@ public abstract class AbstractIntegrationTest {
             Response response = get(path);
             String body = response.getBody().asString();
             if (StringUtils.isNotBlank(body)) {
-                available = response.getStatusCode() == 200 && body.length() > 0
-                        && !body.contains("false") && response.getBody().jsonPath().getList("id")
-                        != null;
+                available = response.getStatusCode() == 200 && body.length() > 0 && !body
+                        .contains("false") && response.getBody().jsonPath().getList("id") != null;
                 if (available) {
                     List<Object> ids = response.getBody().jsonPath().getList("id");
                     for (String source : sources) {
@@ -503,12 +498,14 @@ public abstract class AbstractIntegrationTest {
         Map<String, Object> properties = new HashMap<>();
         ObjectClassDefinition bundleMetatype = getObjectClassDefinition(symbolicName, factoryPid);
 
-        for (AttributeDefinition attributeDef : bundleMetatype.getAttributeDefinitions(
-                ObjectClassDefinition.ALL)) {
+        for (AttributeDefinition attributeDef : bundleMetatype
+                .getAttributeDefinitions(ObjectClassDefinition.ALL)) {
             if (attributeDef.getID() != null) {
                 if (attributeDef.getDefaultValue() != null) {
                     if (attributeDef.getCardinality() == 0) {
-                        properties.put(attributeDef.getID(), getAttributeValue(attributeDef.getDefaultValue()[0], attributeDef.getType()));
+                        properties.put(attributeDef.getID(),
+                                getAttributeValue(attributeDef.getDefaultValue()[0],
+                                        attributeDef.getType()));
                     } else {
                         properties.put(attributeDef.getID(), attributeDef.getDefaultValue());
                     }
@@ -554,8 +551,8 @@ public abstract class AbstractIntegrationTest {
                     MetaTypeInformation mti = metatype.getMetaTypeInformation(bundle);
                     if (mti != null) {
                         try {
-                            ObjectClassDefinition ocd = mti.getObjectClassDefinition(pid,
-                                    Locale.getDefault().toString());
+                            ObjectClassDefinition ocd = mti
+                                    .getObjectClassDefinition(pid, Locale.getDefault().toString());
                             if (ocd != null) {
                                 return ocd;
                             }

--- a/test/itests/test-itests-common/pom.xml
+++ b/test/itests/test-itests-common/pom.xml
@@ -11,36 +11,28 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>ddf.test.itests</groupId>
-		<artifactId>itests</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.test.itests</groupId>
+        <artifactId>itests</artifactId>
         <version>2.7.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>test-itests-catalog</artifactId>
-	<name>DDF :: Test :: Integration :: Catalog</name>
+    </parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>ddf.catalog.core</groupId>
-			<artifactId>catalog-core-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-            <version>2.4</version>
-		</dependency>
-		<dependency>
-			<groupId>ddf.test.itests</groupId>
-			<artifactId>test-itests-common</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <artifactId>test-itests-common</artifactId>
+    <name>DDF :: Test :: Integration :: Common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.karaf.itests</groupId>
+            <artifactId>itests</artifactId>
+            <version>2.4.2</version>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/test/itests/test-itests-common/src/test/java/ddf/common/test/KarafConsole.java
+++ b/test/itests/test-itests-common/src/test/java/ddf/common/test/KarafConsole.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package ddf.common.test;
+
+import java.security.Principal;
+
+import org.apache.karaf.itests.KarafTestSupport;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Class that provides access to the Karaf Console.
+ *
+ * Note: This class is needed to expose the protected methods provided by {@link KarafTestSupport}.
+ * Since we already extend from our own base class, out test classes cannot extend from this one
+ * to access its protected methods.
+ */
+public class KarafConsole extends KarafTestSupport {
+
+    /**
+     * Karaf console constructor.
+     *
+     * @param bundleContext bundle context to use when using the console. Cannot be {@code null}.
+     */
+    public KarafConsole(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    /**
+     * Runs a shell command and returns output as a String. Commands have a default timeout of
+     * 10 seconds.
+     *
+     * @param command    command to execute. Cannot be {@code null}.
+     * @param timeout    command timeout in milliseconds
+     * @param principals principals (e.g. RolePrincipal objects) to run the command under
+     *                   (optional)
+     * @return command output. Can be empty but not {@code null}.
+     */
+    public String runCommand(String command, long timeout, Principal... principals) {
+        return executeCommand(command, timeout, false, principals);
+    }
+
+    /**
+     * Runs a shell command and returns output as a String. Commands have a default timeout of
+     * 10 seconds.
+     *
+     * @param command    command to execute. Cannot be {@code null}.
+     * @param principals principals (e.g. RolePrincipal objects) to run the command under
+     *                   (optional)
+     * @return command output. Can be empty but not {@code null}.
+     */
+    public String runCommand(String command, Principal... principals) {
+        return executeCommand(command, principals);
+    }
+}

--- a/test/itests/test-itests-common/src/test/java/ddf/common/test/KarafConsole.java
+++ b/test/itests/test-itests-common/src/test/java/ddf/common/test/KarafConsole.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- */
+ **/
 package ddf.common.test;
 
 import java.security.Principal;


### PR DESCRIPTION
New common integration test package and class added to help testing Karaf console commands.

For some reason, a commit for DDF-1192 was included as part of this pull request. Not sure how I managed to do this, but you can ignore that one as it's already part of a separate PR.

@shaundmorris and @pklinef, please review and make sure you're ok with the new package I created and where I put the class.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/37)
<!-- Reviewable:end -->
