### PR TITLE
DDF-1390 Change root artifactId

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf</groupId>
-        <artifactId>ddf-reactor</artifactId>
+        <artifactId>ddf</artifactId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>ddf</groupId>
-        <artifactId>ddf-reactor</artifactId>
+        <artifactId>ddf</artifactId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
 

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -54,16 +54,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>ddf</groupId>
-				<artifactId>ddf</artifactId>
-				<version>2.8.0-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>ddf.catalog.core</groupId>
                 <artifactId>catalog-core-api</artifactId>
-                <version>2.6.0</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -55,7 +55,7 @@
         <dependencies>
             <dependency>
                 <groupId>ddf</groupId>
-				<artifactId>ddf-reactor</artifactId>
+				<artifactId>ddf</artifactId>
 				<version>2.8.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>ddf</groupId>
-        <artifactId>ddf-reactor</artifactId>
+        <artifactId>ddf</artifactId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
 

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <groupId>ddf</groupId>
-        <artifactId>ddf-reactor</artifactId>
+        <artifactId>ddf</artifactId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ddf</groupId>
-    <artifactId>ddf-reactor</artifactId>
+    <artifactId>ddf</artifactId>
     <version>2.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF Reactor</name>


### PR DESCRIPTION
Changes the root artifact from ddf:ddf-reactor to ddf:ddf to more accurately reflect the fact that this is no longer simply a reactor but a parent pom.

Ryan, could you please hero this? 

I've added the associated ticket as a subtask to repository merge, so until this is completed I can't close out that task (in other words...quickly review, please?)

@pklinef 
@tbatie 
@jckilmer
@rzwiefel
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/89)
<!-- Reviewable:end -->
