### PR TITLE
DDF-1388 migrates common properties to parent pom

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/pom.xml
+++ b/catalog/admin/module/catalog-admin-module-sources/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>ddf.catalog.opensearch</groupId>
             <artifactId>catalog-opensearch-source</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/catalog/content/core/content-core-camelcomponent/pom.xml
+++ b/catalog/content/core/content-core-camelcomponent/pom.xml
@@ -27,10 +27,6 @@
     <name>DDF :: Content :: Core :: CamelComponent</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <camel.version>2.14.2</camel.version>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/catalog/content/core/content-core-camelcontext/pom.xml
+++ b/catalog/content/core/content-core-camelcontext/pom.xml
@@ -27,10 +27,6 @@
     <name>DDF :: Content :: Core :: CamelContext</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <camel.version>2.14.2</camel.version>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/catalog/content/core/content-core-directorymonitor/pom.xml
+++ b/catalog/content/core/content-core-directorymonitor/pom.xml
@@ -27,10 +27,6 @@
     <name>DDF :: Content :: Core :: Directory Monitor</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <camel.version>2.14.2</camel.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/catalog/core/catalog-core-federationstrategy/pom.xml
+++ b/catalog/core/catalog-core-federationstrategy/pom.xml
@@ -27,10 +27,6 @@
     <name>DDF :: Catalog :: Core :: Federation Strategy</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <powermock.version>1.5.4</powermock.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>

--- a/catalog/core/catalog-core-metricsplugin/pom.xml
+++ b/catalog/core/catalog-core-metricsplugin/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
+++ b/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -28,7 +28,6 @@
     <name>DDF Catalog Core</name>
 
     <properties>
-        <powermock.version>1.5.4</powermock.version>
         <powermock.agent>
             ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
         </powermock.agent>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -25,8 +25,6 @@
     <name>DDF Catalog</name>
 
     <properties>
-        <org.codice.ddf.notifications.version>2.8.0-SNAPSHOT</org.codice.ddf.notifications.version>
-        <org.codice.ddf.activities.version>2.8.0-SNAPSHOT</org.codice.ddf.activities.version>
         <abdera.version>1.1.3</abdera.version>
         <xstream.bundle.version>1.4.3_1</xstream.bundle.version>
         <jts.version>1.12</jts.version>
@@ -160,12 +158,12 @@
             <dependency>
                 <groupId>org.codice.ddf</groupId>
                 <artifactId>notifications</artifactId>
-                <version>${org.codice.ddf.notifications.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf</groupId>
                 <artifactId>activities</artifactId>
-                <version>${org.codice.ddf.activities.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.abdera</groupId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -29,19 +29,10 @@
         <org.codice.ddf.activities.version>2.8.0-SNAPSHOT</org.codice.ddf.activities.version>
         <abdera.version>1.1.3</abdera.version>
         <xstream.bundle.version>1.4.3_1</xstream.bundle.version>
-        <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
         <jts.version>1.12</jts.version>
-        <jts.bundle.version>1.12_1</jts.bundle.version>
-        <org.geotools.version>8.4</org.geotools.version>
-        <org.geotools.bundle.version>${org.geotools.version}_1</org.geotools.bundle.version>
-        <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>
-        <tika.version>1.7</tika.version>
         <xalan.version>2.7.2</xalan.version>
         <xerces.version>2.11.0</xerces.version>
         <saxon.version>9.6.0-4</saxon.version>
-        <karaf.version>2.4.3</karaf.version>
-        <camel.version>2.14.2</camel.version>
-        <cxf.version>3.0.4</cxf.version>
         <!--
             Remove restlet.version property and restlet dependencies from the dependencyManagement section when
             Solr version is updated (see DDF-1203).
@@ -53,7 +44,6 @@
             dependencies found in the dependencyManagement section should be removed (see DDF-1203).
         -->
         <restlet.version>2.1.4</restlet.version>
-        <lux.version>1.0.1</lux.version>
         <solr.saxon.version>9.5.1-5</solr.saxon.version>
         <handlebars.version>2.0.0</handlebars.version>
         <antlr.version>4.3</antlr.version>

--- a/catalog/spatial/csw/pom.xml
+++ b/catalog/spatial/csw/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>csw</artifactId>
     <name>DDF :: Spatial :: CSW</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <packaging>pom</packaging>
     <modules>
         <module>spatial-csw-schema-bindings</module>

--- a/catalog/spatial/csw/spatial-csw-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-common/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>spatial-csw-common</artifactId>
     <name>DDF :: Spatial :: CSW :: Common</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/catalog/spatial/geocoding/pom.xml
+++ b/catalog/spatial/geocoding/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>geocoding</artifactId>
     <name>DDF :: Spatial :: Geocoding</name>
     <packaging>pom</packaging>
-    <version>2.8.0-SNAPSHOT</version>
 
     <modules>
         <module>spatial-geocoding-api</module>

--- a/catalog/spatial/ogc/pom.xml
+++ b/catalog/spatial/ogc/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>ogc</artifactId>
     <name>DDF :: Spatial :: OGC</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <packaging>pom</packaging>
     <modules>
         <module>spatial-ogc-api</module>

--- a/catalog/spatial/pom.xml
+++ b/catalog/spatial/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>org.codice.ddf.spatial</groupId>
     <artifactId>spatial</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF :: Spatial</name>
 

--- a/catalog/spatial/spatial-commands/pom.xml
+++ b/catalog/spatial/spatial-commands/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>spatial-commands</artifactId>
     <name>DDF :: Spatial :: Commands</name>
     <packaging>bundle</packaging>
-    <version>2.8.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/catalog/spatial/wcs/pom.xml
+++ b/catalog/spatial/wcs/pom.xml
@@ -27,10 +27,6 @@
     <packaging>pom</packaging>
     <name>DDF :: Spatial :: WCS</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <modules>
         <module>spatial-wcs-common</module>
     </modules>

--- a/catalog/spatial/wcs/spatial-wcs-common/pom.xml
+++ b/catalog/spatial/wcs/spatial-wcs-common/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>spatial-wcs-common</artifactId>
     <name>DDF :: Spatial :: WCS :: Common</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/catalog/spatial/wfs/1.0.0/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>wfs-v1.0.0</artifactId>
     <name>DDF :: Spatial :: WFS :: 1.0.0</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <packaging>pom</packaging>
     <modules>
         <module>spatial-wfs-v1_0_0-schema-bindings</module>

--- a/catalog/spatial/wfs/2.0.0/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>wfs-v2.0.0</artifactId>
     <name>DDF :: Spatial :: WFS :: 2.0.0</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <packaging>pom</packaging>
     <modules>
         <module>spatial-wfs-v2_0_0-schema-bindings</module>

--- a/catalog/spatial/wfs/pom.xml
+++ b/catalog/spatial/wfs/pom.xml
@@ -23,9 +23,7 @@
     </parent>
     <artifactId>wfs</artifactId>
     <name>DDF :: Spatial :: WFS</name>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+
     <packaging>pom</packaging>
     <modules>
         <module>spatial-wfs-api</module>

--- a/catalog/transformer/catalog-transformer-xml/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>ddf.platform</groupId>
             <artifactId>platform-parser-xml</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
 

--- a/catalog/transformer/pom.xml
+++ b/catalog/transformer/pom.xml
@@ -23,7 +23,6 @@
 		
 	<groupId>ddf.catalog.transformer</groupId>
 	<artifactId>transformer</artifactId>
-	<version>2.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>DDF Catalog Transformers</name>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -27,8 +27,6 @@
     <name>DDF Distribution</name>
 
     <properties>
-        <commons-io.version>2.1</commons-io.version>
-        <karaf.version>2.4.3</karaf.version>
         <pax.web.version>3.2.4</pax.web.version>
         <pax.cdi.version>0.11.0</pax.cdi.version>
     </properties>

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -26,10 +26,6 @@
     <packaging>pom</packaging>
     <name>DDF SDK</name>
 
-    <properties>
-        <cxf.version>3.0.4</cxf.version>
-    </properties>
-
     <modules>
         <module>sample-plugins</module>
         <module>sample-transformers</module>

--- a/distribution/sdk/sample-metrics/pom.xml
+++ b/distribution/sdk/sample-metrics/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
     </dependencies>
 

--- a/distribution/sdk/sample-soap-endpoint/pom.xml
+++ b/distribution/sdk/sample-soap-endpoint/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>ddf.security.core</groupId>
             <artifactId>security-core-impl</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/distribution/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
+++ b/distribution/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml
@@ -23,7 +23,6 @@
     </parent>
 
     <properties>
-        <camel.version>2.14.2</camel.version>
         <osgi.version>4.3.1</osgi.version>
     </properties>
 

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -54,16 +54,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>ddf</groupId>
-				<artifactId>ddf-reactor</artifactId>
-				<version>2.8.0-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>ddf.catalog.core</groupId>
                 <artifactId>catalog-core-api</artifactId>
-                <version>2.6.0</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/libs/httpproxy/pom.xml
+++ b/libs/httpproxy/pom.xml
@@ -26,16 +26,6 @@
     <packaging>pom</packaging>
     <name>Codice DDF HTTP Proxy</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.slf4j.version>1.7.1</org.slf4j.version>
-
-        <!-- Karaf-defined Properties -->
-        <karaf.version>2.4.3</karaf.version>
-        <camel.version>2.14.2</camel.version>
-
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -25,13 +25,6 @@
     <description>Implementation of ConfigurationWatcher Interface for use by bundles.</description>
     <packaging>bundle</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <!-- Karaf-defined Properties -->
-        <org.slf4j.version>1.7.1</org.slf4j.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>ddf.platform</groupId>

--- a/platform/metrics/platform-metrics-collector/pom.xml
+++ b/platform/metrics/platform-metrics-collector/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
 
         <dependency>

--- a/platform/metrics/platform-metrics-interceptor/pom.xml
+++ b/platform/metrics/platform-metrics-interceptor/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
 
     </dependencies>

--- a/platform/metrics/platform-metrics-reporting/pom.xml
+++ b/platform/metrics/platform-metrics-reporting/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.2</version>
         </dependency>
 
         <dependency>

--- a/platform/metrics/platform-metrics-webconsole-plugin/pom.xml
+++ b/platform/metrics/platform-metrics-webconsole-plugin/pom.xml
@@ -25,7 +25,6 @@
 
     <groupId>ddf.metrics.webconsoleplugin</groupId>
     <artifactId>metrics-webconsole-plugin</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
     <name>DDF :: Metrics :: Plugin :: WebConsole</name>
     <packaging>bundle</packaging>
 

--- a/platform/persistence/platform-persistence-core-impl/pom.xml
+++ b/platform/persistence/platform-persistence-core-impl/pom.xml
@@ -145,12 +145,11 @@
         <dependency>
             <groupId>ddf.security.encryption</groupId>
             <artifactId>security-encryption-api</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.platform</groupId>
             <artifactId>platform-configuration</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -149,7 +149,6 @@
         <cxf.xerces.version>2.11.0</cxf.xerces.version>
         <cxf.xmlbeans.version>2.6.0</cxf.xmlbeans.version>
         <cxf.xmlschema.version>2.2.1</cxf.xmlschema.version>
-        <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
         <cxf.validation.api.version>1.1.0.Final</cxf.validation.api.version>
         <cxf.cdi.api.version>1.1</cxf.cdi.api.version>
         <cxf.json.api.version>1.0</cxf.json.api.version>
@@ -206,10 +205,6 @@
         <org.ops4j.pax.swissbox.version>1.8.0</org.ops4j.pax.swissbox.version>
         <saxon.version>9.6.0-4</saxon.version>
         <saxon.bundle.plugin>${saxon.version}_1</saxon.bundle.plugin>
-
-        <jts.bundle.version>1.12_1</jts.bundle.version>
-        <org.geotools.bundle.version>${org.geotools.version}_1</org.geotools.bundle.version>
-        <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>
     </properties>
 
     <build>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -29,17 +29,11 @@
     <packaging>pom</packaging>
 
     <properties>
-        <cxf.version>3.0.4</cxf.version>
         <cxf.jaxb.version>2.2.6</cxf.jaxb.version>
-        <commons-io.version>2.1</commons-io.version>
         <joda-time.version>2.2</joda-time.version>
         <joda-convert.version>1.7</joda-convert.version>
-        <org.slf4j.version>1.7.1</org.slf4j.version>
         <osgi.version>5.0.0</osgi.version>
         <shiro.version>1.2.3</shiro.version>
-        <org.geotools.version>8.4</org.geotools.version>
-        <karaf.version>2.4.3</karaf.version>
-        <tika.version>1.7</tika.version>
         <cas.client.version>3.1.10</cas.client.version>
         <cas.client.bundle.version>${cas.client.version}_1</cas.client.bundle.version>
     </properties>

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -23,7 +23,6 @@
 
     <groupId>ddf.platform.security</groupId>
     <artifactId>security</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
     <name>DDF Platform Security</name>
     <packaging>pom</packaging>
 

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -30,7 +30,6 @@
     <properties>
         <jasypt.version>1.9.0</jasypt.version>
         <wss4j.version>2.0.3</wss4j.version>
-        <powermock.version>1.5.4</powermock.version>
         <powermock.agent>${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar</powermock.agent>
     </properties>
 

--- a/platform/solr/pom.xml
+++ b/platform/solr/pom.xml
@@ -39,7 +39,6 @@
           dependencies found in the dependencyManagement section should be removed.
       -->
       <restlet.version>2.1.4</restlet.version>
-      <lux.version>1.0.1</lux.version>
 	  <saxon.version>9.5.1-5</saxon.version>
   </properties>
   

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
             <dependency>
                 <groupId>org.rrd4j</groupId>
                 <artifactId>rrd4j</artifactId>
+                <!-- See DDF-1397 for issues with the upgrade to 2.2.1-->
                 <version>2.2</version>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,19 +71,18 @@
         <npm.version>1.4.12</npm.version>
 
         <camel.version>2.14.2</camel.version>
-        <karaf.version>2.4.3</karaf.version>
+        <commons-io.version>2.1</commons-io.version>
         <cxf.version>3.0.4</cxf.version>
-        <powermock.version>1.5.4</powermock.version>
-        <org.slf4j.version>1.7.1</org.slf4j.version>
         <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
         <jts.bundle.version>1.12_1</jts.bundle.version>
-        <org.geotools.version>8.4</org.geotools.version>
-        <org.geotools.bundle.version>${org.geotools.version}_1</org.geotools.bundle.version>
-        <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>
-        <tika.version>1.7</tika.version>
+        <karaf.version>2.4.3</karaf.version>
         <lux.version>1.0.1</lux.version>
-        <commons-io.version>2.1</commons-io.version>
-
+        <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>
+        <org.geotools.bundle.version>${org.geotools.version}_1</org.geotools.bundle.version>
+        <org.geotools.version>8.4</org.geotools.version>
+        <org.slf4j.version>1.7.1</org.slf4j.version>
+        <powermock.version>1.5.4</powermock.version>
+        <tika.version>1.7</tika.version>
     </properties>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,20 @@
         <node.version>v0.10.30</node.version>
         <npm.version>1.4.12</npm.version>
 
+        <camel.version>2.14.2</camel.version>
+        <karaf.version>2.4.3</karaf.version>
+        <cxf.version>3.0.4</cxf.version>
+        <powermock.version>1.5.4</powermock.version>
+        <org.slf4j.version>1.7.1</org.slf4j.version>
+        <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
+        <jts.bundle.version>1.12_1</jts.bundle.version>
+        <org.geotools.version>8.4</org.geotools.version>
+        <org.geotools.bundle.version>${org.geotools.version}_1</org.geotools.bundle.version>
+        <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>
+        <tika.version>1.7</tika.version>
+        <lux.version>1.0.1</lux.version>
+        <commons-io.version>2.1</commons-io.version>
+
     </properties>
 
     <!--
@@ -82,6 +96,16 @@
         <developerConnection>scm:git:git://github.com/codice/ddf.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.rrd4j</groupId>
+                <artifactId>rrd4j</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <distributionManagement>
         <snapshotRepository>
@@ -531,7 +555,6 @@
                </file>
 	    </activation>
 		<properties>
-                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
                 <packaging>pom</packaging>
                 <module>docs</module>


### PR DESCRIPTION
Finds duplicate properties throughout the project submodules and, where there is no localized variation in the value, moves them up to the parent pom. Also adds a dependencyManagement section to the parent pom where the rrd4j version is stabilized at 2.2 (2.2.1 having a bug).

There were a few outstanding properties I found that specified different versions in different poms. While some of them might be intentional, there was no indication in the poms why that might be the case.

property | declaration pom | version
-------- | --------------- | -------
saxon.version | catalog/pom.xml | 9.6.0-4
              | platform/platform-app/pom.xml | 9.6.0-4
              | platform/solr/pom.xml | 9.5.1-5
xerces.version | catalog/pom.xml | 2.11.0
              | platform/solr/solr-query/pom.xml | 2.9.1
cxf.servicemix.specs.version | catalog/content/endpoint/content-endpoint-rest/pom.xml | 2.2.0
              | platform/platform-app/pom.xml | 2.4.0
osgi.version  | distribution/sdk/sample-transformers/xslt-identity-input-transformer/pom.xml | 4.3.1
              | platform/pom.xml | 5.0.0
cxf.jaxb.version |	platform/pom.xml | 2.2.6
                 | platform/platform-app/pom.xml | 2.1 (through another property)


Armand, please be the hero for this PR.

@pklinef 
@tbatie 
@jckilmer
@rzwiefel
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/91)
<!-- Reviewable:end -->
