### PR TITLE
DDF-1443: Added fromString() method to LinearUnit enum.

### DIFF
--- a/catalog/measure/catalog-measure-api/pom.xml
+++ b/catalog/measure/catalog-measure-api/pom.xml
@@ -25,24 +25,37 @@
     <artifactId>measure-api</artifactId>
     <name>DDF :: Measure :: Measure API</name>
     <packaging>bundle</packaging>
-    <dependencies>
 
+    <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.jscience</groupId>
             <artifactId>jscience</artifactId>
             <version>4.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
-
         <plugins>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -98,7 +111,5 @@
                 </executions>
             </plugin>
         </plugins>
-
     </build>
-
 </project>

--- a/catalog/measure/catalog-measure-api/src/main/java/ddf/measure/Distance.java
+++ b/catalog/measure/catalog-measure-api/src/main/java/ddf/measure/Distance.java
@@ -17,8 +17,8 @@ package ddf.measure;
 import static javax.measure.unit.NonSI.MILE;
 import static org.apache.commons.lang.Validate.notNull;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.measure.unit.NonSI;
 import javax.measure.unit.SI;
@@ -47,14 +47,14 @@ public final class Distance {
 
     private double getAsMeters(double distance, LinearUnit unitOfMeasure) {
 
-        double convertedDistance = 0.0;
+        double convertedDistance;
 
         if (unitOfMeasure == null) {
-            return Double.valueOf(distance);
+            return distance;
         }
 
         if (distance <= 0) {
-            return Double.valueOf(0);
+            return 0.0;
         }
 
         switch (unitOfMeasure) {
@@ -80,19 +80,20 @@ public final class Distance {
             throw new IllegalArgumentException(
                     "Invalid " + LinearUnit.class.getSimpleName() + " for conversion.");
         }
+
         return convertedDistance;
     }
 
     public double getAs(LinearUnit unitOfMeasure) {
 
-        double result = distanceInMeters;
+        double result;
 
         if (unitOfMeasure == null) {
-            return Double.valueOf(distanceInMeters);
+            return distanceInMeters;
         }
 
         if (distanceInMeters <= 0) {
-            return Double.valueOf(0);
+            return 0.0;
         }
 
         switch (unitOfMeasure) {
@@ -128,49 +129,61 @@ public final class Distance {
      * Enumeration for the linear units supported by DDF.
      */
     public enum LinearUnit {
-        METER, KILOMETER, NAUTICAL_MILE, MILE, FOOT_U_S, YARD;
+        METER("meter"), KILOMETER("kilometer"), NAUTICAL_MILE("nautical_mile",
+                "nauticalmile"), MILE("mile"), FOOT_U_S("foot", "foot_u_s"), YARD("yard");
 
-        static Map<String, LinearUnit> stringsToValues = new HashMap<>();
+        private Set<String> stringRepresentationSet;
 
-        static {
-            for (LinearUnit linearUnit : LinearUnit.values()) {
-                stringsToValues.put(linearUnit.name().toUpperCase(), linearUnit);
+        /**
+         * Initializes the enum constants with the list a strings that can be used when
+         * calling {@link #fromString(String)}.
+         *
+         * @param stringRepresentations list of valid string representation for this enum constant.
+         *                              At least one string representation must be provided when
+         *                              defining {@link ddf.measure.Distance.LinearUnit} constant.
+         *                              The strings are case insensitive.
+         */
+        LinearUnit(String... stringRepresentations) {
+            if (stringRepresentations == null || stringRepresentations.length == 0) {
+                throw new IllegalArgumentException("LinearUnit enumeration " + name()
+                        + " must be defined with at least one valid string representation");
             }
 
-            stringsToValues.put("NAUTICALMILE", NAUTICAL_MILE);
-            stringsToValues.put("FOOT", FOOT_U_S);
+            this.stringRepresentationSet = new HashSet<>();
+
+            for (String stringRepresentation : stringRepresentations) {
+                this.stringRepresentationSet.add(stringRepresentation.toLowerCase());
+            }
         }
 
         /**
-         * Returns the {@link ddf.measure.Distance.LinearUnit} enumeration value corresponding to
+         * Returns the {@link ddf.measure.Distance.LinearUnit} enum constant corresponding to
          * the string provided. It should be used as a replacement for the default
          * {@code valueOf()} method.
          * <p>
-         * This method can map all values supported by the default {@code valueOf()} method in
-         * addition to the following:
-         * <ul>
-         * <li><i>foot</i> (for {@link ddf.measure.Distance.LinearUnit#FOOT_U_S})</li>
-         * <li><i>nauticalmile</i> (for {@link ddf.measure.Distance.LinearUnit#NAUTICAL_MILE})</li>
-         * </ul>
+         * This method supports all the string representations provided when the enum constants
+         * are created.
          * </p>
          * As opposed to {@code valueOf()}, this method is case-insensitive and will for instance
          * work with <i>nauticalmile</i>, <i>NAUTICALMILE</i> and <i>nauticalMile</i>.
          *
-         * @param enumValueString string representing the enumeration value to return.
-         *                        Cannot be {@code null} or empty.
-         * @return enumeration value corresponding to the string provided
+         * @param enumValueString string representing the enum constant to return. Cannot be
+         *                        {@code null} or empty.
+         * @return enum constant corresponding to the string representation provided
          * @throws IllegalArgumentException thrown if the string provided doesn't map to any
-         *                                  enumeration value, is {@code null} or empty
+         *                                  enum constant, is {@code null} or empty
          */
         public static LinearUnit fromString(String enumValueString) {
             notNull(enumValueString, "Enumeration string cannot be null");
 
-            LinearUnit linearUnit = stringsToValues.get(enumValueString.toUpperCase());
+            for (LinearUnit linearUnit : values()) {
+                if (linearUnit.stringRepresentationSet.contains(enumValueString.toLowerCase())) {
+                    return linearUnit;
+                }
+            }
 
-            notNull(linearUnit,
+            throw new IllegalArgumentException(
                     "Invalid enumeration string provided for LinearUnit: " + enumValueString);
-
-            return linearUnit;
         }
     }
 }

--- a/catalog/measure/catalog-measure-api/src/main/java/ddf/measure/Distance.java
+++ b/catalog/measure/catalog-measure-api/src/main/java/ddf/measure/Distance.java
@@ -15,6 +15,10 @@
 package ddf.measure;
 
 import static javax.measure.unit.NonSI.MILE;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.measure.unit.NonSI;
 import javax.measure.unit.SI;
@@ -32,11 +36,8 @@ public final class Distance {
     private double distanceInMeters = 0.0;
 
     /**
-     *
-     * @param distance
-     *            scalar value
-     * @param unitOfMeasure
-     *            the units of measure of the scalar distance
+     * @param distance      scalar value
+     * @param unitOfMeasure the units of measure of the scalar distance
      */
     public Distance(double distance, LinearUnit unitOfMeasure) {
 
@@ -124,10 +125,52 @@ public final class Distance {
     }
 
     /**
-     * The Enum LinearUnit for the distance in meters
+     * Enumeration for the linear units supported by DDF.
      */
     public enum LinearUnit {
-        METER, KILOMETER, NAUTICAL_MILE, MILE, FOOT_U_S, YARD
-    }
+        METER, KILOMETER, NAUTICAL_MILE, MILE, FOOT_U_S, YARD;
 
+        static Map<String, LinearUnit> stringsToValues = new HashMap<>();
+
+        static {
+            for (LinearUnit linearUnit : LinearUnit.values()) {
+                stringsToValues.put(linearUnit.name().toUpperCase(), linearUnit);
+            }
+
+            stringsToValues.put("NAUTICALMILE", NAUTICAL_MILE);
+            stringsToValues.put("FOOT", FOOT_U_S);
+        }
+
+        /**
+         * Returns the {@link ddf.measure.Distance.LinearUnit} enumeration value corresponding to
+         * the string provided. It should be used as a replacement for the default
+         * {@code valueOf()} method.
+         * <p>
+         * This method can map all values supported by the default {@code valueOf()} method in
+         * addition to the following:
+         * <ul>
+         * <li><i>foot</i> (for {@link ddf.measure.Distance.LinearUnit#FOOT_U_S})</li>
+         * <li><i>nauticalmile</i> (for {@link ddf.measure.Distance.LinearUnit#NAUTICAL_MILE})</li>
+         * </ul>
+         * </p>
+         * As opposed to {@code valueOf()}, this method is case-insensitive and will for instance
+         * work with <i>nauticalmile</i>, <i>NAUTICALMILE</i> and <i>nauticalMile</i>.
+         *
+         * @param enumValueString string representing the enumeration value to return.
+         *                        Cannot be {@code null} or empty.
+         * @return enumeration value corresponding to the string provided
+         * @throws IllegalArgumentException thrown if the string provided doesn't map to any
+         *                                  enumeration value, is {@code null} or empty
+         */
+        public static LinearUnit fromString(String enumValueString) {
+            notNull(enumValueString, "Enumeration string cannot be null");
+
+            LinearUnit linearUnit = stringsToValues.get(enumValueString.toUpperCase());
+
+            notNull(linearUnit,
+                    "Invalid enumeration string provided for LinearUnit: " + enumValueString);
+
+            return linearUnit;
+        }
+    }
 }

--- a/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitFromStringParametrizedTest.java
+++ b/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitFromStringParametrizedTest.java
@@ -38,7 +38,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class LinearUnitFromStringParametrizedTest {
 
-    @Parameters
+    @Parameters(name = "fromString({0})")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] {{"FOOT_U_S", FOOT_U_S}, {"foot_u_s", FOOT_U_S},
                 {"foot", FOOT_U_S}, {"FOOT", FOOT_U_S}, {"meter", METER}, {"METER", METER},

--- a/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitFromStringParametrizedTest.java
+++ b/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitFromStringParametrizedTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.measure;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
+import static ddf.measure.Distance.LinearUnit;
+import static ddf.measure.Distance.LinearUnit.FOOT_U_S;
+import static ddf.measure.Distance.LinearUnit.KILOMETER;
+import static ddf.measure.Distance.LinearUnit.METER;
+import static ddf.measure.Distance.LinearUnit.MILE;
+import static ddf.measure.Distance.LinearUnit.NAUTICAL_MILE;
+import static ddf.measure.Distance.LinearUnit.YARD;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests the different string values supported by the {@link LinearUnit#fromString(String)} method.
+ */
+@RunWith(Parameterized.class)
+public class LinearUnitFromStringParametrizedTest {
+
+    @Parameters
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {{"FOOT_U_S", FOOT_U_S}, {"foot_u_s", FOOT_U_S},
+                {"foot", FOOT_U_S}, {"FOOT", FOOT_U_S}, {"meter", METER}, {"METER", METER},
+                {"kilometer", KILOMETER}, {"KILOMETER", KILOMETER},
+                {"nautical_mile", NAUTICAL_MILE}, {"NAUTICAL_MILE", NAUTICAL_MILE},
+                {"nauticalMile", NAUTICAL_MILE}, {"mile", MILE}, {"MILE", MILE}, {"yard", YARD},
+                {"YARD", YARD}});
+    }
+
+    @Parameter
+    public String enumValueString;
+
+    @Parameter(1)
+    public LinearUnit expectedEnumValue;
+
+    @Test
+    public void testLinearUnit() {
+        assertThat(LinearUnit.fromString(enumValueString), equalTo(expectedEnumValue));
+    }
+}

--- a/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitTest.java
+++ b/catalog/measure/catalog-measure-api/src/test/java/ddf/measure/LinearUnitTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.measure;
+
+import static ddf.measure.Distance.LinearUnit;
+
+import org.junit.Test;
+
+public class LinearUnitTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromStringWithNull() {
+        LinearUnit.fromString(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromStringWithEmptyString() {
+        LinearUnit.fromString("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromStringWithInvalidValue() {
+        LinearUnit.fromString("abc");
+    }
+}


### PR DESCRIPTION
Added a new method to support different variations of enum strings so that clients can use "foot" for FOOT_U_S for instance and also don't have to worry about case sensitivity,

@brendan-hofmann, @pklinef, can you please take a look before I merge this PR? I'd like to have it done before the end of the sprint. If you can't, no worries. Just let me know.

@shaundmorris, can you take a quick look at this before the tech session on Friday?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/128)
<!-- Reviewable:end -->
