### PR TITLE
DDF-1515 Adds thread pool setting to system properties, updates various instances of thread pools

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePoller.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePoller.java
@@ -60,7 +60,7 @@ public class SourcePoller {
 
         this.runner = incomingRunner;
 
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
 
         handle = scheduler.scheduleAtFixedRate(runner, INITIAL_DELAY, INTERVAL, TimeUnit.SECONDS);
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/util/SourcePoller.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/util/SourcePoller.java
@@ -65,7 +65,7 @@ public class SourcePoller {
 
         this.runner = incomingRunner;
 
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
 
         handle = scheduler.scheduleAtFixedRate(runner, INITIAL_DELAY, INTERVAL, TimeUnit.SECONDS);
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -1585,29 +1585,6 @@ public class CatalogFrameworkImpl extends DescribableImpl
     }
 
     /**
-     * To be set via Spring/Blueprint
-     *
-     * @param poolSize the number of threads in the pool, 0 for an automatically-managed pool
-     */
-    public synchronized void setPoolSize(int poolSize) {
-        LOGGER.debug("Setting poolSize = " + poolSize);
-        if (pool != null) {
-            if (this.threadPoolSize == poolSize || this.threadPoolSize <= 0 && poolSize <= 0) {
-                return;
-            } else {
-                pool.shutdown();
-            }
-        }
-
-        this.threadPoolSize = poolSize;
-        if (threadPoolSize > 0) {
-            pool = Executors.newFixedThreadPool(poolSize);
-        } else {
-            pool = Executors.newCachedThreadPool();
-        }
-    }
-
-    /**
      * String representation of this {@code CatalogFrameworkImpl}.
      */
     @Override

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -50,6 +50,8 @@ public class ReliableResourceDownloadManager {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ReliableResourceDownloadManager.class);
 
+    private static final int DEFAULT_THREAD_POOL_SIZE = 128;
+
     private DownloadsStatusEventPublisher eventPublisher;
 
     private ResourceResponse resourceResponse;
@@ -58,7 +60,7 @@ public class ReliableResourceDownloadManager {
 
     private DownloadStatusInfo downloadStatusInfo;
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor = Executors.newFixedThreadPool(getThreadPoolSize());
 
     private ReliableResourceDownloaderConfig downloaderConfig = new ReliableResourceDownloaderConfig();
 
@@ -193,5 +195,26 @@ public class ReliableResourceDownloadManager {
 
     public void setChunkSize(int chunkSize) {
         downloaderConfig.setChunkSize(chunkSize);
+    }
+
+    /**
+     * Gets the org.codice.ddf.system.threadPoolSize property,
+     * returns default value if property is null or invalid
+     *
+     * @return threadPoolSize property or default if null
+     */
+    private int getThreadPoolSize() {
+        try {
+            int threadPoolSize = Integer
+                    .parseInt(System.getProperty("org.codice.ddf.system.threadPoolSize"));
+
+            if (threadPoolSize > 0) {
+                return threadPoolSize;
+            } else {
+                return DEFAULT_THREAD_POOL_SIZE;
+            }
+        } catch (NumberFormatException e) {
+            return DEFAULT_THREAD_POOL_SIZE;
+        }
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -16,7 +16,6 @@ package ddf.catalog.resource.download;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -50,8 +50,6 @@ public class ReliableResourceDownloadManager {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ReliableResourceDownloadManager.class);
 
-    private static final int DEFAULT_THREAD_POOL_SIZE = 128;
-
     private DownloadsStatusEventPublisher eventPublisher;
 
     private ResourceResponse resourceResponse;
@@ -60,7 +58,7 @@ public class ReliableResourceDownloadManager {
 
     private DownloadStatusInfo downloadStatusInfo;
 
-    private ExecutorService executor = Executors.newFixedThreadPool(getThreadPoolSize());
+    private ExecutorService executor;
 
     private ReliableResourceDownloaderConfig downloaderConfig = new ReliableResourceDownloaderConfig();
 
@@ -74,9 +72,10 @@ public class ReliableResourceDownloadManager {
      * @param downloadStatusInfo
      *            reference to the {@link DownloadStatusInfo}
      */
-    public ReliableResourceDownloadManager(ResourceCache resourceCache,
-            DownloadsStatusEventPublisher eventPublisher,
-            DownloadsStatusEventListener eventListener, DownloadStatusInfo downloadStatusInfo) {
+    public ReliableResourceDownloadManager(ExecutorService executor, ResourceCache resourceCache,
+                                           DownloadsStatusEventPublisher eventPublisher,
+                                           DownloadsStatusEventListener eventListener, DownloadStatusInfo downloadStatusInfo) {
+        this.executor = executor;
         this.downloaderConfig.setResourceCache(resourceCache);
         this.eventPublisher = eventPublisher;
         this.downloaderConfig.setEventPublisher(this.eventPublisher);
@@ -110,7 +109,7 @@ public class ReliableResourceDownloadManager {
      * @throws DownloadException
      */
     public ResourceResponse download(ResourceRequest resourceRequest, Metacard metacard,
-            ResourceRetriever retriever) throws DownloadException {
+                                     ResourceRetriever retriever) throws DownloadException {
 
         if (metacard == null) {
             throw new DownloadException("Cannot download resource if metacard is null");
@@ -195,26 +194,5 @@ public class ReliableResourceDownloadManager {
 
     public void setChunkSize(int chunkSize) {
         downloaderConfig.setChunkSize(chunkSize);
-    }
-
-    /**
-     * Gets the org.codice.ddf.system.threadPoolSize property,
-     * returns default value if property is null or invalid
-     *
-     * @return threadPoolSize property or default if null
-     */
-    private int getThreadPoolSize() {
-        try {
-            int threadPoolSize = Integer
-                    .parseInt(System.getProperty("org.codice.ddf.system.threadPoolSize"));
-
-            if (threadPoolSize > 0) {
-                return threadPoolSize;
-            } else {
-                return DEFAULT_THREAD_POOL_SIZE;
-            }
-        } catch (NumberFormatException e) {
-            return DEFAULT_THREAD_POOL_SIZE;
-        }
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -242,7 +242,6 @@
 		<argument ref="productCache"/>
 		<argument ref="retrieveStatusEventPublisher"/>
 		<argument ref="reliableResourceDownloadManager"/>
-		<property name="poolSize" value="0"/>
 		<property name="id" value="ddf"/>
 		<property name="version" value="DDF v2.0"/>
 		<property name="organization" value="Codice"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,8 +15,8 @@
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="
-	    http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-        ">
+           http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           ">
 
     <ext:property-placeholder/>
 
@@ -176,7 +176,7 @@
 	<service ref="sorted" interface="ddf.catalog.federation.FederationStrategy"
              ranking="100">
 		<service-properties>
-			<entry key="shortname" value="sorted"/>
+            <entry key="shortname" value="sorted"/>
 		</service-properties>
 	</service>
     <service ref="sorted" interface="ddf.catalog.plugin.PostIngestPlugin"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -133,12 +133,12 @@
                             unbind-method="unbindPlugin" ref="resourceReaderSortedList"/>
 	</reference-list>
 
-	<bean id="cachedThreadPool" class="java.util.concurrent.Executors"
+	<bean id="queryThreadPool" class="java.util.concurrent.Executors"
           factory-method="newCachedThreadPool"/>
 
-    <bean id="fixedThreadPool" class="java.util.concurrent.Executors"
+    <bean id="cacheThreadPool" class="java.util.concurrent.Executors"
           factory-method="newFixedThreadPool">
-        <argument ref="nThreads" value="${org.codice.ddf.system.threadPoolSize}"/>
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
     </bean>
 
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
@@ -165,8 +165,8 @@
 		<cm:managed-properties
                 persistent-id="ddf.catalog.federation.impl.CachingFederationStrategy"
                 update-strategy="container-managed"/>
-		<argument ref="cachedThreadPool"/>
-        <argument ref="fixedThreadPool"/>
+		<argument ref="queryThreadPool"/>
+        <argument ref="cacheThreadPool"/>
 		<argument ref="preFederatedQuerySortedList"/>
 		<argument ref="postFederatedQuerySortedList"/>
         <argument ref="solrCatalogCache"/>
@@ -246,7 +246,7 @@
 		<argument ref="federatedSources"/>
 		<argument ref="resourceReaderSortedList"/>
 		<argument ref="sorted"/>
-		<argument ref="cachedThreadPool"/>
+		<argument ref="queryThreadPool"/>
         <argument ref="queryResponsePostProcessor"/>
 		<argument ref="sourcePoller"/>
 		<argument ref="productCache"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,9 +13,12 @@
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="
 	    http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
         ">
+
+    <ext:property-placeholder/>
 
 <!-- According to the schema the type-converters element must be above all other elements except 'description' -->
     <type-converters>
@@ -130,8 +133,13 @@
                             unbind-method="unbindPlugin" ref="resourceReaderSortedList"/>
 	</reference-list>
 
-	<bean id="pool" class="java.util.concurrent.Executors"
+	<bean id="cachedThreadPool" class="java.util.concurrent.Executors"
           factory-method="newCachedThreadPool"/>
+
+    <bean id="fixedThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newFixedThreadPool">
+        <argument ref="nThreads" value="${org.codice.ddf.system.threadPoolSize}"/>
+    </bean>
 
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
                filter="id=catalog.data.metacard.resource"
@@ -157,7 +165,8 @@
 		<cm:managed-properties
                 persistent-id="ddf.catalog.federation.impl.CachingFederationStrategy"
                 update-strategy="container-managed"/>
-		<argument ref="pool"/>
+		<argument ref="cachedThreadPool"/>
+        <argument ref="fixedThreadPool"/>
 		<argument ref="preFederatedQuerySortedList"/>
 		<argument ref="postFederatedQuerySortedList"/>
         <argument ref="solrCatalogCache"/>
@@ -214,6 +223,7 @@
     <bean id="reliableResourceDownloadManager"
           class="ddf.catalog.resource.download.ReliableResourceDownloadManager"
           init-method="init" destroy-method="cleanUp">
+        <argument ref="fixedThreadPool"/>
     	<argument ref="productCache"/>
     	<argument ref="retrieveStatusEventPublisher"/>
     	<argument ref="retrieveStatusEventListener"/>
@@ -236,7 +246,7 @@
 		<argument ref="federatedSources"/>
 		<argument ref="resourceReaderSortedList"/>
 		<argument ref="sorted"/>
-		<argument ref="pool"/>
+		<argument ref="cachedThreadPool"/>
         <argument ref="queryResponsePostProcessor"/>
 		<argument ref="sourcePoller"/>
 		<argument ref="productCache"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,8 +21,6 @@
         <AD name="Enable Fanout Proxy" id="fanoutEnabled" required="true" type="Boolean"
             default="false"
             description="When enabled the Framework acts as a proxy, federating requests to all available sources. All requests are executed as federated queries and resource retrievals, allowing the framework to be the sole component exposing the functionality of all of its Federated Sources."/>
-        <AD name="Federation Thread Pool Size (0 for unlimited)" id="poolSize" required="true"
-            type="Integer" default="0"/>
         <AD name="Product Cache Directory" id="productCacheDirectory" required="false"
             type="String" default=""
             description="Directory where retrieved products will be cached for faster, future retrieval. If a directory path is specified with directories that do not exist, Catalog Framework will attempt to create those directories. Out of the box (without configuration), the product cache directory is INSTALL_DIR/data/product-cache. If a relative path is provided it will be relative to the INSTALL_DIR. It is recommended to enter an absolute directory path such as /opt/product-cache in Linux or C:/product-cache in Windows."/>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet; 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.BeforeClass;
@@ -73,7 +74,7 @@ public class DownloadsStatusEventListenerTest {
         DownloadsStatusEventPublisher testEventPublisher = mock(
                 DownloadsStatusEventPublisher.class);
         testEventListener = new DownloadsStatusEventListener();
-        testDownloadManager = new ReliableResourceDownloadManager(testResourceCache,
+        testDownloadManager = new ReliableResourceDownloadManager(Executors.newSingleThreadExecutor(), testResourceCache,
                 testEventPublisher, testEventListener, testDownloadStatusInfo);
         testDownloadManager.setMaxRetryAttempts(1);
         testDownloadManager.setDelayBetweenAttempts(0);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -151,7 +151,7 @@ public class ReliableResourceDownloadManagerTest {
         eventListener = mock(DownloadsStatusEventListener.class);
         downloadStatusInfo = new DownloadStatusInfoImpl();
 
-        downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
+        downloadMgr = new ReliableResourceDownloadManager(Executors.newSingleThreadExecutor(), resourceCache, eventPublisher,
                 eventListener, downloadStatusInfo);
 
     }
@@ -610,7 +610,7 @@ public class ReliableResourceDownloadManagerTest {
         Metacard metacard = getMockMetacard(EXPECTED_METACARD_ID, EXPECTED_METACARD_SOURCE_ID);
         resourceResponse = getMockResourceResponse();
 
-        downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
+        downloadMgr = new ReliableResourceDownloadManager(Executors.newSingleThreadExecutor(), resourceCache, eventPublisher,
                 eventListener, downloadStatusInfo);
 
         // Use small chunk size so download takes long enough for client
@@ -651,7 +651,7 @@ public class ReliableResourceDownloadManagerTest {
 
     private void startDownload(boolean cacheEnabled, int chunkSize, boolean cacheWhenCanceled,
             Metacard metacard, ResourceRetriever retriever) throws Exception {
-        downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
+        downloadMgr = new ReliableResourceDownloadManager(Executors.newSingleThreadExecutor(), resourceCache, eventPublisher,
                 eventListener, downloadStatusInfo);
         downloadMgr.setCacheEnabled(cacheEnabled);
         downloadMgr.setChunkSize(chunkSize);

--- a/catalog/docs/src/main/resources/ExtContents.adoc
+++ b/catalog/docs/src/main/resources/ExtContents.adoc
@@ -2007,14 +2007,6 @@ _Catalog Standard Framework_
 |false
 |yes
 
-|poolSize
-|Integer
-|The federation thread pool size
-
-(0 for unlimited)
-|0
-|yes
-
 |productCacheDirectory
 |String
 |Directory where retrieved products will be cached for faster, future retrieval. If a directory path is specified with directories that do not exist, Catalog Framework will attempt to create those directories. Out of the box (without configuration), the product cache directory is `<INSTALL_DIR>/data/product-cache`. If a relative path is provided it will be relative to the `<INSTALL_DIR>`.
@@ -2272,15 +2264,6 @@ Catalog Fanout Framework configuration in the Web Console.
 |Description
 |Default Value
 |Required
-
-|Federation Thread Pool Size
-(0 for unlimited)
-|poolSize
-|Integer
-|The federation thread pool size.
-(0 for unlimited)
-|0
-|yes
 
 |Default Timeout
 (in milliseconds)

--- a/catalog/plugin/catalog-plugin-jpeg2000-thumbnail-converter/pom.xml
+++ b/catalog/plugin/catalog-plugin-jpeg2000-thumbnail-converter/pom.xml
@@ -64,7 +64,7 @@
             </snapshots>
             <id>mygrid-repository</id>
             <name>myGrid Repository</name>
-            <url>http://www.mygrid.org.uk/maven/repository</url>
+            <url>http://repository.mygrid.org.uk/artifactory/ext-release-local</url>
         </repository>
     </repositories>
 

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -541,7 +541,7 @@
             </snapshots>
             <id>mygrid-repository</id>
             <name>myGrid Repository</name>
-            <url>http://www.mygrid.org.uk/maven/repository</url>
+            <url>http://repository.mygrid.org.uk/artifactory/ext-release-local</url>
         </repository>
     </repositories>
 </project>

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -1,17 +1,16 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
- **/
+ */
 package org.codice.ddf.ui.searchui.query.controller;
 
 import java.util.Collections;
@@ -51,6 +50,8 @@ import ddf.security.Subject;
 public class SearchController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchController.class);
+
+    private static final int DEFAULT_THREAD_POOL_SIZE = 128;
 
     private final ExecutorService executorService = getExecutorService();
 
@@ -150,7 +151,7 @@ public class SearchController {
             // Send any previously cached results
             cacheFuture = executorService
                     .submit(new CacheQueryRunnable(this, request, subject, search, session, results,
-                                    solrIndexFuture));
+                            solrIndexFuture));
         } else {
             cacheFuture = Futures.immediateFuture(null);
         }
@@ -208,11 +209,32 @@ public class SearchController {
 
     // Override for unit testing
     ExecutorService getExecutorService() {
-        return Executors.newCachedThreadPool();
+        return Executors.newFixedThreadPool(getThreadPoolSize());
     }
 
     public void setNormalizationDisabled(Boolean normalizationDisabled) {
         this.normalizationDisabled = normalizationDisabled;
+    }
+
+    /**
+     * Gets the org.codice.ddf.system.threadPoolSize property,
+     * returns default value if property is null or invalid
+     *
+     * @return threadPoolSize property or default if null
+     */
+    private int getThreadPoolSize() {
+        try {
+            int threadPoolSize = Integer
+                    .parseInt(System.getProperty("org.codice.ddf.system.threadPoolSize"));
+
+            if (threadPoolSize > 0) {
+                return threadPoolSize;
+            } else {
+                return DEFAULT_THREAD_POOL_SIZE;
+            }
+        } catch (NumberFormatException e) {
+            return DEFAULT_THREAD_POOL_SIZE;
+        }
     }
 
 }

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.codice.ddf.ui.searchui.query.controller.search.CacheQueryRunnable;
@@ -204,11 +203,6 @@ public class SearchController {
 
     public FilterAdapter getFilterAdapter() {
         return filterAdapter;
-    }
-
-    // Override for unit testing
-    ExecutorService getExecutorService() {
-        return Executors.newFixedThreadPool(getThreadPoolSize());
     }
 
     public void setNormalizationDisabled(Boolean normalizationDisabled) {

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -51,9 +51,7 @@ public class SearchController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchController.class);
 
-    private static final int DEFAULT_THREAD_POOL_SIZE = 128;
-
-    private final ExecutorService executorService = getExecutorService();
+    private final ExecutorService executorService;
 
     private final FilterAdapter filterAdapter;
 
@@ -75,10 +73,11 @@ public class SearchController {
      * @param filterAdapter
      */
     public SearchController(CatalogFramework framework, ActionRegistry actionRegistry,
-            FilterAdapter filterAdapter) {
+                            FilterAdapter filterAdapter, ExecutorService executorService) {
         this.framework = framework;
         this.actionRegistry = actionRegistry;
         this.filterAdapter = filterAdapter;
+        this.executorService = executorService;
     }
 
     /**
@@ -95,7 +94,7 @@ public class SearchController {
      * @param serverSession
      */
     public synchronized void pushResults(String channel, Map<String, Object> jsonData,
-            ServerSession serverSession) {
+                                         ServerSession serverSession) {
         String channelName;
         //you can't have 2 leading slashes, but if there isn't one, add it
         if (channel.startsWith("/")) {
@@ -131,7 +130,7 @@ public class SearchController {
      *            - Cometd ServerSession
      */
     public void executeQuery(final SearchRequest request, final ServerSession session,
-            final Subject subject) {
+                             final Subject subject) {
 
         final Search search = new Search(request, actionRegistry);
         final Map<String, Result> results = Collections
@@ -215,26 +214,4 @@ public class SearchController {
     public void setNormalizationDisabled(Boolean normalizationDisabled) {
         this.normalizationDisabled = normalizationDisabled;
     }
-
-    /**
-     * Gets the org.codice.ddf.system.threadPoolSize property,
-     * returns default value if property is null or invalid
-     *
-     * @return threadPoolSize property or default if null
-     */
-    private int getThreadPoolSize() {
-        try {
-            int threadPoolSize = Integer
-                    .parseInt(System.getProperty("org.codice.ddf.system.threadPoolSize"));
-
-            if (threadPoolSize > 0) {
-                return threadPoolSize;
-            } else {
-                return DEFAULT_THREAD_POOL_SIZE;
-            }
-        } catch (NumberFormatException e) {
-            return DEFAULT_THREAD_POOL_SIZE;
-        }
-    }
-
 }

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
@@ -14,9 +14,9 @@
  **/
 package org.codice.ddf.ui.searchui.query.endpoint;
 
-import java.util.concurrent.ExecutorService;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.concurrent.ExecutorService;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
@@ -14,6 +14,7 @@
  **/
 package org.codice.ddf.ui.searchui.query.endpoint;
 
+import java.util.concurrent.ExecutorService;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -88,11 +89,11 @@ public class CometdEndpoint {
      */
     public CometdEndpoint(CometdServlet cometdServlet, CatalogFramework framework,
             FilterBuilder filterBuilder, FilterAdapter filterAdapter, PersistentStore persistentStore,
-            BundleContext bundleContext, EventAdmin eventAdmin, ActionRegistry actionRegistry) {
+            BundleContext bundleContext, EventAdmin eventAdmin, ActionRegistry actionRegistry, ExecutorService executorService) {
         this.bundleContext = bundleContext;
         this.cometdServlet = cometdServlet;
         this.filterBuilder = filterBuilder;
-        this.searchController = new SearchController(framework, actionRegistry, filterAdapter);
+        this.searchController = new SearchController(framework, actionRegistry, filterAdapter, executorService);
         this.persistentStore = persistentStore;
         this.notificationController = new NotificationController(persistentStore, bundleContext,
                 eventAdmin);

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,9 +22,9 @@
     <bean id="comet" class="org.cometd.server.CometdServlet">
     </bean>
 
-    <bean id="fixedThreadPool" class="java.util.concurrent.Executors"
+    <bean id="searchThreadPool" class="java.util.concurrent.Executors"
           factory-method="newFixedThreadPool">
-        <argument ref="nThreads" value="${org.codice.ddf.system.threadPoolSize}"/>
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
     </bean>
 
     <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
@@ -55,7 +55,7 @@
         <argument ref="blueprintBundleContext"/>
         <argument ref="eventAdmin"/>
         <argument ref="actionRegistry"/>
-        <argument ref="fixedThreadPool"/>
+        <argument ref="searchThreadPool"/>
     </bean>
 
 

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,9 +14,17 @@
 -->
 
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
+    <ext:property-placeholder/>
+
     <bean id="comet" class="org.cometd.server.CometdServlet">
+    </bean>
+
+    <bean id="fixedThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newFixedThreadPool">
+        <argument ref="nThreads" value="${org.codice.ddf.system.threadPoolSize}"/>
     </bean>
 
     <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
@@ -47,6 +55,7 @@
         <argument ref="blueprintBundleContext"/>
         <argument ref="eventAdmin"/>
         <argument ref="actionRegistry"/>
+        <argument ref="fixedThreadPool"/>
     </bean>
 
 

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
@@ -102,12 +102,7 @@ public class SearchControllerTest {
 
         searchController = new SearchController(framework,
                 new ActionRegistryImpl(Collections.<ActionProvider>emptyList()),
-                new GeotoolsFilterAdapterImpl()) {
-            @Override
-            ExecutorService getExecutorService() {
-                return new SequentialExectorService();
-            }
-        };
+                new GeotoolsFilterAdapterImpl(), new SequentialExectorService());
 
         mockServerSession = mock(ServerSession.class);
 

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.concurrent.Executors;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -135,7 +136,7 @@ public class CometdEndpointTest {
         cometdEndpoint = new CometdEndpoint(cometdServlet, mock(CatalogFramework.class),
                 mock(FilterBuilder.class), mock(FilterAdapter.class), mock(PersistentStore.class),
                 mock(BundleContext.class), mock(EventAdmin.class),
-                new ActionRegistryImpl(Collections.EMPTY_LIST));
+                new ActionRegistryImpl(Collections.EMPTY_LIST), Executors.newSingleThreadExecutor());
     }
 
     /**

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -30,6 +30,9 @@ javax.net.ssl.trustStore=etc/keystores/serverTruststore.jks
 javax.net.ssl.trustStorePassword=changeit
 javax.net.ssl.keyStoreType=jks
 
+#Thread Pool Settings
+org.codice.ddf.system.threadPoolSize=128
+
 # HTTPS Specific settings.  If making a Secure Connection not leveraging the HTTPS Jaav libraries and 
 # classes (e.g. if you are using secure sockets directly) then you will have to set this directly
 https.cipherSuites=TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -22,7 +22,7 @@
 # properties at the very beginning of the Karaf's boot process.
 #
 
-#START DDF SETTINGS
+# START DDF SETTINGS
 # Set the keystore and truststore Java properties
 javax.net.ssl.keyStore=etc/keystores/serverKeystore.jks
 javax.net.ssl.keyStorePassword=changeit
@@ -30,7 +30,9 @@ javax.net.ssl.trustStore=etc/keystores/serverTruststore.jks
 javax.net.ssl.trustStorePassword=changeit
 javax.net.ssl.keyStoreType=jks
 
-#Thread Pool Settings
+# Thread Pool Settings
+# Size of thread pool used for handling queries, federating requests, and downloading resources
+# See "Configuring Thread Pools" under "Managing" documentation.
 org.codice.ddf.system.threadPoolSize=128
 
 # HTTPS Specific settings.  If making a Secure Connection not leveraging the HTTPS Jaav libraries and 

--- a/distribution/docs/src/main/resources/ManContents.adoc
+++ b/distribution/docs/src/main/resources/ManContents.adoc
@@ -2301,17 +2301,14 @@ Event event = new Event("ddf/notification/catalog/downloads", properties);
 eventAdmin.postEvent(event);
 ----
 
-=== Configuring system.properties
+=== Configuring Thread Pools
 
-The `system.properties` file found under `$DDF_HOME/etc` contains properties that will be made available through system properties at the very beginning of Karaf's boot process. This file can be used to change specific system-level properties such as thread-pool count and default directory locations.
+The `system.properties` file found under `$DDF_HOME/etc` contains properties that will be made available through system properties at the beginning of Karaf's boot process. The `org.codice.ddf.system.threadPoolSize` property can be used to specify the size of thread pools used by:
+* Federating requests between {branding} systems
+* Downloading resources
+* Handling asynchronous queries, such as queries from the UI
 
-==== Thread Pool
-
-The `org.codice.ddf.system.threadPoolSize` property can be used to specify the size of the thread pool used by the federation strategy for handling queries.
-
-* By default, this value is set to 128.
-* The ideal and recommended value for this setting should the the number of cores of the system on which {branding} is running.
-* It is not recommended to set this value extremely high. If unsure, leave this setting at it's defualt value of 128.
+By default, this value is set to 128. It is not recommended to set this value extremely high. If unsure, leave this setting at it's default value of 128.
 
 == Managing Web Service Security
 

--- a/distribution/docs/src/main/resources/ManContents.adoc
+++ b/distribution/docs/src/main/resources/ManContents.adoc
@@ -2301,6 +2301,18 @@ Event event = new Event("ddf/notification/catalog/downloads", properties);
 eventAdmin.postEvent(event);
 ----
 
+=== Configuring system.properties
+
+The `system.properties` file found under `$DDF_HOME/etc` contains properties that will be made available through system properties at the very beginning of Karaf's boot process. This file can be used to change specific system-level properties such as thread-pool count and default directory locations.
+
+==== Thread Pool
+
+The `org.codice.ddf.system.threadPoolSize` property can be used to specify the size of the thread pool used by the federation strategy for handling queries.
+
+* By default, this value is set to 128.
+* The ideal and recommended value for this setting should the the number of cores of the system on which {branding} is running.
+* It is not recommended to set this value extremely high. If unsure, leave this setting at it's defualt value of 128.
+
 == Managing Web Service Security
 
 === Configuring WSS

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -325,8 +325,8 @@ public class TestSecurity extends AbstractIntegrationTest {
     @Test
     public void testX509TokenSTS() throws Exception {
         String onBehalfOf = "<wst:OnBehalfOf>\n"
-                + "                    <wsse:BinarySecurityToken xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\" ValueType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3\" >\n"
-                + "                        MIIDEzCCAnygAwIBAgIJAIzc4FYrIp9mMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNV"
+                + "                    <wsse:BinarySecurityToken xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\" ValueType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3\" >"
+                + "MIIDEzCCAnygAwIBAgIJAIzc4FYrIp9mMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNV\n"
                 + "BAYTAlVTMQswCQYDVQQIDAJBWjEMMAoGA1UECgwDRERGMQwwCgYDVQQLDANEZXYx\n"
                 + "GTAXBgNVBAMMEERERiBEZW1vIFJvb3QgQ0ExJDAiBgkqhkiG9w0BCQEWFWRkZnJv\n"
                 + "b3RjYUBleGFtcGxlLm9yZzAeFw0xNDEyMTAyMTU4MThaFw0xNTEyMTAyMTU4MTha\n"
@@ -343,7 +343,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "JD2Kj/+CTWqu8Elx13S0TxoIqv3gMoBW0ehyzEKjJi0bb1gUxO7n1SmOESp5sE3j\n"
                 + "GTnh0GtYV0D219z/09n90cd/imAEhknJlayyd0SjpnaL9JUd8uYxJexy8TJ2sMhs\n"
                 + "GAZ6EMTZCfT9m07XduxjsmDz0hlSGV0="
-                + "                   </wsse:BinarySecurityToken>\n"
+                + "</wsse:BinarySecurityToken>\n"
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 


### PR DESCRIPTION
 - The default thread pool size is currently set to 128.
 - Used system property for CachingFederationStrategy
 - Use System Property for ReliableResourceDownloadManager
 - Also updated the default thread pool size to be 128 for CachingFederationStrategy
 - Removes setPoolSize method from CatalogFrameworkImpl, blueprint, and metatype
   - Removes ability to set Federation Thread Pool Size from Admin UI.
   - Removes setter from blueprint.
   - Removes setPoolSize method from CatalogFrameworkImpl.  The pool is passed in through the constructor now.  Previously, the setPoolSize method wasn't actually doing anything.
 - Updates ThreadPools of size 1 to be single threads
   - While they are technically the same thing, this is more explicit.  This changes two instances of newScheduledThreadPools of size 1 to be newSingleThreadScheduledExecutors.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/206)
<!-- Reviewable:end -->
