### PR TITLE
DDF-1502 Moves docs module above ddf module

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,9 +39,9 @@
         <module>ddf-common</module>
         <module>kernel</module>
         <module>install-profiles</module>
+        <module>docs</module>
         <module>ddf</module>
         <module>test</module>
-        <module>docs</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
 - There is an issue with ddf being built before the docs, as ddf is expecting certain docs to already exist.  In the current state, it will not find them locally and attempt to find them in the nexus (which won't have them, or in some cases just happens to have them).

https://codice.atlassian.net/browse/DDF-1502

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/187)
<!-- Reviewable:end -->
