### PR TITLE
DDF-1430  - check for null argument map in MetcardMarshallerImpl

### DIFF
--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -117,10 +117,13 @@ public class MetacardMarshallerImpl implements MetacardMarshaller {
             throws XmlPullParserException, IOException, CatalogTransformerException {
         PrintWriter writer = this.writerProvider.build(Metacard.class);
 
-        Boolean omitXmlDec = (Boolean) arguments.get(OMIT_XML_DECL);
-        if (omitXmlDec == null || !omitXmlDec) {
-            writer.setRawValue(XML_DECL);
+        if (arguments != null && arguments.get(OMIT_XML_DECL) != null) {
+            Boolean omitXmlDec = Boolean.valueOf(String.valueOf(arguments.get(OMIT_XML_DECL)));
+            if (omitXmlDec == null || !omitXmlDec) {
+                writer.setRawValue(XML_DECL);
+            }
         }
+
 
         writer.startNode("metacard");
         for (Map.Entry<String, String> nsRow : NAMESPACE_MAP.entrySet()) {


### PR DESCRIPTION
The itests logs were getting filled with NPE's so dug into and found the root cause.  I also updated many of the assertions we make in the itests to be much more specific because looking for a string anywhere in the response is insufficient in many of the tests.

@lessarderic 
@coyotesqrl 
@pklinef

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/219)
<!-- Reviewable:end -->
