### PR TITLE
DDF-1426 - Fixed Directory Monitor Security error

### DIFF
--- a/catalog/content/core/content-core-catalogerplugin/src/main/java/ddf/content/plugin/cataloger/CatalogContentPlugin.java
+++ b/catalog/content/core/content-core-catalogerplugin/src/main/java/ddf/content/plugin/cataloger/CatalogContentPlugin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -23,6 +23,7 @@ import javax.activation.MimeType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.subject.Subject;
 import org.slf4j.LoggerFactory;
 import org.slf4j.ext.XLogger;
@@ -241,6 +242,8 @@ public class CatalogContentPlugin implements ContentPlugin {
                             }
                         } catch (IllegalStateException e) {
                             LOGGER.debug("Unable to retrieve user from request.", e);
+                        } catch (UnavailableSecurityManagerException e) {
+                            LOGGER.debug("Unable to retrieve Security Manager.", e);
                         }
 
                         if (uri != null) {

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
@@ -23,9 +23,14 @@ import static com.jayway.restassured.RestAssured.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -185,6 +190,40 @@ public class TestCatalog extends AbstractIntegrationTest {
         } catch (Exception e) {
             LOGGER.error("Couldn't start filter plugin");
         }
+    }
+
+    @Test
+    public void testContentDirectoryMonitor() throws Exception {
+        startFeature(true, "content-core-directorymonitor");
+        final String TMP_PREFIX = "tcdm_";
+        Path tmpDir = Files.createTempDirectory(TMP_PREFIX);
+        tmpDir.toFile().deleteOnExit();
+        Path tmpFile = Files.createTempFile(tmpDir, TMP_PREFIX, "_tmp.xml");
+        tmpFile.toFile().deleteOnExit();
+        Files.copy(this.getClass().getClassLoader().getResourceAsStream("metacard5.xml"), tmpFile,
+                StandardCopyOption.REPLACE_EXISTING);
+
+        Map<String, Object> cdmProperties = new HashMap<>();
+        cdmProperties.putAll(getMetatypeDefaults("content-core-directorymonitor",
+                "ddf.content.core.directorymonitor.ContentDirectoryMonitor"));
+        cdmProperties.put("monitoredDirectoryPath", tmpDir.toString() + "/"); // Must end with /
+        cdmProperties.put("directive", "STORE_AND_PROCESS");
+        createManagedService("ddf.content.core.directorymonitor.ContentDirectoryMonitor",
+                cdmProperties);
+
+        long startTime = System.nanoTime();
+        ValidatableResponse response = null;
+        do {
+            response = executeOpenSearch("xml", "q=*SysAdmin*");
+            if (response.extract().xmlPath().getList("metacards.metacard").size() == 1) {
+                break;
+            }
+            try {
+                TimeUnit.MILLISECONDS.sleep(50);
+            } catch (InterruptedException e) {
+            }
+        } while (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) < ONE_MINUTE_MILLIS);
+        response.body("metcards.metacard.size()", equalTo(1));
     }
 
     private void configureRestForBasic() throws IOException, InterruptedException {

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/metacard5.xml
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/metacard5.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+          xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/"
+          xmlns:ns5="http://www.w3.org/2001/SMIL20/Language">
+    <type>ddf.metacard</type>
+    <source>ddf.distribution</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>Metacard-5</value>
+    </string>
+     <geometry name="location">
+        <value>
+            <ns2:Point>
+                <ns2:pos>31.14926 53.58979</ns2:pos>
+            </ns2:Point>
+        </value>
+    </geometry>
+    <dateTime name="created">
+        <value>2015-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2015-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>CA==</value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;All Hail Michael Our SysAdmin May His Systems Be Ever Administered&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>


### PR DESCRIPTION
Recent changes that check for a security subject on a thread broke the
Directory Monitors ingest (Since it has no security subject) and was
throwing an uncaught runtime exception. Now we catch the exception to
allow the ingest to proceed and simply don't add a point of contact to
the metacard.

@coyotesqrl @brendan-hofmann @stustison 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/129)
<!-- Reviewable:end -->
