### PR TITLE
DDF-1374 Fix maven coordinates for sdk-app in itests

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -272,7 +272,7 @@ public abstract class AbstractIntegrationTest {
                         "security-services-app,catalog-app,solr-app,spatial-app,sdk-app"),
                 editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                         "featuresRepositories",
-                        "mvn:ddf.sdk/sdk-app/2.8.0-SNAPSHOT/xml/features"));
+                        "mvn:ddf.distribution/sdk-app/2.8.0-SNAPSHOT/xml/features"));
     }
 
     /**


### PR DESCRIPTION
The sdk module was moved under the distribution module, so the itests need to be updated to the correct maven coordinates for the sdk-app.

@coyotesqrl @rzwiefel @roelens8 @pklinef @tbatie
