### PR TITLE
DDF-1452 Fixes racy configuration changes in Integration Tests

### DIFF
--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -34,6 +34,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ddf.security.policy</groupId>
+			<artifactId>security-policy-api</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/CatalogBundle.java
@@ -48,7 +48,6 @@ public class CatalogBundle {
         this.adminConfig = adminConfig;
     }
 
-
     public CatalogProvider waitForCatalogProvider() throws InterruptedException {
         LOGGER.info("Waiting for CatalogProvider to become available.");
         serviceManager.printInactiveBundles();
@@ -136,8 +135,8 @@ public class CatalogBundle {
     }
 
     public void setFanout(boolean fanoutEnabled) throws IOException {
-        Map<String, Object> properties = adminConfig.getDdfConfigAdmin().getProperties(
-                CATALOG_FRAMEWORK_PID);
+        Map<String, Object> properties = adminConfig.getDdfConfigAdmin()
+                .getProperties(CATALOG_FRAMEWORK_PID);
         if (properties == null) {
             properties = new Hashtable<>();
         }

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/SecurityPolicyConfigurator.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/SecurityPolicyConfigurator.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.codice.ddf.security.policy.context.ContextPolicy;
+import org.codice.ddf.security.policy.context.ContextPolicyManager;
+
+import ddf.common.test.AdminConfig;
+import ddf.common.test.ServiceManager;
+import ddf.common.test.SynchronizedConfiguration;
+
+public class SecurityPolicyConfigurator {
+    private static final String SYMBOLIC_NAME = "security-policy-context";
+
+    private static final String FACTORY_PID = "org.codice.ddf.security.policy.context.impl.PolicyManager";
+
+    private static final String[] AUTH_TYPES = {"/=SAML|%s", "/admin=SAML|basic",
+            "/jolokia=SAML|basic", "/system=SAML|basic", "/solr=SAML|PKI|basic"};
+
+    public static void configureRestForAnonymous(AdminConfig adminConfig,
+            ServiceManager serviceManager, String serviceRoot) throws Exception {
+        configure(adminConfig, serviceManager, serviceRoot, "ANON");
+    }
+
+    public static void configureRestForBasic(AdminConfig adminConfig, ServiceManager serviceManager,
+            String serviceRoot) throws Exception {
+        configure(adminConfig, serviceManager, serviceRoot, "basic");
+    }
+
+    private static void configure(AdminConfig adminConfig, ServiceManager serviceManager,
+            String serviceRoot, String policyType) throws Exception {
+        ContextPolicyManager ctxPolicyMgr = serviceManager.getService(ContextPolicyManager.class);
+
+        new SynchronizedConfiguration(FACTORY_PID, null,
+                getConfigProps(serviceManager, serviceRoot, policyType),
+                createChecker(policyType, ctxPolicyMgr)).updateConfig(adminConfig);
+
+    }
+
+    private static Callable<Boolean> createChecker(final String policyType,
+            final ContextPolicyManager ctxPolicyMgr) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                ContextPolicy contextPolicy = ctxPolicyMgr.getContextPolicy("/");
+
+                return contextPolicy.getAuthenticationMethods().contains(policyType);
+            }
+        };
+    }
+
+    private static Map<String, Object> getConfigProps(ServiceManager serviceManager,
+            String serviceRoot, String policyType) {
+        Map<String, Object> map = new HashMap<>();
+        map.putAll(serviceManager.getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
+        map.put("whiteListContexts",
+                "/services/SecurityTokenService,/services/internal,/proxy," + serviceRoot
+                        + "/sdk/SoapService");
+        map.put("authenticationTypes", getAuthTypes(policyType));
+        return map;
+
+    }
+
+    private static String[] getAuthTypes(String policyType) {
+        String[] subbedAuths = new String[AUTH_TYPES.length];
+        for (int i = 0; i < AUTH_TYPES.length; i++) {
+            subbedAuths[i] = String.format(AUTH_TYPES[i], policyType);
+        }
+
+        return subbedAuths;
+    }
+}

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
@@ -22,6 +22,9 @@ import static com.jayway.restassured.RestAssured.delete;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 
+import static ddf.catalog.test.SecurityPolicyConfigurator.configureRestForAnonymous;
+import static ddf.catalog.test.SecurityPolicyConfigurator.configureRestForBasic;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -282,12 +285,12 @@ public class TestCatalog extends AbstractIntegrationTest {
             response.body(not(hasXPath(xPath)));
 
             // Test filtering with point of contact
-            configureRestForBasic();
+            configureRestForBasic(getAdminConfig(), getServiceManager(), SERVICE_ROOT);
 
             response = executeAdminOpenSearch("xml", "q=*");
             response.body(hasXPath(xPath));
 
-            configureRestForAnon();
+            configureRestForAnonymous(getAdminConfig(), getServiceManager(), SERVICE_ROOT);
 
             stopFeature(true, "sample-filter");
             stopFeature(true, "filter-plugin");
@@ -333,32 +336,6 @@ public class TestCatalog extends AbstractIntegrationTest {
         response.body("metcards.metacard.size()", equalTo(1));
     }
 
-    private void configureRestForBasic() throws IOException, InterruptedException {
-        PolicyProperties policyProperties = new PolicyProperties();
-        policyProperties.put("authenticationTypes",
-                "/=SAML|basic,/admin=SAML|basic,/jolokia=SAML|basic,/system=SAML|basic,/solr=SAML|PKI|basic");
-        policyProperties.put("whiteListContexts",
-                "/services/SecurityTokenService,/services/internal,/proxy," + SERVICE_ROOT
-                        + "/sdk/SoapService");
-        Configuration config = configAdmin.getConfiguration(PolicyProperties.FACTORY_PID, null);
-        Dictionary<String, ?> configProps = new Hashtable<>(policyProperties);
-        config.update(configProps);
-        waitForAllBundles();
-    }
-
-    private void configureRestForAnon() throws IOException, InterruptedException {
-        PolicyProperties policyProperties = new PolicyProperties();
-        policyProperties.put("authenticationTypes",
-                "/=SAML|anon,/admin=SAML|anon,/jolokia=SAML|anon,/system=SAML|anon,/solr=SAML|PKI|anon");
-        policyProperties.put("whiteListContexts",
-                "/services/SecurityTokenService,/services/internal,/proxy," + SERVICE_ROOT
-                        + "/sdk/SoapService");
-        Configuration config = configAdmin.getConfiguration(PolicyProperties.FACTORY_PID, null);
-        Dictionary<String, ?> configProps = new Hashtable<>(policyProperties);
-        config.update(configProps);
-        waitForAllBundles();
-    }
-
     private ValidatableResponse executeOpenSearch(String format, String... query) {
         StringBuilder buffer = new StringBuilder(OPENSEARCH_PATH).append("?").append("format=")
                 .append(format);
@@ -400,18 +377,6 @@ public class TestCatalog extends AbstractIntegrationTest {
         public static final String FACTORY_PID = "ddf.security.pdp.realm.SimpleAuthzRealm";
 
         public PdpProperties() {
-            this.putAll(getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
-        }
-
-    }
-
-    public class PolicyProperties extends HashMap<String, Object> {
-
-        public static final String SYMBOLIC_NAME = "security-policy-context";
-
-        public static final String FACTORY_PID = "org.codice.ddf.security.policy.context.impl.PolicyManager";
-
-        public PolicyProperties() {
             this.putAll(getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
         }
 


### PR DESCRIPTION
Removes arbitrary Thread.sleep() calls and favors explicit calls to updated services to see that their configurations have been changed before moving on.

@pklinef 
@jckilmer
@roelens8
@brendan-hofmann

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/141)
<!-- Reviewable:end -->
