### PR TITLE
DDF-1539: Radius value is set correctly after a search

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -47,7 +47,6 @@ define([
                 timeType: 'modified',
                 radiusUnits: 'meters',
                 radius: 0,
-                radiusValue: 0,
                 count: properties.resultCount,
                 start: 1,
                 format: "geojson",
@@ -469,7 +468,7 @@ define([
                     result = new Metacard.SearchResult();
                     this.set({result: result});
                 }
-                
+
                 result.set('initiated', moment().format('lll'));
 
                 var progress = progressFunction || function() {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -343,7 +343,7 @@ define([
                     };
 
                 var queryModelBindings = Backbone.ModelBinder.createDefaultBindings(this.el, 'name');
-                queryModelBindings.radius.selector = '[name=radiusValue]';
+                queryModelBindings.radius.selector = '#radiusValue';
                 queryModelBindings.radius.converter = radiusConverter;
                 queryModelBindings.offsetTime.converter = offsetConverter;
                 queryModelBindings.offsetTimeUnits.converter = offsetConverter;
@@ -424,7 +424,7 @@ define([
                 this.$('#offsetTimeUnits').multiselect(singleselectOptions);
 
                 this.$('#scheduleUnits').multiselect(singleselectOptions);
-                
+
                 this.setupPopOver('[data-toggle="keyword-popover"]', 'Search by free text using the grammar of the underlying source. For wildcard searches, use % or * after partial keywords (e.g. earth%).');
                 this.setupPopOver('[data-toggle="time-popover"]', 'Search based on relative or absolute time of the created, modified, or effective date.');
                 this.setupPopOver('[data-toggle="location-popover"]', 'Search by latitude/longitude or the USNG using a polygon, point-radius, or bounding box.');
@@ -435,7 +435,7 @@ define([
                 this.updateZoomOnResults();
                 this.updateLocationFields();
             },
-            
+
             setupPopOver: function(selector, content) {
                 var options = {
                     trigger: 'hover',
@@ -615,7 +615,7 @@ define([
             },
 
             onRadiusUnitsChanged: function () {
-                this.$('input[name=radiusValue]').val(
+                this.$('#radiusValue').val(
                     this.getDistanceFromMeters(this.model.get('radius'), this.$('#radiusUnits').val()));
             },
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
@@ -179,7 +179,7 @@
 
                         <div class="input-group input-group-sm">
                             <span class="input-group-addon">Radius&nbsp;</span>
-                            <input class="form-control" id="radiusValue" name="radiusValue" type="number" min="0" step="any" placeholder=""/>
+                            <input class="form-control" id="radiusValue" type="number" min="0" step="any" placeholder=""/>
                             <span class="input-group-btn">
                                 <select id="radiusUnits" name="radiusUnits" class="input-group-addon">
                                     <option value="meters" selected="selected">meters</option>


### PR DESCRIPTION
The “radiusValue” input field was receiving a default Backbone binding
because default bindings are assigned to elements with a name
attribute, and the input field had one. This binding overwrote the
value for the input field given by the binding for the hidden “radius”
field, which is the binding we want to control the view. Removing the
“radiusValue” input field’s name attribute prevents this default
binding from being instantiated.

This change required us to update the existing code that interacts with
the input field element to select it by id rather than by name.

@millerw8 is the hero
@beyelerb 
@stustison 
@andrewkfiedler

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/214)
<!-- Reviewable:end -->
