### PR TITLE
DDF-1512 Updates conversions to cause minimal loss of precision, fixes up / down arrows

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -285,19 +285,21 @@ define([
 
                 var radiusConverter = function (direction, value) {
                         var radiusUnitVal = view.model.get("radiusUnits");
-                        var distanceFromMeters = view.getDistanceFromMeters(parseFloat(view.model.get('radius'), 10), radiusUnitVal);
-                        var distanceInMeters = view.getDistanceInMeters(parseFloat(value, 10), radiusUnitVal);
-
-                        if (direction === 'ViewToModel') {
-                            //radius value is bound to radius since radiusValue is converted, so we just need to set
-                            //the value so that it shows up in the view
-                            view.model.set("radius", distanceInMeters);
-                            return distanceInMeters;
-                        } else if (direction === 'ModelToView') {
-                            return distanceFromMeters;
+                        switch (direction) {
+                            case 'ViewToModel':
+                                var distanceInMeters = view.getDistanceInMeters(value, radiusUnitVal);
+                                //radius value is bound to radius since radiusValue is converted, so we just need to set
+                                //the value so that it shows up in the view
+                                view.model.set("radius", distanceInMeters);
+                                return distanceInMeters;
+                            case 'ModelToView':
+                                var distanceFromMeters = view.getDistanceFromMeters(view.model.get('radius'), radiusUnitVal);
+                                var currentValue = this.boundEls[0].value;
+                                var deltaThreshold = 0.00000000001;
+                                // only update the view's value if it's significantly different from the model's value
+                                return (Math.abs(currentValue - distanceFromMeters) > deltaThreshold) ?
+                                    distanceFromMeters : currentValue;
                         }
-
-                        return value;
                     },
 
                     offsetConverter = function (direction, value) {
@@ -634,11 +636,11 @@ define([
                     case "kilometers":
                         return distance * 1000;
                     case "feet":
-                        return Math.ceil(distance * 0.3048);
+                        return distance * 0.3048;
                     case "yards":
-                        return Math.ceil(distance * 0.9144);
+                        return distance * 0.9144;
                     case "miles":
-                        return Math.ceil(distance * 1609.34);
+                        return distance * 1609.34;
                     default:
                         return distance;
                 }
@@ -652,11 +654,11 @@ define([
                     case "kilometers":
                         return distance / 1000;
                     case "feet":
-                        return Math.ceil(distance / 0.3048);
+                        return distance / 0.3048;
                     case "yards":
-                        return Math.ceil(distance / 0.9144);
+                        return distance / 0.9144;
                     case "miles":
-                        return Math.ceil(distance / 1609.34);
+                        return distance / 1609.34;
                     default:
                         return distance;
                 }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -14,6 +14,7 @@
 define([
         'jquery',
         'backbone',
+        'cesium',
         'marionette',
         'underscore',
         'icanhaz',
@@ -26,7 +27,7 @@ define([
         'maptype',
         'bootstrapselect'
     ],
-    function ($, Backbone, Marionette, _, ich, properties, MetaCard, Progress, wreqr, searchFormTemplate, dir, maptype) {
+    function ($, Backbone, Cesium, Marionette, _, ich, properties, MetaCard, Progress, wreqr, searchFormTemplate, dir, maptype) {
         "use strict";
         var Query = {};
 
@@ -295,7 +296,7 @@ define([
                             case 'ModelToView':
                                 var distanceFromMeters = view.getDistanceFromMeters(view.model.get('radius'), radiusUnitVal);
                                 var currentValue = this.boundEls[0].value;
-                                var deltaThreshold = 0.00000000001;
+                                var deltaThreshold = Cesium.Math.EPSILON7;  // same used in cesium.bbox.js
                                 // only update the view's value if it's significantly different from the model's value
                                 return (Math.abs(currentValue - distanceFromMeters) > deltaThreshold) ?
                                     distanceFromMeters : currentValue;


### PR DESCRIPTION
 - Previously we were using the Math.ceil function during certain conversions.  This caused a significant loss of precision in both directions (view to model, and model to view).
 - For the most part, this fixed the issue with the up / down arrows seen in https://codice.atlassian.net/browse/DDF-1513.  I went ahead and refactored the radiusConverter function to fix a seperate issue that cropped up, which was also related to precision.  Instead of always updating the view based on the model, the view is now only updated when the difference between view and model is greater than a certain threshold.  ~~I couldn't track down an example value (I searched cesium and ddf for thresholds, but couldn't find any references).~~   The threshold is based on a value I found in cesium.bbox.js (used for a similar-ish issue).  I tested with the greatest zoom and the largest unit (mile) and it seemed to perform as expected.  Without this threshold for change, when using the up and down arrows (on a unit other than meters) you will see the value sometimes increases or decreases by a number close to 1 instead of 1. (ex: 54 to 54.99999999999 instead of 55)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/210)
<!-- Reviewable:end -->
