### PR TITLE
DDF-1472: DDF should support more standard ways of specifying a SAML assertion in the http header

### DIFF
--- a/distribution/docs/src/main/resources/ExtContents.adoc
+++ b/distribution/docs/src/main/resources/ExtContents.adoc
@@ -892,6 +892,11 @@ They are passed in the AuthorizationInfo of the Subject along with the Permissio
 
 |===
 
+[WARNING]
+====
+An update was made to the SAML Assertion Handler to pass SAML assertions via headers instead of cookies. Cookies are still accepted and processed to maintain legacy federation compatibility, but only headers are used when federating out. This means that it is still possible to federate and pass a machine's identity, but federation of a user's identity will ONLY work when federating from 2.7.x to 2.8.x+ or between 2.8.x+ and 2.8.x+.
+====
+
 === Securing REST
 
 [ditaa,security_architecture,png]

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -52,7 +52,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                     + "                <wsu:Expires>EXPIRES</wsu:Expires>\n"
                     + "            </wsu:Timestamp>\n" + "        </wsse:Security>\n"
                     + "    </soap:Header>\n" + "    <soap:Body>\n"
-                    + "        <wst:RequestSecurityToken xmlns:wst=\"http://docs.oasis-open.org/ws-sTx/ws-trust/200512\">\n"
+                    + "        <wst:RequestSecurityToken xmlns:wst=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">\n"
                     + "            <wst:SecondaryParameters>\n"
                     + "                <t:TokenType xmlns:t=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</t:TokenType>\n"
                     + "                <t:KeyType xmlns:t=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</t:KeyType>\n"
@@ -340,6 +340,23 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
                 .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
 
+    }
+
+    @Test
+    public void testSamlAssertionInHeaders() throws Exception {
+        String onBehalfOf = "<wst:OnBehalfOf>"
+                + "                    <wsse:UsernameToken xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n"
+                + "                        <wsse:Username>admin</wsse:Username>\n"
+                + "                        <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">admin</wsse:Password>\n"
+                + "                   </wsse:UsernameToken>\n"
+                + "                </wst:OnBehalfOf>\n";
+        String body = getSoapEnvelope(onBehalfOf);
+
+        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+                .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
+                .expect().statusCode(equalTo(200)).when()
+                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
+                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
     }
 
     private String getSoapEnvelope(String onBehalfOf) {

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -52,7 +52,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                     + "                <wsu:Expires>EXPIRES</wsu:Expires>\n"
                     + "            </wsu:Timestamp>\n" + "        </wsse:Security>\n"
                     + "    </soap:Header>\n" + "    <soap:Body>\n"
-                    + "        <wst:RequestSecurityToken xmlns:wst=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">\n"
+                    + "        <wst:RequestSecurityToken xmlns:wst=\"http://docs.oasis-open.org/ws-sTx/ws-trust/200512\">\n"
                     + "            <wst:SecondaryParameters>\n"
                     + "                <t:TokenType xmlns:t=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</t:TokenType>\n"
                     + "                <t:KeyType xmlns:t=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</t:KeyType>\n"

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -10,7 +10,7 @@
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- **/
+ */
 package ddf.catalog.test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -18,11 +18,21 @@ import static org.hamcrest.Matchers.equalTo;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
 
+import org.apache.commons.codec.binary.Base64;
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.wss4j.common.ext.WSSecurityException;
 import org.hamcrest.xml.HasXPath;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +42,7 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
 import ddf.common.test.BeforeExam;
+import ddf.security.SecurityConstants;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -106,7 +117,8 @@ public class TestSecurity extends AbstractIntegrationTest {
 
         //test that anonymous works and check that we get an sso token
         String cookie = when().get(url).then().log().all().assertThat().statusCode(equalTo(200))
-                .assertThat().header("Set-Cookie", containsString("JSESSIONID")).extract().cookie("JSESSIONID");
+                .assertThat().header("Set-Cookie", containsString("JSESSIONID")).extract()
+                .cookie("JSESSIONID");
 
         //try again with the sso token
         given().cookie("JSESSIONID", cookie).when().get(url).then().log().all().assertThat()
@@ -352,11 +364,42 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        String assertionHeader = given().log().all().body(body)
+                .header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
-                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
+                .post(SERVICE_ROOT + "/SecurityTokenService").then().extract().response()
+                .asString();
+        assertionHeader = assertionHeader.substring(assertionHeader.indexOf("<saml2:Assertion"),
+                assertionHeader.indexOf("</saml2:Assertion>") + "</saml2:Assertion>".length());
+
+        LOGGER.trace(assertionHeader);
+
+        //try that admin level assertion token on a restricted resource
+        given().header(SecurityConstants.SAML_HEADER_NAME, "SAML " + encodeSaml(assertionHeader))
+                .when().get("https://localhost:9993/admin/index.html").then().log().all()
+                .assertThat().statusCode(equalTo(200));
+    }
+
+    /**
+     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Header.
+     *
+     * @param token SAML assertion as a string
+     * @return String
+     * @throws WSSecurityException if the assertion in the token cannot be converted
+     */
+    public static String encodeSaml(String token) throws WSSecurityException {
+        ByteArrayOutputStream tokenBytes = new ByteArrayOutputStream();
+        try (OutputStream tokenStream = new DeflaterOutputStream(tokenBytes,
+                new Deflater(Deflater.DEFAULT_COMPRESSION, false))) {
+            IOUtils.copy(new ByteArrayInputStream(token.getBytes(StandardCharsets.UTF_8)),
+                    tokenStream);
+            tokenStream.close();
+
+            return new String(Base64.encodeBase64(tokenBytes.toByteArray()));
+        } catch (IOException e) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, e);
+        }
     }
 
     private String getSoapEnvelope(String onBehalfOf) {

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/HttpUtils.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/HttpUtils.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -18,9 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
@@ -28,6 +26,7 @@ import java.util.zip.InflaterInputStream;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.cxf.helpers.IOUtils;
+
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.wss4j.common.ext.WSSecurityException;
@@ -50,7 +49,7 @@ public final class RestSecurity {
     private static final Logger LOGGER = LoggerFactory.getLogger(RestSecurity.class);
 
     /**
-     * Parses the incoming subject for a saml assertion and sets that as a cookie on the client.
+     * Parses the incoming subject for a saml assertion and sets that as a header on the client.
      *
      * @param subject Subject containing a SAML-based security token.
      * @param client  Non-null client to set the cookie on.
@@ -77,24 +76,15 @@ public final class RestSecurity {
     private static String createSamlHeader(Subject subject) {
         String encodedSamlHeader = null;
         org.w3c.dom.Element samlToken = null;
-        Date expires = null;
         try {
             for (Object principal : subject.getPrincipals().asList()) {
                 if (principal instanceof SecurityAssertion) {
                     SecurityToken securityToken = ((SecurityAssertion) principal)
                             .getSecurityToken();
                     samlToken = securityToken.getToken();
-                    expires = securityToken.getExpires();
                 }
             }
             if (samlToken != null) {
-                BigDecimal maxAge = null;
-                if (expires == null) {
-                    //default to 10 minutes
-                    maxAge = new BigDecimal(600);
-                } else {
-                    maxAge = new BigDecimal((expires.getTime() - new Date().getTime()) / 1000);
-                }
                 SamlAssertionWrapper assertion = new SamlAssertionWrapper(samlToken);
                 String saml = assertion.assertionToString();
                 encodedSamlHeader = SAML_HEADER_PREFIX + encodeSaml(saml);

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -45,6 +45,8 @@ public final class RestSecurity {
 
     public static final String SAML_HEADER_PREFIX = "SAML ";
 
+    public static final String SAML_HEADER_NAME = "Authorization";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(RestSecurity.class);
 
     /**
@@ -62,7 +64,7 @@ public final class RestSecurity {
                 LOGGER.debug("SAML Header was null. Unable to set the header for the client.");
                 return;
             }
-            client.header("Authorization", encodedSamlHeader);
+            client.header(SAML_HEADER_NAME, encodedSamlHeader);
         }
     }
 

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -25,7 +25,7 @@ import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.cxf.helpers.IOUtils;
+import org.apache.commons.io.IOUtils;
 
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -96,9 +96,9 @@ public final class RestSecurity {
     }
 
     /**
-     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Cookie.
+     * Encodes the SAML assertion as a deflated Base64 String so that it can be used as a Header.
      *
-     * @param token SAML assertion as a token
+     * @param token SAML assertion as a string
      * @return String
      * @throws WSSecurityException if the assertion in the token cannot be converted
      */

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -73,7 +73,8 @@ public class RestSecurityTest {
         return db.parse(is);
     }
 
-    @Test public void testSetSubjectOnClient() throws Exception {
+    @Test
+    public void testSetSubjectOnClient() throws Exception {
         Element samlToken = readDocument("/saml.xml").getDocumentElement();
         Subject subject = mock(Subject.class);
         SecurityAssertion assertion = mock(SecurityAssertion.class);
@@ -94,7 +95,8 @@ public class RestSecurityTest {
         assertTrue(containsSaml);
     }
 
-    @Test public void testNotSetSubjectOnClient() throws Exception {
+    @Test
+    public void testNotSetSubjectOnClient() throws Exception {
         Element samlToken = readDocument("/saml.xml").getDocumentElement();
         Subject subject = mock(Subject.class);
         SecurityAssertion assertion = mock(SecurityAssertion.class);

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -84,11 +84,11 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("https://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNotNull(client.getHeaders().get("Cookie"));
-        ArrayList cookies = (ArrayList) client.getHeaders().get("Cookie");
+        assertNotNull(client.getHeaders().get("Authorization"));
+        ArrayList headers = (ArrayList) client.getHeaders().get("Authorization");
         boolean containsSaml = false;
-        for (Object cookie : cookies) {
-            if (StringUtils.contains(cookie.toString(), RestSecurity.SECURITY_COOKIE_NAME)) {
+        for (Object header : headers) {
+            if (StringUtils.contains(header.toString(), RestSecurity.SAML_HEADER_PREFIX)) {
                 containsSaml = true;
             }
         }
@@ -106,7 +106,7 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("http://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNull(client.getHeaders().get("Cookie"));
+        assertNull(client.getHeaders().get("Authorization"));
     }
 
     @Test

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -73,8 +73,7 @@ public class RestSecurityTest {
         return db.parse(is);
     }
 
-    @Test
-    public void testSetSubjectOnClient() throws Exception {
+    @Test public void testSetSubjectOnClient() throws Exception {
         Element samlToken = readDocument("/saml.xml").getDocumentElement();
         Subject subject = mock(Subject.class);
         SecurityAssertion assertion = mock(SecurityAssertion.class);
@@ -95,8 +94,7 @@ public class RestSecurityTest {
         assertTrue(containsSaml);
     }
 
-    @Test
-    public void testNotSetSubjectOnClient() throws Exception {
+    @Test public void testNotSetSubjectOnClient() throws Exception {
         Element samlToken = readDocument("/saml.xml").getDocumentElement();
         Subject subject = mock(Subject.class);
         SecurityAssertion assertion = mock(SecurityAssertion.class);

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -84,8 +84,8 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("https://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNotNull(client.getHeaders().get("Authorization"));
-        ArrayList headers = (ArrayList) client.getHeaders().get("Authorization");
+        assertNotNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
+        ArrayList headers = (ArrayList) client.getHeaders().get(RestSecurity.SAML_HEADER_NAME);
         boolean containsSaml = false;
         for (Object header : headers) {
             if (StringUtils.contains(header.toString(), RestSecurity.SAML_HEADER_PREFIX)) {
@@ -106,7 +106,7 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("http://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNull(client.getHeaders().get("Authorization"));
+        assertNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
     }
 
     @Test

--- a/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
+++ b/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -59,8 +59,7 @@ public class WebSSOFilter implements Filter {
 
     ContextPolicyManager contextPolicyManager;
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    @Override public void init(FilterConfig filterConfig) throws ServletException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("handlerList size is {}", handlerList.size());
 
@@ -88,8 +87,7 @@ public class WebSSOFilter implements Filter {
      * @throws IOException
      * @throws ServletException
      */
-    @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+    @Override public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
             FilterChain filterChain) throws IOException, ServletException {
         LOGGER.debug("Performing doFilter() on WebSSOFilter");
         HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
@@ -306,13 +304,11 @@ public class WebSSOFilter implements Filter {
         }
     }
 
-    @Override
-    public void destroy() {
+    @Override public void destroy() {
 
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return WebSSOFilter.class.getName();
     }
 

--- a/platform/security/filter/security-filter-web-sso/src/test/java/org/codice/ddf/security/filter/websso/WebSSOFilterTest.java
+++ b/platform/security/filter/security-filter-web-sso/src/test/java/org/codice/ddf/security/filter/websso/WebSSOFilterTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -54,12 +54,14 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
         LOGGER.debug("Creating SAML Assertion handler.");
     }
 
-    @Override public String getAuthenticationType() {
+    @Override
+    public String getAuthenticationType() {
         return AUTH_TYPE;
     }
 
-    @Override public HandlerResult getNormalizedToken(ServletRequest request,
-            ServletResponse response, FilterChain chain, boolean resolve) {
+    @Override
+    public HandlerResult getNormalizedToken(ServletRequest request,
+                                            ServletResponse response, FilterChain chain, boolean resolve) {
         HandlerResult handlerResult = new HandlerResult();
         String realm = (String) request.getAttribute(ContextPolicy.ACTIVE_REALM);
 
@@ -71,11 +73,11 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
         // check for full SAML assertions coming in (federated requests, etc.)
         if (authHeader != null) {
             String[] tokenizedAuthHeader = authHeader.split(" ");
-            if(tokenizedAuthHeader.length != 2){
+            if (tokenizedAuthHeader.length != 2) {
                 LOGGER.warn("Unexpected error - Authorization header tokenized incorrectly.");
                 return handlerResult;
             }
-            if(!tokenizedAuthHeader[0].equals("SAML")){
+            if (!tokenizedAuthHeader[0].equals("SAML")) {
                 LOGGER.trace("Header is not a SAML assertion.");
                 return handlerResult;
             }
@@ -140,8 +142,9 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
      * @return result containing the potential credentials and status
      * @throws ServletException
      */
-    @Override public HandlerResult handleError(ServletRequest servletRequest,
-            ServletResponse servletResponse, FilterChain chain) throws ServletException {
+    @Override
+    public HandlerResult handleError(ServletRequest servletRequest,
+                                     ServletResponse servletResponse, FilterChain chain) throws ServletException {
         HandlerResult result = new HandlerResult();
 
         HttpServletRequest httpRequest = servletRequest instanceof HttpServletRequest ?

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,10 +15,6 @@ package org.codice.ddf.security.handler.saml;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
-import java.util.zip.DataFormatException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -31,7 +27,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
-import org.codice.ddf.security.common.HttpUtils;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.codice.ddf.security.handler.api.AuthenticationHandler;
 import org.codice.ddf.security.handler.api.HandlerResult;
@@ -59,27 +54,27 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
         LOGGER.debug("Creating SAML Assertion handler.");
     }
 
-    @Override
-    public String getAuthenticationType() {
+    @Override public String getAuthenticationType() {
         return AUTH_TYPE;
     }
 
-    @Override
-    public HandlerResult getNormalizedToken(ServletRequest request, ServletResponse response,
-                                               FilterChain chain, boolean resolve) {
+    @Override public HandlerResult getNormalizedToken(ServletRequest request,
+            ServletResponse response, FilterChain chain, boolean resolve) {
         HandlerResult handlerResult = new HandlerResult();
         String realm = (String) request.getAttribute(ContextPolicy.ACTIVE_REALM);
 
         SecurityToken securityToken;
         HttpServletRequest httpRequest = (HttpServletRequest) request;
-        String authorizationHeader = ((HttpServletRequest) request).getHeader(SecurityConstants.SAML_HEADER_NAME);
+        String authorizationHeader = ((HttpServletRequest) request)
+                .getHeader(SecurityConstants.SAML_HEADER_NAME);
 
         // check for full SAML assertions coming in (federated requests, etc.)
-        if(authorizationHeader != null) {
-            String encodedSamlAssertion = authorizationHeader.substring(RestSecurity.SAML_HEADER_PREFIX.length());
+        if (authorizationHeader != null) {
+            String encodedSamlAssertion = authorizationHeader
+                    .substring(RestSecurity.SAML_HEADER_PREFIX.length());
             LOGGER.trace("Header retrieved");
             try {
-                String tokenString = RestSecurity.decodeSaml(cookieValue);
+                String tokenString = RestSecurity.decodeSaml(encodedSamlAssertion);
                 LOGGER.trace("Cookie value: {}", tokenString);
                 securityToken = new SecurityToken();
                 Element thisToken = StaxUtils.read(new StringReader(tokenString))
@@ -90,10 +85,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
                 handlerResult.setToken(samlToken);
                 handlerResult.setStatus(HandlerResult.Status.COMPLETED);
             } catch (IOException e) {
-                LOGGER.warn(
-                        "Unexpected error converting header value to string",
-                        e);
-            } catch(XMLStreamException e){
+                LOGGER.warn("Unexpected error converting header value to string", e);
+            } catch (XMLStreamException e) {
                 LOGGER.warn(
                         "Unexpected error converting XML string to element - proceeding without SAML token.",
                         e);
@@ -139,9 +132,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
      * @return result containing the potential credentials and status
      * @throws ServletException
      */
-    @Override
-    public HandlerResult handleError(ServletRequest servletRequest, ServletResponse servletResponse,
-            FilterChain chain) throws ServletException {
+    @Override public HandlerResult handleError(ServletRequest servletRequest,
+            ServletResponse servletResponse, FilterChain chain) throws ServletException {
         HandlerResult result = new HandlerResult();
 
         HttpServletRequest httpRequest = servletRequest instanceof HttpServletRequest ?
@@ -154,7 +146,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
             return result;
         }
 
-        LOGGER.debug("In error handler for saml - setting status code to 401 and returning status REDIRECTED.");
+        LOGGER.debug(
+                "In error handler for saml - setting status code to 401 and returning status REDIRECTED.");
 
         // we tried to process an invalid or missing SAML assertion
         try {

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -66,8 +66,7 @@ public class SAMLAssertionHandlerTest {
      * This test ensures the proper functionality of SAMLAssertionHandler's
      * method, getNormalizedToken(), when given a valid HttpServletRequest.
      */
-    @Test
-    public void testGetNormalizedTokenSuccess() throws Exception {
+    @Test public void testGetNormalizedTokenSuccess() throws Exception {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -79,11 +78,8 @@ public class SAMLAssertionHandlerTest {
         SecurityToken samlToken = new SecurityToken(assertionId, assertion, null);
         SamlAssertionWrapper wrappedAssertion = new SamlAssertionWrapper(samlToken.getToken());
         String saml = wrappedAssertion.assertionToString();
-        Cookie cookie = new Cookie(SecurityConstants.SAML_COOKIE_NAME,
-                RestSecurity.encodeSaml(saml));
-        when(request.getCookies()).thenReturn(new Cookie[] {cookie});
 
-        doReturn("SAML " + encodeSaml(samlToken.getToken())).when(request)
+        doReturn("SAML " + RestSecurity.encodeSaml(saml)).when(request)
                 .getHeader(SecurityConstants.SAML_HEADER_NAME);
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
@@ -96,8 +92,7 @@ public class SAMLAssertionHandlerTest {
      * This test ensures the proper functionality of SAMLAssertionHandler's
      * method, getNormalizedToken(), when given an invalid HttpServletRequest.
      */
-    @Test
-    public void testGetNormalizedTokenFailure() {
+    @Test public void testGetNormalizedTokenFailure() {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -15,14 +15,13 @@ package org.codice.ddf.security.handler.saml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import javax.servlet.FilterChain;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.parsers.DocumentBuilder;
@@ -84,6 +83,9 @@ public class SAMLAssertionHandlerTest {
                 RestSecurity.encodeSaml(saml));
         when(request.getCookies()).thenReturn(new Cookie[] {cookie});
 
+        doReturn("SAML " + encodeSaml(samlToken.getToken())).when(request)
+                .getHeader(SecurityConstants.SAML_HEADER_NAME);
+
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 
         assertNotNull(result);
@@ -102,7 +104,7 @@ public class SAMLAssertionHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain chain = mock(FilterChain.class);
 
-        when(request.getCookies()).thenReturn(null);
+        doReturn(null).when(request).getHeader(SecurityConstants.SAML_HEADER_NAME);
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -17,11 +17,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import javax.servlet.FilterChain;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.parsers.DocumentBuilder;
@@ -66,7 +68,8 @@ public class SAMLAssertionHandlerTest {
      * This test ensures the proper functionality of SAMLAssertionHandler's
      * method, getNormalizedToken(), when given a valid HttpServletRequest.
      */
-    @Test public void testGetNormalizedTokenSuccess() throws Exception {
+    @Test
+    public void testGetNormalizedTokenSuccessWithHeader() throws Exception {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -92,7 +95,8 @@ public class SAMLAssertionHandlerTest {
      * This test ensures the proper functionality of SAMLAssertionHandler's
      * method, getNormalizedToken(), when given an invalid HttpServletRequest.
      */
-    @Test public void testGetNormalizedTokenFailure() {
+    @Test
+    public void testGetNormalizedTokenFailureWithHeader() {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -100,6 +104,55 @@ public class SAMLAssertionHandlerTest {
         FilterChain chain = mock(FilterChain.class);
 
         doReturn(null).when(request).getHeader(SecurityConstants.SAML_HEADER_NAME);
+
+        HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
+
+        assertNotNull(result);
+        assertEquals(HandlerResult.Status.NO_ACTION, result.getStatus());
+    }
+
+    /**
+     * This test ensures the proper functionality of SAMLAssertionHandler's
+     * method, getNormalizedToken(), when given a valid HttpServletRequest.
+     * Uses legacy SAML cookie
+     */
+    @Test
+    public void testGetNormalizedTokenSuccessWithCookie() throws Exception {
+        SAMLAssertionHandler handler = new SAMLAssertionHandler();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        Element assertion = readDocument("/saml.xml").getDocumentElement();
+        String assertionId = assertion.getAttributeNodeNS(null, "ID").getNodeValue();
+        SecurityToken samlToken = new SecurityToken(assertionId, assertion, null);
+        SamlAssertionWrapper wrappedAssertion = new SamlAssertionWrapper(samlToken.getToken());
+        String saml = wrappedAssertion.assertionToString();
+        Cookie cookie = new Cookie(SecurityConstants.SAML_COOKIE_NAME,
+                RestSecurity.encodeSaml(saml));
+        when(request.getCookies()).thenReturn(new Cookie[] {cookie});
+
+        HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
+
+        assertNotNull(result);
+        assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
+    }
+
+    /**
+     * This test ensures the proper functionality of SAMLAssertionHandler's
+     * method, getNormalizedToken(), when given an invalid HttpServletRequest.
+     * Uses legacy SAML cookie
+     */
+    @Test
+    public void testGetNormalizedTokenFailurewithCookie() {
+        SAMLAssertionHandler handler = new SAMLAssertionHandler();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(request.getCookies()).thenReturn(null);
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/SecurityConstants.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/SecurityConstants.java
@@ -36,6 +36,16 @@ public final class SecurityConstants {
     public static final String SAML_ASSERTION = "saml.assertion";
 
     /**
+     * Property key to obtain the legacy saml cookie from an incoming HTTP Request
+     */
+    public static final String SAML_COOKIE_NAME = "org.codice.websso.saml.token";
+
+    /**
+     * Property key to obtain the legacy saml cookie reference from an incoming HTTP request
+     */
+    public static final String SAML_COOKIE_REF = "or.codice.websso.saml.ref";
+
+    /**
      * Name of the header containing the saml assertion for HTTP requests/responses
      */
     public static final String SAML_HEADER_NAME = "Authorization";

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/SecurityConstants.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/SecurityConstants.java
@@ -36,14 +36,9 @@ public final class SecurityConstants {
     public static final String SAML_ASSERTION = "saml.assertion";
 
     /**
-     * Property key to obtain the saml cookie from an incoming HTTP request.
+     * Name of the header containing the saml assertion for HTTP requests/responses
      */
-    public static final String SAML_COOKIE_NAME = "org.codice.websso.saml.token";
-
-    /**
-     * Property key to obtain the saml cookie reference from an incoming HTTP request.
-     */
-    public static final String SAML_COOKIE_REF = "org.codice.websso.saml.ref";
+    public static final String SAML_HEADER_NAME = "Authorization";
 
     private SecurityConstants() {
 


### PR DESCRIPTION
Update ddf to use Authorization headers instead of cookies for storing SAML assertions.

Hero: @djblue
@stustison 
@pklinef
@andrew-fiedler
@mverret 
@brendan-hofmann 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/174)
<!-- Reviewable:end -->
