### PR TITLE
DDF-1198 Removed owasp profile from distribution pom.xml

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -17,7 +17,6 @@
 
 
     <parent>
-        <!-- FIXME (DDF-1198) - Remove owasp profile when this pom uses the latest ddf-parent pom -->
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
         <version>3.0.4-SNAPSHOT</version>
@@ -68,58 +67,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- FIXME (DDF-1198) - Remove this profile when this pom inherits from the latest ddf-parent pom -->
-        <profile>
-            <id>owasp</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>1.2.9</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ddf.support</groupId>
-                                <artifactId>support-owasp</artifactId>
-                                <version>2.3.1</version>
-                            </dependency>
-                        </dependencies>
-                        <configuration>
-                            <failBuildOnCVSS>7</failBuildOnCVSS>
-                            <format>ALL</format>
-                            <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-            <reporting>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>1.2.9</version>
-                        <reportSets>
-                            <reportSet>
-                                <reports>
-                                    <report>aggregate</report>
-                                </reports>
-                            </reportSet>
-                        </reportSets>
-                    </plugin>
-                </plugins>
-            </reporting>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
The owasp profile is now inherited from ddf-parent.

@coyotesqrl @rzwiefel @roelens8 @pklinef @tbatieConnexta

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/73)
<!-- Reviewable:end -->
