### PR TITLE
DDF-1249: Include Documentation in DDF 2.8 Distribution

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -85,6 +85,11 @@
       <fileMode>0755</fileMode>
     </fileSet>
 
+    <!-- HTML & PDF Documentation -->
+    <fileSet>
+      <directory>${setup.folder}/docs</directory>
+      <outputDirectory>/documentation</outputDirectory>
+    </fileSet>
 
     <!-- Javadoc -->
     <fileSet>

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -122,7 +122,142 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>ddf</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/ddf</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.admin</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.admin.app.version}</version>
+                                    <type>zip</type>
+                                    <classifier>export</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${setup.folder}/docs/admin</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.catalog</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.catalog.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/catalog</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.catalog.solr</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.catalog.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/solr</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.content</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.content.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/content</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.platform</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.platform.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/platform</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.platform.security</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.platform.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/security</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.spatial</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.spatial.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/spatial</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf.ui</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${ddf.searchui.app.version}</version>
+                                    <outputDirectory>${setup.folder}/docs/ui</outputDirectory>
+                                    <classifier>export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.3</version>
+                <executions>
+                    <execution>
+                        <id>simplify-directory</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <move todir="${setup.folder}/docs/ddf">
+                                    <fileset dir="${setup.folder}/docs/ddf/docs-${project.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/admin">
+                                    <fileset dir="${setup.folder}/docs/admin/docs-${ddf.admin.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/catalog">
+                                    <fileset dir="${setup.folder}/docs/catalog/docs-${ddf.catalog.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/solr">
+                                    <fileset dir="${setup.folder}/docs/solr/docs-${ddf.catalog.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/content">
+                                    <fileset dir="${setup.folder}/docs/content/docs-${ddf.content.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/platform">
+                                    <fileset dir="${setup.folder}/docs/platform/docs-${ddf.platform.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/security">
+                                    <fileset dir="${setup.folder}/docs/security/docs-${ddf.platform.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/spatial">
+                                    <fileset dir="${setup.folder}/docs/spatial/docs-${ddf.spatial.app.version}"/>
+                                </move>
+                                <move todir="${setup.folder}/docs/ui">
+                                    <fileset dir="${setup.folder}/docs/ui/docs-${ddf.searchui.app.version}"/>
+                                </move>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
         <!-- FIXME (DDF-1198) - Remove owasp profile when this pom uses the latest ddf-parent pom -->
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution</artifactId>

--- a/sdk/ddf-sso-query-widget/pom.xml
+++ b/sdk/ddf-sso-query-widget/pom.xml
@@ -11,130 +11,139 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>ddf.sdk</groupId>
-    <artifactId>sdk</artifactId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>ddf.sdk</groupId>
+        <artifactId>sdk</artifactId>
+        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    </parent>
 
-  <groupId>org.codice.ddf.ui</groupId>
-  <artifactId>ddf-sso-query-widget</artifactId>
-  <name>DDF :: SDK :: UI :: SSO Query Widget</name>
-  <description>DDF SSO Query Widget</description>
-  <packaging>war</packaging>
+    <groupId>org.codice.ddf.ui</groupId>
+    <artifactId>ddf-sso-query-widget</artifactId>
+    <name>DDF :: SDK :: UI :: SSO Query Widget</name>
+    <description>DDF SSO Query Widget</description>
+    <packaging>war</packaging>
 
-  <properties>
-    <web.contextPath>ddf</web.contextPath>
-  </properties>
+    <properties>
+        <web.contextPath>ddf</web.contextPath>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>ddf.catalog.core</groupId>
-      <artifactId>catalog-core-api</artifactId>
-      <version>${ddf.catalog.app.version}</version>    
-    </dependency>
-    <dependency>
-      <groupId>org.jasig.cas</groupId>
-      <artifactId>cas-client-core</artifactId>
-      <version>3.1.10</version>
-    </dependency>
-    <dependency>
-      <groupId>ddf.security.core</groupId>
-      <artifactId>security-core-api</artifactId>
-      <version>${ddf.platform.app.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ddf.security.core</groupId>
-      <artifactId>security-core-impl</artifactId>
-      <version>${ddf.security.app.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ddf.security.cas</groupId>
-      <artifactId>security-cas-impl</artifactId>
-      <version>${ddf.security.app.version}</version>     
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-ws-security</artifactId>
-      <version>${cxf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf.services.sts</groupId>
-      <artifactId>cxf-services-sts-core</artifactId>
-      <version>${cxf.version}</version>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jasig.cas</groupId>
+            <artifactId>cas-client-core</artifactId>
+            <version>3.1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${ddf.platform.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
+            <version>${ddf.security.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.cas</groupId>
+            <artifactId>security-cas-impl</artifactId>
+            <version>${ddf.security.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-ws-security</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.services.sts</groupId>
+            <artifactId>cxf-services-sts-core</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+    </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Version>${project.version}</Bundle-Version>
-            <Export-Package>
-              ddf.sso.widget;version=${project.version}
-            </Export-Package>
-            <Import-Package>
-              javax.servlet;version="[2.5,3)",
-              javax.servlet.http;version="[2.5,3)",
-              *
-            </Import-Package>
-            <Bundle-ClassPath>.,WEB-INF/classes</Bundle-ClassPath>
-            <Web-ContextPath>${web.contextPath}</Web-ContextPath>
-            <Webapp-Context>${web.contextPath}</Webapp-Context>
-          </instructions>
-          <supportedProjectTypes>
-            <supportedProjectType>jar</supportedProjectType>
-            <supportedProjectType>bundle</supportedProjectType>
-            <supportedProjectType>war</supportedProjectType>
-          </supportedProjectTypes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>2.2</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-					<!-- Including web.xml in WEB-INF causes Karaf to throw the exception: 
-						java.lang.IllegalStateException: Http context already used. Context params 
-						can be set only before first usage -->
-					<!-- <webXml>src\main\resources\WEB-INF\web.xml</webXml> -->
-          <packagingExcludes>WEB-INF/lib/,WEB-INF/classes/META-INF/,WEB-INF/classes/OSGI-INF/,WEB-INF/classes/WEB-INF/</packagingExcludes>
-          <webResources>
-            <resource>
-							<!-- this is relative to the pom.xml directory -->
-              <directory>src/main/resources</directory>
-              <includes>
-                <include>OSGI-INF/blueprint/*.xml</include>
-              </includes>
-            </resource>
-          </webResources>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>
+                            ddf.sso.widget;version=${project.version}
+                        </Export-Package>
+                        <Import-Package>
+                            javax.servlet;version="[2.5,3)",
+                            javax.servlet.http;version="[2.5,3)",
+                            *
+                        </Import-Package>
+                        <Bundle-ClassPath>.,WEB-INF/classes</Bundle-ClassPath>
+                        <Web-ContextPath>${web.contextPath}</Web-ContextPath>
+                        <Webapp-Context>${web.contextPath}</Webapp-Context>
+                    </instructions>
+                    <supportedProjectTypes>
+                        <supportedProjectType>jar</supportedProjectType>
+                        <supportedProjectType>bundle</supportedProjectType>
+                        <supportedProjectType>war</supportedProjectType>
+                    </supportedProjectTypes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <!-- Including web.xml in WEB-INF causes Karaf to throw the exception:
+                        java.lang.IllegalStateException: Http context already used. Context params
+                        can be set only before first usage -->
+                    <!-- <webXml>src\main\resources\WEB-INF\web.xml</webXml> -->
+                    <packagingExcludes>
+                        WEB-INF/lib/,WEB-INF/classes/META-INF/,WEB-INF/classes/OSGI-INF/,WEB-INF/classes/WEB-INF/
+                    </packagingExcludes>
+                    <webResources>
+                        <resource>
+                            <!-- this is relative to the pom.xml directory -->
+                            <directory>src/main/resources</directory>
+                            <includes>
+                                <include>OSGI-INF/blueprint/*.xml</include>
+                            </includes>
+                        </resource>
+                    </webResources>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF
+                        </manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -12,22 +12,30 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
-     </parent>
+        <version>3.0.3-SNAPSHOT</version>
+    </parent>
 
-
-    <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.sdk</groupId>
     <artifactId>sdk</artifactId>
     <version>2.3.0.ALPHA1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF SDK</name>
+
+    <properties>
+        <cxf.version>3.0.4</cxf.version>
+        <ddf.catalog.app.version>2.8.0-SNAPSHOT</ddf.catalog.app.version>
+        <ddf.security.app.version>2.8.0-SNAPSHOT</ddf.security.app.version>
+        <ddf.platform.app.version>2.8.0-SNAPSHOT</ddf.platform.app.version>
+    </properties>
+
     <modules>
         <module>sample-plugins</module>
         <module>sample-transformers</module>
@@ -44,10 +52,53 @@
             <url>http://artifacts.codice.org/content/groups/public/</url>
         </repository>
     </repositories>
-    <properties>
-        <cxf.version>3.0.4</cxf.version>
-        <ddf.catalog.app.version>2.8.0-SNAPSHOT</ddf.catalog.app.version>
-        <ddf.security.app.version>2.8.0-SNAPSHOT</ddf.security.app.version>
-        <ddf.platform.app.version>2.8.0-SNAPSHOT</ddf.platform.app.version>
-    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <haltOnFailure>true</haltOnFailure>
+                                <rules>
+                                    <rule>
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>INSTRUCTION</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                            <limit>
+                                                <counter>BRANCH</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                            <limit>
+                                                <counter>COMPLEXITY</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                            <limit>
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/sdk/sample-metrics/pom.xml
+++ b/sdk/sample-metrics/pom.xml
@@ -11,85 +11,90 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <parent>
-    <artifactId>sdk</artifactId>
-    <groupId>ddf.sdk</groupId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>sample-metrics</artifactId>
-  <name>DDF :: SDK :: Metrics :: SampleMetrics</name>
-  <packaging>bundle</packaging>
-  
-  
-  <dependencies>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-    <dependency>
-		<groupId>ddf.catalog.core</groupId>
-		<artifactId>catalog-core-api</artifactId>
-		<version>${ddf.catalog.app.version}</version>	
-	</dependency>
-	
-	<dependency>
-		<groupId>ddf.catalog.core</groupId>
-		<artifactId>filter-proxy</artifactId>
-		<version>${ddf.catalog.app.version}</version>	
-	</dependency>
-	
-	<dependency>
-		<groupId>com.codahale.metrics</groupId>
-		<artifactId>metrics-core</artifactId>
-		<version>3.0.1</version>
-	</dependency>
-	
-    <dependency>
-	    <groupId>ddf.metrics.collector</groupId>
-		<artifactId>metrics-collector</artifactId>
-		<version>${ddf.platform.app.version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.rrd4j</groupId>
-		<artifactId>rrd4j</artifactId>
-		<version>2.0.7</version>
-	</dependency>
-  </dependencies>
-  
-  
-  <build>
-    
-	<plugins>
-		<!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
-		<!-- Add in additional imports that this bundle requires using a comma-separated list. -->
-		<plugin>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>maven-bundle-plugin</artifactId>
-			<configuration>
-				<instructions>
-					<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-					<Embed-Dependency>
-						    metrics-core,
-						    metrics-collector,
-						    rrd4j;scope=compile|runtime;artifactId=!slf4j-api
-						</Embed-Dependency> 
-						<Embed-Transitive>true</Embed-Transitive>
-						<Import-Package>
-						    <!-- START: imports specific for embedding rrd4j -->
-							!com.mongodb, 
-							!com.sleepycat.je, 
-							sun.misc;resolution:=optional,
-							sun.nio.ch;resolution:=optional,
-							com.sun.image.codec.jpeg;resolution:=optional,
-							<!-- END: imports specific for embedding rrd4j -->
-							*
-			            </Import-Package>
-                    <Export-Package />					
-				</instructions>
-			</configuration>
-		</plugin>
-	</plugins>
-  </build>
-  
+    <parent>
+        <artifactId>sdk</artifactId>
+        <groupId>ddf.sdk</groupId>
+        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sample-metrics</artifactId>
+    <name>DDF :: SDK :: Metrics :: SampleMetrics</name>
+    <packaging>bundle</packaging>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.metrics.collector</groupId>
+            <artifactId>metrics-collector</artifactId>
+            <version>${ddf.platform.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.rrd4j</groupId>
+            <artifactId>rrd4j</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
+            <!-- Add in additional imports that this bundle requires using a comma-separated list. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            metrics-core,
+                            metrics-collector,
+                            rrd4j;scope=compile|runtime;artifactId=!slf4j-api
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Import-Package>
+                            <!-- START: imports specific for embedding rrd4j -->
+                            !com.mongodb,
+                            !com.sleepycat.je,
+                            sun.misc;resolution:=optional,
+                            sun.nio.ch;resolution:=optional,
+                            com.sun.image.codec.jpeg;resolution:=optional,
+                            <!-- END: imports specific for embedding rrd4j -->
+                            *
+                        </Import-Package>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/sdk/sample-plugins/pom.xml
+++ b/sdk/sample-plugins/pom.xml
@@ -13,127 +13,133 @@
  **/
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <parent>
-	<artifactId>sdk</artifactId>
-	<groupId>ddf.sdk</groupId>
-	<version>2.3.0.ALPHA1-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>sample-plugins</artifactId>
-  <name>DDF :: SDK :: Plugin :: SamplePlugins</name>
-  <packaging>bundle</packaging>
-  
-  
-  <dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-    <dependency>
-		<groupId>ddf.catalog.core</groupId>
-		<artifactId>catalog-core-api</artifactId>
-                <version>${ddf.catalog.app.version}</version>
-	</dependency>
-	
-	<dependency>
-		<groupId>ddf.catalog.core</groupId>
-		<artifactId>filter-proxy</artifactId>
-                <version>${ddf.catalog.app.version}</version>
-	</dependency>
+    <parent>
+        <artifactId>sdk</artifactId>
+        <groupId>ddf.sdk</groupId>
+        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    </parent>
 
-  </dependencies>
-  
-  
-  <build>
-    
-	<plugins>
-		<!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
-		<!-- Add in additional imports that this bundle requires using a comma-separated list. -->
-		<plugin>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>maven-bundle-plugin</artifactId>
-			<configuration>
-				<instructions>
-					<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>					
-					<Import-Package>  
-						ddf.catalog,
-						ddf.catalog.data, 
-						ddf.catalog.event, 
-						ddf.catalog.filter, 
-						ddf.catalog.filter.delegate, 
-						ddf.catalog.source,
-						ddf.catalog.operation,
-					    ddf.catalog.plugin,
-					    ddf.catalog.validation,
-                        org.opengis.filter,
-                        org.opengis.filter.sort,				
-						org.osgi.service.blueprint,
-						javax.security.auth,
-						org.slf4j
-					</Import-Package>
-				</instructions>
-			</configuration>
-		</plugin>
-	  
-	  <!--
-	  Run filtering on the features.xml file (to substitute values for the
-	  project.version references) and then copy features.xml file to the
-	  target/classes directory. 
-	  --> 
-	  <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes</outputDirectory>
-              <resources>          
-                <resource>
-                  <directory>src/main/resources</directory>
-                  <filtering>true</filtering>
-                  <includes>
-			          <include>features.xml</include>
-			      </includes>
-                </resource>
-              </resources>              
-            </configuration>            
-          </execution>
-        </executions>
-      </plugin>
-             
-      <!--
-      Puts the features XML file for this SDK sample-plugins distribution 
-      into the maven repo, assigning it a repo URL of
-          mvn:ddf.sdk/sample-plugins/${project.version}/xml/features 
-      -->
-      <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <executions>
-              <execution>
-                  <id>attach-artifacts</id>
-                  <phase>package</phase>
-                  <inherited>false</inherited>
-                  <goals>
-                      <goal>attach-artifact</goal>
-                  </goals>
-                  <configuration>
-                      <artifacts>
-                          <artifact>
-                              <file>target/classes/features.xml</file>
-                              <type>xml</type>
-                              <classifier>features</classifier>
-                          </artifact>
-                      </artifacts>
-                  </configuration>
-              </execution>
-          </executions>
-      </plugin>
-	</plugins>
-  </build>
-	
+    <artifactId>sample-plugins</artifactId>
+    <name>DDF :: SDK :: Plugin :: SamplePlugins</name>
+    <packaging>bundle</packaging>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
+            <!-- Add in additional imports that this bundle requires using a comma-separated list. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            ddf.catalog,
+                            ddf.catalog.data,
+                            ddf.catalog.event,
+                            ddf.catalog.filter,
+                            ddf.catalog.filter.delegate,
+                            ddf.catalog.source,
+                            ddf.catalog.operation,
+                            ddf.catalog.plugin,
+                            ddf.catalog.validation,
+                            org.opengis.filter,
+                            org.opengis.filter.sort,
+                            org.osgi.service.blueprint,
+                            javax.security.auth,
+                            org.slf4j
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <!--
+            Run filtering on the features.xml file (to substitute values for the
+            project.version references) and then copy features.xml file to the
+            target/classes directory.
+            -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>features.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+            Puts the features XML file for this SDK sample-plugins distribution
+            into the maven repo, assigning it a repo URL of
+                mvn:ddf.sdk/sample-plugins/${project.version}/xml/features
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <inherited>false</inherited>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/sdk/sample-soap-endpoint/pom.xml
+++ b/sdk/sample-soap-endpoint/pom.xml
@@ -12,8 +12,8 @@
  *
  **/
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sdk</artifactId>
@@ -97,6 +97,11 @@
                         <Export-Package/>
                     </instructions>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
+++ b/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
@@ -11,77 +11,86 @@
  *
  **/
  -->
- <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <artifactId>sample-transformers</artifactId>
-    <groupId>ddf.sdk</groupId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
-  </parent>
-  
-  <properties>
-    <camel.version>2.14.2</camel.version>
-    <osgi.version>4.3.1</osgi.version>
-  </properties>
-  
-  <groupId>ddf.sdk.sample.transformers</groupId>
-  <artifactId>xslt-identity-input-transformer</artifactId>
-  <name>DDF :: SDK :: Sample Transformers :: XSLT Identity Input Transformer</name>
-  <packaging>bundle</packaging>
-  
-  <dependencies>
-       <dependency>
-	      <groupId>org.apache.camel</groupId>
-	      <artifactId>camel-core</artifactId>
-	      <version>${camel.version}</version>
-	   </dependency>
-	   <dependency>
-          <groupId>ddf.catalog.core</groupId>
-          <artifactId>catalog-core-camelcomponent</artifactId>
-          <version>${ddf.catalog.app.version}</version>
-   </dependency>
-        <dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.core</artifactId>
-			<version>${osgi.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.compendium</artifactId>
-			<version>${osgi.version}</version>	
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-ext</artifactId>
-			<version>1.7.1</version>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>0.9.24</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-		  <groupId>org.apache.camel</groupId>
-		  <artifactId>camel-test-blueprint</artifactId>
-		  <version>${camel.version}</version>
-		  <scope>test</scope>
-		</dependency>
-	</dependencies>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-						<Export-Package>
-						</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <parent>
+        <artifactId>sample-transformers</artifactId>
+        <groupId>ddf.sdk</groupId>
+        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <camel.version>2.14.2</camel.version>
+        <osgi.version>4.3.1</osgi.version>
+    </properties>
+
+    <groupId>ddf.sdk.sample.transformers</groupId>
+    <artifactId>xslt-identity-input-transformer</artifactId>
+    <name>DDF :: SDK :: Sample Transformers :: XSLT Identity Input Transformer</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-camelcomponent</artifactId>
+            <version>${ddf.catalog.app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>${osgi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+            <version>1.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>0.9.24</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-blueprint</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
* Changed the build to download the documentation artifacts for each of the apps and place them in a "documentation" directory in the distribution .zip file. The html and pdf formats are included, not the asciidocs.
* Modified the following repos to reference the current ddf-parent version (3.0.3-SNAPSHOT), since the version they were referencing (3.0.2-SNAPSHOT) does not build the documentation automatically.
 * ddf-admin
 * ddf-catalog
 * ddf-content
 * ddf-platform
 * ddf-spatial
 * ddf-ui
* Along the way, I ran into some build errors in the ddf.sdk project because maven could not load the ${argLine} class. I fixed these

Reviewers: @ricklarsen @pklinef @clockard @roelens8 as hero
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/57)
<!-- Reviewable:end -->
