### PR TITLE
DDF-1486 DDF start scripts should not set permsize when requiring java8

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -46,8 +46,6 @@ export DDF_HOME
 
 # export JAVA_MIN_MEM # Minimum memory for the JVM
 export JAVA_MAX_MEM=2048M 
-export JAVA_PERM_MEM=128M
-export JAVA_MAX_PERM_MEM=512M
 # export KARAF_HOME # Karaf home folder
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder


### PR DESCRIPTION
Since Permgen was removed from the Java8 heap, command line startup arguments that
set its size issue a warning when the JVM is started.  This change removes those
arguments from distribution/ddf-common/src/main/resources/bin/setenv.

@kcwire 
@beyelerb 
@shane-voisard

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/170)
<!-- Reviewable:end -->
