### PR TITLE
DDF-1372 Use correct maven coordinates in sdk features files

### DIFF
--- a/distribution/sdk/sample-plugins/src/main/resources/features.xml
+++ b/distribution/sdk/sample-plugins/src/main/resources/features.xml
@@ -15,7 +15,7 @@
 
 	<feature name="ddf-sdk-sample-plugins" version="${project.version}"
 		description="Sample Plugins for DDF">
-		<bundle start-level='80'>mvn:ddf.sdk/sample-plugins/${project.version}</bundle>
+		<bundle start-level='80'>mvn:ddf.distribution/sample-plugins/${project.version}</bundle>
 	</feature>
 
 </features>

--- a/distribution/sdk/sdk-app/src/main/resources/features.xml
+++ b/distribution/sdk/sdk-app/src/main/resources/features.xml
@@ -15,12 +15,12 @@
 
     <feature name="sdk-metrics" version="${project.version}" install="manual"
              description="SDK sample metrics.">
-        <bundle>mvn:ddf.sdk/sample-metrics/${project.version}</bundle>
+        <bundle>mvn:ddf.distribution/sample-metrics/${project.version}</bundle>
     </feature>
 
     <feature name="sdk-soap" version="${project.version}" install="manual"
              description="SDK sample soap endpoint.">
-        <bundle>mvn:ddf.sdk/sample-soap-endpoint/${project.version}</bundle>
+        <bundle>mvn:ddf.distribution/sample-soap-endpoint/${project.version}</bundle>
     </feature>
 
     <feature name="sdk-app" version="${project.version}" description="SDK app.">


### PR DESCRIPTION
The sdk module was moved under the distribution module, but the features files were not updated to have the correct maven coordinates.

@coyotesqrl @rzwiefel @roelens8 @pklinef @tbatieConnexta @shaundmorris

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/84)
<!-- Reviewable:end -->
