### PR TITLE
DDF-1498 Fixes issue where magically and non-deterministically null authorization field causes auth failures.

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
+import org.apache.cxf.configuration.security.AuthorizationPolicy;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.interceptor.LoggingInInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
@@ -230,10 +231,12 @@ public class SecureCxfClientFactory<T> {
         }
 
         if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
-            if (httpConduit.getAuthorization() != null) {
-                httpConduit.getAuthorization().setUserName(username);
-                httpConduit.getAuthorization().setPassword(password);
+            if (httpConduit.getAuthorization() == null) {
+                httpConduit.setAuthorization(new AuthorizationPolicy());
             }
+
+            httpConduit.getAuthorization().setUserName(username);
+            httpConduit.getAuthorization().setPassword(password);
         }
 
         if (disableCnCheck) {

--- a/platform/security/security-admin-module/pom.xml
+++ b/platform/security/security-admin-module/pom.xml
@@ -24,7 +24,9 @@
 
     <groupId>ddf.security.admin</groupId>
     <artifactId>security-admin-module</artifactId>
+    <name>DDF :: Security :: Admin</name>
     <packaging>bundle</packaging>
+
     <dependencies>
         <dependency>
             <groupId>ddf.admin.core</groupId>
@@ -51,7 +53,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v0.10.18</nodeVersion>
+                            <nodeVersion>v0.10.40</nodeVersion>
                             <npmVersion>2.0.2</npmVersion>
                             <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
                         </configuration>


### PR DESCRIPTION
In the case where the authorization bean is null, we can simply create a new one and move forward.

@kcwire is the hero
@AzGoalie 
@stustison

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/183)
<!-- Reviewable:end -->
