### PR TITLE
DDF-1442 Ensures that anonymous REST access is reestablished at the start of each security test

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -28,6 +28,7 @@ import java.util.Hashtable;
 import java.util.TimeZone;
 
 import org.hamcrest.xml.HasXPath;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -87,6 +88,12 @@ public class TestSecurity extends AbstractIntegrationTest {
     }
 
     public void configurePDP() throws Exception {
+    }
+
+    @Before
+    public void before() throws Exception {
+        configureRestForAnonymous();
+        Thread.sleep(2000);
     }
 
     @Test
@@ -201,7 +208,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         DDF-1442: Sleeps for a small time so that the web context policy can be updated and make authentication not be
         required for the deletion of the metacard.
          */
-        Thread.sleep(CONFIG_UPDATE_WAIT_INTERVAL);
+        Thread.sleep(2000);
         TestCatalog.deleteMetacard(recordId);
     }
 


### PR DESCRIPTION
We need to ensure that we always start tests with anon access turned on because our tests expect to be able to ingest anonymously. Additionally, we have a new integration test that is making a configuration change and not waiting long enough for it to propagate.

@brendan-hofmann 
@lessarderic 
@pklinef 
@rzwiefel

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/137)
<!-- Reviewable:end -->
