### PR TITLE
DDF-1447 Fixes incorrectly formatted .gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ target/
 bin/
 atlassian-ide-plugin.xml
 *.sonar-ide.properties
-*/webapp/css/styles.css
+**/webapp/css/styles.css
 platform/solr/**/overlays


### PR DESCRIPTION
Fixes the matching line for the generated styles.css files to have the correct lead-in of two stars to match any initial directory prior to the webapp directory.

@tbatie 
@jckilmer
@rzwiefel
@roelens8

Ryan, please hero. I would suggest that this particular delta probably needs a full compile but as long as all the files are correctly ignored and none are incorrectly ignored, testing is overkill.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/132)
<!-- Reviewable:end -->
