### PR TITLE
DDF-1446: Disables owasp dependency-check on docs

### DIFF
--- a/catalog/content/docs/pom.xml
+++ b/catalog/content/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -33,7 +33,7 @@
               <artifactId>dependency-check-maven</artifactId>
               <executions>
                   <execution>
-                      <phase>package</phase>
+                      <phase>none</phase>
                       <goals>
                           <goal>check</goal>
                       </goals>

--- a/catalog/content/docs/pom.xml
+++ b/catalog/content/docs/pom.xml
@@ -37,9 +37,6 @@
                       <goals>
                           <goal>check</goal>
                       </goals>
-                      <configuration>
-                          <failBuildOnCVSS>11</failBuildOnCVSS>
-                      </configuration>
                   </execution>
               </executions>
           </plugin>

--- a/catalog/docs/pom.xml
+++ b/catalog/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/catalog/docs/pom.xml
+++ b/catalog/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/catalog/solr/docs/pom.xml
+++ b/catalog/solr/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/catalog/solr/docs/pom.xml
+++ b/catalog/solr/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/catalog/spatial/docs/pom.xml
+++ b/catalog/spatial/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/catalog/spatial/docs/pom.xml
+++ b/catalog/spatial/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/catalog/ui/docs/pom.xml
+++ b/catalog/ui/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -34,7 +34,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/catalog/ui/docs/pom.xml
+++ b/catalog/ui/docs/pom.xml
@@ -38,9 +38,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/platform/admin/docs/pom.xml
+++ b/platform/admin/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/platform/admin/docs/pom.xml
+++ b/platform/admin/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/platform/docs/pom.xml
+++ b/platform/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/platform/docs/pom.xml
+++ b/platform/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/platform/security/docs/pom.xml
+++ b/platform/security/docs/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -32,7 +32,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/platform/security/docs/pom.xml
+++ b/platform/security/docs/pom.xml
@@ -36,9 +36,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <failBuildOnCVSS>11</failBuildOnCVSS>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Sets the execution phase of the owasp dependency-check plugin to none on docs projects so that it is not run.

@lessarderic 
@ricklarsen 
@tbatie 
@shaundmorris

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/130)
<!-- Reviewable:end -->
