### PR TITLE
DDF-1254: Upgraded OpenDJ-embedded-app to 1.3.0-SNAPSHOT

### DIFF
--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <distribution.file.name>ddf-${project.version}</distribution.file.name>
-        <opendj-embedded.app.version>1.2.0</opendj-embedded.app.version>
+        <opendj-embedded.app.version>1.3.0-SNAPSHOT</opendj-embedded.app.version>
         <ddf.platform.app.version>2.8.0-SNAPSHOT</ddf.platform.app.version>
         <ddf.content.app.version>2.5.0</ddf.content.app.version>
         <ddf.catalog.app.version>2.7.0</ddf.catalog.app.version>


### PR DESCRIPTION
The opendj-embedded.app 1.3.0-SNAPSHOT should be in the nexus
@shaundmorris 
@lessarderic 
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/50)
<!-- Reviewable:end -->
