### PR TITLE
DDF-1475 Support SecurityUtils.getSubject() in SOAP endpoints

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
@@ -252,7 +252,7 @@ public abstract class AbstractEventController implements EventHandler {
 
     protected String getUserId(ServerSession serverSession, Subject subject) {
         String userId = null;
-        if (subject != null) {
+        if (subject != null && subject.getPrincipals() != null) {
             PrincipalCollection principalCollection = subject.getPrincipals();
             for (Object principal : principalCollection.asList()) {
                 if (principal instanceof SecurityAssertion) {

--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -40,6 +40,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>ddf.security.policy</groupId>
+			<artifactId>security-policy-context</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -125,6 +125,8 @@ public abstract class AbstractIntegrationTest {
 
     private ServiceManager serviceManager;
 
+    private SecurityPolicyConfigurator securityPolicy;
+
     private CatalogBundle catalogBundle;
 
     static {
@@ -140,6 +142,7 @@ public abstract class AbstractIntegrationTest {
         adminConfig = new AdminConfig(configAdmin);
         serviceManager = new ServiceManager(bundleCtx, metatype, adminConfig);
         catalogBundle = new CatalogBundle(serviceManager, adminConfig);
+        securityPolicy = new SecurityPolicyConfigurator(serviceManager, configAdmin);
     }
 
     /**
@@ -164,6 +167,10 @@ public abstract class AbstractIntegrationTest {
 
     protected CatalogBundle getCatalogBundle() {
         return catalogBundle;
+    }
+
+    protected SecurityPolicyConfigurator getSecurityPolicy() {
+        return securityPolicy;
     }
 
     private Option[] combineOptions(Option[]... options) {

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
@@ -22,9 +22,6 @@ import static com.jayway.restassured.RestAssured.delete;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 
-import static ddf.catalog.test.SecurityPolicyConfigurator.configureRestForAnonymous;
-import static ddf.catalog.test.SecurityPolicyConfigurator.configureRestForBasic;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -285,12 +282,12 @@ public class TestCatalog extends AbstractIntegrationTest {
             response.body(not(hasXPath(xPath)));
 
             // Test filtering with point of contact
-            configureRestForBasic(getAdminConfig(), getServiceManager(), SERVICE_ROOT);
+            getSecurityPolicy().configureRestForBasic();
 
             response = executeAdminOpenSearch("xml", "q=*");
             response.body(hasXPath(xPath));
 
-            configureRestForAnonymous(getAdminConfig(), getServiceManager(), SERVICE_ROOT);
+            getSecurityPolicy().configureRestForAnonymous();
 
             stopFeature(true, "sample-filter");
             stopFeature(true, "filter-plugin");

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/SynchronizedConfiguration.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/SynchronizedConfiguration.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,11 +15,16 @@ package ddf.common.test;
 
 import static org.junit.Assert.fail;
 
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 public class SynchronizedConfiguration {
+
     private static final long CONFIG_UPDATE_MAX_WAIT_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
     private static final int LOOP_SLEEP_MILLIS = 5;
@@ -32,16 +37,20 @@ public class SynchronizedConfiguration {
 
     private final Callable<Boolean> configCallable;
 
+    private ConfigurationAdmin configAdmin;
+
     public SynchronizedConfiguration(String pid, String location, Map<String, Object> configProps,
-            Callable<Boolean> configCallable) {
+            Callable<Boolean> configCallable, ConfigurationAdmin configAdmin) {
         this.pid = pid;
         this.location = location;
         this.configProps = configProps;
         this.configCallable = configCallable;
+        this.configAdmin = configAdmin;
     }
 
-    public final void updateConfig(AdminConfig adminConfig) throws Exception {
-        adminConfig.getDdfConfigAdmin().update(pid, configProps);
+    public final void updateConfig() throws Exception {
+        Configuration config = configAdmin.getConfiguration(pid, location);
+        config.update(new Hashtable<>(configProps));
 
         long timeoutLimit = System.currentTimeMillis() + CONFIG_UPDATE_MAX_WAIT_MILLIS;
         while (true) {
@@ -56,4 +65,5 @@ public class SynchronizedConfiguration {
             }
         }
     }
+
 }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/SecurityProperties.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/SecurityProperties.java
@@ -36,6 +36,8 @@ public class SecurityProperties extends HashMap<String, Serializable> {
      *
      * @param message
      *            Incoming CXF message that may contain a subject
+     *
+     * @deprecated use SecurityUtils.getSubject()
      */
     public SecurityProperties(Message message) {
         if (message != null) {

--- a/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
+++ b/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
@@ -36,6 +36,7 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessageInfo;
 import org.apache.cxf.ws.addressing.JAXWSAConstants;
 import org.apache.cxf.ws.addressing.Names;
+import org.apache.shiro.util.ThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -128,6 +129,7 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
                     SecurityLogger.logInfo(
                             "Is user [" + user.getPrincipal() + "] permitted: " + isPermitted);
                     // store the subject so the DDF framework can use it later
+                    ThreadContext.bind(user);
                     message.put(SecurityConstants.SAML_ASSERTION, user);
                     logger.debug("Added assertion information to message at key {}",
                             SecurityConstants.SAML_ASSERTION);


### PR DESCRIPTION
- Added binding the subject to the thread in PEPAuthorizingInterceptor.
- Added support in SecurityPolicyConfigurator to configure all policy
  options.
- Fixed whitelist context for SDK SOAP service in itests.
- Fixed potential NPE in search endpoint event controller.

@stustison @coyotesqrl @rzwiefel

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/155)
<!-- Reviewable:end -->
