### PR TITLE
DDF-1453 Use java.util.zip to deflate/inflate tokens

### DIFF
--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -74,6 +74,14 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -13,17 +13,24 @@
  */
 package org.codice.ddf.security.common.jaxrs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -31,7 +38,9 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.rs.security.saml.DeflateEncoderDecoder;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.junit.Test;
@@ -98,6 +107,34 @@ public class RestSecurityTest {
         WebClient client = WebClient.create("http://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
         assertNull(client.getHeaders().get("Cookie"));
+    }
+
+    @Test
+    public void testInflateDeflateWithTokenDuplication() throws Exception {
+        String token = "valid_grant valid_grant valid_grant valid_grant valid_grant valid_grant";
+
+        DeflateEncoderDecoder deflateEncoderDecoder = new DeflateEncoderDecoder();
+        byte[] deflatedToken = deflateEncoderDecoder.deflateToken(token.getBytes());
+
+        String cxfInflatedToken = IOUtils
+                .toString(deflateEncoderDecoder.inflateToken(deflatedToken));
+
+        String streamInflatedToken = IOUtils.toString(
+                new InflaterInputStream(new ByteArrayInputStream(deflatedToken),
+                        new Inflater(true)));
+
+        assertNotSame(cxfInflatedToken, token);
+        assertEquals(streamInflatedToken, token);
+    }
+
+    @Test
+    public void testInflateDeflate() throws Exception {
+        String token = "valid_grant";
+
+        String encodedToken = RestSecurity.encodeSaml(token);
+        String decodedToken = RestSecurity.decodeSaml(encodedToken);
+
+        assertThat(decodedToken, is(token));
     }
 
     /**


### PR DESCRIPTION
- CXF DeflateEncoderDecoder has a bug related to inflating a token
  that inflated size is more than twice the size of the deflated token.
  Replaced CXF deflate/inflate utility with java.util.zip.
- Replaced CXF Base64 with Apache Commons Base64 utility.
- Added decodeSaml to mirror encodeSaml to RestSecurity for better
  cohesion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/144)
<!-- Reviewable:end -->
