### PR TITLE
DDF-1489 Fixed OpenSearchSource and added ITest

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
@@ -413,6 +413,53 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
                 client.replaceQueryParam(URL_SRC_PARAMETER, "");
             }
             return true;
+
+            // ensure that there is no search phrase - we will add our own
+        } else if ((visitor.getSpatialSearch() != null && contextualFilter != null
+                && StringUtils.isEmpty(contextualFilter.getSearchPhrase())) || (visitor.getSpatialSearch() != null &&
+                contextualFilter == null)) {
+
+            OpenSearchSiteUtil.populateSearchOptions(client, query, subject, parameters);
+
+            // add a wildcard search term - this query came in with no search phrase and a search phrase is necessary
+            OpenSearchSiteUtil.populateContextual(client, "*", parameters);
+
+            TemporalFilter temporalFilter = visitor.getTemporalSearch();
+            if (temporalFilter != null) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("startDate = " + temporalFilter.getStartDate().toString());
+                    LOGGER.debug("endDate = " + temporalFilter.getEndDate().toString());
+                }
+                OpenSearchSiteUtil.populateTemporal(client, temporalFilter, parameters);
+            }
+
+            SpatialFilter spatialFilter = visitor.getSpatialSearch();
+            if (spatialFilter != null) {
+                if (spatialFilter instanceof SpatialDistanceFilter) {
+                    try {
+                        OpenSearchSiteUtil
+                                .populateGeospatial(client, (SpatialDistanceFilter) spatialFilter,
+                                        shouldConvertToBBox, parameters);
+                    } catch (UnsupportedQueryException e) {
+                        LOGGER.info("Problem with populating geospatial criteria. ", e);
+                    }
+                } else {
+                    try {
+                        OpenSearchSiteUtil
+                                .populateGeospatial(client, spatialFilter, shouldConvertToBBox,
+                                        parameters);
+                    } catch (UnsupportedQueryException e) {
+                        LOGGER.info("Problem with populating geospatial criteria. ", e);
+                    }
+                }
+            }
+
+            if (localQueryOnly) {
+                client.replaceQueryParam(URL_SRC_PARAMETER, LOCAL_SEARCH_PARAMETER);
+            } else {
+                client.replaceQueryParam(URL_SRC_PARAMETER, "");
+            }
+            return true;
         }
         return false;
     }

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
@@ -204,6 +204,18 @@ public class TestFederation extends AbstractIntegrationTest {
     }
 
     /**
+     * Tests given bad spatial query, no result should be returned
+     * @throws Exception
+     */
+    @Test
+    public void testFederatedNegativeSpatial() throws Exception {
+        String queryUrl = OPENSEARCH_PATH + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS" + "&format=xml&src="
+                + OPENSEARCH_SOURCE_ID;
+        when().get(queryUrl).then().log().all().assertThat()
+                .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
+    }
+
+    /**
      * Tests that given a bad test phrase, no records should have been returned.
      *
      * @throws Exception

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
@@ -192,6 +192,18 @@ public class TestFederation extends AbstractIntegrationTest {
     }
 
     /**
+     * Tests Source can retrieve based on a pure spatial query
+     * @throws Exception
+     */
+    @Test
+    public void testFederatedSpatial() throws Exception {
+        String queryUrl = OPENSEARCH_PATH + "?lat=10.0&lon=30.0&radius=250000&spatialType=POINT_RADIUS" + "&format=xml&src="
+                + OPENSEARCH_SOURCE_ID;
+        when().get(queryUrl).then().log().all().assertThat()
+                .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2));
+    }
+
+    /**
      * Tests that given a bad test phrase, no records should have been returned.
      *
      * @throws Exception


### PR DESCRIPTION
Added logic to accept purely spatial queries to OpenSearchSource
and added a wildcard character as a contextual filter since
OpenSearch needs it. In addition, added an ITest to ensure pure
spatial federated OpenSearches work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/175)
<!-- Reviewable:end -->
