### PR TITLE
DDF-1402: Wrong ddf-site URL in libs pom file breaks nightly build

### DIFF
--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -35,20 +35,4 @@
         <module>platform-configuration-impl</module>
     </modules>
 
-    <distributionManagement>
-        <site>
-            <id>ddf-site</id>
-            <url>${ddf.site.repo}/ddf-libs/${project.version}</url>
-        </site>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <url>${snapshots.repository.url}</url>
-        </snapshotRepository>
-        <repository>
-            <id>releases</id>
-            <url>${releases.repository.url}</url>
-        </repository>
-    </distributionManagement>
-
 </project>
-  


### PR DESCRIPTION
Removed the <distributionManagement> section from libs/pom.xml file so that the one defined in the parent pom is used instead. This makes the pom file consistent with all the other pom files and ensures that the same URL is used for ddf-site.

@coyotesqrl, please review.

@garrettfreibott, can you the hero this?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/102)
<!-- Reviewable:end -->
