### PR TITLE
DDF-1411 Enforce cardinality in ConfigurationAdmin

### DIFF
--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -45,6 +45,11 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>ddf.admin.core</groupId>
+			<artifactId>admin-core-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
     <build>

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Dictionary;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.TimeZone;
 
 import org.hamcrest.xml.HasXPath;
@@ -215,26 +213,26 @@ public class TestSecurity extends AbstractIntegrationTest {
     private void configureRestForAnonymous() throws IOException, InterruptedException {
         PolicyProperties policyProperties = new PolicyProperties();
         policyProperties.put("authenticationTypes",
-                "/=SAML|ANON,/admin=SAML|basic,/jolokia=SAML|basic,/system=SAML|basic,/solr=SAML|PKI|basic");
+                new String[] {"/=SAML|ANON", "/admin=SAML|basic", "/jolokia=SAML|basic",
+                        "/system=SAML|basic", "/solr=SAML|PKI|basic"});
         policyProperties.put("whiteListContexts",
-                "/services/SecurityTokenService,/services/internal,/proxy," + SERVICE_ROOT
-                        + "/sdk/SoapService");
+                new String[] {"/services/SecurityTokenService", "/services/internal", "/proxy",
+                        SERVICE_ROOT + "/sdk/SoapService"});
         Configuration config = configAdmin.getConfiguration(PolicyProperties.FACTORY_PID, null);
-        Dictionary<String, ?> configProps = new Hashtable<>(policyProperties);
-        config.update(configProps);
+        startManagedService(config.getPid(), policyProperties);
         waitForAllBundles();
     }
 
     private void configureRestForBasic() throws IOException, InterruptedException {
         PolicyProperties policyProperties = new PolicyProperties();
         policyProperties.put("authenticationTypes",
-                "/=SAML|basic,/admin=SAML|basic,/jolokia=SAML|basic,/system=SAML|basic,/solr=SAML|PKI|basic");
+                new String[] {"/=SAML|basic", "/admin=SAML|basic", "/jolokia=SAML|basic",
+                        "/system=SAML|basic", "/solr=SAML|PKI|basic"});
         policyProperties.put("whiteListContexts",
-                "/services/SecurityTokenService,/services/internal,/proxy," + SERVICE_ROOT
-                        + "/sdk/SoapService");
+                new String[] {"/services/SecurityTokenService", "/services/internal", "/proxy",
+                        SERVICE_ROOT + "/sdk/SoapService"});
         Configuration config = configAdmin.getConfiguration(PolicyProperties.FACTORY_PID, null);
-        Dictionary<String, ?> configProps = new Hashtable<>(policyProperties);
-        config.update(configProps);
+        startManagedService(config.getPid(), policyProperties);
         waitForAllBundles();
     }
 

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -86,22 +86,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.94</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.drapostolos</groupId>
+            <artifactId>type-parser</artifactId>
+            <version>0.5.0</version>
+        </dependency>
     </dependencies>
 
     <artifactId>admin-core-api</artifactId>
@@ -70,6 +75,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>type-parser</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>
@@ -91,22 +97,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.93</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.94</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -53,6 +53,11 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <artifactId>admin-core-api</artifactId>

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -86,22 +86,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.94</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.93</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -50,7 +50,8 @@ import org.slf4j.ext.XLogger;
 import com.github.drapostolos.typeparser.TypeParser;
 
 /**
- * @author Scott Tustison
+ * This class provides convenience methods for interacting with
+ * OSGi/Felix ConfigurationAdmin services.
  */
 public class ConfigurationAdmin implements ConfigurationAdminMBean {
     private static final String NEW_FACTORY_PID = "newFactoryPid";
@@ -201,7 +202,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         return modules;
     }
 
-    String getDefaultFactoryLdapFilter() {
+    private String getDefaultFactoryLdapFilter() {
         if (CollectionUtils.isNotEmpty(filterList)) {
             StringBuilder ldapFilter = new StringBuilder();
             ldapFilter.append("(");
@@ -222,7 +223,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         return "(" + SERVICE_FACTORYPID + "=" + "*)";
     }
 
-    String getDefaultLdapFilter() {
+    private String getDefaultLdapFilter() {
         if (CollectionUtils.isNotEmpty(filterList)) {
             StringBuilder ldapFilter = new StringBuilder();
             ldapFilter.append("(");

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -39,6 +39,8 @@ import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.ui.admin.api.module.AdminModule;
 import org.codice.ddf.ui.admin.api.module.ValidationDecorator;
 import org.codice.ddf.ui.admin.api.plugin.ConfigurationAdminPlugin;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.metatype.AttributeDefinition;
@@ -535,7 +537,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         mBeanServer = server;
     }
 
-    private static class CardinalityTransformer implements Transformer {
+    private class CardinalityTransformer implements Transformer {
         private final List<Map<String, Object>> metatype;
 
         private final String pid;
@@ -586,6 +588,13 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
             } else {
                 // negative cardinality means a vector, 0 is a string, and positive is an array
                 TYPE currentType = TYPE.forType(type);
+                if (value instanceof String && cardinality != 0) {
+                    try {
+                        value = new JSONParser().parse(String.valueOf(value));
+                    } catch (ParseException e) {
+                        logger.debug("{} is not a JSON array.", value, e);
+                    }
+                }
                 if (cardinality < 0) {
                     if (!(value instanceof Vector)) {
                         Vector<Object> newValue = new Vector<>();

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -420,8 +420,8 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         List<Map<String, Object>> tempMetatype = null;
         for (Map<String, Object> service : services) {
             String id = (String) service.get(ConfigurationAdminExt.MAP_ENTRY_ID);
-            if (id.equals(config.getPid()) || (id.equals(config.getFactoryPid())
-                    && (boolean) service.get(ConfigurationAdminExt.MAP_FACTORY))) {
+            if (id.equals(config.getPid()) || (id.equals(config.getFactoryPid()) && Boolean
+                    .valueOf(String.valueOf(service.get(ConfigurationAdminExt.MAP_FACTORY))))) {
                 tempMetatype = (List<Map<String, Object>>) service
                         .get(ConfigurationAdminExt.MAP_ENTRY_METATYPE);
             }
@@ -549,23 +549,32 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         // the method signature precludes a safer parameter type
         @SuppressWarnings("unchecked")
         public Object transform(Object input) {
+            if (!(input instanceof Map.Entry)) {
+                throw new IllegalArgumentException("Cannot transform " + input);
+            }
             Map.Entry<String, Object> entry = (Map.Entry<String, Object>) input;
-            if (entry.getKey().equals(SERVICE_PID)) {
-                return entry;
+            String attrId = entry.getKey();
+            if (attrId == null) {
+                throw new IllegalArgumentException("Found null key for " + pid);
             }
             Integer cardinality = null;
             Integer type = null;
-            for (Map<String, Object> property : metatype) {
-                if (entry.getKey().equals(property.get(ConfigurationAdminExt.MAP_ENTRY_ID))) {
-                    cardinality = (Integer) property
-                            .get(ConfigurationAdminExt.MAP_ENTRY_CARDINALITY);
-                    type = (Integer) property.get(ConfigurationAdminExt.MAP_ENTRY_TYPE);
+            // the PIDs have no metatype, but they should be strings
+            if (attrId.equals(SERVICE_PID) || attrId.equals(SERVICE_FACTORYPID)) {
+                cardinality = 0;
+                type = TYPE.STRING.getType();
+            } else {
+                for (Map<String, Object> property : metatype) {
+                    if (attrId.equals(property.get(ConfigurationAdminExt.MAP_ENTRY_ID))) {
+                        cardinality = (Integer) property
+                                .get(ConfigurationAdminExt.MAP_ENTRY_CARDINALITY);
+                        type = (Integer) property.get(ConfigurationAdminExt.MAP_ENTRY_TYPE);
+                    }
                 }
             }
             if (cardinality == null || type == null) {
                 throw new IllegalArgumentException(
-                        "Could not find property " + entry.getKey() + " in metatype for config "
-                                + pid);
+                        "Could not find property " + attrId + " in metatype for config " + pid);
             }
             Object value = entry.getValue();
 
@@ -595,9 +604,8 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
                     if (value.getClass().isArray() || value instanceof Collection) {
                         if (CollectionUtils.size(value) != 1) {
                             throw new IllegalArgumentException(
-                                    "Attempt on 0-cardinality property " + entry.getKey()
-                                            + " in config " + pid + " to set multiple values:"
-                                            + value);
+                                    "Attempt on 0-cardinality property " + attrId + " in config "
+                                            + pid + " to set multiple values:" + value);
                         }
                         value = CollectionUtils.get(value, 0);
                     }

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -436,7 +436,6 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
     }
 
     // unfortunately listServices returns a bunch of nested untyped objects
-    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> findMetatypeForConfig(Configuration config) {
         List<Map<String, Object>> services = listServices();
         List<Map<String, Object>> tempMetatype = null;
@@ -444,8 +443,10 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
             String id = String.valueOf(service.get(ConfigurationAdminExt.MAP_ENTRY_ID));
             if (id.equals(config.getPid()) || (id.equals(config.getFactoryPid()) && Boolean
                     .valueOf(String.valueOf(service.get(ConfigurationAdminExt.MAP_FACTORY))))) {
-                tempMetatype = (List<Map<String, Object>>) service
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> mapList = (List<Map<String, Object>>) service
                         .get(ConfigurationAdminExt.MAP_ENTRY_METATYPE);
+                tempMetatype = mapList;
                 break;
             }
         }
@@ -556,11 +557,11 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
 
         @Override
         // the method signature precludes a safer parameter type
-        @SuppressWarnings("unchecked")
         public Object transform(Object input) {
             if (!(input instanceof Map.Entry)) {
                 throw loggedException("Cannot transform " + input);
             }
+            @SuppressWarnings("unchecked")
             Map.Entry<String, Object> entry = (Map.Entry<String, Object>) input;
             String attrId = entry.getKey();
             if (attrId == null) {

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -445,6 +445,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
                     .valueOf(String.valueOf(service.get(ConfigurationAdminExt.MAP_FACTORY))))) {
                 tempMetatype = (List<Map<String, Object>>) service
                         .get(ConfigurationAdminExt.MAP_ENTRY_METATYPE);
+                break;
             }
         }
         return tempMetatype;

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -581,9 +581,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
             Object value = entry.getValue();
 
             // ensure we don't allow any empty values
-            if (value == null || StringUtils.isEmpty(String.valueOf(value)) || (
-                    (value.getClass().isArray() || value instanceof Collection) && CollectionUtils
-                            .sizeIsEmpty(value))) {
+            if (value == null || StringUtils.isEmpty(String.valueOf(value))) {
                 value = "";
             } else {
                 // negative cardinality means a vector, 0 is a string, and positive is an array
@@ -592,7 +590,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
                     try {
                         value = new JSONParser().parse(String.valueOf(value));
                     } catch (ParseException e) {
-                        logger.debug("{} is not a JSON array.", value, e);
+                        LOGGER.debug("{} is not a JSON array.", value, e);
                     }
                 }
                 if (cardinality < 0) {

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -15,7 +15,11 @@ package org.codice.ddf.ui.admin.api;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -23,19 +27,21 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Vector;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.ui.admin.api.module.AdminModule;
 import org.codice.ddf.ui.admin.api.module.ValidationDecorator;
 import org.codice.ddf.ui.admin.api.plugin.ConfigurationAdminPlugin;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
+import org.osgi.service.metatype.AttributeDefinition;
 import org.slf4j.LoggerFactory;
 import org.slf4j.ext.XLogger;
 
@@ -77,16 +83,15 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
     /**
      * Constructor for use in unit tests. Needed for testing listServices() and getService().
      *
-     * @param configurationAdmin
-     *              instance of org.osgi.service.cm.ConfigurationAdmin service
-     * @param configurationAdminExt
-     *              mocked instance of ConfigurationAdminExt
+     * @param configurationAdmin    instance of org.osgi.service.cm.ConfigurationAdmin service
+     * @param configurationAdminExt mocked instance of ConfigurationAdminExt
      */
     public ConfigurationAdmin(org.osgi.service.cm.ConfigurationAdmin configurationAdmin,
             ConfigurationAdminExt configurationAdminExt) {
         this.configurationAdmin = configurationAdmin;
         this.configurationAdminExt = configurationAdminExt;
     }
+
     /**
      * Constructs a ConfigurationAdmin implementation
      *
@@ -315,7 +320,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         if (filter == null || filter.length() < 1) {
             throw new IOException("Argument filter cannot be null or empty");
         }
-        List<String[]> result = new ArrayList<String[]>();
+        List<String[]> result = new ArrayList<>();
         Configuration[] configurations;
         try {
             configurations = configurationAdmin.listConfigurations(filter);
@@ -363,7 +368,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         if (pid == null || pid.length() < 1) {
             throw new IOException("Argument pid cannot be null or empty");
         }
-        Map<String, Object> propertiesTable = new HashMap<String, Object>();
+        Map<String, Object> propertiesTable = new HashMap<>();
         Configuration config = configurationAdmin.getConfiguration(pid, location);
         Dictionary<String, Object> properties = config.getProperties();
         if (properties != null) {
@@ -398,7 +403,9 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
      * @see ConfigurationAdminMBean#updateForLocation(java.lang.String, java.lang.String,
      * java.util.Map)
      */
-    public void updateForLocation(String pid, String location,
+    // unfortunately listServices returns a bunch of nested untyped objects
+    @SuppressWarnings("unchecked")
+    public void updateForLocation(final String pid, String location,
             Map<String, Object> configurationTable) throws IOException {
         if (pid == null || pid.length() < 1) {
             throw new IOException("Argument pid cannot be null or empty");
@@ -407,19 +414,32 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
             throw new IOException("Argument configurationTable cannot be null");
         }
 
-        // sanity check to make sure no values are
-        // null
-        for (Entry<String, Object> curEntry : configurationTable.entrySet()) {
-            Object value = curEntry.getValue();
-            if (value == null || (value instanceof ArrayList && CollectionUtils
-                    .sizeIsEmpty(value))) {
-                curEntry.setValue("");
+        // find the config's metatype so we can check cardinality
+        Configuration config = configurationAdmin.getConfiguration(pid, location);
+        List<Map<String, Object>> services = listServices();
+        List<Map<String, Object>> tempMetatype = null;
+        for (Map<String, Object> service : services) {
+            String id = (String) service.get(ConfigurationAdminExt.MAP_ENTRY_ID);
+            if (id.equals(config.getPid()) || (id.equals(config.getFactoryPid())
+                    && (boolean) service.get(ConfigurationAdminExt.MAP_FACTORY))) {
+                tempMetatype = (List<Map<String, Object>>) service
+                        .get(ConfigurationAdminExt.MAP_ENTRY_METATYPE);
             }
         }
 
-        Dictionary<String, Object> configurationProperties = new Hashtable<String, Object>(
-                configurationTable);
-        Configuration config = configurationAdmin.getConfiguration(pid, location);
+        final List<Map<String, Object>> metatype = tempMetatype;
+        List<Map.Entry<String, Object>> configEntries = new ArrayList<>();
+        configEntries.addAll(configurationTable.entrySet());
+        if (metatype == null) {
+            throw new IllegalArgumentException("Could not find metatype for " + pid);
+        }
+        // now we have to filter each property based on its cardinality
+        CollectionUtils.transform(configEntries, new CardinalityTransformer(metatype, pid));
+
+        Dictionary<String, Object> configurationProperties = new Hashtable<>();
+        for (Map.Entry<String, Object> configEntry : configEntries) {
+            configurationProperties.put(configEntry.getKey(), configEntry.getValue());
+        }
         config.update(configurationProperties);
     }
 
@@ -463,7 +483,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         // remove original configuration
         originalConfig.delete();
 
-        Map<String, Object> rval = new HashMap<String, Object>();
+        Map<String, Object> rval = new HashMap<>();
         rval.put(ORIGINAL_PID, servicePid);
         rval.put(ORIGINAL_FACTORY_PID, originalFactoryPid);
         rval.put(NEW_PID, disabledConfig.getPid());
@@ -500,7 +520,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
 
         disabledConfig.delete();
 
-        Map<String, Object> rval = new HashMap<String, Object>();
+        Map<String, Object> rval = new HashMap<>();
         rval.put(ORIGINAL_PID, servicePid);
         rval.put(ORIGINAL_FACTORY_PID, disabledFactoryPid);
         rval.put(NEW_PID, enabledConfiguration.getPid());
@@ -513,5 +533,326 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
      */
     void setMBeanServer(MBeanServer server) {
         mBeanServer = server;
+    }
+
+    private static class CardinalityTransformer implements Transformer {
+        private final List<Map<String, Object>> metatype;
+
+        private final String pid;
+
+        public CardinalityTransformer(List<Map<String, Object>> metatype, String pid) {
+            this.metatype = metatype;
+            this.pid = pid;
+        }
+
+        @Override
+        // the method signature precludes a safer parameter type
+        @SuppressWarnings("unchecked")
+        public Object transform(Object input) {
+            Map.Entry<String, Object> entry = (Map.Entry<String, Object>) input;
+            if (entry.getKey().equals(SERVICE_PID)) {
+                return entry;
+            }
+            Integer cardinality = null;
+            Integer type = null;
+            for (Map<String, Object> property : metatype) {
+                if (entry.getKey().equals(property.get(ConfigurationAdminExt.MAP_ENTRY_ID))) {
+                    cardinality = (Integer) property
+                            .get(ConfigurationAdminExt.MAP_ENTRY_CARDINALITY);
+                    type = (Integer) property.get(ConfigurationAdminExt.MAP_ENTRY_TYPE);
+                }
+            }
+            if (cardinality == null || type == null) {
+                throw new IllegalArgumentException(
+                        "Could not find property " + entry.getKey() + " in metatype for config "
+                                + pid);
+            }
+            Object value = entry.getValue();
+
+            // ensure we don't allow any empty values
+            if (value == null || StringUtils.isEmpty(String.valueOf(value)) || (
+                    value.getClass().isArray() || value instanceof Collection && CollectionUtils
+                            .sizeIsEmpty(value))) {
+                value = "";
+            } else {
+                // negative cardinality means a vector, 0 is a string, and positive is an array
+                TYPE currentType = TYPE.forType(type);
+                if (cardinality < 0) {
+                    if (!(value instanceof Vector)) {
+                        Vector<Object> newValue = new Vector<>();
+                        if (value.getClass().isArray()) {
+                            for (int i = 0; i < Array.getLength(value); i++) {
+                                newValue.add(Array.get(value, i));
+                            }
+                        } else if (value instanceof Collection) {
+                            newValue.addAll((Collection) value);
+                        } else {
+                            newValue.add(value);
+                        }
+                        value = currentType.toTypedVector(newValue);
+                    }
+                } else if (cardinality == 0) {
+                    if (value.getClass().isArray() || value instanceof Collection) {
+                        if (CollectionUtils.size(value) != 1) {
+                            throw new IllegalArgumentException(
+                                    "Attempt on 0-cardinality property " + entry.getKey()
+                                            + " in config " + pid + " to set multiple values:"
+                                            + value);
+                        }
+                        value = CollectionUtils.get(value, 0);
+                    }
+                } else if (cardinality > 0) {
+                    if (!value.getClass().isArray()) {
+                        if (value instanceof Collection) {
+                            value = currentType.toTypedArray(((Collection) (value)).toArray());
+                        } else {
+                            value = currentType
+                                    .toTypedArray((Collections.singletonList(value)).toArray());
+                        }
+                    }
+                }
+            }
+
+            entry.setValue(value);
+
+            return entry;
+        }
+    }
+
+    // felix won't take Object[] or Vector<Object>, so here we
+    // map all the osgi constants to strongly typed arrays/vectors
+    private enum TYPE {
+        STRING(AttributeDefinition.STRING) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                String[] ret = new String[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = String.valueOf(array[i]);
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<String> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add(String.valueOf(o));
+                }
+                return ret;
+            }
+        }, LONG(AttributeDefinition.LONG) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Long[] ret = new Long[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Long) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Long> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Long) o);
+                }
+                return ret;
+            }
+        }, INTEGER(AttributeDefinition.INTEGER) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Integer[] ret = new Integer[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Integer) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Integer> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Integer) o);
+                }
+                return ret;
+            }
+        }, SHORT(AttributeDefinition.SHORT) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Short[] ret = new Short[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Short) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Short> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Short) o);
+                }
+                return ret;
+            }
+        }, CHARACTER(AttributeDefinition.CHARACTER) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Character[] ret = new Character[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Character) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Character> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Character) o);
+                }
+                return ret;
+            }
+        }, BYTE(AttributeDefinition.BYTE) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Byte[] ret = new Byte[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Byte) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Byte> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Byte) o);
+                }
+                return ret;
+            }
+        }, DOUBLE(AttributeDefinition.DOUBLE) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Double[] ret = new Double[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Double) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Double> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Double) o);
+                }
+                return ret;
+            }
+        }, FLOAT(AttributeDefinition.FLOAT) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Float[] ret = new Float[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Float) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Float> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Float) o);
+                }
+                return ret;
+            }
+        }, BIGINTEGER(AttributeDefinition.BIGINTEGER) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                BigInteger[] ret = new BigInteger[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (BigInteger) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<BigInteger> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((BigInteger) o);
+                }
+                return ret;
+            }
+        }, BIGDECIMAL(AttributeDefinition.BIGDECIMAL) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                BigDecimal[] ret = new BigDecimal[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (BigDecimal) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<BigDecimal> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((BigDecimal) o);
+                }
+                return ret;
+            }
+        }, BOOLEAN(AttributeDefinition.BOOLEAN) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                Boolean[] ret = new Boolean[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    ret[i] = (Boolean) array[i];
+                }
+                return ret;
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                Vector<Boolean> ret = new Vector<>();
+                for (Object o : vector) {
+                    ret.add((Boolean) o);
+                }
+                return ret;
+            }
+        }, PASSWORD(AttributeDefinition.PASSWORD) {
+            @Override
+            public Object toTypedArray(Object[] array) {
+                return STRING.toTypedArray(array);
+            }
+
+            @Override
+            public Object toTypedVector(Vector<Object> vector) {
+                return STRING.toTypedVector(vector);
+            }
+        };
+
+        private final int type;
+
+        TYPE(int type) {
+            this.type = type;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public static TYPE forType(int type) {
+            for (TYPE theType : TYPE.values()) {
+                if (theType.getType() == type) {
+                    return theType;
+                }
+            }
+            return STRING;
+        }
+
+        public abstract Object toTypedArray(Object[] array);
+
+        public abstract Object toTypedVector(Vector<Object> array);
     }
 }

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -580,7 +580,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
 
             // ensure we don't allow any empty values
             if (value == null || StringUtils.isEmpty(String.valueOf(value)) || (
-                    value.getClass().isArray() || value instanceof Collection && CollectionUtils
+                    (value.getClass().isArray() || value instanceof Collection) && CollectionUtils
                             .sizeIsEmpty(value))) {
                 value = "";
             } else {
@@ -599,6 +599,8 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
                             newValue.add(value);
                         }
                         value = currentType.toTypedVector(newValue);
+                    } else {
+                        value = currentType.toTypedVector((Vector<Object>) value);
                     }
                 } else if (cardinality == 0) {
                     if (value.getClass().isArray() || value instanceof Collection) {
@@ -617,6 +619,8 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
                             value = currentType
                                     .toTypedArray((Collections.singletonList(value)).toArray());
                         }
+                    } else {
+                        value = currentType.toTypedArray((Object[]) value);
                     }
                 }
             }

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -197,7 +197,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         return modules;
     }
 
-    private String getDefaultFactoryLdapFilter() {
+    String getDefaultFactoryLdapFilter() {
         if (CollectionUtils.isNotEmpty(filterList)) {
             StringBuilder ldapFilter = new StringBuilder();
             ldapFilter.append("(");
@@ -218,7 +218,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         return "(" + SERVICE_FACTORYPID + "=" + "*)";
     }
 
-    private String getDefaultLdapFilter() {
+    String getDefaultLdapFilter() {
         if (CollectionUtils.isNotEmpty(filterList)) {
             StringBuilder ldapFilter = new StringBuilder();
             ldapFilter.append("(");
@@ -629,7 +629,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
 
     // felix won't take Object[] or Vector<Object>, so here we
     // map all the osgi constants to strongly typed arrays/vectors
-    private enum TYPE {
+    enum TYPE {
         STRING(AttributeDefinition.STRING) {
             @Override
             public Object toTypedArray(Object[] array) {

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExt.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExt.java
@@ -58,7 +58,7 @@ public class ConfigurationAdminExt {
 
     private static final String DISABLED_SERVICE_ID = "_disabled";
 
-    private static final String MAP_ENTRY_ID = "id";
+    public static final String MAP_ENTRY_ID = "id";
 
     private static final String MAP_ENTRY_FPID = "fpid";
 
@@ -72,21 +72,21 @@ public class ConfigurationAdminExt {
 
     private static final String MAP_ENTRY_PROPERTIES = "properties";
 
-    private static final String MAP_ENTRY_METATYPE = "metatype";
+    public static final String MAP_ENTRY_METATYPE = "metatype";
 
-    private static final String MAP_ENTRY_CARDINALITY = "cardinality";
+    public static final String MAP_ENTRY_CARDINALITY = "cardinality";
 
     private static final String MAP_ENTRY_DEFAULT_VALUE = "defaultValue";
 
     private static final String MAP_ENTRY_DESCRIPTION = "description";
 
-    private static final String MAP_ENTRY_TYPE = "type";
+    public static final String MAP_ENTRY_TYPE = "type";
 
     private static final String MAP_ENTRY_OPTION_LABELS = "optionLabels";
 
     private static final String MAP_ENTRY_OPTION_VALUES = "optionValues";
 
-    private static final String MAP_FACTORY = "factory";
+    public static final String MAP_FACTORY = "factory";
 
     /**
      * The implementation of the {@link IdGetter} interface returning the PIDs listed in the meta

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExtTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExtTest.java
@@ -145,7 +145,7 @@ public class ConfigurationAdminExtTest {
                 .thenReturn(new AttributeDefinition[] {testAttDef});
 
         when(testMTI.getBundle()).thenReturn(testBundle);
-        when(testMTI.getFactoryPids()).thenReturn(new String[] {TEST_PID});
+        when(testMTI.getFactoryPids()).thenReturn(new String[] {TEST_FACTORY_PID});
         when(testMTI.getPids()).thenReturn(new String[] {TEST_PID});
         when(testMTI.getObjectClassDefinition(anyString(), anyString())).thenReturn(testOCD);
 

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.ui.admin.api;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -51,6 +52,7 @@ import org.codice.ddf.ui.admin.api.module.AdminModule;
 import org.codice.ddf.ui.admin.api.plugin.ConfigurationAdminPlugin;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -780,6 +782,14 @@ public class ConfigurationAdminTest {
             configAdmin.update(TEST_PID, testConfigTable);
             verify(testConfig, times(i + 1)).update(any(Dictionary.class));
         }
+        Hashtable<String, Object> values = new Hashtable<>();
+        String key = getKey(CARDINALITY_ARRAY, TYPE.STRING);
+        String value = "[\"foo\",\"bar\",\"baz\"]";
+        values.put(key, value);
+        configAdmin.update(TEST_PID, values);
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        verify(testConfig, times(4)).update(captor.capture());
+        assertThat(((String[]) captor.getValue().get(key)).length, equalTo(3));
     }
 
     private Object getValue(int cardinality, TYPE type) {

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -105,9 +105,9 @@ public class ConfigurationAdminTest {
 
     public static final int CARDINALITY_VECTOR = -100;
 
-    public static final int CARDINALITY_STRING = 0;
+    public static final int CARDINALITY_PRIMITIVE = 0;
 
-    public static final int[] CARDINALITIES = new int[] {CARDINALITY_VECTOR, CARDINALITY_STRING,
+    public static final int[] CARDINALITIES = new int[] {CARDINALITY_VECTOR, CARDINALITY_PRIMITIVE,
             CARDINALITY_ARRAY};
 
     public static final int TEST_INT = 42;
@@ -784,12 +784,16 @@ public class ConfigurationAdminTest {
         }
         Hashtable<String, Object> values = new Hashtable<>();
         String key = getKey(CARDINALITY_ARRAY, TYPE.STRING);
-        String value = "[\"foo\",\"bar\",\"baz\"]";
-        values.put(key, value);
+        values.put(key, "[\"foo\",\"bar\",\"baz\"]");
         configAdmin.update(TEST_PID, values);
         ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
         verify(testConfig, times(4)).update(captor.capture());
         assertThat(((String[]) captor.getValue().get(key)).length, equalTo(3));
+        key = getKey(CARDINALITY_PRIMITIVE, TYPE.BOOLEAN);
+        values.put(key, "true");
+        configAdmin.update(TEST_PID, values);
+        verify(testConfig, times(5)).update(captor.capture());
+        assertThat((Boolean) captor.getValue().get(key), equalTo(true));
     }
 
     private Object getValue(int cardinality, TYPE type) {
@@ -835,7 +839,7 @@ public class ConfigurationAdminTest {
             Vector<Object> vector = new Vector<>();
             vector.add(value);
             return vector;
-        case CARDINALITY_STRING:
+        case CARDINALITY_PRIMITIVE:
             return value;
         case CARDINALITY_ARRAY:
             return new Object[] {value};
@@ -888,7 +892,7 @@ public class ConfigurationAdminTest {
     public void testUpdateNullValue() throws Exception {
         ConfigurationAdmin configAdmin = getConfigAdmin();
         Map<String, Object> testConfigTable = new HashMap<>();
-        testConfigTable.put(getKey(CARDINALITY_STRING, TYPE.STRING), null);
+        testConfigTable.put(getKey(CARDINALITY_PRIMITIVE, TYPE.STRING), null);
 
         configAdmin.update(TEST_PID, testConfigTable);
         verify(testConfig).update(any(Dictionary.class));

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -731,9 +731,24 @@ public class ConfigurationAdminTest {
     public void testUpdate() throws Exception {
         org.osgi.service.cm.ConfigurationAdmin testConfigAdmin = mock(
                 org.osgi.service.cm.ConfigurationAdmin.class);
-        ConfigurationAdmin configAdmin = new ConfigurationAdmin(testConfigAdmin);
+        ConfigurationAdminExt testConfigAdminExt = mock(ConfigurationAdminExt.class);
+        ConfigurationAdmin configAdmin = new ConfigurationAdmin(testConfigAdmin, testConfigAdminExt);
+        List<Map<String, Object>> services = new ArrayList<>();
+        List<Map<String, Object>> metatype = new ArrayList<>();
+        Map<String, Object> service = new HashMap<>();
+        Map<String, Object> attributes = new HashMap<>();
+        service.put("metatype", metatype);
+        service.put("factory", false);
+        service.put("id", TEST_PID);
+        services.add(service);
+        attributes.put("id", TEST_KEY);
+        attributes.put("cardinality", 0);
+        attributes.put("type", 1);
+        metatype.add(attributes);
+        when(testConfigAdminExt.listServices(anyString(), anyString())).thenReturn(services);
 
         Configuration testConfig = mock(Configuration.class);
+        when(testConfig.getPid()).thenReturn(TEST_PID);
         Map<String, Object> testConfigTable = new Hashtable<>();
         testConfigTable.put(TEST_KEY, TEST_VALUE);
 
@@ -793,9 +808,24 @@ public class ConfigurationAdminTest {
     public void testUpdateNullValue() throws Exception {
         org.osgi.service.cm.ConfigurationAdmin testConfigAdmin = mock(
                 org.osgi.service.cm.ConfigurationAdmin.class);
-        ConfigurationAdmin configAdmin = new ConfigurationAdmin(testConfigAdmin);
+        ConfigurationAdminExt testConfigAdminExt = mock(ConfigurationAdminExt.class);
+        ConfigurationAdmin configAdmin = new ConfigurationAdmin(testConfigAdmin, testConfigAdminExt);
+        List<Map<String, Object>> services = new ArrayList<>();
+        List<Map<String, Object>> metatype = new ArrayList<>();
+        Map<String, Object> service = new HashMap<>();
+        Map<String, Object> attributes = new HashMap<>();
+        service.put("metatype", metatype);
+        service.put("factory", false);
+        service.put("id", TEST_PID);
+        services.add(service);
+        attributes.put("id", TEST_KEY);
+        attributes.put("cardinality", 0);
+        attributes.put("type", 1);
+        metatype.add(attributes);
+        when(testConfigAdminExt.listServices(anyString(), anyString())).thenReturn(services);
 
         Configuration testConfig = mock(Configuration.class);
+        when(testConfig.getPid()).thenReturn(TEST_PID);
         Map<String, Object> testConfigTable = new HashMap<>();
         testConfigTable.put(TEST_KEY, null);
 

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -783,17 +783,25 @@ public class ConfigurationAdminTest {
             verify(testConfig, times(i + 1)).update(any(Dictionary.class));
         }
         Hashtable<String, Object> values = new Hashtable<>();
-        String key = getKey(CARDINALITY_ARRAY, TYPE.STRING);
-        values.put(key, "[\"foo\",\"bar\",\"baz\"]");
-        configAdmin.update(TEST_PID, values);
+        String arrayString = getKey(CARDINALITY_ARRAY, TYPE.STRING);
         ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
-        verify(testConfig, times(4)).update(captor.capture());
-        assertThat(((String[]) captor.getValue().get(key)).length, equalTo(3));
-        key = getKey(CARDINALITY_PRIMITIVE, TYPE.BOOLEAN);
-        values.put(key, "true");
+        // test string jsonarray parsing
+        values.put(arrayString, "[\"foo\",\"bar\",\"baz\"]");
+        String primitiveBoolean = getKey(CARDINALITY_PRIMITIVE, TYPE.BOOLEAN);
+        // test string valueof parsing
+        values.put(primitiveBoolean, "true");
+        String primitiveInteger = getKey(CARDINALITY_PRIMITIVE, TYPE.INTEGER);
+        // test string valueof parsing for non-strings
+        values.put(primitiveInteger, (long) TEST_INT);
+        String arrayInteger = getKey(CARDINALITY_ARRAY, TYPE.INTEGER);
+        // test empty  array substitution
+        values.put(arrayInteger, "");
         configAdmin.update(TEST_PID, values);
-        verify(testConfig, times(5)).update(captor.capture());
-        assertThat((Boolean) captor.getValue().get(key), equalTo(true));
+        verify(testConfig, times(4)).update(captor.capture());
+        assertThat(((String[]) captor.getValue().get(arrayString)).length, equalTo(3));
+        assertThat((Boolean) captor.getValue().get(primitiveBoolean), equalTo(true));
+        assertThat((int) captor.getValue().get(primitiveInteger), equalTo(TEST_INT));
+        assertThat(((Integer[]) captor.getValue().get(arrayInteger)).length, equalTo(0));
     }
 
     private Object getValue(int cardinality, TYPE type) {

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -853,7 +853,7 @@ public class ConfigurationAdminTest {
      * {@link ConfigurationAdmin#updateForLocation(String, String, Map)} methods
      * for the case where the pid argument is null
      */
-    @Test(expected = IOException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testUpdateNullPid() throws Exception {
         org.osgi.service.cm.ConfigurationAdmin testConfigAdmin = mock(
                 org.osgi.service.cm.ConfigurationAdmin.class);
@@ -872,7 +872,7 @@ public class ConfigurationAdminTest {
      *
      * @throws Exception
      */
-    @Test(expected = IOException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testUpdateNullConfigTable() throws Exception {
         org.osgi.service.cm.ConfigurationAdmin testConfigAdmin = mock(
                 org.osgi.service.cm.ConfigurationAdmin.class);


### PR DESCRIPTION
This resolves issues with preferences getting rejected
after being set by the Admin UI. Since Felix also requires
strongly typed properties, added an enum to do the
type-casted mapping in addition to cardinality.

@andrewkfiedler @shaundmorris @stustison 
Unit tests need work, but I wanted to start getting feedback on the implementation.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/123)
<!-- Reviewable:end -->
