### PR TITLE
DDF-1354: Updated SDK version and integration tests catalog timeout.

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -270,8 +270,7 @@ public abstract class AbstractIntegrationTest {
                         "security-services-app,catalog-app,solr-app,spatial-app,sdk-app"),
                 editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                         "featuresRepositories",
-                        "mvn:ddf.sdk/sdk-app/2.3.0.ALPHA1-SNAPSHOT/xml/features"));
-
+                        "mvn:ddf.sdk/sdk-app/2.8.0-SNAPSHOT/xml/features"));
     }
 
     /**
@@ -328,7 +327,7 @@ public abstract class AbstractIntegrationTest {
         sourceConfig.update(new Hashtable<>(properties));
 
         long millis = 0;
-        while (!listener.isUpdated() && millis < TimeUnit.MINUTES.toMillis(5)) {
+        while (!listener.isUpdated() && millis < TimeUnit.MINUTES.toMillis(10)) {
             try {
                 Thread.sleep(CONFIG_UPDATE_WAIT_INTERVAL);
                 millis += CONFIG_UPDATE_WAIT_INTERVAL;

--- a/sdk/ddf-sso-query-widget/pom.xml
+++ b/sdk/ddf-sso-query-widget/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>ddf.sdk</groupId>
         <artifactId>sdk</artifactId>
-        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.ui</groupId>

--- a/sdk/ddf-sso-widget/pom.xml
+++ b/sdk/ddf-sso-widget/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>ddf.sdk</groupId>
 		<artifactId>sdk</artifactId>
-		<version>2.2.0.ALPHA5-SNAPSHOT</version>
+		<version>2.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.codice.ddf.ui</groupId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>ddf.sdk</groupId>
     <artifactId>sdk</artifactId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF SDK</name>
 

--- a/sdk/sample-metrics/pom.xml
+++ b/sdk/sample-metrics/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>ddf.sdk</groupId>
-        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-metrics</artifactId>

--- a/sdk/sample-plugins/pom.xml
+++ b/sdk/sample-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>ddf.sdk</groupId>
-        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-plugins</artifactId>

--- a/sdk/sample-soap-endpoint/pom.xml
+++ b/sdk/sample-soap-endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>ddf.sdk</groupId>
-        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sdk/sample-transformers/pom.xml
+++ b/sdk/sample-transformers/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>sdk</artifactId>
     <groupId>ddf.sdk</groupId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>sample-transformers</artifactId>

--- a/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
+++ b/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>sample-transformers</artifactId>
         <groupId>ddf.sdk</groupId>
-        <version>2.3.0.ALPHA1-SNAPSHOT</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/sdk/sdk-app/pom.xml
+++ b/sdk/sdk-app/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>sdk</artifactId>
     <groupId>ddf.sdk</groupId>
-    <version>2.3.0.ALPHA1-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sdk-app</artifactId>


### PR DESCRIPTION
Updated SDK version to 2.8.0-SNAPSHOT from 2.3.0.ALPHA1-SNAPSHOT and increased catalog timeout to 10 minutes as 5 minutes isn't always enough depending on the number of builds running on the AWS instance.

@shaundmorris, @pklinef: Please review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/77)
<!-- Reviewable:end -->