### PR TITLE
DDF-1476 - Updating bounding box causes inconsistent behavior

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -130,10 +130,10 @@ define([
 
                 //we need these to always be inferred
                 //as numeric values and never as strings
-                var north = parseInt(this.get('north')),
-                    south = parseInt(this.get('south')),
-                    west = parseInt(this.get('west')),
-                    east = parseInt(this.get('east'));
+                var north = parseFloat(this.get('north'));
+                var south = parseFloat(this.get('south'));
+                var west = parseFloat(this.get('west'));
+                var east = parseFloat(this.get('east'));
 
                 if (north && south && east && west){
                     this.set('bbox', [west, south, east, north].join(','), {silent:this.get('locationType') === 'usng' && !this.drawing});

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -127,10 +127,14 @@ define([
             },
 
             setBBox : function() {
-                var north = this.get('north'),
-                    south = this.get('south'),
-                    west = this.get('west'),
-                    east = this.get('east');
+
+                //we need these to always be inferred
+                //as numeric values and never as strings
+                var north = parseInt(this.get('north')),
+                    south = parseInt(this.get('south')),
+                    west = parseInt(this.get('west')),
+                    east = parseInt(this.get('east'));
+
                 if (north && south && east && west){
                     this.set('bbox', [west, south, east, north].join(','), {silent:this.get('locationType') === 'usng' && !this.drawing});
                 }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/openlayers.bbox.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/openlayers.bbox.js
@@ -54,10 +54,20 @@ define([
             },
 
             modelToRectangle: function (model) {
-                var northWest = ol.proj.transform([model.get('west'), model.get('north')], 'EPSG:4326', properties.projection);
-                var northEast = ol.proj.transform([model.get('east'), model.get('north')], 'EPSG:4326', properties.projection);
-                var southWest = ol.proj.transform([model.get('west'), model.get('south')], 'EPSG:4326', properties.projection);
-                var southEast = ol.proj.transform([model.get('east'), model.get('south')], 'EPSG:4326', properties.projection);
+
+                //ensure that the values are numeric
+                //so that the openlayer projections
+                //do not fail
+                var north  = parseInt(model.get('north'));
+                var south = parseInt(model.get('south'));
+                var east = parseInt(model.get('east'));
+                var west = parseInt(model.get('west'));
+
+                var northWest = ol.proj.transform([west,north], 'EPSG:4326', properties.projection);
+                var northEast = ol.proj.transform([east,north], 'EPSG:4326', properties.projection);
+                var southWest = ol.proj.transform([west,south], 'EPSG:4326', properties.projection);
+                var southEast = ol.proj.transform([east,south], 'EPSG:4326', properties.projection);
+
                 var coords = [];
                 coords.push(northWest);
                 coords.push(northEast);

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/openlayers.bbox.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/openlayers.bbox.js
@@ -58,10 +58,10 @@ define([
                 //ensure that the values are numeric
                 //so that the openlayer projections
                 //do not fail
-                var north  = parseInt(model.get('north'));
-                var south = parseInt(model.get('south'));
-                var east = parseInt(model.get('east'));
-                var west = parseInt(model.get('west'));
+                var north  = parseFloat(model.get('north'));
+                var south = parseFloat(model.get('south'));
+                var east = parseFloat(model.get('east'));
+                var west = parseFloat(model.get('west'));
 
                 var northWest = ol.proj.transform([west,north], 'EPSG:4326', properties.projection);
                 var northEast = ol.proj.transform([east,north], 'EPSG:4326', properties.projection);


### PR DESCRIPTION
When using the numeric input boxes to adjust the bounding box
North and South values, the box is either removed or moved to a
unknown location on the 2d map. This was because the values are
not being treated as numeric. This was solved by ensuring they are
numeric once they are retrieved from model.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/159)
<!-- Reviewable:end -->
