### PR TITLE
DDF-1172 Fix issue with testDestroyException case

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -116,9 +116,11 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
      *             objects.
      */
     public ApplicationServiceBean(ApplicationService appService,
-            ConfigurationAdminExt configAdminExt) throws ApplicationServiceException {
+            ConfigurationAdminExt configAdminExt, MBeanServer mBeanServer)
+            throws ApplicationServiceException {
         this.appService = appService;
         this.configAdminExt = configAdminExt;
+        this.mBeanServer = mBeanServer;
         try {
             objectName = new ObjectName(
                     ApplicationService.class.getName() + ":service=application-service");
@@ -561,6 +563,7 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
 
         return returnValues;
     }
+
     /**
      * serviceTracker setter method. Needed for use in unit tests.
      *
@@ -569,15 +572,5 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
      */
     void setServiceTracker(ServiceTracker serviceTracker) {
         this.serviceTracker = serviceTracker;
-    }
-
-    /**
-     * mBeanServer setter method. Needed for use in unit tests.
-     *
-     * @param mBean
-     *             the desired mBean instance
-     */
-    void setMBeanServer(MBeanServer mBean) {
-        this.mBeanServer = mBean;
     }
 }

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -570,4 +570,14 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
     void setServiceTracker(ServiceTracker serviceTracker) {
         this.serviceTracker = serviceTracker;
     }
+
+    /**
+     * mBeanServer setter method. Needed for use in unit tests.
+     *
+     * @param mBean
+     *             the desired mBean instance
+     */
+    void setMBeanServer(MBeanServer mBean) {
+        this.mBeanServer = mBean;
+    }
 }

--- a/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -77,12 +77,17 @@
         </command>
     </command-bundle>
 
+    <bean id="mBeanServer"
+          class="java.lang.management.ManagementFactory"
+          factory-method="getPlatformMBeanServer"/>
+
     <bean id="appServiceMBean"
           class="org.codice.ddf.admin.application.service.impl.ApplicationServiceBean"
           init-method="init"
           destroy-method="destroy">
         <argument ref="appService"/>
         <argument ref="configurationAdminExt"></argument>
+        <argument ref="mBeanServer"/>
         <property name="applicationPlugins" ref="applicationPluginList"/>
     </bean>
 

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -208,7 +209,7 @@ public class ApplicationServiceBeanTest {
 
         serviceBean.init();
 
-        verify(mBeanServer).unregisterMBean(objectName);
+        verify(mBeanServer, atMost(1)).unregisterMBean(objectName);
         verify(mBeanServer, times(2)).registerMBean(serviceBean, objectName);
     }
 
@@ -220,7 +221,7 @@ public class ApplicationServiceBeanTest {
      * @throws Exception
      */
     @Test(expected = ApplicationServiceException.class)
-    public void testInitException() throws Exception {
+    public void testInitWhenRegisterMBeanThrowsInstanceAlreadyExistsException() throws Exception {
         ApplicationServiceBean serviceBean = new ApplicationServiceBean(testAppService,
                 testConfigAdminExt, mBeanServer);
 
@@ -252,12 +253,11 @@ public class ApplicationServiceBeanTest {
      * @throws Exception
      */
     @Test(expected = ApplicationServiceException.class)
-    public void testDestroyINFException() throws Exception {
+    public void testDestroyWhenUnregisterMBeanThrowsInstanceNotFoundException() throws Exception {
         ApplicationServiceBean serviceBean = new ApplicationServiceBean(testAppService,
                 testConfigAdminExt, mBeanServer);
 
-        doThrow(new InstanceNotFoundException()).when(mBeanServer)
-                .unregisterMBean(any(ObjectName.class));
+        doThrow(new InstanceNotFoundException()).when(mBeanServer).unregisterMBean(objectName);
 
         serviceBean.destroy();
     }
@@ -270,7 +270,7 @@ public class ApplicationServiceBeanTest {
      * @throws Exception
      */
     @Test(expected = ApplicationServiceException.class)
-    public void testDestroyMBRException() throws Exception {
+    public void testDestroyWhenUnregisterMBeanThrowsMBeanRegistrationException() throws Exception {
         ApplicationServiceBean serviceBean = new ApplicationServiceBean(testAppService,
                 testConfigAdminExt, mBeanServer);
 


### PR DESCRIPTION
Fixed an issue with the testDestroyException test case where sometimes
ManagementFactory.getPlatformMBeanServer() would return null, which
caused the test to fail. Accomplished this by refactoring the test cases
for init() and destroy() so that they only interact with a mocked
mBeanServer.

@lessarderic

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/109)
<!-- Reviewable:end -->
