### PR TITLE
DDF-1515 Adds thread pool setting to system properties, updates various instances of thread pools

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePoller.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePoller.java
@@ -60,7 +60,7 @@ public class SourcePoller {
 
         this.runner = incomingRunner;
 
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
 
         handle = scheduler.scheduleAtFixedRate(runner, INITIAL_DELAY, INTERVAL, TimeUnit.SECONDS);
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/util/SourcePoller.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/util/SourcePoller.java
@@ -65,7 +65,7 @@ public class SourcePoller {
 
         this.runner = incomingRunner;
 
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
 
         handle = scheduler.scheduleAtFixedRate(runner, INITIAL_DELAY, INTERVAL, TimeUnit.SECONDS);
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -116,7 +116,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private final SolrCache cache;
 
-    private final ExecutorService cacheExecutorService = Executors.newFixedThreadPool(8);
+    private final ExecutorService cacheExecutorService;
 
     /**
      * The {@link List} of pre-federated query plugins to execute on the query request before the
@@ -148,12 +148,13 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
      */
     public CachingFederationStrategy(ExecutorService queryExecutorService,
             List<PreFederatedQueryPlugin> preQuery, List<PostFederatedQueryPlugin> postQuery,
-            SolrCache cache) {
+            SolrCache cache, ExecutorService cacheExecutorService) {
         this.queryExecutorService = queryExecutorService;
         this.preQuery = preQuery;
         this.postQuery = postQuery;
         this.maxStartIndex = DEFAULT_MAX_START_INDEX;
         this.cache = cache;
+        this.cacheExecutorService = cacheExecutorService;
         cacheBulkProcessor = new CacheBulkProcessor(cache);
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -1582,29 +1581,6 @@ public class CatalogFrameworkImpl extends DescribableImpl
 
         LOGGER.exit(methodName);
         return resourceResponse;
-    }
-
-    /**
-     * To be set via Spring/Blueprint
-     *
-     * @param poolSize the number of threads in the pool, 0 for an automatically-managed pool
-     */
-    public synchronized void setPoolSize(int poolSize) {
-        LOGGER.debug("Setting poolSize = " + poolSize);
-        if (pool != null) {
-            if (this.threadPoolSize == poolSize || this.threadPoolSize <= 0 && poolSize <= 0) {
-                return;
-            } else {
-                pool.shutdown();
-            }
-        }
-
-        this.threadPoolSize = poolSize;
-        if (threadPoolSize > 0) {
-            pool = Executors.newFixedThreadPool(poolSize);
-        } else {
-            pool = Executors.newCachedThreadPool();
-        }
     }
 
     /**

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -16,7 +16,6 @@ package ddf.catalog.resource.download;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -58,7 +57,7 @@ public class ReliableResourceDownloadManager {
 
     private DownloadStatusInfo downloadStatusInfo;
 
-    private ExecutorService executor = Executors.newCachedThreadPool();
+    private ExecutorService executor;
 
     private ReliableResourceDownloaderConfig downloaderConfig = new ReliableResourceDownloaderConfig();
 
@@ -74,12 +73,14 @@ public class ReliableResourceDownloadManager {
      */
     public ReliableResourceDownloadManager(ResourceCache resourceCache,
             DownloadsStatusEventPublisher eventPublisher,
-            DownloadsStatusEventListener eventListener, DownloadStatusInfo downloadStatusInfo) {
+            DownloadsStatusEventListener eventListener, DownloadStatusInfo downloadStatusInfo,
+                                           ExecutorService executor) {
         this.downloaderConfig.setResourceCache(resourceCache);
         this.eventPublisher = eventPublisher;
         this.downloaderConfig.setEventPublisher(this.eventPublisher);
         this.downloaderConfig.setEventListener(eventListener);
         this.downloadStatusInfo = downloadStatusInfo;
+        this.executor = executor;
         this.downloadIdentifier = UUID.randomUUID().toString();
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,6 +13,7 @@
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="
 	    http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
         ">
@@ -21,6 +22,8 @@
     <type-converters>
 		<bean id="listConverter" class="ddf.catalog.util.impl.ListConverter"/>
 	</type-converters>
+
+    <ext:property-placeholder/>
 
 	<bean id="sourceListener" class="ddf.catalog.util.impl.Masker"/>
 
@@ -130,8 +133,18 @@
                             unbind-method="unbindPlugin" ref="resourceReaderSortedList"/>
 	</reference-list>
 
-	<bean id="pool" class="java.util.concurrent.Executors"
+	<bean id="queryThreadPool" class="java.util.concurrent.Executors"
           factory-method="newCachedThreadPool"/>
+
+    <bean id="cacheThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newFixedThreadPool">
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
+    </bean>
+
+    <bean id="downloadThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newFixedThreadPool">
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
+    </bean>
 
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
                filter="id=catalog.data.metacard.resource"
@@ -157,10 +170,11 @@
 		<cm:managed-properties
                 persistent-id="ddf.catalog.federation.impl.CachingFederationStrategy"
                 update-strategy="container-managed"/>
-		<argument ref="pool"/>
+		<argument ref="queryThreadPool"/>
 		<argument ref="preFederatedQuerySortedList"/>
 		<argument ref="postFederatedQuerySortedList"/>
         <argument ref="solrCatalogCache"/>
+        <argument ref="cacheThreadPool"/>
 		<property name="maxStartIndex" value="50000"/>
 	</bean>
 
@@ -218,6 +232,7 @@
     	<argument ref="retrieveStatusEventPublisher"/>
     	<argument ref="retrieveStatusEventListener"/>
     	<argument ref="downloadStatusInfo"/>
+        <argument ref="downloadThreadPool"/>
     </bean>
 
     <!-- create the ddf bean -->
@@ -236,13 +251,12 @@
 		<argument ref="federatedSources"/>
 		<argument ref="resourceReaderSortedList"/>
 		<argument ref="sorted"/>
-		<argument ref="pool"/>
+		<argument ref="queryThreadPool"/>
         <argument ref="queryResponsePostProcessor"/>
 		<argument ref="sourcePoller"/>
 		<argument ref="productCache"/>
 		<argument ref="retrieveStatusEventPublisher"/>
 		<argument ref="reliableResourceDownloadManager"/>
-		<property name="poolSize" value="0"/>
 		<property name="id" value="ddf"/>
 		<property name="version" value="DDF v2.0"/>
 		<property name="organization" value="Codice"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,8 +21,6 @@
         <AD name="Enable Fanout Proxy" id="fanoutEnabled" required="true" type="Boolean"
             default="false"
             description="When enabled the Framework acts as a proxy, federating requests to all available sources. All requests are executed as federated queries and resource retrievals, allowing the framework to be the sole component exposing the functionality of all of its Federated Sources."/>
-        <AD name="Federation Thread Pool Size (0 for unlimited)" id="poolSize" required="true"
-            type="Integer" default="0"/>
         <AD name="Product Cache Directory" id="productCacheDirectory" required="false"
             type="String" default=""
             description="Directory where retrieved products will be cached for faster, future retrieval. If a directory path is specified with directories that do not exist, Catalog Framework will attempt to create those directories. Out of the box (without configuration), the product cache directory is INSTALL_DIR/data/product-cache. If a relative path is provided it will be relative to the INSTALL_DIR. It is recommended to enter an absolute directory path such as /opt/product-cache in Linux or C:/product-cache in Windows."/>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet; 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.BeforeClass;
@@ -74,7 +75,7 @@ public class DownloadsStatusEventListenerTest {
                 DownloadsStatusEventPublisher.class);
         testEventListener = new DownloadsStatusEventListener();
         testDownloadManager = new ReliableResourceDownloadManager(testResourceCache,
-                testEventPublisher, testEventListener, testDownloadStatusInfo);
+                testEventPublisher, testEventListener, testDownloadStatusInfo, Executors.newSingleThreadExecutor());
         testDownloadManager.setMaxRetryAttempts(1);
         testDownloadManager.setDelayBetweenAttempts(0);
         testDownloadManager.setMonitorPeriod(5);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -152,7 +152,7 @@ public class ReliableResourceDownloadManagerTest {
         downloadStatusInfo = new DownloadStatusInfoImpl();
 
         downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
-                eventListener, downloadStatusInfo);
+                eventListener, downloadStatusInfo, Executors.newSingleThreadExecutor());
 
     }
 
@@ -611,7 +611,7 @@ public class ReliableResourceDownloadManagerTest {
         resourceResponse = getMockResourceResponse();
 
         downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
-                eventListener, downloadStatusInfo);
+                eventListener, downloadStatusInfo, Executors.newSingleThreadExecutor());
 
         // Use small chunk size so download takes long enough for client
         // to have time to simulate FileBackedOutputStream exception
@@ -652,7 +652,7 @@ public class ReliableResourceDownloadManagerTest {
     private void startDownload(boolean cacheEnabled, int chunkSize, boolean cacheWhenCanceled,
             Metacard metacard, ResourceRetriever retriever) throws Exception {
         downloadMgr = new ReliableResourceDownloadManager(resourceCache, eventPublisher,
-                eventListener, downloadStatusInfo);
+                eventListener, downloadStatusInfo, Executors.newSingleThreadExecutor());
         downloadMgr.setCacheEnabled(cacheEnabled);
         downloadMgr.setChunkSize(chunkSize);
         downloadMgr.setCacheWhenCanceled(cacheWhenCanceled);

--- a/catalog/docs/src/main/resources/ExtContents.adoc
+++ b/catalog/docs/src/main/resources/ExtContents.adoc
@@ -2007,14 +2007,6 @@ _Catalog Standard Framework_
 |false
 |yes
 
-|poolSize
-|Integer
-|The federation thread pool size
-
-(0 for unlimited)
-|0
-|yes
-
 |productCacheDirectory
 |String
 |Directory where retrieved products will be cached for faster, future retrieval. If a directory path is specified with directories that do not exist, Catalog Framework will attempt to create those directories. Out of the box (without configuration), the product cache directory is `<INSTALL_DIR>/data/product-cache`. If a relative path is provided it will be relative to the `<INSTALL_DIR>`.
@@ -2272,15 +2264,6 @@ Catalog Fanout Framework configuration in the Web Console.
 |Description
 |Default Value
 |Required
-
-|Federation Thread Pool Size
-(0 for unlimited)
-|poolSize
-|Integer
-|The federation thread pool size.
-(0 for unlimited)
-|0
-|yes
 
 |Default Timeout
 (in milliseconds)

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.codice.ddf.ui.searchui.query.controller.search.CacheQueryRunnable;
@@ -52,7 +51,7 @@ public class SearchController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchController.class);
 
-    private final ExecutorService executorService = getExecutorService();
+    private final ExecutorService executorService;
 
     private final FilterAdapter filterAdapter;
 
@@ -74,10 +73,11 @@ public class SearchController {
      * @param filterAdapter
      */
     public SearchController(CatalogFramework framework, ActionRegistry actionRegistry,
-            FilterAdapter filterAdapter) {
+            FilterAdapter filterAdapter, ExecutorService executorService) {
         this.framework = framework;
         this.actionRegistry = actionRegistry;
         this.filterAdapter = filterAdapter;
+        this.executorService = executorService;
     }
 
     /**
@@ -204,11 +204,6 @@ public class SearchController {
 
     public FilterAdapter getFilterAdapter() {
         return filterAdapter;
-    }
-
-    // Override for unit testing
-    ExecutorService getExecutorService() {
-        return Executors.newCachedThreadPool();
     }
 
     public void setNormalizationDisabled(Boolean normalizationDisabled) {

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
@@ -16,6 +16,7 @@ package org.codice.ddf.ui.searchui.query.endpoint;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.concurrent.ExecutorService;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -88,11 +89,12 @@ public class CometdEndpoint {
      */
     public CometdEndpoint(CometdServlet cometdServlet, CatalogFramework framework,
             FilterBuilder filterBuilder, FilterAdapter filterAdapter, PersistentStore persistentStore,
-            BundleContext bundleContext, EventAdmin eventAdmin, ActionRegistry actionRegistry) {
+            BundleContext bundleContext, EventAdmin eventAdmin, ActionRegistry actionRegistry,
+                          ExecutorService executorService) {
         this.bundleContext = bundleContext;
         this.cometdServlet = cometdServlet;
         this.filterBuilder = filterBuilder;
-        this.searchController = new SearchController(framework, actionRegistry, filterAdapter);
+        this.searchController = new SearchController(framework, actionRegistry, filterAdapter, executorService);
         this.persistentStore = persistentStore;
         this.notificationController = new NotificationController(persistentStore, bundleContext,
                 eventAdmin);

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,9 +14,17 @@
 -->
 
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
+    <ext:property-placeholder/>
+
     <bean id="comet" class="org.cometd.server.CometdServlet">
+    </bean>
+
+    <bean id="searchThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newFixedThreadPool">
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
     </bean>
 
     <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
@@ -47,6 +55,7 @@
         <argument ref="blueprintBundleContext"/>
         <argument ref="eventAdmin"/>
         <argument ref="actionRegistry"/>
+        <argument ref="searchThreadPool"/>
     </bean>
 
 

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
@@ -102,12 +102,7 @@ public class SearchControllerTest {
 
         searchController = new SearchController(framework,
                 new ActionRegistryImpl(Collections.<ActionProvider>emptyList()),
-                new GeotoolsFilterAdapterImpl()) {
-            @Override
-            ExecutorService getExecutorService() {
-                return new SequentialExectorService();
-            }
-        };
+                new GeotoolsFilterAdapterImpl(), new SequentialExectorService());
 
         mockServerSession = mock(ServerSession.class);
 

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.concurrent.Executors;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -135,7 +136,7 @@ public class CometdEndpointTest {
         cometdEndpoint = new CometdEndpoint(cometdServlet, mock(CatalogFramework.class),
                 mock(FilterBuilder.class), mock(FilterAdapter.class), mock(PersistentStore.class),
                 mock(BundleContext.class), mock(EventAdmin.class),
-                new ActionRegistryImpl(Collections.EMPTY_LIST));
+                new ActionRegistryImpl(Collections.EMPTY_LIST), Executors.newSingleThreadExecutor());
     }
 
     /**

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -43,7 +43,10 @@ org.codice.ddf.system.siteContact=
 org.codice.ddf.system.version=${project.version}
 org.codice.ddf.system.organization=${organization.name}
 
-
+# Thread Pool Settings
+# Size of thread pool used for handling UI queries, federating requests, and downloading resources
+# See "Configuring Thread Pools" under "Managing" documentation.
+org.codice.ddf.system.threadPoolSize=128
 
 # HTTPS Specific settings.  If making a Secure Connection not leveraging the HTTPS Jaav libraries and 
 # classes (e.g. if you are using secure sockets directly) then you will have to set this directly

--- a/distribution/docs/src/main/resources/ManContents.adoc
+++ b/distribution/docs/src/main/resources/ManContents.adoc
@@ -2301,6 +2301,15 @@ Event event = new Event("ddf/notification/catalog/downloads", properties);
 eventAdmin.postEvent(event);
 ----
 
+=== Configuring Thread Pools
+
+The `system.properties` file found under `$DDF_HOME/etc` contains properties that will be made available through system properties at the beginning of Karaf's boot process. The `org.codice.ddf.system.threadPoolSize` property can be used to specify the size of thread pools used by:
+* Federating requests between {branding} systems
+* Downloading resources
+* Handling asynchronous queries, such as queries from the UI
+
+By default, this value is set to 128. It is not recommended to set this value extremely high. If unsure, leave this setting at it's default value of 128.
+
 == Managing Web Service Security
 
 === Configuring WSS


### PR DESCRIPTION
 - The default thread pool size is currently set to 128.
 - Used system property for CachingFederationStrategy
 - Use System Property for ReliableResourceDownloadManager
 - Also updated the default thread pool size to be 128 for CachingFederationStrategy
 - Removes setPoolSize method from CatalogFrameworkImpl, blueprint, and metatype
   - Removes ability to set Federation Thread Pool Size from Admin UI.
   - Removes setter from blueprint.
   - Removes setPoolSize method from CatalogFrameworkImpl.  The pool is passed in through the constructor now.  Previously, the setPoolSize method wasn't actually doing anything.
 - Updates ThreadPools of size 1 to be single threads
   - While they are technically the same thing, this is more explicit.  This changes two instances of newScheduledThreadPools of size 1 to be newSingleThreadScheduledExecutors.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/213)
<!-- Reviewable:end -->
