### PR TITLE
DDF-1540 Fixes x509 token/path validator.

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -342,9 +342,55 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "b2NhbGhvc3RAZXhhbXBsZS5vcmcwDQYJKoZIhvcNAQEFBQADgYEAtRUp7fAxU/E6\n"
                 + "JD2Kj/+CTWqu8Elx13S0TxoIqv3gMoBW0ehyzEKjJi0bb1gUxO7n1SmOESp5sE3j\n"
                 + "GTnh0GtYV0D219z/09n90cd/imAEhknJlayyd0SjpnaL9JUd8uYxJexy8TJ2sMhs\n"
-                + "GAZ6EMTZCfT9m07XduxjsmDz0hlSGV0="
-                + "</wsse:BinarySecurityToken>\n"
+                + "GAZ6EMTZCfT9m07XduxjsmDz0hlSGV0=" + "</wsse:BinarySecurityToken>\n"
                 + "                </wst:OnBehalfOf>\n";
+        String body = getSoapEnvelope(onBehalfOf);
+
+        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+                .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
+                .expect().statusCode(equalTo(200)).when()
+                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
+                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
+
+    }
+
+    @Test
+    public void testX509PathSTS() throws Exception {
+        String onBehalfOf = "<wst:OnBehalfOf>\n"
+                + "                    <wsse:BinarySecurityToken xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\" ValueType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509PKIPathv1\" >"
+                + "MIIF1zCCArwwggIloAMCAQICCQCM3OBWKyKfZTANBgkqhkiG9w0BAQUFADB3MQsw"
+                + "CQYDVQQGEwJVUzELMAkGA1UECAwCQVoxDDAKBgNVBAoMA0RERjEMMAoGA1UECwwD"
+                + "RGV2MRkwFwYDVQQDDBBEREYgRGVtbyBSb290IENBMSQwIgYJKoZIhvcNAQkBFhVk"
+                + "ZGZyb290Y2FAZXhhbXBsZS5vcmcwHhcNMTQxMjEwMjE1NjMwWhcNMTcxMjA5MjE1"
+                + "NjMwWjB3MQswCQYDVQQGEwJVUzELMAkGA1UECAwCQVoxDDAKBgNVBAoMA0RERjEM"
+                + "MAoGA1UECwwDRGV2MRkwFwYDVQQDDBBEREYgRGVtbyBSb290IENBMSQwIgYJKoZI"
+                + "hvcNAQkBFhVkZGZyb290Y2FAZXhhbXBsZS5vcmcwgZ8wDQYJKoZIhvcNAQEBBQAD"
+                + "gY0AMIGJAoGBALVtFJIVYgb+07/jBZ1KXZVCxuf0hUoOMOw2vYJ8VqhS755Sf74q"
+                + "RcVaPm8BcrWVG80OdutXtzP+ylnO/tjmr+myxsKnpodXZcLqCzQE58rh57bFJRAJ"
+                + "SjqJjny+JBSy0MdI3NtJS3yVmrUgZRVHdIquYBPMjxIxgRsT230F1MnfAgMBAAGj"
+                + "UDBOMB0GA1UdDgQWBBThVMeX3wrCv6lfeF47CyvkSBe9xjAfBgNVHSMEGDAWgBTh"
+                + "VMeX3wrCv6lfeF47CyvkSBe9xjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUA"
+                + "A4GBAJ8QlzOYMjNiqA6YAIJ+LGbTSXbc1nnAgP6unnvatSmew8o/nGIzcrmRCeGg"
+                + "d5Bsx/xHncFtSeLRidgp6AvXA96/0ik7W5PWxFzbwy7vWIrkHx/tnWka6b95/FlB"
+                + "I+GxycJiGZZCwNWGFBWXWrn/aVCVicZQ7q+nPAuCkV+TKIalMIIDEzCCAnygAwIB"
+                + "AgIJAIzc4FYrIp9mMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNVBAYTAlVTMQswCQYD"
+                + "VQQIDAJBWjEMMAoGA1UECgwDRERGMQwwCgYDVQQLDANEZXYxGTAXBgNVBAMMEERE"
+                + "RiBEZW1vIFJvb3QgQ0ExJDAiBgkqhkiG9w0BCQEWFWRkZnJvb3RjYUBleGFtcGxl"
+                + "Lm9yZzAeFw0xNDEyMTAyMTU4MThaFw0xNTEyMTAyMTU4MThaMIGDMQswCQYDVQQG"
+                + "EwJVUzELMAkGA1UECAwCQVoxETAPBgNVBAcMCEdvb2R5ZWFyMQwwCgYDVQQKDANE"
+                + "REYxDDAKBgNVBAsMA0RldjESMBAGA1UEAwwJbG9jYWxob3N0MSQwIgYJKoZIhvcN"
+                + "AQkBFhVsb2NhbGhvc3RAZXhhbXBsZS5vcmcwgZ8wDQYJKoZIhvcNAQEBBQADgY0A"
+                + "MIGJAoGBAMeCyNZbCTZphHQfB5g8FrgBq1RYzV7ikVw/pVGkz8gx3l3A99s8WtA4"
+                + "mRAeb6n0vTR9yNBOekW4nYOiEOq//YTi/frI1kz0QbEH1s2cI5nFButabD3PYGxU"
+                + "Suapbc+AS7+Pklr0TDI4MRzPPkkTp4wlORQ/a6CfVsNr/mVgL2CfAgMBAAGjgZkw"
+                + "gZYwCQYDVR0TBAIwADAnBglghkgBhvhCAQ0EGhYYRk9SIFRFU1RJTkcgUFVSUE9T"
+                + "RSBPTkxZMB0GA1UdDgQWBBSA95QIMyBAHRsd0R4s7C3BreFrsDAfBgNVHSMEGDAW"
+                + "gBThVMeX3wrCv6lfeF47CyvkSBe9xjAgBgNVHREEGTAXgRVsb2NhbGhvc3RAZXhh"
+                + "bXBsZS5vcmcwDQYJKoZIhvcNAQEFBQADgYEAtRUp7fAxU/E6JD2Kj/+CTWqu8Elx"
+                + "13S0TxoIqv3gMoBW0ehyzEKjJi0bb1gUxO7n1SmOESp5sE3jGTnh0GtYV0D219z/"
+                + "09n90cd/imAEhknJlayyd0SjpnaL9JUd8uYxJexy8TJ2sMhsGAZ6EMTZCfT9m07X"
+                + "duxjsmDz0hlSGV0=\n"
+                + "</wsse:BinarySecurityToken>\n" + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
         given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")

--- a/platform/security/sts/security-sts-x509validator/src/main/java/org/codice/ddf/security/validator/x509/X509PathTokenValidator.java
+++ b/platform/security/sts/security-sts-x509validator/src/main/java/org/codice/ddf/security/validator/x509/X509PathTokenValidator.java
@@ -48,6 +48,7 @@
  */
 package org.codice.ddf.security.validator.x509;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
 
@@ -138,13 +139,10 @@ public class X509PathTokenValidator implements TokenValidator {
      */
     public boolean canHandleToken(ReceivedToken validateTarget, String realm) {
         Object token = validateTarget.getToken();
-        if ((token instanceof BinarySecurityTokenType) && (
+        return (token instanceof BinarySecurityTokenType) && (
                 X509_PKI_PATH.equals(((BinarySecurityTokenType) token).getValueType())
                         || X509TokenValidator.X509_V3_TYPE
-                        .equals(((BinarySecurityTokenType) token).getValueType()))) {
-            return true;
-        }
-        return false;
+                        .equals(((BinarySecurityTokenType) token).getValueType()));
     }
 
     /**
@@ -201,9 +199,15 @@ public class X509PathTokenValidator implements TokenValidator {
             if (merlin != null) {
                 byte[] token = binarySecurity.getToken();
                 if (token != null) {
-                    X509Certificate[] certificates = merlin.getCertificatesFromBytes(token);
-                    if (certificates != null) {
-                        credential.setCertificates(certificates);
+                    if (binarySecurityType.getValueType().equals(X509_PKI_PATH)) {
+                        X509Certificate[] certificates = merlin.getCertificatesFromBytes(token);
+                        if (certificates != null) {
+                            credential.setCertificates(certificates);
+                        }
+                    } else {
+                        X509Certificate singleCert = merlin
+                                .loadCertificate(new ByteArrayInputStream(token));
+                        credential.setCertificates(new X509Certificate[]{singleCert});
                     }
                 } else {
                     LOGGER.debug("Binary Security Token bytes were null.");

--- a/platform/security/sts/security-sts-x509validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-x509validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,18 +35,11 @@
 
     <ext:property-placeholder/>
 
-    <bean id="x509TokenValidator" class="org.apache.cxf.sts.token.validator.X509TokenValidator">
-
-    </bean>
-
     <bean id="x509PathTokenValidator"
           class="org.codice.ddf.security.validator.x509.X509PathTokenValidator" init-method="init">
         <property name="signaturePropertiesPath"
                   value="${ddf.home}/etc/ws-security/server/signature.properties"/>
     </bean>
-
-    <service ref="x509TokenValidator"
-             interface="org.apache.cxf.sts.token.validator.TokenValidator"/>
 
     <service ref="x509PathTokenValidator"
              interface="org.apache.cxf.sts.token.validator.TokenValidator"/>

--- a/platform/security/sts/security-sts-x509validator/src/test/java/org/codice/ddf/security/validator/x509/TestX509PathTokenValidator.java
+++ b/platform/security/sts/security-sts-x509validator/src/test/java/org/codice/ddf/security/validator/x509/TestX509PathTokenValidator.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.InputStream;
 import java.security.cert.X509Certificate;
 
 import javax.security.auth.x500.X500Principal;
@@ -27,6 +28,7 @@ import org.apache.cxf.sts.STSPropertiesMBean;
 import org.apache.cxf.sts.request.ReceivedToken;
 import org.apache.cxf.sts.token.validator.TokenValidatorParameters;
 import org.apache.cxf.sts.token.validator.TokenValidatorResponse;
+import org.apache.cxf.sts.token.validator.X509TokenValidator;
 import org.apache.cxf.ws.security.sts.provider.model.secext.BinarySecurityTokenType;
 import org.apache.wss4j.common.crypto.Crypto;
 import org.apache.wss4j.common.crypto.Merlin;
@@ -34,22 +36,45 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.validate.Credential;
 import org.apache.wss4j.dom.validate.Validator;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestX509PathTokenValidator {
-    @Test
-    public void testValidateGoodToken() {
-        X509PathTokenValidator x509PathTokenValidator = new X509PathTokenValidator();
+
+    private X509PathTokenValidator x509PathTokenValidator;
+
+    private Validator validator;
+
+    @Before
+    public void setUp() {
+        x509PathTokenValidator = new X509PathTokenValidator();
         x509PathTokenValidator.merlin = mock(Merlin.class);
         try {
-            X509Certificate[] x509Certificates = new X509Certificate[] {
-                    mock(X509Certificate.class)};
+            X509Certificate mockCert = mock(X509Certificate.class);
+            X509Certificate[] x509Certificates = new X509Certificate[] {mockCert};
             when(x509PathTokenValidator.merlin.getCertificatesFromBytes(any(byte[].class)))
                     .thenReturn(x509Certificates);
+
+            when(x509PathTokenValidator.merlin.loadCertificate(any(InputStream.class)))
+                    .thenReturn(mockCert);
         } catch (WSSecurityException e) {
             //ignore
         }
-        Validator validator = mock(Validator.class);
+        validator = mock(Validator.class);
+    }
+
+    @Test
+    public void testValidateGoodPath() {
+        goodToken(X509PathTokenValidator.X509_PKI_PATH);
+    }
+
+    @Test
+    public void testValidateGoodToken() {
+        goodToken(X509TokenValidator.X509_V3_TYPE);
+    }
+
+    private void goodToken(String type) {
+
         try {
             Credential credential = mock(Credential.class);
             X509Certificate x509Certificate = mock(X509Certificate.class);
@@ -74,11 +99,13 @@ public class TestX509PathTokenValidator {
         doCallRealMethod().when(receivedToken).getState();
         when(tokenParameters.getToken()).thenReturn(receivedToken);
         when(receivedToken.isBinarySecurityToken()).thenReturn(true);
+
         BinarySecurityTokenType binarySecurityTokenType = mock(BinarySecurityTokenType.class);
+        when(binarySecurityTokenType.getValueType()).thenReturn(type);
+
         when(receivedToken.getToken()).thenReturn(binarySecurityTokenType);
         when(binarySecurityTokenType.getEncodingType())
                 .thenReturn(X509PathTokenValidator.BASE64_ENCODING);
-        when(binarySecurityTokenType.getValueType()).thenReturn("valuetype");
         when(binarySecurityTokenType.getValue()).thenReturn("data");
 
         TokenValidatorResponse tokenValidatorResponse = x509PathTokenValidator
@@ -90,16 +117,7 @@ public class TestX509PathTokenValidator {
     @Test
     public void testValidateBadToken() {
         X509PathTokenValidator x509PathTokenValidator = new X509PathTokenValidator();
-        x509PathTokenValidator.merlin = mock(Merlin.class);
-        try {
-            X509Certificate[] x509Certificates = new X509Certificate[] {
-                    mock(X509Certificate.class)};
-            when(x509PathTokenValidator.merlin.getCertificatesFromBytes(any(byte[].class)))
-                    .thenReturn(x509Certificates);
-        } catch (WSSecurityException e) {
-            //ignore
-        }
-        Validator validator = mock(Validator.class);
+
         try {
             Credential credential = mock(Credential.class);
             X509Certificate x509Certificate = mock(X509Certificate.class);


### PR DESCRIPTION
The CXF x509 validator was being registered alongside our own path-token validator and at runtime we were getting one or the other non-deterministically. Additionally, the path-token validator was not differentiating between path and certificate validation.

@kcwire You're my hero!
@stustison 
@brendan-hofmann 
@lessarderic

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/215)
<!-- Reviewable:end -->
