### PR TITLE
DDF-1332: Changed path for AbstractIntegrationTest.java configureStar…

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -258,7 +258,7 @@ public abstract class AbstractIntegrationTest {
                         "security-services-app,catalog-app,solr-app,spatial-app,sdk-app"),
                 editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                         "featuresRepositories",
-                        "mvn:ddf.sdk/sdk-app/2.3.0.ALPHA1-SNAPSHOT/xml/features"));
+                        "mvn:ddf.sdk/sdk-app/2.7.0.RC2/xml/features"));
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
          If access to the previous tags are needed, please refer back to an older DDF repository
          before the transition over to a modular structure. -->
 	<modules>
-        <module>distribution</module>
 		<module>sdk</module>
+	        <module>distribution</module>
 	</modules>
 
     <build>


### PR DESCRIPTION
…tScript and changed module ordering in pom to fix integration test dependency on sdk.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/70)
<!-- Reviewable:end -->
