### PR TITLE
DDF-1462: Address node.js and npm intermittent download failures

### DIFF
--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -108,7 +108,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                            <arguments>test</arguments>
+                            <arguments>test --force</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/platform/security/security-admin-module/pom.xml
+++ b/platform/security/security-admin-module/pom.xml
@@ -45,7 +45,7 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>0.0.23</version>
                 <executions>
-                    <execution>
+                     <execution>
                         <id>install node and npm</id>
                         <goals>
                             <goal>install-node-and-npm</goal>
@@ -53,6 +53,7 @@
                         <configuration>
                             <nodeVersion>v0.10.18</nodeVersion>
                             <npmVersion>2.0.2</npmVersion>
+                            <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
                         </configuration>
                     </execution>
                     <execution>
@@ -70,7 +71,7 @@
                             <goal>grunt</goal>
                         </goals>
                         <configuration>
-                            <arguments>build test</arguments>
+                            <arguments>build test --force</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,7 @@
                             <configuration>
                                 <nodeVersion>${node.version}</nodeVersion>
                                 <npmVersion>${npm.version}</npmVersion>
+                                <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
                             </configuration>
                         </execution>
                         <execution>


### PR DESCRIPTION
Changed pom files to download node.js and npm from artifacts.codice.org
and temporarily added --force option to grunt tests.

@coyotesqrl, @stustison, can you take a quick look at this? This is not the final solution for our DDF build failures and I won't close DDF-1462 right now, but it should at least put the builds back on track until we have final solutions for the node.js/npm download and UI test failures.

I tested it yesterday and the build passed fine with those changes and I can even run the build on a faster machine.

Let me know what you think.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/145)
<!-- Reviewable:end -->
