### PR TITLE
DDF-1430 Optimize CSW Query transformation.

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/pom.xml
@@ -88,6 +88,11 @@
             <groupId>ddf.action.core</groupId>
             <artifactId>action-core-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>catalog-transformer-xml</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
@@ -1,30 +1,40 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.transformer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.CharArrayWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.activation.MimeType;
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
@@ -33,23 +43,27 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.QName;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordCollection;
-import org.codice.ddf.spatial.ogc.csw.catalog.converter.GetRecordsResponseConverter;
+import org.codice.ddf.spatial.ogc.csw.catalog.converter.DefaultCswRecordMap;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.XStreamException;
-import com.thoughtworks.xstream.io.naming.NoNameCoder;
-import com.thoughtworks.xstream.io.xml.StaxDriver;
-
 import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.MetacardTransformer;
 import ddf.catalog.transform.QueryResponseTransformer;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.api.PrintWriterProvider;
+
 import net.opengis.cat.csw.v_2_0_2.AcknowledgementType;
 import net.opengis.cat.csw.v_2_0_2.EchoedRequestType;
 import net.opengis.cat.csw.v_2_0_2.ElementSetType;
@@ -58,147 +72,286 @@ import net.opengis.cat.csw.v_2_0_2.ObjectFactory;
 import net.opengis.cat.csw.v_2_0_2.ResultType;
 
 /**
- * Implementation of {@link ddf.catalog.transform.QueryResponseTransformer} for CSW 2.0.2
+ * Implementation of {@link QueryResponseTransformer} for CSW 2.0.2
  * GetRecordsResponse
  */
 public class CswQueryResponseTransformer implements QueryResponseTransformer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CswQueryResponseTransformer.class);
 
-    private XStream xstreamGetRecordsResponse;
+    private static final String QUERY_POOL_NAME = "csw-query-pool";
 
-    private XStream xstreamGetRecordByIdResponse;
+    private static final String CSW_PREFIX =
+            CswConstants.CSW_NAMESPACE_PREFIX + CswConstants.NAMESPACE_DELIMITER;
 
-    public CswQueryResponseTransformer(GetRecordsResponseConverter converter) {
-        xstreamGetRecordsResponse = initXstream(CswConstants.GET_RECORDS_RESPONSE, converter);
-        xstreamGetRecordByIdResponse = initXstream(CswConstants.GET_RECORD_BY_ID_RESPONSE,
-                converter);
+    private static final String XML_PREFIX =
+            XMLConstants.XMLNS_ATTRIBUTE + CswConstants.NAMESPACE_DELIMITER;
+
+    private static final String GET_RECORDS_RESPONSE_NODE_NAME = "GetRecordsResponse";
+
+    private static final String SEARCH_STATUS_NODE_NAME = "SearchStatus";
+
+    private static final String SEARCH_RESULTS_NODE_NAME = "SearchResults";
+
+    private static final String VERSION_ATTRIBUTE = "version";
+
+    private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+
+    private static final String NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE = "numberOfRecordsMatched";
+
+    private static final String NEXT_RECORD_ATTRIBUTE = "nextRecord";
+
+    private static final String RECORD_SCHEMA_ATTRIBUTE = "recordSchema";
+
+    private static final String ELEMENT_SET_ATTRIBUTE = "elementSet";
+
+    private static final String XML_DECL = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n";
+
+    public static final String RECORDS_RESPONSE_QNAME = CSW_PREFIX + GET_RECORDS_RESPONSE_NODE_NAME;
+
+    public static final String SEARCH_STATUS_QNAME = CSW_PREFIX + SEARCH_STATUS_NODE_NAME;
+
+    public static final String SEARCH_RESULTS_QNAME = CSW_PREFIX + SEARCH_RESULTS_NODE_NAME;
+
+    public static final String NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE = "numberOfRecordsReturned";
+
+    private TransformerManager metacardTransformerManager;
+
+    private ThreadPoolExecutor queryExecutor;
+
+    private PrintWriterProvider writerProvider;
+
+    private static final int BLOCKING_Q_INITIAL_SIZE = 1024;
+
+    private static final int ACCUM_INITIAL_SIZE = 4096;
+
+    public CswQueryResponseTransformer(TransformerManager metacardTransformerManager,
+            PrintWriterProvider writerProvider) {
+        this.metacardTransformerManager = metacardTransformerManager;
+        this.writerProvider = writerProvider;
     }
 
     @Override
     public BinaryContent transform(SourceResponse sourceResponse,
             Map<String, Serializable> arguments) throws CatalogTransformerException {
-        LOGGER.debug("Entering CswQueryResponseTransformer.transform()");
-        if (sourceResponse.getResults() == null
-                && arguments.get(CswConstants.RESULT_TYPE_PARAMETER) == null) {
-            LOGGER.warn("Attempted to Transform and empty Result list.");
-            return null;
+
+        validateInput(sourceResponse, arguments);
+
+        CswRecordCollection recordCollection = buildCollection(sourceResponse, arguments);
+
+        ByteArrayInputStream bais;
+
+        if (ResultType.VALIDATE.equals(recordCollection.getResultType())) {
+            ByteArrayOutputStream baos = writeAcknowledgement(recordCollection.getRequest());
+            bais = new ByteArrayInputStream(baos.toByteArray());
+        } else {
+            // "catches" recordCollection.getResultType() == null
+            List<Result> results = sourceResponse.getResults();
+            String xmlString = convert(recordCollection, results, arguments);
+            bais = new ByteArrayInputStream(xmlString.getBytes());
         }
 
-        BinaryContent transformedContent = null;
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        BinaryContent transformedContent = new BinaryContentImpl(bais, new MimeType());
+        return transformedContent;
+    }
 
-        LOGGER.debug("Creating recordCollection");
+    private String convert(CswRecordCollection cswRecordCollection, List<Result> results,
+            Map<String, Serializable> arguments) throws CatalogTransformerException {
+
+        PrintWriter writer = writerProvider.build(Metacard.class);
+        writer.setRawValue(XML_DECL);
+
+        writer.startNode(RECORDS_RESPONSE_QNAME);
+        for (Map.Entry<String, String> entry : DefaultCswRecordMap.getDefaultCswRecordMap()
+                .getPrefixToUriMapping().entrySet()) {
+            writer.addAttribute(XML_PREFIX + entry.getKey(), entry.getValue());
+        }
+
+        long start = (cswRecordCollection.getStartPosition() > 0) ?
+                cswRecordCollection.getStartPosition() :
+                1;
+        long nextRecord = start + cswRecordCollection.getNumberOfRecordsReturned();
+        if (nextRecord > cswRecordCollection.getNumberOfRecordsMatched()) {
+            nextRecord = 0;
+        }
+
+        if (!cswRecordCollection.isById()) {
+            writer.addAttribute(VERSION_ATTRIBUTE, CswConstants.VERSION_2_0_2);
+
+            writer.startNode(SEARCH_STATUS_QNAME);
+            writer.addAttribute(TIMESTAMP_ATTRIBUTE,
+                    ISODateTimeFormat.dateTime().print(new DateTime()));
+            writer.endNode();
+
+            writer.startNode(SEARCH_RESULTS_QNAME);
+            writer.addAttribute(NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE,
+                    Long.toString(cswRecordCollection.getNumberOfRecordsMatched()));
+
+            if (ResultType.HITS.equals(cswRecordCollection.getResultType())) {
+                writer.addAttribute(NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE, Long.toString(0));
+            } else {
+                writer.addAttribute(NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE,
+                        Long.toString(cswRecordCollection.getNumberOfRecordsReturned()));
+            }
+
+            writer.addAttribute(NEXT_RECORD_ATTRIBUTE, Long.toString(nextRecord));
+            writer.addAttribute(RECORD_SCHEMA_ATTRIBUTE, cswRecordCollection.getOutputSchema());
+
+            if (cswRecordCollection.getElementSetType() != null && StringUtils
+                    .isNotBlank(cswRecordCollection.getElementSetType().value())) {
+                writer.addAttribute(ELEMENT_SET_ATTRIBUTE,
+                        cswRecordCollection.getElementSetType().value());
+            }
+        }
+
+        if (!ResultType.HITS.equals(cswRecordCollection.getResultType())) {
+            arguments.put(CswConstants.OMIT_XML_DECLARATION, Boolean.TRUE);
+
+            String metacardsString = multiThreadedMarshal(results,
+                    cswRecordCollection.getOutputSchema(), arguments);
+            writer.setRawValue(metacardsString);
+        }
+
+        if (!cswRecordCollection.isById()) {
+            writer.endNode(); // SEARCH_RESULTS_QNAME
+        }
+
+        writer.endNode(); // RECORDS_RESPONSE_QNAME
+
+        return writer.makeString();
+    }
+
+    /*
+        Multi-threaded marshal of metacard assumes:
+        - cpu-bound => optimum utilization from availableProcessors()+1 thread pool.
+        - query size is unbounded => guard against resource exhaustion with fixed thread-pool,
+          fixed work-queue.
+     */
+    //private void multiThreadedMarshal(PrintWriter writer, List<Result> results,
+    private String multiThreadedMarshal(List<Result> results, String recordSchema,
+            final Map<String, Serializable> arguments) throws CatalogTransformerException {
+
+        CompletionService<BinaryContent> completionService = new ExecutorCompletionService<>(
+                queryExecutor);
+
+        try {
+            for (Result result : results) {
+                final Metacard mc = result.getMetacard();
+
+                final MetacardTransformer transformer = metacardTransformerManager
+                        .getTransformerBySchema(recordSchema);
+
+                if (transformer == null) {
+                    throw new CatalogTransformerException(
+                            "Cannot find transformer for schema: " + recordSchema);
+                }
+
+                // the "current" thread will run submitted task when queueSize exceeded; effectively
+                // blocking enqueue of more tasks.
+                completionService.submit(new Callable<BinaryContent>() {
+                    @Override
+                    public BinaryContent call() throws Exception {
+                        BinaryContent content = transformer.transform(mc, arguments);
+                        return content;
+                    }
+                });
+            }
+
+            int metacardCount = results.size();
+            CharArrayWriter accum = new CharArrayWriter(ACCUM_INITIAL_SIZE);
+            for (int i = 0; i < metacardCount; i++) {
+                Future<BinaryContent> binaryContentFuture = completionService.take(); // blocks
+                BinaryContent binaryContent = binaryContentFuture.get();
+                IOUtils.copy(binaryContent.getInputStream(), accum);
+            }
+
+            return accum.toString();
+
+        } catch (IOException | InterruptedException | ExecutionException xe) {
+            throw new CatalogTransformerException(xe);
+        }
+
+    } // end multiThreadedMarshal()
+
+    private void validateInput(SourceResponse sourceResponse, Map<String, Serializable> arguments) {
+
+        if (null == sourceResponse) {
+            throw new IllegalArgumentException("Null source response.");
+        } else if (null == arguments) {
+            throw new IllegalArgumentException("Null argument map.");
+        } else if (null == sourceResponse.getResults()) {
+            throw new IllegalArgumentException("Null results list.");
+        } else if (null == arguments.get(CswConstants.RESULT_TYPE_PARAMETER)) {
+            throw new IllegalArgumentException("Null result type argument.");
+        } else if (null == sourceResponse.getRequest()) {
+            throw new IllegalArgumentException("Null source response query request.");
+        } else if (null == sourceResponse.getRequest().getQuery()) {
+            throw new IllegalArgumentException("Null source response query.");
+        }
+
+    }
+
+    private CswRecordCollection buildCollection(SourceResponse sourceResponse,
+            Map<String, Serializable> arguments) {
+
         CswRecordCollection recordCollection = new CswRecordCollection();
-        for (Result result : sourceResponse.getResults()) {
-            recordCollection.getCswRecords().add(result.getMetacard());
-        }
 
         recordCollection.setNumberOfRecordsMatched(sourceResponse.getHits());
         recordCollection.setNumberOfRecordsReturned(sourceResponse.getResults().size());
         recordCollection.setStartPosition(sourceResponse.getRequest().getQuery().getStartIndex());
 
-        LOGGER.debug("Evaluating Arguments");
-        evaluateArguments(arguments, recordCollection);
-
-        if (recordCollection.isById()) {
-            LOGGER.debug("Transforming GetRecordByIdResponse");
-            try {
-                xstreamGetRecordByIdResponse.toXML(recordCollection, os);
-            } catch (XStreamException e) {
-                throw new CatalogTransformerException(e);
-            }
-        } else if (recordCollection.getResultType() != null && ResultType.VALIDATE
-                .equals(recordCollection.getResultType())) {
-            LOGGER.debug("Transforming Acknowledgement");
-            try {
-                writeAcknowledgement(recordCollection.getRequest(), os);
-            } catch (IOException e) {
-                throw new CatalogTransformerException(e);
-            }
-        } else {
-            LOGGER.debug("Transforming GetRecordsResponse");
-            try {
-                xstreamGetRecordsResponse.toXML(recordCollection, os);
-            } catch (XStreamException e) {
-                LOGGER.warn("Failed to transform GetRecordsResponse", e);
-                throw new CatalogTransformerException(e);
-            }
+        Object elementSetTypeArg = arguments.get(CswConstants.ELEMENT_SET_TYPE);
+        if (elementSetTypeArg instanceof ElementSetType) {
+            ElementSetType elementSetType = (ElementSetType) elementSetTypeArg;
+            recordCollection.setElementSetType(elementSetType);
         }
 
-        ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
-        transformedContent = new BinaryContentImpl(bais, new MimeType());
-        return transformedContent;
-    }
-
-    /*
-     * Method to handle all the arguments and update the recordCollection based on which arguments are provided.
-     */
-    private void evaluateArguments(Map<String, Serializable> arguments,
-            CswRecordCollection recordCollection) {
-        if (arguments != null) {
-            Object elementSetTypeArg = arguments.get(CswConstants.ELEMENT_SET_TYPE);
-            if (elementSetTypeArg instanceof ElementSetType) {
-                ElementSetType elementSetType = (ElementSetType) elementSetTypeArg;
-                recordCollection.setElementSetType(elementSetType);
-            }
-
-            Object elementNamesArg = arguments.get(CswConstants.ELEMENT_NAMES);
-            if (elementNamesArg instanceof QName[]) {
-                QName[] qnames = (QName[]) elementNamesArg;
-                if (qnames.length > 0) {
-                    List<QName> elementNames = new ArrayList<QName>();
-                    for (QName entry : qnames) {
-                        elementNames.add(entry);
-                    }
-                    recordCollection.setElementName(elementNames);
+        Object elementNamesArg = arguments.get(CswConstants.ELEMENT_NAMES);
+        if (elementNamesArg instanceof QName[]) {
+            QName[] qnames = (QName[]) elementNamesArg;
+            if (qnames.length > 0) {
+                List<QName> elementNames = new ArrayList();
+                for (QName entry : qnames) {
+                    elementNames.add(entry);
                 }
+                recordCollection.setElementName(elementNames);
             }
-
-            Object isByIdQuery = arguments.get(CswConstants.IS_BY_ID_QUERY);
-            if (isByIdQuery != null) {
-                recordCollection.setById((Boolean) isByIdQuery);
-            }
-
-            Object arg = arguments.get((CswConstants.GET_RECORDS));
-            if (arg != null && arg instanceof GetRecordsType) {
-                recordCollection.setRequest((GetRecordsType) arg);
-            }
-
-            Object resultType = arguments.get(CswConstants.RESULT_TYPE_PARAMETER);
-            if (resultType instanceof ResultType) {
-                recordCollection.setResultType((ResultType) resultType);
-            }
-
-            Object outputSchema = arguments.get(CswConstants.OUTPUT_SCHEMA_PARAMETER);
-            if (outputSchema instanceof String) {
-                recordCollection.setOutputSchema((String) outputSchema);
-            }
-
-            Object doWriteNamespaces = arguments.get(CswConstants.WRITE_NAMESPACES);
-            if (doWriteNamespaces instanceof Boolean) {
-                recordCollection.setDoWriteNamespaces((Boolean) doWriteNamespaces);
-            }
-
         }
+
+        Object isByIdQuery = arguments.get(CswConstants.IS_BY_ID_QUERY);
+        if (isByIdQuery != null) {
+            recordCollection.setById((Boolean) isByIdQuery);
+        }
+
+        Object arg = arguments.get((CswConstants.GET_RECORDS));
+        if (arg != null && arg instanceof GetRecordsType) {
+            recordCollection.setRequest((GetRecordsType) arg);
+        }
+
+        Object resultType = arguments.get(CswConstants.RESULT_TYPE_PARAMETER);
+        if (resultType instanceof ResultType) {
+            recordCollection.setResultType((ResultType) resultType);
+        }
+
+        Object outputSchema = arguments.get(CswConstants.OUTPUT_SCHEMA_PARAMETER);
+        if (outputSchema instanceof String) {
+            recordCollection.setOutputSchema((String) outputSchema);
+        } else {
+            recordCollection.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
+        }
+
+        Object doWriteNamespaces = arguments.get(CswConstants.WRITE_NAMESPACES);
+        if (doWriteNamespaces instanceof Boolean) {
+            recordCollection.setDoWriteNamespaces((Boolean) doWriteNamespaces);
+        }
+
+        return recordCollection;
     }
 
-    private XStream initXstream(final String elementName, GetRecordsResponseConverter converter) {
-        XStream xstream = new XStream(new StaxDriver(new NoNameCoder()));
-        xstream.setClassLoader(xstream.getClass().getClassLoader());
-
-        xstream.registerConverter(converter);
-
-        xstream.alias(
-                CswConstants.CSW_NAMESPACE_PREFIX + CswConstants.NAMESPACE_DELIMITER + elementName,
-                CswRecordCollection.class);
-
-        return xstream;
-    }
-
-    private void writeAcknowledgement(GetRecordsType request, OutputStream outStream) throws
-            IOException {
+    private ByteArrayOutputStream writeAcknowledgement(GetRecordsType request)
+            throws CatalogTransformerException {
         try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             JAXBContext jaxBContext = JAXBContext.newInstance("net.opengis.cat.csw.v_2_0_2:"
                     + "net.opengis.filter.v_1_1_0:net.opengis.gml.v_3_1_1:net.opengis.ows.v_1_0_0");
             Marshaller marshaller = jaxBContext.createMarshaller();
@@ -211,16 +364,66 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
             ack.setEchoedRequest(echoedRequest);
             try {
                 ack.setTimeStamp(DatatypeFactory.newInstance()
-                                .newXMLGregorianCalendar(new GregorianCalendar()));
+                        .newXMLGregorianCalendar(new GregorianCalendar()));
             } catch (DatatypeConfigurationException e) {
                 LOGGER.warn("Failed to set timestamp on Acknowledgement, Exception {}", e);
             }
 
             JAXBElement<AcknowledgementType> jaxBAck = new ObjectFactory()
                     .createAcknowledgement(ack);
-            marshaller.marshal(jaxBAck, outStream);
+            marshaller.marshal(jaxBAck, byteArrayOutputStream);
+            return byteArrayOutputStream;
         } catch (JAXBException e) {
-            throw new IOException(e);
+            throw new CatalogTransformerException(e);
+        }
+    }
+
+    public void init() {
+        int numThreads = Runtime.getRuntime().availableProcessors();
+        LOGGER.debug(QUERY_POOL_NAME + " size: {}", numThreads);
+
+        /*
+            - when first two args the same, get fixed size thread pool.
+            - 3rd arg, keepAliveTime, ignored when !allowsCoreThreadTimeOut (the default); thus pass zero.
+            - fixed (and arbitrarily) size blocking queue.
+            - CswThreadFactory gives pool threads a name to ease debug.
+            - tried arbitrarily large numThreads/queue-size, but did not see performance gain.
+            - big queue + small pool minimizes CPU usage, OS resources, and context-switching overhead,
+              but *can* lead to artificially low throughput.
+            - todo: externalize config to support runtime tuning.
+        */
+        queryExecutor = new ThreadPoolExecutor(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingDeque<Runnable>(BLOCKING_Q_INITIAL_SIZE), new CswThreadFactory(),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+
+        queryExecutor.prestartAllCoreThreads();
+    }
+
+    public void destroy() {
+        queryExecutor.shutdown(); // wait for all submitted task to finish.
+
+        // Block until shutdown() complete, or the timeout occurs, or
+        // the current thread is interrupted, whichever happens first.
+        try {
+            queryExecutor.awaitTermination(2L, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(QUERY_POOL_NAME + " graceful shutdown interrupted.", e);
+        }
+    }
+
+    private static class CswThreadFactory implements ThreadFactory {
+        private static AtomicInteger suffix = new AtomicInteger();
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r, QUERY_POOL_NAME + "-" + suffix.incrementAndGet());
+            thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    LOGGER.error("UNCAUGHT exception in thread " + t.getName(), e);
+                }
+            });
+            return thread;
         }
     }
 }

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,17 +17,11 @@
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
                filter="id=catalog.data.metacard.resource"/>
 
+    <reference id="writerProvider" interface="ddf.catalog.transformer.api.PrintWriterProvider"
+               filter="(id=print.writer.provider)"/>
+
     <!-- Register the Transformers -->
     <service interface="ddf.catalog.transform.InputTransformer">
-		<service-properties>
-			<entry key="id" value="csw"/>
-			<entry key="mime-type" value="text/xml"/>
-            <entry key="schema" value="http://www.opengis.net/cat/csw/2.0.2"/>
-		</service-properties>
-		<bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter"/>
-	</service>
-
-    <service interface="ddf.catalog.transform.MetacardTransformer">
         <service-properties>
             <entry key="id" value="csw"/>
             <entry key="mime-type" value="text/xml"/>
@@ -36,15 +30,13 @@
         <bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter"/>
     </service>
 
-    <service interface="ddf.catalog.transform.QueryResponseTransformer">
+    <service interface="ddf.catalog.transform.MetacardTransformer">
         <service-properties>
             <entry key="id" value="csw"/>
             <entry key="mime-type" value="text/xml"/>
             <entry key="schema" value="http://www.opengis.net/cat/csw/2.0.2"/>
         </service-properties>
-        <bean class="org.codice.ddf.spatial.ogc.csw.catalog.transformer.CswQueryResponseTransformer">
-            <argument ref="getRecordsResponseConverter"/>
-        </bean>
+        <bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter"/>
     </service>
 
     <bean id="getRecordsResponseConverter"
@@ -92,5 +84,22 @@
 
     <service ref="cswTransformProvider" id="CswTransformProvider"
              interface="com.thoughtworks.xstream.converters.Converter"/>
+
+    <service ref="CswQueryResponseTransformer"
+             interface="ddf.catalog.transform.QueryResponseTransformer">
+        <service-properties>
+            <entry key="id" value="csw"/>
+            <entry key="mime-type" value="text/xml"/>
+            <entry key="schema" value="http://www.opengis.net/cat/csw/2.0.2"/>
+        </service-properties>
+    </service>
+
+    <bean id="CswQueryResponseTransformer"
+          class="org.codice.ddf.spatial.ogc.csw.catalog.transformer.CswQueryResponseTransformer"
+          init-method="init" destroy-method="destroy">
+        <argument ref="metacardTransformerManager"/>
+        <argument ref="writerProvider"/>
+    </bean>
+
 
 </blueprint>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
@@ -1,32 +1,35 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.transformer;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,86 +43,288 @@ import javax.xml.bind.JAXBException;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswJAXBElementProvider;
-import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordCollection;
-import org.codice.ddf.spatial.ogc.csw.catalog.converter.CswTransformProvider;
-import org.codice.ddf.spatial.ogc.csw.catalog.converter.GetRecordsResponseConverter;
+import org.hamcrest.core.IsEqual;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.opengis.filter.Filter;
-
-import com.thoughtworks.xstream.converters.MarshallingContext;
-import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.MetacardTransformer;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.api.PrintWriterProvider;
+
 import net.opengis.cat.csw.v_2_0_2.AcknowledgementType;
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 import net.opengis.cat.csw.v_2_0_2.ResultType;
 
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.mockito.Matchers.eq;
+
 public class TestCswQueryResponseTransformer {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(TestCswQueryResponseTransformer.class);
 
     private CswQueryResponseTransformer transformer;
 
-    private GetRecordsResponseConverter mockConverter;
-
-    private CswTransformProvider mockTransformProvider;
-
     private Filter filter = mock(Filter.class);
+
+    private TransformerManager mockTransformerManager;
+
+    private PrintWriterProvider mockPrintWriterProvider;
+
+    private PrintWriter mockPrintWriter;
+
+    private MetacardTransformer mockMetacardTransformer;
+
+    private BinaryContent mockBinaryContent;
+
+    private Query mockQuery;
+
+    private SourceResponse mockSourceResponse;
+
+    private QueryRequest mockQueryRequest;
+
+    private Map<String, Serializable> mockArguments;
+
+    private List<Result> mockResults;
+
+    private Serializable mockSerializable;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void before() {
-        mockConverter = mock(GetRecordsResponseConverter.class);
-        mockTransformProvider = mock(CswTransformProvider.class);
-        transformer = new CswQueryResponseTransformer(mockConverter);
-        when(mockConverter.canConvert(any(Class.class))).thenReturn(true);
-        when(mockTransformProvider.canConvert(any(Class.class))).thenReturn(true);
+        mockTransformerManager = mock(TransformerManager.class);
+        mockPrintWriterProvider = mock(PrintWriterProvider.class);
+        mockPrintWriter = mock(PrintWriter.class);
+        mockMetacardTransformer = mock(MetacardTransformer.class);
+        mockQuery = mock(Query.class);
+        mockSourceResponse = mock(SourceResponse.class);
+        mockQueryRequest = mock(QueryRequest.class);
+        mockArguments = mock(Map.class);
+        mockResults = mock(List.class);
+        mockSerializable = mock(Serializable.class);
+        mockBinaryContent = mock(BinaryContent.class);
+
+        transformer = new CswQueryResponseTransformer(mockTransformerManager,
+                mockPrintWriterProvider);
+
     }
 
     @Test
-    public void testMarshalRecordCollection() throws WebApplicationException, IOException,
-            JAXBException, CatalogTransformerException {
+    public void whenNullArgumentsThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null argument map.");
 
-        GetRecordsType query = new GetRecordsType();
-        query.setResultType(ResultType.RESULTS);
-        query.setMaxRecords(BigInteger.valueOf(6));
-        query.setStartPosition(BigInteger.valueOf(4));
-        SourceResponse sourceResponse = createSourceResponse(query, 22);
-
-        Map<String, Serializable> args = new HashMap<>();
-        args.put(CswConstants.OUTPUT_SCHEMA_PARAMETER, CswConstants.CSW_OUTPUT_SCHEMA);
-        args.put(CswConstants.RESULT_TYPE_PARAMETER, ResultType.RESULTS);
-
-        ArgumentCaptor<CswRecordCollection> captor = ArgumentCaptor
-                .forClass(CswRecordCollection.class);
-
-        BinaryContent content = transformer.transform(sourceResponse, args);
-
-        verify(mockConverter, times(1))
-                .marshal(captor.capture(), any(HierarchicalStreamWriter.class),
-                        any(MarshallingContext.class));
-
-        CswRecordCollection collection = captor.getValue();
-
-        assertThat(collection.getResultType(), is(ResultType.RESULTS));
-        assertThat(collection.getOutputSchema(), is(CswConstants.CSW_OUTPUT_SCHEMA));
-        assertThat(collection.getStartPosition(), is(4));
-        assertThat(collection.isById(), is(false));
-        assertThat(collection.getNumberOfRecordsMatched(), is(22L));
-        assertThat(collection.getNumberOfRecordsReturned(), is(6L));
-        assertThat(collection.getCswRecords().isEmpty(), is(false));
+        transformer.transform(mockSourceResponse, null);
     }
 
     @Test
-    public void testMarshalAcknowledgement() throws WebApplicationException, IOException,
-            JAXBException, CatalogTransformerException {
+    public void whenNullSourceResponseThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null source response.");
+
+        transformer.transform(null, mockArguments);
+    }
+
+    @Test
+    public void whenNullResultListThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null results list.");
+
+        when(mockSourceResponse.getResults()).thenReturn(null);
+
+        transformer.transform(mockSourceResponse, mockArguments);
+    }
+
+    @Test
+    public void whenNullResultTypeArgumentThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null result type argument.");
+
+        when(mockSourceResponse.getResults()).thenReturn(mockResults);
+        when(mockArguments.get(anyString())).thenReturn(null);
+
+        transformer.transform(mockSourceResponse, mockArguments);
+    }
+
+    @Test
+    public void whenNullQueryRequestThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null source response query request.");
+
+        when(mockSourceResponse.getResults()).thenReturn(mockResults);
+        when(mockArguments.get(anyString())).thenReturn(ResultType.RESULTS);
+        when(mockSourceResponse.getRequest()).thenReturn(null);
+
+        transformer.transform(mockSourceResponse, mockArguments);
+    }
+
+    @Test
+    public void whenNullQueryThenThrowException() throws CatalogTransformerException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Null source response query.");
+
+        when(mockSourceResponse.getResults()).thenReturn(mockResults);
+        when(mockArguments.get(anyString())).thenReturn(ResultType.RESULTS);
+        when(mockSourceResponse.getRequest()).thenReturn(mockQueryRequest);
+        when(mockQueryRequest.getQuery()).thenReturn(null);
+
+        transformer.transform(mockSourceResponse, mockArguments);
+    }
+
+    @Test
+    public void whenQueryByIdThenExpectOnlyOneXMLNode()
+            throws CatalogTransformerException, IOException {
+        // when
+        when(mockPrintWriterProvider.build((Class<Metacard>) notNull()))
+                .thenReturn(mockPrintWriter);
+        when(mockPrintWriter.makeString()).thenReturn(new String());
+
+        when(mockSourceResponse.getResults()).thenReturn(Collections.<Result>emptyList());
+        when(mockSourceResponse.getRequest()).thenReturn(mockQueryRequest);
+        when(mockQueryRequest.getQuery()).thenReturn(mockQuery);
+        when(mockArguments.get(CswConstants.RESULT_TYPE_PARAMETER)).thenReturn(ResultType.RESULTS);
+        when(mockArguments.get(CswConstants.IS_BY_ID_QUERY)).thenReturn(true);
+
+        // given
+        transformer.init();
+        BinaryContent bc = transformer.transform(mockSourceResponse, mockArguments);
+        transformer.destroy();
+
+        // then
+        ArgumentCaptor<String> strArgCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPrintWriter, times(1)).startNode(strArgCaptor.capture());
+
+        //LOGGER.info("[" + StringUtils.join(strArgCaptor.getAllValues(), ", ") + "]");
+        List<String> values = strArgCaptor.getAllValues();
+        assertThat("Missing XML node.", values.get(0),
+                new IsEqual(CswQueryResponseTransformer.RECORDS_RESPONSE_QNAME));
+
+    }
+
+    @Test
+    public void whenQueryByHitsThenTransformZeroMetacards()
+            throws CatalogTransformerException, IOException {
+        // when
+        when(mockPrintWriterProvider.build((Class<Metacard>) notNull()))
+                .thenReturn(mockPrintWriter);
+        when(mockPrintWriter.makeString()).thenReturn(new String());
+
+        when(mockSourceResponse.getResults()).thenReturn(createResults(1, 10));
+        when(mockSourceResponse.getRequest()).thenReturn(mockQueryRequest);
+        when(mockQueryRequest.getQuery()).thenReturn(mockQuery);
+        when(mockArguments.get(CswConstants.RESULT_TYPE_PARAMETER)).thenReturn(ResultType.HITS);
+
+        // given
+        transformer.init();
+        BinaryContent bc = transformer.transform(mockSourceResponse, mockArguments);
+        transformer.destroy();
+
+        // then
+        ArgumentCaptor<String> tmCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockTransformerManager, never()).getTransformerBySchema(tmCaptor.capture());
+
+        ArgumentCaptor<Map> mapCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Metacard> mcCaptor = ArgumentCaptor.forClass(Metacard.class);
+        verify(mockMetacardTransformer, never()).transform(mcCaptor.capture(), mapCaptor.capture());
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> valCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPrintWriter, atLeastOnce())
+                .addAttribute(keyCaptor.capture(), valCaptor.capture());
+
+        List<String> keys = keyCaptor.getAllValues();
+        List<String> vals = valCaptor.getAllValues();
+        int numAttrKeyIndex = keys
+                .indexOf(CswQueryResponseTransformer.NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE);
+        assertThat("Missing XML attribute.", numAttrKeyIndex != -1, is(true));
+
+        String numAttrValue = vals.get(numAttrKeyIndex);
+        assertThat("Missing XML attribute value.", numAttrValue, new IsEqual("0"));
+    }
+
+    @Test
+    public void whenEmptyResultListThenTransformZeroMetacards()
+            throws CatalogTransformerException, IOException {
+        // when
+        when(mockPrintWriterProvider.build((Class<Metacard>) notNull()))
+                .thenReturn(mockPrintWriter);
+        when(mockPrintWriter.makeString()).thenReturn(new String());
+        when(mockSourceResponse.getResults()).thenReturn(Collections.<Result>emptyList());
+        when(mockSourceResponse.getRequest()).thenReturn(mockQueryRequest);
+        when(mockQueryRequest.getQuery()).thenReturn(mockQuery);
+        when(mockArguments.get(CswConstants.RESULT_TYPE_PARAMETER)).thenReturn(ResultType.RESULTS);
+
+        // given
+        transformer.init();
+        BinaryContent bc = transformer.transform(mockSourceResponse, mockArguments);
+        transformer.destroy();
+
+        // then
+        ArgumentCaptor<String> tmCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockTransformerManager, never()).getTransformerBySchema(tmCaptor.capture());
+
+        ArgumentCaptor<Map> mapCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Metacard> mcCaptor = ArgumentCaptor.forClass(Metacard.class);
+        verify(mockMetacardTransformer, never()).transform(mcCaptor.capture(), mapCaptor.capture());
+
+    }
+
+    @Test
+    public void whenEmptyResultListExpectOnlyThreeXMLNodes()
+            throws CatalogTransformerException, IOException {
+        // when
+        when(mockPrintWriterProvider.build((Class<Metacard>) notNull()))
+                .thenReturn(mockPrintWriter);
+        when(mockPrintWriter.makeString()).thenReturn(new String());
+        when(mockSourceResponse.getResults()).thenReturn(Collections.<Result>emptyList());
+        when(mockSourceResponse.getRequest()).thenReturn(mockQueryRequest);
+        when(mockQueryRequest.getQuery()).thenReturn(mockQuery);
+        when(mockArguments.get(CswConstants.RESULT_TYPE_PARAMETER)).thenReturn(ResultType.RESULTS);
+
+        // given
+        transformer.init();
+        BinaryContent bc = transformer.transform(mockSourceResponse, mockArguments);
+        transformer.destroy();
+
+        // then
+        ArgumentCaptor<String> pwCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPrintWriter, times(3)).startNode(pwCaptor.capture());
+
+        //LOGGER.info("[" + StringUtils.join(strArgCaptor.getAllValues(), ", ") + "]");
+        List<String> values = pwCaptor.getAllValues();
+        assertThat("Missing XML node.", values.get(0),
+                new IsEqual(CswQueryResponseTransformer.RECORDS_RESPONSE_QNAME));
+        assertThat("Missing XML node.", values.get(1),
+                new IsEqual(CswQueryResponseTransformer.SEARCH_STATUS_QNAME));
+        assertThat("Missing XML node.", values.get(2),
+                new IsEqual(CswQueryResponseTransformer.SEARCH_RESULTS_QNAME));
+
+    }
+
+    @Test
+    public void testMarshalAcknowledgement()
+            throws WebApplicationException, IOException, JAXBException,
+            CatalogTransformerException {
 
         GetRecordsType query = new GetRecordsType();
         query.setResultType(ResultType.VALIDATE);
@@ -143,27 +348,6 @@ public class TestCswQueryResponseTransformer {
         assertThat(response.getEchoedRequest().getAny(), is(instanceOf(JAXBElement.class)));
         JAXBElement<?> jaxB = (JAXBElement<?>) response.getEchoedRequest().getAny();
         assertThat(jaxB.getValue(), is(instanceOf(GetRecordsType.class)));
-    }
-
-    @Test
-    public void testMarshalRecordCollectionByIdRequest() throws WebApplicationException,
-            IOException, JAXBException, CatalogTransformerException {
-        SourceResponse sourceResponse = createSourceResponse(null, 2);
-
-        Map<String, Serializable> args = new HashMap<String, Serializable>();
-        args.put(CswConstants.IS_BY_ID_QUERY, true);
-        ArgumentCaptor<CswRecordCollection> captor = ArgumentCaptor
-                .forClass(CswRecordCollection.class);
-
-        BinaryContent content = transformer.transform(sourceResponse, args);
-
-        verify(mockConverter, times(1))
-                .marshal(captor.capture(), any(HierarchicalStreamWriter.class),
-                        any(MarshallingContext.class));
-
-        CswRecordCollection collection = captor.getValue();
-
-        assertThat(collection.isById(), is(true));
     }
 
     private SourceResponse createSourceResponse(GetRecordsType request, int resultCount) {

--- a/catalog/transformer/catalog-transformer-xml/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml/pom.xml
@@ -123,7 +123,9 @@
                             ddf.catalog.operation.impl,
                             ddf.catalog.util.impl
                         </Private-Package>
-                        <Export-Package/>
+                        <Export-Package>
+                            ddf.catalog.transformer.api
+                        </Export-Package>
                         <Import-Package>
                             org.joda.time;version="[1.6.0,3.0.0)",
                             *
@@ -154,7 +156,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.49</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/MetacardMarshaller.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/MetacardMarshaller.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.api;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.transform.CatalogTransformerException;
+
+/**
+ * MetacardMarshaller transforms a Metacard to a StringWriter.
+ */
+public interface MetacardMarshaller {
+
+    /**
+     * Transform a {@link Metacard} into an XML {@link String}.
+     * <p>
+     * Convenience method that always produces xml string with XML declaration prepended.
+     *
+     * @param metacard the Metacard instance to transform.
+     * @return String
+     * @throws XmlPullParserException
+     * @throws IOException
+     * @throws CatalogTransformerException
+     */
+    String marshal(Metacard metacard)
+            throws XmlPullParserException, IOException, CatalogTransformerException;
+
+    /**
+     * Transform a {@link Metacard} into an XML {@link String}.
+     * <p>
+     * Use the map of arguments to configure the xml output. For example, to turn off
+     * the XML declaration, do {@code arguments.put("OMIT_XML_DECLARATION", Boolean.TRUE)}.
+     *
+     * @param metacard  the Metacard instance to transform.
+     * @param arguments map of arguments.
+     * @return String
+     * @throws XmlPullParserException
+     * @throws IOException
+     * @throws CatalogTransformerException
+     */
+    String marshal(Metacard metacard, Map<String, Serializable> arguments)
+            throws XmlPullParserException, IOException, CatalogTransformerException;
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/PrintWriter.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/PrintWriter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.transformer.api;
+
+import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriter;
+
+/**
+ * PrintWriter writes String values to a Stream for XML output.
+ */
+public interface PrintWriter extends ExtendedHierarchicalStreamWriter {
+
+    /**
+     * Write text without any escaping.
+     *
+     * @param text the string to this printwriter should write.
+     */
+    void setRawValue(String text);
+
+    /**
+     * Get string representation of PrintWriter.
+     *
+     * @return String the string representation of this PrintWriter.
+     */
+    String makeString();
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/PrintWriterProvider.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/api/PrintWriterProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.transformer.api;
+
+/**
+ * PrintWriterProvider is an abstraction layer that supports the export of PrintWriter
+ * across bundle boundaries.
+ * <p>
+ */
+public interface PrintWriterProvider {
+
+    /**
+     * Build a new instance of a PrintWriter that will not be shared with other
+     * callers.
+     *
+     * @param klass the {@link Class} of object this PrintWriter can write.
+     * @return PrintWriter.
+     */
+    <T> PrintWriter build(Class<T> klass);
+
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/EscapingPrintWriter.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/EscapingPrintWriter.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.transformer.xml;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.BitSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.thoughtworks.xstream.core.util.QuickWriter;
+import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
+
+import ddf.catalog.transformer.api.PrintWriter;
+
+/**
+ * EscapingPrintWriter supports the examination of individual 16 bit characters in a stream writer.
+ * <p>
+ * In the default mode, EscapingPrintWriter escapes XML/HTML metacharacters,
+ * supplementary UNICODE characters, most control characters and any undefined char values.
+ * <p>
+ * EscapingPrintWriter is optimized for speed by caching well-known characters locally and by
+ * calling write() on the underlying writer only once, after examining every character in the
+ * stream.
+ * <p>
+ * In raw mode, EscapingPrintWriter does no escaping of characters.
+ * <p>
+ * EscapingPrintWriter is not thread-safe; instances should not be shared.
+ * <p>
+ * There are existing XML escaping libraries, such as
+ * https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/StringEscapeUtils.html
+ * <p>
+ * But the public static String escapeXml(String str) method supports only the five basic
+ * XML entities (gt, lt, quot, amp, apos).
+ * </p>
+ */
+public class EscapingPrintWriter extends PrettyPrintWriter implements PrintWriter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EscapingPrintWriter.class);
+
+    private static final char[] AMP = "&amp;".toCharArray();
+
+    private static final char[] LT = "&lt;".toCharArray();
+
+    private static final char[] GT = "&gt;".toCharArray();
+
+    private static final char[] CR = "&#xd;".toCharArray();
+
+    private static final char[] APOS = "&apos;".toCharArray();
+
+    private static final char[] QUOT = "&quot;".toCharArray();
+
+    private boolean isRawText = false;
+
+    private static final BitSet WELL_KNOWN_CHARACTERS;
+
+    static {
+        /*
+            - BitSet is vector of bits that grows as needed.
+            - Each component of the bit set has a boolean value.
+            - The bits of a BitSet are indexed by nonnegative integers.
+            - Individual indexed bits can be examined, set, or cleared.
+            - By default, all bits in the set initially have the value false.
+            - A BitSet is not safe for multithreaded use without external synchronization, but
+              this bitset does not need synchronization b/c it is:
+                - private to this class.
+                - statically initialized; java guarantees to be single-threaded.
+                - only read, and never written, by instances.
+            - using a bitset to cache the lookup of characters trades away space efficiency
+              to gain time efficiency.
+            - if space efficiency becomes a concern, this cache could be implemented
+              differently, perhaps as a collection of "ranges".
+         */
+        WELL_KNOWN_CHARACTERS = new BitSet();
+        for (int i = 0; i < Character.MAX_CODE_POINT + 1; i++) {
+            //  Basic Multilingual Plane (BMP) *can* be represented using a single char.
+            if (Character.isBmpCodePoint(i) && isWellKnownCharacter((char) i)) {
+                WELL_KNOWN_CHARACTERS.set(i);
+            }
+        }
+    }
+
+    private final Writer writer;
+
+    public EscapingPrintWriter(Writer writer) {
+        super(writer);
+        this.writer = writer;
+    }
+
+    private static boolean isWellKnownCharacter(char c) {
+        return Character.isDefined(c) && !Character.isISOControl(c) && !Character.isSurrogate(c);
+    }
+
+    @Override
+    public void setRawValue(String text) {
+        try {
+            isRawText = true;
+            setValue(text);
+        } finally {
+            isRawText = false;
+        }
+    }
+
+    @Override
+    public String makeString() {
+        try {
+            writer.flush();
+        } catch (IOException e) {
+            LOGGER.error("Error flushing.", e);
+        }
+        return writer.toString();
+    }
+
+    /*
+        - String#length is equal to the number of "Unicode code units" in the string.
+        - Java "Unicode code unit" means a 16-bit char value in the UTF-16 encoding.
+        - Java uses the UTF-16 representation in char arrays, String and StringBuffer classes.
+        - original char data type (Character object) defines "characters" as fixed-width 16-bit entities.
+        - Unicode Standard has since been changed to allow for "characters" whose representation requires more than 16 bits.
+        - Characters whose code points are greater than max char value (U+FFFF) are called "supplementary characters."
+        - "supplementary characters" are represented by a pair of char values, the first from
+           the high-surrogates range, (\uD800-\uDBFF), the second from the low-surrogates range
+           (\uDC00-\uDFFF).
+
+        - Character#isDefined(char ch) cannot handle supplementary characters.
+        -
+        - A char value
+            - *can* always represent a valid Basic Multilingual Plane (BMP) code point
+            - but, the valid code point may map to "undefined" character
+            - but, the valid code point may map to "surrogate" (partial) character
+     */
+    @Override
+    protected void writeText(QuickWriter writer, String text) {
+        if (text == null) {
+            return;
+        }
+
+        if (isRawText) {
+            writer.write(text);
+        } else {
+            int length = text.length();
+            StringBuilder sb = new StringBuilder();
+            char c;
+            for (int i = 0; i < length; i++) {
+                c = text.charAt(i);
+                switch (c) {
+                case '&':
+                    sb.append(AMP);
+                    break;
+                case '<':
+                    sb.append(LT);
+                    break;
+                case '>':
+                    sb.append(GT);
+                    break;
+                case '\'':
+                    sb.append(APOS);
+                    break;
+                case '\"':
+                    sb.append(QUOT);
+                    break;
+                case '\r':
+                    sb.append(CR);
+                    break;
+                case '\t':
+                case '\n':
+                    sb.append(c); // allow these control chars as is.
+                    break;
+                default:
+                    if (WELL_KNOWN_CHARACTERS.get((int) c)) {
+                        sb.append(c);
+                    } else {
+                        sb.append("&#x").append(Integer.toHexString(c)).append(';');
+                    }
+                }
+            } // for loop
+            writer.write(sb.toString());
+        }
+    } // end writeText()
+
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.xml;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.xerces.impl.dv.util.Base64;
+import org.codice.ddf.parser.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import com.google.common.collect.ImmutableMap;
+import com.thoughtworks.xstream.io.copy.HierarchicalStreamCopier;
+import com.thoughtworks.xstream.io.xml.XppReader;
+import com.thoughtworks.xstream.io.xml.xppdom.XppFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transformer.api.MetacardMarshaller;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.api.PrintWriterProvider;
+
+public class MetacardMarshallerImpl implements MetacardMarshaller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetacardMarshallerImpl.class);
+
+    /*
+     * This lookup map is...unfortunate. The current JAXB, which will remain in use for many
+     * contexts until/unless we refactor and rewrite all XML processing, determines the attribute
+     * names from the metacard schema. This lookup map provides an ugly shortcut for our purposes.
+     */
+    private static final Map<AttributeType.AttributeFormat, String> TYPE_NAME_LOOKUP;
+
+    // see https://en.wikipedia.org/wiki/ISO_8601
+    private static final String DF_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
+
+    private static final String GML_PREFIX = "gml";
+
+    private static final Map<String, String> NAMESPACE_MAP;
+
+    public static final String OMIT_XML_DECL = "OMIT_XML_DECLARATION";
+
+    static {
+        TYPE_NAME_LOOKUP = new ImmutableMap.Builder<AttributeType.AttributeFormat, String>()
+                .put(AttributeType.AttributeFormat.BINARY, "base64Binary")
+                .put(AttributeType.AttributeFormat.STRING, "string")
+                .put(AttributeType.AttributeFormat.BOOLEAN, "boolean")
+                .put(AttributeType.AttributeFormat.DATE, "dateTime")
+                .put(AttributeType.AttributeFormat.DOUBLE, "double")
+                .put(AttributeType.AttributeFormat.SHORT, "short")
+                .put(AttributeType.AttributeFormat.INTEGER, "int")
+                .put(AttributeType.AttributeFormat.LONG, "long")
+                .put(AttributeType.AttributeFormat.FLOAT, "float")
+                .put(AttributeType.AttributeFormat.GEOMETRY, "geometry")
+                .put(AttributeType.AttributeFormat.XML, "stringxml")
+                .put(AttributeType.AttributeFormat.OBJECT, "object").build();
+
+        String nsPrefix = "xmlns";
+
+        NAMESPACE_MAP = new ImmutableMap.Builder<String, String>()
+                .put(nsPrefix, "urn:catalog:metacard")
+                .put(nsPrefix + ":" + GML_PREFIX, "http://www.opengis.net/gml")
+                .put(nsPrefix + ":xlink", "http://www.w3.org/1999/xlink")
+                .put(nsPrefix + ":smil", "http://www.w3.org/2001/SMIL20/")
+                .put(nsPrefix + ":smillang", "http://www.w3.org/2001/SMIL20/Language").build();
+    }
+
+    private final GeometryTransformer geometryTransformer;
+
+    private final PrintWriterProvider writerProvider;
+
+    private static final String XML_DECL = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n";
+
+    public MetacardMarshallerImpl(Parser parser, PrintWriterProvider writerProvider) {
+        this.geometryTransformer = new GeometryTransformer(parser);
+        this.writerProvider = writerProvider;
+    }
+
+    @Override
+    public String marshal(Metacard metacard)
+            throws XmlPullParserException, IOException, CatalogTransformerException {
+
+        return marshal(metacard, Collections.EMPTY_MAP);
+    }
+
+    @Override
+    public String marshal(Metacard metacard, Map<String, Serializable> arguments)
+            throws XmlPullParserException, IOException, CatalogTransformerException {
+        PrintWriter writer = this.writerProvider.build(Metacard.class);
+
+        Boolean omitXmlDec = (Boolean) arguments.get(OMIT_XML_DECL);
+        if (omitXmlDec == null || !omitXmlDec) {
+            writer.setRawValue(XML_DECL);
+        }
+
+        writer.startNode("metacard");
+        for (Map.Entry<String, String> nsRow : NAMESPACE_MAP.entrySet()) {
+            writer.addAttribute(nsRow.getKey(), nsRow.getValue());
+        }
+
+        if (metacard.getId() != null) {
+            writer.addAttribute(GML_PREFIX + ":id", metacard.getId());
+        }
+
+        writer.startNode("type");
+        if (StringUtils.isBlank(metacard.getMetacardType().getName())) {
+            writer.setValue(MetacardType.DEFAULT_METACARD_TYPE_NAME);
+        } else {
+            writer.setValue(metacard.getMetacardType().getName());
+        }
+        writer.endNode(); // type
+
+        if (StringUtils.isNotBlank(metacard.getSourceId())) {
+            writer.startNode("source");
+            writer.setValue(metacard.getSourceId());
+            writer.endNode(); // source
+        }
+
+        // if multi-threading, cannot abstract XmlPullParser creation to class member.
+        // xmlPullParser used only for geometry
+        XmlPullParser xmlPullParser = XppFactory.createDefaultParser();
+
+        Set<AttributeDescriptor> attributeDescriptors = metacard.getMetacardType()
+                .getAttributeDescriptors();
+
+        for (AttributeDescriptor attributeDescriptor : attributeDescriptors) {
+            String attributeName = attributeDescriptor.getName();
+            if (attributeName.equals("id")) {
+                continue;
+            }
+
+            Attribute attribute = metacard.getAttribute(attributeName);
+
+            if (attribute != null) {
+                AttributeType.AttributeFormat format = attributeDescriptor.getType()
+                        .getAttributeFormat();
+                writeAttributeToXml(writer, xmlPullParser, attribute, format);
+            }
+        }
+        writer.endNode(); // metacard
+        return writer.makeString();
+    }
+
+    private void writeAttributeToXml(PrintWriter writer, XmlPullParser parser, Attribute attribute,
+            AttributeType.AttributeFormat format) throws IOException, CatalogTransformerException {
+        String attributeName = attribute.getName();
+
+        for (Serializable value : attribute.getValues()) {
+            String xmlValue = null;
+
+            switch (format) {
+
+            case STRING:
+            case BOOLEAN:
+            case SHORT:
+            case INTEGER:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                xmlValue = value.toString();
+                break;
+            case DATE:
+                Date date = (Date) value;
+                xmlValue = DateFormatUtils.formatUTC(date, DF_PATTERN);
+                break;
+            case GEOMETRY:
+                xmlValue = geoToXml(geometryTransformer.transform(attribute), parser);
+                break;
+            case OBJECT:
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                try (ObjectOutput output = new ObjectOutputStream(bos)) {
+                    output.writeObject(attribute.getValue());
+                    xmlValue = Base64.encode(bos.toByteArray());
+                }
+                break;
+            case BINARY:
+                xmlValue = Base64.encode((byte[]) value);
+                break;
+            case XML:
+                xmlValue = value.toString().replaceAll("[<][?]xml.*[?][>]", "");
+                break;
+            }
+
+            // Write the node if we were able to convert it.
+            if (xmlValue != null) {
+                // The GeometryTransformer creates an XML fragment containing
+                // both the name - with namespaces declared - and the value
+                if (format != AttributeType.AttributeFormat.GEOMETRY) {
+                    writer.startNode(TYPE_NAME_LOOKUP.get(format));
+                    writer.addAttribute("name", attributeName);
+                    writer.startNode("value");
+                }
+
+                if (format == AttributeType.AttributeFormat.XML
+                        || format == AttributeType.AttributeFormat.GEOMETRY) {
+                    writer.setRawValue(xmlValue);
+                } else {
+                    writer.setValue(xmlValue);
+                }
+
+                if (format != AttributeType.AttributeFormat.GEOMETRY) {
+                    writer.endNode(); // value
+                    writer.endNode(); // type
+                }
+            }
+        }
+    }
+
+    private String geoToXml(BinaryContent content, XmlPullParser parser) {
+        XppReader source = new XppReader(new InputStreamReader(content.getInputStream()), parser);
+
+        // if multi-threading, cannot abstract PrintWriter to class member
+        PrintWriter destination = writerProvider.build(Metacard.class);
+
+        new HierarchicalStreamCopier().copy(source, destination);
+
+        return destination.makeString();
+    }
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/PrintWriterProviderImpl.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/PrintWriterProviderImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.transformer.xml;
+
+import java.io.StringWriter;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.api.PrintWriterProvider;
+
+public class PrintWriterProviderImpl implements PrintWriterProvider {
+
+    private static final int INITIAL_SIZE = 1024;
+
+    @Override
+    public <T> PrintWriter build(Class<T> klass) {
+
+        if (Metacard.class.equals(klass)) {
+            return new EscapingPrintWriter(new StringWriter(INITIAL_SIZE));
+        } else {
+            throw new IllegalArgumentException("No PrintWriter for " + klass.getCanonicalName());
+        }
+
+    }
+
+}

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/XmlResponseQueueTransformer.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/XmlResponseQueueTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,17 +14,11 @@
 package ddf.catalog.transformer.xml;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,35 +26,24 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
 
-import org.apache.commons.lang.time.DateFormatUtils;
-import org.apache.xerces.impl.dv.util.Base64;
 import org.codice.ddf.parser.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.thoughtworks.xstream.converters.ConversionException;
-import com.thoughtworks.xstream.core.util.QuickWriter;
-import com.thoughtworks.xstream.io.copy.HierarchicalStreamCopier;
-import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
-import com.thoughtworks.xstream.io.xml.XppReader;
-import com.thoughtworks.xstream.io.xml.xppdom.XppFactory;
 
-import ddf.catalog.data.Attribute;
-import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.AttributeType;
-import ddf.catalog.data.AttributeType.AttributeFormat;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.QueryResponseTransformer;
+import ddf.catalog.transformer.api.MetacardMarshaller;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.api.PrintWriterProvider;
 
 /**
  * Transforms a {@link SourceResponse} object into Metacard Element XML text, which is GML 3.1.1.
@@ -68,92 +51,10 @@ import ddf.catalog.transform.QueryResponseTransformer;
  */
 public class XmlResponseQueueTransformer extends AbstractXmlTransformer
         implements QueryResponseTransformer {
+
     public static final int BUFFER_SIZE = 1024;
 
-    /**
-     * Writer is not thread-safe; instances should not be shared.
-     */
-    // @NotThreadSafe
-    private static class MetacardPrintWriter extends PrettyPrintWriter {
-        private static final char[] NULL = "&#x0;".toCharArray();
-
-        private static final char[] AMP = "&amp;".toCharArray();
-
-        private static final char[] LT = "&lt;".toCharArray();
-
-        private static final char[] GT = "&gt;".toCharArray();
-
-        private static final char[] CR = "&#xd;".toCharArray();
-
-        private static final char[] APOS = "&apos;".toCharArray();
-
-        private boolean isRawText = false;
-
-        public MetacardPrintWriter(Writer writer) {
-            super(writer);
-        }
-
-        private void setRawValue(String text) {
-            try {
-                isRawText = true;
-                setValue(text);
-            } finally {
-                isRawText = false;
-            }
-        }
-
-        @Override
-        protected void writeText(QuickWriter writer, String text) {
-            if (text == null) {
-                return;
-            }
-
-            if (isRawText) {
-                writer.write(text);
-            } else {
-                int length = text.length();
-                for (int i = 0; i < length; i++) {
-                    char c = text.charAt(i);
-                    switch (c) {
-                    case '\0':
-                        writer.write(NULL);
-                        break;
-                    case '&':
-                        writer.write(AMP);
-                        break;
-                    case '<':
-                        writer.write(LT);
-                        break;
-                    case '>':
-                        writer.write(GT);
-                        break;
-                    case '\'':
-                        writer.write(APOS);
-                        break;
-                    case '\r':
-                        writer.write(CR);
-                        break;
-                    case '\t':
-                    case '\n':
-                        writer.write(c);
-                        break;
-                    default:
-                        if (Character.isDefined(c) && !Character.isISOControl(c)) {
-                            writer.write(c);
-                        } else {
-                            writer.write("&#x");
-                            writer.write(Integer.toHexString(c));
-                            writer.write(';');
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     private static class MetacardForkTask extends RecursiveTask<StringWriter> {
-        private static final String DF_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-
         private final ImmutableList<Result> resultList;
 
         private final ForkJoinPool fjp;
@@ -164,19 +65,22 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
 
         private final AtomicBoolean cancelOperation;
 
+        private final MetacardMarshaller metacardMarshaller;
+
         MetacardForkTask(ImmutableList<Result> resultList, ForkJoinPool fjp,
-                GeometryTransformer geometryTransformer, int threshold) {
-            this(resultList, fjp, geometryTransformer, threshold, new AtomicBoolean(false));
+                GeometryTransformer geometryTransformer, int threshold, MetacardMarshaller mcm) {
+            this(resultList, fjp, geometryTransformer, threshold, new AtomicBoolean(false), mcm);
         }
 
         private MetacardForkTask(ImmutableList<Result> resultList, ForkJoinPool fjp,
                 GeometryTransformer geometryTransformer, int threshold,
-                AtomicBoolean cancelOperation) {
+                AtomicBoolean cancelOperation, MetacardMarshaller mcm) {
             this.resultList = resultList;
             this.fjp = fjp;
             this.geometryTransformer = geometryTransformer;
             this.threshold = threshold;
             this.cancelOperation = cancelOperation;
+            this.metacardMarshaller = mcm;
         }
 
         @Override
@@ -191,195 +95,57 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
                 int half = resultList.size() / 2;
 
                 MetacardForkTask fLeft = new MetacardForkTask(resultList.subList(0, half), fjp,
-                        geometryTransformer, threshold, cancelOperation);
+                        geometryTransformer, threshold, cancelOperation, metacardMarshaller);
                 fLeft.fork();
                 MetacardForkTask fRight = new MetacardForkTask(
                         resultList.subList(half, resultList.size()), fjp, geometryTransformer,
-                        threshold, cancelOperation);
+                        threshold, cancelOperation, metacardMarshaller);
                 StringWriter rightList = fRight.compute();
                 StringWriter leftList = fLeft.join();
 
                 leftList.append(rightList.getBuffer());
                 return leftList;
             }
-        }
+        } // end compute()
 
         private StringWriter doCompute() {
-            StringWriter stringWriter = new StringWriter(BUFFER_SIZE);
-            MetacardPrintWriter writer = new MetacardPrintWriter(stringWriter);
-            XmlPullParser parser;
+            StringWriter sw = new StringWriter(BUFFER_SIZE);
+            Map<String, Serializable> args = new HashMap<>();
+            args.put(MetacardMarshallerImpl.OMIT_XML_DECL, Boolean.TRUE);
             try {
-                parser = XppFactory.createDefaultParser();
-            } catch (XmlPullParserException e) {
-                throw new ConversionException("Unable to initialize pull parser.", e);
+                for (Result result : resultList) {
+                    Metacard metacard = result.getMetacard();
+                    String xmlString = metacardMarshaller.marshal(metacard, args);
+                    sw.append(xmlString);
+                }
+            } catch (XmlPullParserException | IOException | CatalogTransformerException e) {
+                cancelOperation.set(true);
+                throw new RuntimeException("Failure to write node; operation aborted", e);
             }
-
-            for (Result result : resultList) {
-                Metacard metacard = result.getMetacard();
-                writer.startNode("metacard");
-                if (metacard.getId() != null) {
-                    writer.addAttribute(GML_PREFIX + ":id", metacard.getId());
-                }
-
-                writer.startNode("type");
-                if (metacard.getMetacardType().getName() == null
-                        || metacard.getMetacardType().getName().length() == 0) {
-                    writer.setValue(MetacardType.DEFAULT_METACARD_TYPE_NAME);
-                } else {
-                    writer.setValue(metacard.getMetacardType().getName());
-                }
-                writer.endNode(); // type
-
-                if (metacard.getSourceId() != null && metacard.getSourceId().length() > 0) {
-                    writer.startNode("source");
-                    writer.setValue(metacard.getSourceId());
-                    writer.endNode(); // source
-                }
-
-                Set<AttributeDescriptor> attributeDescriptors = metacard.getMetacardType()
-                        .getAttributeDescriptors();
-                for (AttributeDescriptor attributeDescriptor : attributeDescriptors) {
-                    String attributeName = attributeDescriptor.getName();
-                    if (attributeName.equals("id")) {
-                        continue;
-                    }
-
-                    Attribute attribute = metacard.getAttribute(attributeName);
-
-                    if (attribute != null) {
-                        AttributeFormat format = attributeDescriptor.getType().getAttributeFormat();
-                        try {
-                            writeAttributeToXml(writer, parser, attribute, format);
-                        } catch (CatalogTransformerException | IOException e) {
-                            cancelOperation.set(true);
-                            throw new RuntimeException("Failure to write node; operation aborted",
-                                    e);
-                        }
-                    }
-                }
-                writer.endNode(); // metacard
-            }
-            writer.flush();
-            return stringWriter;
+            return sw;
         }
 
-        private void writeAttributeToXml(MetacardPrintWriter writer, XmlPullParser parser,
-                Attribute attribute, AttributeFormat format)
-                throws IOException, CatalogTransformerException {
-            String attributeName = attribute.getName();
-
-            for (Serializable value : attribute.getValues()) {
-                String xmlValue = null;
-
-                switch (format) {
-
-                case STRING:
-                case BOOLEAN:
-                case SHORT:
-                case INTEGER:
-                case LONG:
-                case FLOAT:
-                case DOUBLE:
-                    xmlValue = value.toString();
-                    break;
-                case DATE:
-                    Date date = (Date) value;
-                    xmlValue = DateFormatUtils.formatUTC(date, DF_PATTERN);
-                    break;
-                case GEOMETRY:
-                    xmlValue = geoToXml(geometryTransformer.transform(attribute), parser);
-                    break;
-                case OBJECT:
-                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                    try (ObjectOutput output = new ObjectOutputStream(bos)) {
-                        output.writeObject(attribute.getValue());
-                        xmlValue = Base64.encode(bos.toByteArray());
-                    }
-                    break;
-                case BINARY:
-                    xmlValue = Base64.encode((byte[]) value);
-                    break;
-                case XML:
-                    xmlValue = value.toString().replaceAll("[<][?]xml.*[?][>]", "");
-                    break;
-                }
-
-                // Write the node if we were able to convert it.
-                if (xmlValue != null) {
-                    // The GeometryTransformer creates an XML fragment containing
-                    // both the name - with namespaces declared - and the value
-                    if (format != AttributeFormat.GEOMETRY) {
-                        writer.startNode(TYPE_NAME_LOOKUP.get(format));
-                        writer.addAttribute("name", attributeName);
-                        writer.startNode("value");
-                    }
-
-                    if (format == AttributeFormat.XML || format == AttributeFormat.GEOMETRY) {
-                        writer.setRawValue(xmlValue);
-                    } else {
-                        writer.setValue(xmlValue);
-                    }
-
-                    if (format != AttributeFormat.GEOMETRY) {
-                        writer.endNode(); // value
-                        writer.endNode(); // type
-                    }
-                }
-            }
-        }
-
-        private String geoToXml(BinaryContent content, XmlPullParser parser) {
-            XppReader source = new XppReader(new InputStreamReader(content.getInputStream()),
-                    parser);
-
-            StringWriter stringWriter = new StringWriter(BUFFER_SIZE);
-            PrettyPrintWriter destination = new PrettyPrintWriter(stringWriter);
-
-            new HierarchicalStreamCopier().copy(source, destination);
-
-            return stringWriter.toString();
-        }
-    }
+    } // end MetacardForkTask class
 
     private final ForkJoinPool fjp;
 
     private final GeometryTransformer geometryTransformer;
 
+    private final PrintWriterProvider printWriterProvider;
+
+    private final MetacardMarshaller metacardMarshaller;
+
     private int threshold;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XmlResponseQueueTransformer.class);
 
-    public static final MimeType MIME_TYPE = new MimeType();
-
-    /**
-     * This lookup map is...unfortunate. The current JAXB, which will remain in use for many
-     * contexts until/unless we refactor and rewrite all XML processing, determines the attribute
-     * names from the metacard schema. This lookup map provides an ugly shortcut for our purposes.
-     */
-    private static final Map<AttributeType.AttributeFormat, String> TYPE_NAME_LOOKUP;
+    private final MimeType mimeType;
 
     private static final Map<String, String> NAMESPACE_MAP;
 
     private static final String GML_PREFIX = "gml";
 
     static {
-        try {
-            MIME_TYPE.setPrimaryType("text");
-            MIME_TYPE.setSubType("xml");
-        } catch (MimeTypeParseException e) {
-            LOGGER.info("Failure creating MIME type", e);
-            throw new ExceptionInInitializerError(e);
-        }
-
-        TYPE_NAME_LOOKUP = new ImmutableMap.Builder<AttributeType.AttributeFormat, String>()
-                .put(AttributeFormat.BINARY, "base64Binary").put(AttributeFormat.STRING, "string")
-                .put(AttributeFormat.BOOLEAN, "boolean").put(AttributeFormat.DATE, "dateTime")
-                .put(AttributeFormat.DOUBLE, "double").put(AttributeFormat.SHORT, "short")
-                .put(AttributeFormat.INTEGER, "int").put(AttributeFormat.LONG, "long")
-                .put(AttributeFormat.FLOAT, "float").put(AttributeFormat.GEOMETRY, "geometry")
-                .put(AttributeFormat.XML, "stringxml").put(AttributeFormat.OBJECT, "object")
-                .build();
-
         String nsPrefix = "xmlns";
 
         NAMESPACE_MAP = new ImmutableMap.Builder<String, String>()
@@ -400,10 +166,21 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
      *
      * @param fjp the {@code ForkJoinPool} to inject
      */
-    public XmlResponseQueueTransformer(Parser parser, ForkJoinPool fjp) {
+    public XmlResponseQueueTransformer(Parser parser, ForkJoinPool fjp, PrintWriterProvider pwp,
+            MetacardMarshaller mcm, MimeType mimeType) {
         super(parser);
         this.fjp = fjp;
         geometryTransformer = new GeometryTransformer(parser);
+        this.printWriterProvider = pwp;
+        this.metacardMarshaller = mcm;
+        this.mimeType = mimeType;
+        try {
+            mimeType.setPrimaryType("text");
+            mimeType.setSubType("xml");
+        } catch (MimeTypeParseException e) {
+            LOGGER.info("Failure creating MIME type", e);
+            throw new ExceptionInInitializerError(e);
+        }
     }
 
     /**
@@ -419,10 +196,8 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
     public BinaryContent transform(SourceResponse response, Map<String, Serializable> args)
             throws CatalogTransformerException {
         try {
-            Writer stringWriter = new StringWriter(BUFFER_SIZE);
-            stringWriter.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
-
-            MetacardPrintWriter writer = new MetacardPrintWriter(stringWriter);
+            PrintWriter writer = printWriterProvider.build(Metacard.class);
+            writer.setRawValue("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
 
             writer.startNode("metacards");
             for (Map.Entry<String, String> nsRow : NAMESPACE_MAP.entrySet()) {
@@ -432,17 +207,16 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
             if (response.getResults() != null && !response.getResults().isEmpty()) {
                 StringWriter metacardContent = fjp
                         .invoke(new MetacardForkTask(ImmutableList.copyOf(response.getResults()),
-                                fjp, geometryTransformer, threshold));
+                                fjp, geometryTransformer, threshold, metacardMarshaller));
 
                 writer.setRawValue(metacardContent.getBuffer().toString());
             }
 
             writer.endNode(); // metacards
 
-            ByteArrayInputStream bais = new ByteArrayInputStream(
-                    stringWriter.toString().getBytes());
+            ByteArrayInputStream bais = new ByteArrayInputStream(writer.makeString().getBytes());
 
-            return new BinaryContentImpl(bais, MIME_TYPE);
+            return new BinaryContentImpl(bais, mimeType);
         } catch (Exception e) {
             LOGGER.info("Failed Query response transformation", e);
             throw new CatalogTransformerException("Failed Query response transformation");

--- a/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,7 +41,7 @@
             <entry key="schema" value="urn:catalog:metacard"/>
         </service-properties>
         <bean class="ddf.catalog.transformer.xml.XmlMetacardTransformer">
-            <argument ref="xmlParser"/>
+            <argument ref="mcMarshaller"/>
         </bean>
     </service>
 
@@ -52,6 +52,9 @@
                 update-strategy="container-managed"/>
         <argument ref="xmlParser"/>
         <argument ref="fjp"/>
+        <argument ref="writerProvider"/>
+        <argument ref="mcMarshaller"/>
+        <argument ref="mimeType"/>
         <property name="threshold" value="50"/>
     </bean>
 
@@ -66,5 +69,20 @@
             <entry key="schema" value="urn:catalog:metacard"/>
         </service-properties>
     </service>
+
+    <bean id="writerProvider" class="ddf.catalog.transformer.xml.PrintWriterProviderImpl"/>
+
+    <service ref="writerProvider" interface="ddf.catalog.transformer.api.PrintWriterProvider">
+        <service-properties>
+            <entry key="id" value="print.writer.provider"/>
+        </service-properties>
+    </service>
+
+    <bean id="mcMarshaller" class="ddf.catalog.transformer.xml.MetacardMarshallerImpl">
+        <argument ref="xmlParser"/>
+        <argument ref="writerProvider"/>
+    </bean>
+
+    <bean id="mimeType" class="javax.activation.MimeType"/>
 
 </blueprint>

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/IntegrationTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/IntegrationTest.java
@@ -13,8 +13,12 @@
  */
 package ddf.catalog.transform.xml;
 
+import static org.mockito.Mockito.mock;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
+import java.util.Map;
 
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.xml.XmlParser;
@@ -29,6 +33,9 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.transform.MetacardTransformer;
+import ddf.catalog.transformer.api.MetacardMarshaller;
+import ddf.catalog.transformer.xml.MetacardMarshallerImpl;
+import ddf.catalog.transformer.xml.PrintWriterProviderImpl;
 import ddf.catalog.transformer.xml.XmlInputTransformer;
 import ddf.catalog.transformer.xml.XmlMetacardTransformer;
 
@@ -36,12 +43,16 @@ public class IntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTest.class);
 
+    private Map<String, Serializable> mockArguments = mock(Map.class);
+
     @Test
     public void testInputAndOutput() throws CatalogTransformerException, IOException {
         Parser parser = new XmlParser();
 
         InputTransformer inputTransformer = new XmlInputTransformer(parser);
-        MetacardTransformer outputTransformer = new XmlMetacardTransformer(parser);
+
+        MetacardMarshaller metacardMarshaller = new MetacardMarshallerImpl(parser, new PrintWriterProviderImpl());
+        MetacardTransformer outputTransformer = new XmlMetacardTransformer(metacardMarshaller);
 
         InputStream input = getClass().getResourceAsStream("/extensibleMetacard.xml");
         Metacard metacard = inputTransformer.transform(input);
@@ -55,7 +66,7 @@ public class IntegrationTest {
                     attribute.getValue()));
         }
 
-        BinaryContent output = outputTransformer.transform(metacard, null);
+        BinaryContent output = outputTransformer.transform(metacard, mockArguments);
         String outputString = new String(output.getByteArray());
 
         // TODO test equivalence with XMLUnit.

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestEscapingPrintWriter.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestEscapingPrintWriter.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transform.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transformer.api.PrintWriter;
+import ddf.catalog.transformer.xml.EscapingPrintWriter;
+
+public class TestEscapingPrintWriter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestEscapingPrintWriter.class);
+
+    static {
+        LOGGER.info("defaultCharset: " + Charset.defaultCharset());
+
+        int definedSurrogateCount = 0;
+        int definedIsoCount = 0;
+        int undefinedCount = 0;
+        int bmpCount = 0;
+        int validCount = 0;
+
+        boolean pickedUndef = false;
+        boolean pickedSurrogate = false;
+        boolean pickedISO = false;
+
+        int sampleUndef = -1;
+        int sampleSurrogate = -1;
+        int sampleISO = -1;
+
+        for (int i = 0; i < Character.MAX_CODE_POINT + 1; i++) {
+            if (Character.isBmpCodePoint(i)) {
+                bmpCount += 1;
+
+                if (Character.isValidCodePoint(i)) {
+                    validCount += 1;
+                }
+
+                char theChar = (char) i;
+
+                if (!Character.isDefined(theChar)) {
+                    undefinedCount += 1;
+                    if (!pickedUndef) {
+                        pickedUndef = true;
+                        sampleUndef = i;
+                    }
+                }
+                if (Character.isSurrogate(theChar)) {
+                    definedSurrogateCount += 1;
+                    if (!pickedSurrogate) {
+                        pickedSurrogate = true;
+                        sampleSurrogate = i;
+                    }
+                }
+                if (Character.isISOControl(theChar)) {
+                    definedIsoCount += 1;
+                    if (!pickedISO) {
+                        pickedISO = true;
+                        sampleISO = i;
+                    }
+                }
+            }
+        }
+
+        LOGGER.info("num code points (BMP) representable by char type: {}", bmpCount);
+        LOGGER.info("num valid (BMP) code points: {}", validCount);
+        LOGGER.info("num undefined BMP chars: {}, example: {}", undefinedCount, sampleUndef);
+        LOGGER.info("num surrogate BMP chars: {}, example: {}", definedSurrogateCount,
+                sampleSurrogate);
+        LOGGER.info("num ISO BMP chars: {}, example: {}", definedIsoCount, sampleISO);
+    }
+
+    @Test
+    public void testUndefinedCharacter() throws CatalogTransformerException {
+        String input = new String(Character.toChars(55296));
+        String expected = "&#xd800;";
+
+        StringWriter stringWriter = new StringWriter(8);
+        PrintWriter escapingPrintWriter = new EscapingPrintWriter(stringWriter);
+        escapingPrintWriter.setValue(input);
+
+        escapingPrintWriter.flush();
+        String output = stringWriter.toString();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testSurrogateCharacter() throws CatalogTransformerException {
+        String input = new String(Character.toChars(888));
+        String expected = "&#x378;";
+
+        StringWriter stringWriter = new StringWriter(8);
+        PrintWriter escapingPrintWriter = new EscapingPrintWriter(stringWriter);
+        escapingPrintWriter.setValue(input);
+
+        escapingPrintWriter.flush();
+        String output = stringWriter.toString();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testControlCharacters() throws CatalogTransformerException {
+        String input = "\0 \t \n \r";
+        String expected = "&#x0; \t \n &#xd;";
+
+        StringWriter stringWriter = new StringWriter(8);
+        PrintWriter escapingPrintWriter = new EscapingPrintWriter(stringWriter);
+        escapingPrintWriter.setValue(input);
+
+        escapingPrintWriter.flush();
+        String output = stringWriter.toString();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testXmlMetaCharacters() throws CatalogTransformerException {
+        String unescaped = "& > < \" \'";
+        String escaped = "&amp; &gt; &lt; &quot; &apos;";
+
+        StringWriter stringWriter = new StringWriter(128);
+        PrintWriter escapingPrintWriter = new EscapingPrintWriter(stringWriter);
+        escapingPrintWriter.setValue(unescaped);
+
+        escapingPrintWriter.flush();
+        String processed = stringWriter.toString();
+
+        assertEquals(escaped, processed);
+    }
+
+}

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlMetacardTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -16,32 +16,44 @@ package ddf.catalog.transform.xml;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Serializable;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.xml.XmlParser;
 import org.custommonkey.xmlunit.NamespaceContext;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transformer.api.MetacardMarshaller;
+import ddf.catalog.transformer.xml.MetacardMarshallerImpl;
+import ddf.catalog.transformer.xml.PrintWriterProviderImpl;
 import ddf.catalog.transformer.xml.XmlMetacardTransformer;
 
 public class TestXmlMetacardTransformer {
@@ -50,9 +62,66 @@ public class TestXmlMetacardTransformer {
 
     private XmlMetacardTransformer transformer;
 
+    private Map<String, Serializable> emptyArgs = Collections.EMPTY_MAP;
+
     @Before
     public void setup() {
-        transformer = new XmlMetacardTransformer(new XmlParser());
+        Parser parser = new XmlParser();
+        MetacardMarshaller metacardMarshaller = new MetacardMarshallerImpl(parser,
+                new PrintWriterProviderImpl());
+        transformer = new XmlMetacardTransformer(metacardMarshaller);
+    }
+
+    /*
+    */
+    @Test
+    public void testMetacardTypeNameEmpty()
+            throws CatalogTransformerException, IOException, XpathException, SAXException {
+        Metacard mc = mock(Metacard.class);
+
+        MetacardType mct = mock(MetacardType.class);
+        when(mct.getName()).thenReturn("");
+        when(mct.getAttributeDescriptors()).thenReturn(Collections.<AttributeDescriptor>emptySet());
+
+        when(mc.getMetacardType()).thenReturn(mct);
+        when(mc.getId()).thenReturn(null);
+        when(mc.getSourceId()).thenReturn(null);
+
+        BinaryContent bc = transformer.transform(mc, emptyArgs);
+        String outputXml = new String(bc.getByteArray());
+        //LOGGER.info(outputXml);
+        Map<String, String> m = new HashMap<>();
+        m.put("m", "urn:catalog:metacard");
+        NamespaceContext ctx = new SimpleNamespaceContext(m);
+        XMLUnit.setXpathNamespaceContext(ctx);
+        assertXpathEvaluatesTo(MetacardType.DEFAULT_METACARD_TYPE_NAME, "/m:metacard/m:type",
+                outputXml);
+    }
+
+    /*
+    */
+    @Test
+    public void testMetacardTypeNameNull()
+            throws CatalogTransformerException, SAXException, IOException, XpathException {
+        Metacard mc = mock(Metacard.class);
+
+        MetacardType mct = mock(MetacardType.class);
+        when(mct.getName()).thenReturn(null);
+        when(mct.getAttributeDescriptors()).thenReturn(Collections.<AttributeDescriptor>emptySet());
+
+        when(mc.getMetacardType()).thenReturn(mct);
+        when(mc.getId()).thenReturn(null);
+        when(mc.getSourceId()).thenReturn(null);
+
+        BinaryContent bc = transformer.transform(mc, emptyArgs);
+        String outputXml = new String(bc.getByteArray());
+        //LOGGER.info(outputXml);
+        Map<String, String> m = new HashMap<>();
+        m.put("m", "urn:catalog:metacard");
+        NamespaceContext ctx = new SimpleNamespaceContext(m);
+        XMLUnit.setXpathNamespaceContext(ctx);
+        assertXpathEvaluatesTo(MetacardType.DEFAULT_METACARD_TYPE_NAME, "/m:metacard/m:type",
+                outputXml);
     }
 
     @Test
@@ -64,7 +133,8 @@ public class TestXmlMetacardTransformer {
         mc.setSourceId("FooBarSource");
         mc.setTitle("Title!");
         mc.setExpirationDate(new Date());
-        mc.setLocation("POLYGON ((35 10, 10 20, 15 40, 45 45, 35 10),(20 30, 35 35, 30 20, 20 30))");
+        mc.setLocation(
+                "POLYGON ((35 10, 10 20, 15 40, 45 45, 35 10),(20 30, 35 35, 30 20, 20 30))");
         mc.setMetadata(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><foo><bar/></foo>");
         byte[] bytes = {0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0,
@@ -73,7 +143,7 @@ public class TestXmlMetacardTransformer {
 
         Metacard mci = (Metacard) mc;
 
-        BinaryContent bc = transformer.transform(mci, null);
+        BinaryContent bc = transformer.transform(mci, emptyArgs);
 
         if (bc == null) {
             fail("Binary Content is null.");
@@ -133,7 +203,7 @@ public class TestXmlMetacardTransformer {
 
         Metacard mci = (Metacard) mc;
 
-        BinaryContent bc = transformer.transform(mci, null);
+        BinaryContent bc = transformer.transform(mci, emptyArgs);
 
         if (bc == null) {
             fail("Binary Content is null.");


### PR DESCRIPTION
@kcwire @millerw8 @beyelerb @wmcnalli @coyotesqrl

- abstract and reuse xstream code as OSGI services.
- remove use of XStream facade.
- remove XStream walking object graph.
- multi-thread csw metacard marshalling.
- refine character/stream handling.
- lower unit test branch COVEREDRATIO b/c lack of other-code coverage skews build failure.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/163)
<!-- Reviewable:end -->
