### PR TITLE
DDF-1354: Added logging to track down integration test failures

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -70,6 +71,7 @@ import org.osgi.service.metatype.MetaTypeService;
 import org.osgi.service.metatype.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.osgi.util.OsgiStringUtils;
 
 import com.jayway.restassured.response.Response;
 
@@ -92,10 +94,16 @@ public abstract class AbstractIntegrationTest {
     protected static final String LOGGER_PREFIX = "log4j.logger.";
 
     protected static final String KARAF_VERSION = "2.4.3";
-
+    
     protected static final int ONE_MINUTE_MILLIS = 60000;
 
-    protected static final int FIVE_MINUTES_MILLIS = ONE_MINUTE_MILLIS * 5;
+    protected static final long REQUIRED_BUNDLES_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
+
+    protected static final long MANAGED_SERVICE_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
+
+    protected static final long CATALOG_PROVIDER_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
+
+    protected static final long HTTP_ENDPOINT_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
 
     // TODO: Use the Camel AvailablePortFinder.getNextAvailable() test method
     protected static final String HTTP_PORT = "9081";
@@ -192,7 +200,7 @@ public abstract class AbstractIntegrationTest {
 
     protected Option[] configurePaxExam() {
         return options(logLevel(LogLevelOption.LogLevel.INFO), useOwnExamBundlesStartLevel(100),
-                // increase timeout for TravisCI
+                // increase timeout for CI environment
                 systemTimeout(TimeUnit.MINUTES.toMillis(10)),
                 when(Boolean.getBoolean("keepRuntimeFolder")).useOptions(keepRuntimeFolder()));
     }
@@ -334,7 +342,7 @@ public abstract class AbstractIntegrationTest {
         sourceConfig.update(new Hashtable<>(properties));
 
         long millis = 0;
-        while (!listener.isUpdated() && millis < TimeUnit.MINUTES.toMillis(10)) {
+        while (!listener.isUpdated() && millis < MANAGED_SERVICE_TIMEOUT) {
             try {
                 Thread.sleep(CONFIG_UPDATE_WAIT_INTERVAL);
                 millis += CONFIG_UPDATE_WAIT_INTERVAL;
@@ -346,7 +354,9 @@ public abstract class AbstractIntegrationTest {
         }
 
         if (!listener.isUpdated()) {
-            throw new RuntimeException("Service was not updated before timeout.");
+            throw new RuntimeException(
+                    String.format("Service was not updated within %d minute timeout.",
+                            TimeUnit.MILLISECONDS.toMinutes(MANAGED_SERVICE_TIMEOUT)));
         }
     }
 
@@ -395,7 +405,7 @@ public abstract class AbstractIntegrationTest {
                     blueprintListener, null);
         }
 
-        long timeoutLimit = System.currentTimeMillis() + FIVE_MINUTES_MILLIS;
+        long timeoutLimit = System.currentTimeMillis() + REQUIRED_BUNDLES_TIMEOUT;
         while (!ready) {
             List<Bundle> bundles = Arrays.asList(bundleCtx.getBundles());
 
@@ -425,7 +435,9 @@ public abstract class AbstractIntegrationTest {
 
             if (!ready) {
                 if (System.currentTimeMillis() > timeoutLimit) {
-                    fail("Bundles and blueprint did not start in time.");
+                    printInactiveBundles();
+                    fail(String.format("Bundles and blueprint did not start within %d minutes.",
+                            TimeUnit.MILLISECONDS.toMinutes(REQUIRED_BUNDLES_TIMEOUT)));
                 }
                 LOGGER.info("Bundles not up, sleeping...");
                 Thread.sleep(1000);
@@ -435,9 +447,10 @@ public abstract class AbstractIntegrationTest {
 
     protected CatalogProvider waitForCatalogProvider() throws InterruptedException {
         LOGGER.info("Waiting for CatalogProvider to become available.");
+        printInactiveBundles();
 
         CatalogProvider provider = null;
-        long timeoutLimit = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
+        long timeoutLimit = System.currentTimeMillis() + CATALOG_PROVIDER_TIMEOUT;
         boolean available = false;
 
         while (!available) {
@@ -452,9 +465,13 @@ public abstract class AbstractIntegrationTest {
             if (provider != null) {
                 available = provider.isAvailable();
             }
+
             if (!available) {
                 if (System.currentTimeMillis() > timeoutLimit) {
-                    fail("Catalog provider timed out.");
+                    LOGGER.info("CatalogProvider.isAvailable = {}", available);
+                    printInactiveBundles();
+                    fail(String.format("Catalog provider timed out after %d minutes.",
+                            TimeUnit.MILLISECONDS.toMinutes(CATALOG_PROVIDER_TIMEOUT)));
                 }
                 Thread.sleep(100);
             }
@@ -462,6 +479,28 @@ public abstract class AbstractIntegrationTest {
 
         LOGGER.info("CatalogProvider is available.");
         return provider;
+    }
+
+    private void printInactiveBundles() {
+        LOGGER.info("Listing inactive bundles");
+
+        for (Bundle bundle : bundleCtx.getBundles()) {
+            if (bundle.getState() != Bundle.ACTIVE) {
+                StringBuffer headerString = new StringBuffer("[ ");
+                Dictionary<String, String> headers = bundle.getHeaders();
+                Enumeration<String> keys = headers.keys();
+
+                while (keys.hasMoreElements()) {
+                    String key = keys.nextElement();
+                    headerString.append(key).append("=").append(headers.get(key)).append(", ");
+                }
+
+                headerString.append(" ]");
+                LOGGER.info("{} | {} | {} | {}", bundle.getSymbolicName(),
+                        bundle.getVersion().toString(), OsgiStringUtils.bundleStateAsString(bundle),
+                        headerString.toString());
+            }
+        }
     }
 
     protected FederatedSource waitForFederatedSource(String id)
@@ -503,7 +542,7 @@ public abstract class AbstractIntegrationTest {
     protected void waitForHttpEndpoint(String path) throws InterruptedException {
         LOGGER.info("Waiting for {}", path);
 
-        long timeoutLimit = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
+        long timeoutLimit = System.currentTimeMillis() + HTTP_ENDPOINT_TIMEOUT;
         boolean available = false;
 
         while (!available) {
@@ -511,7 +550,8 @@ public abstract class AbstractIntegrationTest {
             available = response.getStatusCode() == 200 && response.getBody().print().length() > 0;
             if (!available) {
                 if (System.currentTimeMillis() > timeoutLimit) {
-                    fail(path + " did not start in time.");
+                    fail(String.format("%s did not start within %d minutes.", path,
+                            TimeUnit.MILLISECONDS.toMinutes(HTTP_ENDPOINT_TIMEOUT)));
                 }
                 Thread.sleep(100);
             }

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -354,9 +354,10 @@ public abstract class AbstractIntegrationTest {
         }
 
         if (!listener.isUpdated()) {
-            throw new RuntimeException(
-                    String.format("Service was not updated within %d minute timeout.",
-                            TimeUnit.MILLISECONDS.toMinutes(MANAGED_SERVICE_TIMEOUT)));
+            throw new RuntimeException(String.format(
+                    "Service configuration {} was not updated within %d minute timeout.",
+                    sourceConfig.getPid(),
+                    TimeUnit.MILLISECONDS.toMinutes(MANAGED_SERVICE_TIMEOUT)));
         }
     }
 

--- a/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
+++ b/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
@@ -53,8 +53,6 @@ public class WebSSOFilter implements Filter {
 
     private static final String SAML_COOKIE_REF = "org.codice.websso.saml.ref";
 
-    private static final String DDF_SECURITY_TOKEN = "ddf.security.securityToken";
-
     private static final String DDF_AUTHENTICATION_TOKEN = "ddf.security.token";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSSOFilter.class);
@@ -63,7 +61,7 @@ public class WebSSOFilter implements Filter {
      * Dynamic list of handlers that are registered to provide authentication
      * services.
      */
-    List<AuthenticationHandler> handlerList = new ArrayList<AuthenticationHandler>();
+    List<AuthenticationHandler> handlerList = new ArrayList<>();
 
     ContextPolicyManager contextPolicyManager;
 
@@ -73,7 +71,7 @@ public class WebSSOFilter implements Filter {
             LOGGER.debug("handlerList size is {}", handlerList.size());
 
             for (AuthenticationHandler authenticationHandler : handlerList) {
-                LOGGER.debug("AuthenticationHandler info: {}, {}",
+                LOGGER.debug("AuthenticationHandler type: {}, class: {}",
                         authenticationHandler.getAuthenticationType(),
                         authenticationHandler.getClass().getSimpleName());
             }
@@ -270,7 +268,7 @@ public class WebSSOFilter implements Filter {
     }
 
     private List<AuthenticationHandler> getHandlerList(String path) {
-        List<AuthenticationHandler> handlers = new ArrayList<AuthenticationHandler>();
+        List<AuthenticationHandler> handlers = new ArrayList<>();
         String handlerAuthMethod;
         if (contextPolicyManager != null) {
             ContextPolicy policy = contextPolicyManager.getContextPolicy(path);

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/PKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/PKIHandler.java
@@ -45,6 +45,10 @@ public class PKIHandler implements AuthenticationHandler {
 
     protected PKIAuthenticationTokenFactory tokenFactory;
 
+    public PKIHandler() {
+        LOGGER.debug("Creating PKI handler.");
+    }
+
     @Override
     public String getAuthenticationType() {
         return AUTH_TYPE;

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -60,6 +60,10 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SAMLAssertionHandler.class);
 
+    public SAMLAssertionHandler() {
+        LOGGER.debug("Creating SAML Assertion handler.");
+    }
+
     @Override
     public String getAuthenticationType() {
         return AUTH_TYPE;


### PR DESCRIPTION
Added extra logging statements to WebSSOFilter and all the handlers to figure out if they all get registered before the first doFilter() call.

Also, increased integration test timeouts and added code to log the state of all the inactive bundles when the test setup fails to help with debugging.

@stustison, @andrewkfiedler please review.

Let me know if you're ok with these changes and if so I'll have @shaundmorris hero it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/101)
<!-- Reviewable:end -->
