### PR TITLE
DDF-1505: Add methods in integration test common classes to restart bundles and wait for configuration updates

### DIFF
--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,11 +15,16 @@ package ddf.common.test;
 
 import java.io.IOException;
 import java.util.Dictionary;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.common.test.config.ConfigurationPredicate;
 
 public class AdminConfig {
     public static final String LOG_CONFIG_PID = "org.ops4j.pax.logging";
@@ -29,6 +34,10 @@ public class AdminConfig {
     public static final String DEFAULT_LOG_LEVEL = "TRACE";
 
     public static final String TEST_LOGLEVEL_PROPERTY = "org.codice.test.defaultLoglevel";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdminConfig.class);
+
+    public static final int CONFIG_WAIT_POLLING_INTERVAL = 50;
 
     private final ConfigurationAdmin configAdmin;
 
@@ -58,6 +67,46 @@ public class AdminConfig {
 
     public Configuration[] listConfigurations(String s) throws IOException, InvalidSyntaxException {
         return configAdmin.listConfigurations(s);
+    }
+
+    /**
+     * Waits until a {@link ConfigurationPredicate} returns {@code true}.
+     *
+     * @param pid       ID of the {@link Configuration} object that the {@link ConfigurationPredicate}
+     *                  will use to validate the condition
+     * @param predicate predicate to wait on
+     * @param timeoutMs wait timeout
+     * @return {@link Configuration} object
+     * @throws IOException          thrown if the {@link Configuration} object cannot be accessed
+     * @throws InterruptedException thrown if the wait times out
+     */
+    public Configuration waitForConfiguration(String pid, ConfigurationPredicate predicate,
+            long timeoutMs) throws IOException, InterruptedException {
+        LOGGER.debug("Waiting for condition {} in Configuration object [{}] to be true",
+                predicate.toString(), pid);
+
+        Configuration configuration = configAdmin.getConfiguration(pid);
+
+        int waitPeriod = 0;
+
+        while ((waitPeriod < timeoutMs) && !predicate.test(configuration)) {
+            TimeUnit.MILLISECONDS.sleep(CONFIG_WAIT_POLLING_INTERVAL);
+            waitPeriod += CONFIG_WAIT_POLLING_INTERVAL;
+            configuration = configAdmin.getConfiguration(pid);
+        }
+
+        LOGGER.debug("Waited for {}ms", waitPeriod);
+
+        if (waitPeriod >= timeoutMs) {
+            LOGGER.error(
+                    "Timed out after waiting {}ms for condition {} to be true on configuration object {}",
+                    waitPeriod, predicate.toString(), pid);
+            throw new InterruptedException(String.format(
+                    "Timed out waiting for condition [%s] to be true in configuration object [%s]",
+                    predicate.toString(), pid));
+        }
+
+        return configuration;
     }
 
     public void setLogLevels() throws IOException {

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPredicate.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPredicate.java
@@ -1,0 +1,10 @@
+package ddf.common.test.config;
+
+import org.osgi.service.cm.Configuration;
+
+/**
+ * Created by elessard on 9/21/15.
+ */
+public interface ConfigurationPredicate {
+    public boolean test(Configuration configuration);
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPredicate.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPredicate.java
@@ -1,10 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
 package ddf.common.test.config;
 
 import org.osgi.service.cm.Configuration;
 
 /**
- * Created by elessard on 9/21/15.
+ * Base interface for all {@link Configuration} related predicates.
  */
 public interface ConfigurationPredicate {
-    public boolean test(Configuration configuration);
+    /**
+     * Tests whether the predicate's condition has been met or not.
+     *
+     * @param configuration {@link Configuration} object to run the predicate on. Predicate class
+     *                      should assume that this can be {@code null}.
+     * @return {@code true} only if the predicate's condition has been met
+     */
+    boolean test(Configuration configuration);
+
+    /**
+     * Should be overridden to provide a detailed description of what the predicate does, e.g.,
+     * "property XYZ equals 123". This message will be used in log statements and exception
+     * messages.
+     */
+    String toString();
 }

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertyMatches.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertyMatches.java
@@ -1,0 +1,27 @@
+package ddf.common.test.config;
+
+import org.osgi.service.cm.Configuration;
+
+/**
+ * Created by elessard on 9/21/15.
+ */
+public class ConfigurationPropertyMatches implements ConfigurationPredicate {
+    private String propertyName;
+
+    private String valueRegex;
+
+    public ConfigurationPropertyMatches(String propertyName, String valueRegex) {
+        this.propertyName = propertyName;
+        this.valueRegex = valueRegex;
+    }
+
+    @Override
+    public boolean test(Configuration configuration) {
+        if ((configuration == null) || (configuration.getProperties() == null) || (
+                configuration.getProperties().get(propertyName) == null)) {
+            return false;
+        }
+
+        return ((String) configuration.getProperties().get(propertyName)).matches(valueRegex);
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertyMatches.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertyMatches.java
@@ -1,15 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
 package ddf.common.test.config;
 
 import org.osgi.service.cm.Configuration;
 
 /**
- * Created by elessard on 9/21/15.
+ * Configuration predicate class that checks to see if a {@link Configuration} property exists and
+ * matches a specific regular expression.
  */
 public class ConfigurationPropertyMatches implements ConfigurationPredicate {
     private String propertyName;
 
     private String valueRegex;
 
+    /**
+     * Constructor.
+     *
+     * @param propertyName name of the property this predicate will use
+     * @param valueRegex   regular expression the property value needs to match for this predicate
+     *                     to return {@code true}.
+     */
     public ConfigurationPropertyMatches(String propertyName, String valueRegex) {
         this.propertyName = propertyName;
         this.valueRegex = valueRegex;
@@ -23,5 +44,10 @@ public class ConfigurationPropertyMatches implements ConfigurationPredicate {
         }
 
         return ((String) configuration.getProperties().get(propertyName)).matches(valueRegex);
+    }
+
+    public String toString() {
+        return String
+                .format("property [%s] matches regular expression [%s]", propertyName, valueRegex);
     }
 }


### PR DESCRIPTION
Added a method to ServiceManager to restart one or more bundles. Also added a 
waitForConfiguration() method to AdminConfig along with a ConfigurationPredicate
class that wait for a property value to match a regular expression.

@garrettfreibott, @figliold, please review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/189)
<!-- Reviewable:end -->
