### PR TITLE
DDF-1546 Fixes federated query timeouts so they are measured from the start of the query.

### DIFF
--- a/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/FifoFederationStrategy.java
+++ b/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/FifoFederationStrategy.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -50,7 +50,10 @@ import ddf.catalog.source.Source;
  * strategy that returns results in the order they are received. This means that the first results
  * received by this strategy are the first results sent back to the client.
  *
+ * @deprecated This federation strategy has been left for historical purposes. Refer to the
+ * {@code CachingFederationStrategy} provided by the {@code catalog-core-standardframework} bundle.
  */
+@Deprecated
 public class FifoFederationStrategy implements FederationStrategy {
 
     private static final XLogger LOGGER = new XLogger(
@@ -144,7 +147,7 @@ public class FifoFederationStrategy implements FederationStrategy {
                                         .process(source, modifiedQueryRequest);
                             } catch (PluginExecutionException e) {
                                 LOGGER.warn("Error executing PreFederatedQueryPlugin: " + e
-                                                .getMessage(), e);
+                                        .getMessage(), e);
                             }
                         }
                     } catch (StopProcessingException e) {
@@ -215,13 +218,6 @@ public class FifoFederationStrategy implements FederationStrategy {
 
     }
 
-    /**
-     * Gets the time remaining before the timeout on a query
-     *
-     * @param deadline
-     *            - the deadline for the timeout to occur
-     * @return the time remaining prior to the timeout
-     */
     private static class FifoQueryMonitor implements Runnable {
 
         private QueryResponseImpl returnResults;
@@ -290,12 +286,16 @@ public class FifoFederationStrategy implements FederationStrategy {
 
             private Source site = null;
 
+            private long deadline;
+
             public SourceQueryThread(Source site, Future<SourceResponse> curFuture,
                     QueryResponseImpl returnResults, long maxResults) {
                 this.curFuture = curFuture;
                 this.returnResults = returnResults;
                 this.site = site;
                 this.maxResults = maxResults;
+
+                deadline = System.currentTimeMillis() + query.getTimeoutMillis();
             }
 
             @Override
@@ -305,9 +305,7 @@ public class FifoFederationStrategy implements FederationStrategy {
                 try {
                     sourceResponse = query.getTimeoutMillis() < 1 ?
                             curFuture.get() :
-                            curFuture.get(getTimeRemaining(
-                                    System.currentTimeMillis() + query.getTimeoutMillis()),
-                                    TimeUnit.MILLISECONDS);
+                            curFuture.get(getTimeRemaining(deadline), TimeUnit.MILLISECONDS);
                     sourceResponse = curFuture.get();
                 } catch (Exception e) {
                     LOGGER.warn("Federated query returned exception " + e.getMessage());

--- a/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
+++ b/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
@@ -62,7 +62,10 @@ import ddf.catalog.util.impl.TemporalResultComparator;
  * @see Metacard
  * @see Query
  * @see SortBy
+ * @deprecated This federation strategy has been left for historical purposes. Refer to the
+ * {@code CachingFederationStrategy} provided by the {@code catalog-core-standardframework} bundle.
  */
+@Deprecated
 public class SortedFederationStrategy extends AbstractFederationStrategy {
 
     /**
@@ -101,6 +104,8 @@ public class SortedFederationStrategy extends AbstractFederationStrategy {
 
         private Query query;
 
+        private long deadline;
+
         public SortedQueryMonitor(ExecutorService pool,
                 Map<Source, Future<SourceResponse>> futuress, QueryResponseImpl returnResults,
                 Query query) {
@@ -108,6 +113,8 @@ public class SortedFederationStrategy extends AbstractFederationStrategy {
             this.returnResults = returnResults;
             this.query = query;
             this.futures = futuress;
+
+            deadline = System.currentTimeMillis() + query.getTimeoutMillis();
         }
 
         @SuppressWarnings({"rawtypes", "unchecked"})
@@ -142,8 +149,6 @@ public class SortedFederationStrategy extends AbstractFederationStrategy {
             List<Result> resultList = new ArrayList<Result>();
             long totalHits = 0;
             Set<ProcessingDetails> processingDetails = returnResults.getProcessingDetails();
-
-            long deadline = System.currentTimeMillis() + query.getTimeoutMillis();
 
             Map<String, Serializable> returnProperties = returnResults.getProperties();
             for (final Entry<Source, Future<SourceResponse>> entry : futures.entrySet()) {

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -316,22 +316,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.3</minimum>
+                                            <minimum>0.39</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,9 +13,7 @@
  */
 package ddf.catalog.cache.solr.impl;
 
-import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -24,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,11 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.codice.ddf.platform.util.Exceptions;
-import org.opengis.filter.expression.PropertyName;
-import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +39,6 @@ import ddf.catalog.data.Result;
 import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteResponse;
-import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
@@ -64,17 +56,22 @@ import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.Source;
 import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.util.impl.DistanceResultComparator;
 import ddf.catalog.util.impl.RelevanceResultComparator;
-import ddf.catalog.util.impl.TemporalResultComparator;
 
 /**
- * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link ddf.catalog.data.Metacard}s. The
- * sorting is based on the {@link ddf.catalog.operation.Query}'s {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values
- * are {@link ddf.catalog.data.Metacard.EFFECTIVE}, {@link ddf.catalog.data.Result.TEMPORAL}, {@link ddf.catalog.data.Result.DISTANCE}, or
- * {@link ddf.catalog.data.Result.RELEVANCE} . The supported ordering includes {@link org.opengis.filter.sort.SortOrder.DESCENDING} and
- * {@link org.opengis.filter.sort.SortOrder.ASCENDING}. For this class to function properly a sort value and sort order must
- * be provided.
+ * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting
+ * {@link ddf.catalog.data.Metacard}s. The sorting is based on the {@link ddf.catalog.operation.Query}'s
+ * {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values
+ * are
+ * <ul>
+ *     <li>{@link ddf.catalog.data.Metacard#EFFECTIVE}</li>
+ *     <li>{@link ddf.catalog.data.Result#TEMPORAL}</li>
+ *     <li>{@link ddf.catalog.data.Result#DISTANCE}</li>
+ *     <li>{@link ddf.catalog.data.Result#RELEVANCE}</li>
+ * </ul>
+ * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and
+ * {@link org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort
+ * value and sort order must be provided.
  *
  * @see ddf.catalog.data.Metacard
  * @see ddf.catalog.operation.Query
@@ -83,7 +80,8 @@ import ddf.catalog.util.impl.TemporalResultComparator;
 public class CachingFederationStrategy implements FederationStrategy, PostIngestPlugin {
 
     /**
-     * The default comparator for sorting by {@link ddf.catalog.data.Result.RELEVANCE}, {@link org.opengis.filter.sort.SortOrder.DESCENDING}
+     * The default comparator for sorting by {@link ddf.catalog.data.Result#RELEVANCE},
+     * {@link org.opengis.filter.sort.SortOrder#DESCENDING}
      */
     protected static final Comparator<Result> DEFAULT_COMPARATOR = new RelevanceResultComparator(
             SortOrder.DESCENDING);
@@ -143,8 +141,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
     /**
      * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
      *
-     * @param queryExecutorService
-     *            the {@link ExecutorService} for queries
+     * @param queryExecutorService the {@link ExecutorService} for queries
      */
     public CachingFederationStrategy(ExecutorService queryExecutorService,
             List<PreFederatedQueryPlugin> preQuery, List<PostFederatedQueryPlugin> postQuery,
@@ -175,7 +172,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         }
     }
 
-    private QueryResponse queryCache(QueryRequest queryRequest) {
+    QueryResponse queryCache(QueryRequest queryRequest) {
         final QueryResponseImpl queryResponse = new QueryResponseImpl(queryRequest);
         try {
             SourceResponse result = cache.query(queryRequest);
@@ -376,8 +373,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
     /**
      * To be set via Spring/Blueprint
      *
-     * @param maxStartIndex
-     *            the new default max start index value
+     * @param maxStartIndex the new default max start index value
      */
     public void setMaxStartIndex(int maxStartIndex) {
         this.maxStartIndex = DEFAULT_MAX_START_INDEX;
@@ -410,7 +406,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
             final Map<Future<SourceResponse>, Source> futures,
             final QueryResponseImpl returnResults, final QueryRequest request) {
 
-        return new SortedQueryMonitor(completionService, futures, returnResults, request);
+        return new SortedQueryMonitor(this, completionService, futures, returnResults, request);
     }
 
     public void shutdown() {
@@ -511,161 +507,6 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
             return sourceResponse;
         }
-    }
-
-    private class SortedQueryMonitor implements Runnable {
-
-        private final QueryRequest request;
-
-        private final CompletionService<SourceResponse> completionService;
-
-        private QueryResponseImpl returnResults;
-
-        private Map<Future<SourceResponse>, Source> futures;
-
-        private Query query;
-
-        public SortedQueryMonitor(CompletionService<SourceResponse> completionService,
-                Map<Future<SourceResponse>, Source> futures, QueryResponseImpl returnResults,
-                QueryRequest request) {
-
-            this.completionService = completionService;
-            this.returnResults = returnResults;
-            this.request = request;
-            this.query = request.getQuery();
-            this.futures = futures;
-        }
-
-        @Override
-        public void run() {
-            SortBy sortBy = query.getSortBy();
-            // Prepare the Comparators that we will use
-            Comparator<Result> coreComparator = DEFAULT_COMPARATOR;
-
-            if (sortBy != null && sortBy.getPropertyName() != null) {
-                PropertyName sortingProp = sortBy.getPropertyName();
-                String sortType = sortingProp.getPropertyName();
-                SortOrder sortOrder = (sortBy.getSortOrder() == null) ?
-                        SortOrder.DESCENDING :
-                        sortBy.getSortOrder();
-                logger.debug("Sorting type: {}", sortType);
-                logger.debug("Sorting order: {}", sortBy.getSortOrder());
-
-                // Temporal searches are currently sorted by the effective time
-                if (Metacard.EFFECTIVE.equals(sortType) || Result.TEMPORAL.equals(sortType)) {
-                    coreComparator = new TemporalResultComparator(sortOrder);
-                } else if (Result.DISTANCE.equals(sortType)) {
-                    coreComparator = new DistanceResultComparator(sortOrder);
-                } else if (Result.RELEVANCE.equals(sortType)) {
-                    coreComparator = new RelevanceResultComparator(sortOrder);
-                }
-            }
-
-            List<Result> resultList = new ArrayList<Result>();
-            long totalHits = 0;
-            Set<ProcessingDetails> processingDetails = returnResults.getProcessingDetails();
-
-            long deadline = System.currentTimeMillis() + query.getTimeoutMillis();
-
-            Map<String, Serializable> returnProperties = returnResults.getProperties();
-
-            for (int i = futures.size(); i > 0; i--) {
-                String sourceId = "Unknown Source";
-                try {
-                    Future<SourceResponse> future;
-                    if (query.getTimeoutMillis() < 1) {
-                        future = completionService.take();
-                    } else {
-                        future = completionService
-                                .poll(getTimeRemaining(deadline), TimeUnit.MILLISECONDS);
-                        if (future == null) {
-                            timeoutRemainingSources(processingDetails);
-                            break;
-                        }
-                    }
-
-                    Source source = futures.remove(future);
-                    if (source != null) {
-                        sourceId = source.getId();
-                    }
-
-                    SourceResponse sourceResponse = future.get();
-
-                    if (sourceResponse == null) {
-                        logger.info("Source {} returned null response", sourceId);
-                        processingDetails.add(new ProcessingDetailsImpl(sourceId,
-                                new NullPointerException()));
-                    } else {
-                        resultList.addAll(sourceResponse.getResults());
-                        totalHits += sourceResponse.getHits();
-
-                        Map<String, Serializable> properties = sourceResponse.getProperties();
-                        returnProperties.putAll(properties);
-                    }
-                } catch (InterruptedException e) {
-                    interruptRemainingSources(processingDetails, e);
-                    break;
-                } catch (ExecutionException e) {
-                    logger.warn("Couldn't get results from completed federated query. {}, {}",
-                            sourceId, Exceptions.getFullMessage(e), e);
-
-                    processingDetails.add(new ProcessingDetailsImpl(sourceId,
-                            new Exception(Exceptions.getFullMessage(e))));
-                }
-            }
-            logger.debug("All sources finished returning results: {}", resultList.size());
-
-            returnResults.setHits(totalHits);
-            if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                QueryResponse result = queryCache(request);
-                returnResults.addResults(result.getResults(), true);
-            } else {
-                returnResults.addResults(sortedResults(resultList, coreComparator), true);
-            }
-        }
-
-        List<Result> sortedResults(List<Result> results, Comparator<? super Result> comparator) {
-            Collections.sort(results, comparator);
-
-            int maxResults = Integer.MAX_VALUE;
-            if (query.getPageSize() > 0) {
-                maxResults = query.getPageSize();
-            }
-
-            return results.size() > maxResults ? results.subList(0, maxResults) : results;
-        }
-
-        private void timeoutRemainingSources(Set<ProcessingDetails> processingDetails) {
-            for (Source expiredSource : futures.values()) {
-                if (expiredSource != null) {
-                    logger.info("Search timed out for {}", expiredSource.getId());
-                    processingDetails.add(new ProcessingDetailsImpl(expiredSource.getId(),
-                            new TimeoutException()));
-                }
-            }
-        }
-
-        private void interruptRemainingSources(Set<ProcessingDetails> processingDetails,
-                InterruptedException interruptedException) {
-            for (Source interruptedSource : futures.values()) {
-                if (interruptedSource != null) {
-                    logger.info("Search interrupted for {}", interruptedSource.getId());
-                    processingDetails.add(new ProcessingDetailsImpl(interruptedSource.getId(),
-                            interruptedException));
-                }
-            }
-        }
-
-        private long getTimeRemaining(long deadline) {
-            long timeLeft;
-            if (System.currentTimeMillis() > deadline) {
-                timeLeft = 0;
-            } else {
-                timeLeft = deadline - System.currentTimeMillis();
-            }
-            return timeLeft;
-        }
-
     }
 
     /**

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SortedQueryMonitor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SortedQueryMonitor.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.cache.solr.impl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.codice.ddf.platform.util.Exceptions;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.ProcessingDetailsImpl;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+import ddf.catalog.source.Source;
+import ddf.catalog.util.impl.DistanceResultComparator;
+import ddf.catalog.util.impl.RelevanceResultComparator;
+import ddf.catalog.util.impl.TemporalResultComparator;
+
+class SortedQueryMonitor implements Runnable {
+    private static Logger logger = LoggerFactory.getLogger(SortedQueryMonitor.class);
+
+    private CachingFederationStrategy cachingFederationStrategy;
+
+    private final QueryRequest request;
+
+    private final CompletionService<SourceResponse> completionService;
+
+    private QueryResponseImpl returnResults;
+
+    private Map<Future<SourceResponse>, Source> futures;
+
+    private Query query;
+
+    private long deadline;
+
+    public SortedQueryMonitor(CachingFederationStrategy cachingFederationStrategy,
+            CompletionService<SourceResponse> completionService,
+            Map<Future<SourceResponse>, Source> futures, QueryResponseImpl returnResults,
+            QueryRequest request) {
+        this.cachingFederationStrategy = cachingFederationStrategy;
+
+        this.completionService = completionService;
+        this.returnResults = returnResults;
+        this.request = request;
+        this.query = request.getQuery();
+        this.futures = futures;
+
+        deadline = System.currentTimeMillis() + query.getTimeoutMillis();
+    }
+
+    @Override
+    public void run() {
+        SortBy sortBy = query.getSortBy();
+        // Prepare the Comparators that we will use
+        Comparator<Result> coreComparator = CachingFederationStrategy.DEFAULT_COMPARATOR;
+
+        if (sortBy != null && sortBy.getPropertyName() != null) {
+            PropertyName sortingProp = sortBy.getPropertyName();
+            String sortType = sortingProp.getPropertyName();
+            SortOrder sortOrder = (sortBy.getSortOrder() == null) ?
+                    SortOrder.DESCENDING :
+                    sortBy.getSortOrder();
+            logger.debug("Sorting type: {}", sortType);
+            logger.debug("Sorting order: {}", sortBy.getSortOrder());
+
+            // Temporal searches are currently sorted by the effective time
+            if (Metacard.EFFECTIVE.equals(sortType) || Result.TEMPORAL.equals(sortType)) {
+                coreComparator = new TemporalResultComparator(sortOrder);
+            } else if (Result.DISTANCE.equals(sortType)) {
+                coreComparator = new DistanceResultComparator(sortOrder);
+            } else if (Result.RELEVANCE.equals(sortType)) {
+                coreComparator = new RelevanceResultComparator(sortOrder);
+            }
+        }
+
+        List<Result> resultList = new ArrayList<>();
+        long totalHits = 0;
+        Set<ProcessingDetails> processingDetails = returnResults.getProcessingDetails();
+
+        Map<String, Serializable> returnProperties = returnResults.getProperties();
+
+        for (int i = futures.size(); i > 0; i--) {
+            String sourceId = "Unknown Source";
+            Source source = null;
+            try {
+                Future<SourceResponse> future;
+                if (query.getTimeoutMillis() < 1) {
+                    future = completionService.take();
+                } else {
+                    future = completionService
+                            .poll(getTimeRemaining(deadline), TimeUnit.MILLISECONDS);
+                    if (future == null) {
+                        timeoutRemainingSources(processingDetails);
+                        break;
+                    }
+                }
+
+                source = futures.remove(future);
+                if (source != null) {
+                    sourceId = source.getId();
+                }
+
+                SourceResponse sourceResponse = future.get();
+
+                if (sourceResponse == null) {
+                    logger.info("Source {} returned null response", sourceId);
+                    processingDetails
+                            .add(new ProcessingDetailsImpl(sourceId, new NullPointerException()));
+                } else {
+                    resultList.addAll(sourceResponse.getResults());
+                    totalHits += sourceResponse.getHits();
+
+                    Map<String, Serializable> properties = sourceResponse.getProperties();
+                    returnProperties.putAll(properties);
+                }
+            } catch (InterruptedException e) {
+                if (source != null) {
+                    // First, add interrupted processing detail for this source
+                    logger.info("Search interrupted for {}", source.getId());
+                    processingDetails.add(new ProcessingDetailsImpl(source.getId(), e));
+                }
+
+                // Then add the interrupted exception for the remaining sources
+                interruptRemainingSources(processingDetails, e);
+                break;
+            } catch (ExecutionException e) {
+                logger.warn("Couldn't get results from completed federated query. {}, {}", sourceId,
+                        Exceptions.getFullMessage(e), e);
+
+                processingDetails.add(new ProcessingDetailsImpl(sourceId,
+                        new Exception(Exceptions.getFullMessage(e))));
+            }
+        }
+        logger.debug("All sources finished returning results: {}", resultList.size());
+
+        returnResults.setHits(totalHits);
+        if (CachingFederationStrategy.INDEX_QUERY_MODE
+                .equals(request.getPropertyValue(CachingFederationStrategy.QUERY_MODE))) {
+            QueryResponse result = cachingFederationStrategy.queryCache(request);
+            returnResults.addResults(result.getResults(), true);
+        } else {
+            returnResults.addResults(sortedResults(resultList, coreComparator), true);
+        }
+    }
+
+    List<Result> sortedResults(List<Result> results, Comparator<? super Result> comparator) {
+        Collections.sort(results, comparator);
+
+        int maxResults = Integer.MAX_VALUE;
+        if (query.getPageSize() > 0) {
+            maxResults = query.getPageSize();
+        }
+
+        return results.size() > maxResults ? results.subList(0, maxResults) : results;
+    }
+
+    private void timeoutRemainingSources(Set<ProcessingDetails> processingDetails) {
+        for (Source expiredSource : futures.values()) {
+            if (expiredSource != null) {
+                logger.info("Search timed out for {}", expiredSource.getId());
+                processingDetails.add(new ProcessingDetailsImpl(expiredSource.getId(),
+                        new TimeoutException()));
+            }
+        }
+    }
+
+    private void interruptRemainingSources(Set<ProcessingDetails> processingDetails,
+            InterruptedException interruptedException) {
+        for (Source interruptedSource : futures.values()) {
+            if (interruptedSource != null) {
+                logger.info("Search interrupted for {}", interruptedSource.getId());
+                processingDetails.add(new ProcessingDetailsImpl(interruptedSource.getId(),
+                        interruptedException));
+            }
+        }
+    }
+
+    private long getTimeRemaining(long deadline) {
+        long timeLeft;
+        if (System.currentTimeMillis() > deadline) {
+            timeLeft = 0;
+        } else {
+            timeLeft = deadline - System.currentTimeMillis();
+        }
+        return timeLeft;
+    }
+
+}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.cache.solr.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.extractor.Extractors.byName;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+import ddf.catalog.source.Source;
+
+public class SortedQueryMonitorTest {
+
+    private CachingFederationStrategy cachingFederationStrategy;
+
+    private CompletionService completionService;
+
+    private QueryResponseImpl queryResponse;
+
+    private QueryRequest queryRequest;
+
+    private Map<Future<SourceResponse>, Source> futures;
+
+    private Query query;
+
+    @Before
+    public void setUp() throws Exception {
+        cachingFederationStrategy = mock(CachingFederationStrategy.class);
+        completionService = mock(CompletionService.class);
+        queryRequest = mock(QueryRequest.class);
+        queryResponse = new QueryResponseImpl(queryRequest);
+        query = mock(Query.class);
+
+        // Enforce insertion order for testing purposes
+        futures = new LinkedHashMap<>();
+        for (int i = 0; i < 4; i++) {
+            Source sourceMock = mock(Source.class);
+            when(sourceMock.getId()).thenReturn("Source-" + i);
+
+            SourceResponse sourceResponseMock = null;
+            Future futureMock = mock(Future.class);
+
+            switch (i) {
+            case 1:
+                sourceResponseMock = mock(SourceResponse.class);
+                when(sourceResponseMock.getResults()).thenReturn(
+                        Lists.newArrayList(mock(Result.class), mock(Result.class),
+                                mock(Result.class)));
+                when(sourceResponseMock.getHits()).thenReturn(3L);
+                break;
+            case 2:
+                sourceResponseMock = mock(SourceResponse.class);
+                when(sourceResponseMock.getResults())
+                        .thenReturn(Lists.newArrayList(mock(Result.class)));
+                when(sourceResponseMock.getHits()).thenReturn(1L);
+                break;
+            case 3:
+                sourceResponseMock = mock(SourceResponse.class);
+                when(sourceResponseMock.getResults()).thenReturn(Lists.<Result>emptyList());
+                when(sourceResponseMock.getHits()).thenReturn(0L);
+                break;
+            }
+
+            when(futureMock.get()).thenReturn(sourceResponseMock);
+            futures.put(futureMock, sourceMock);
+        }
+    }
+
+    @Test
+    public void noQueryTimeout() throws Exception {
+        when(query.getTimeoutMillis()).thenReturn(0L);
+        when(queryRequest.getQuery()).thenReturn(query);
+
+        SortedQueryMonitor queryMonitor = new SortedQueryMonitor(cachingFederationStrategy,
+                completionService, futures, queryResponse, queryRequest);
+
+        final Iterator<Future<SourceResponse>> futureIter = getFutureIterator();
+        when(completionService.take()).thenAnswer(new Answer<Future>() {
+            @Override
+            public Future answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return futureIter.next();
+            }
+        });
+        queryMonitor.run();
+        verify(completionService, times(4)).take();
+        verify(completionService, never()).poll(anyLong(), eq(TimeUnit.MILLISECONDS));
+
+        assertThat(queryResponse.getHits()).isEqualTo(4);
+        assertThat(queryResponse.getResults().size()).isEqualTo(4);
+
+        assertThat(queryResponse.getProcessingDetails()).extracting(byName("exception"))
+                .extracting(byName("class")).contains(NullPointerException.class);
+        assertThat(queryResponse.getProcessingDetails()).extracting(byName("sourceId"))
+                .contains("Source-0");
+    }
+
+    @Test
+    public void shortQueryTimeout() throws Exception {
+        when(query.getTimeoutMillis()).thenReturn(5000L);
+        when(queryRequest.getQuery()).thenReturn(query);
+
+        SortedQueryMonitor queryMonitor = new SortedQueryMonitor(cachingFederationStrategy,
+                completionService, futures, queryResponse, queryRequest);
+
+        // Put the first two futures into the list and then set the third
+        // value to be null in order to mock the effect of a null return from
+        // the CompletionService.poll() method
+        Iterator<Future<SourceResponse>> keysIter = futures.keySet().iterator();
+        List<Future<SourceResponse>> futureKeys = Lists
+                .newArrayList(keysIter.next(), keysIter.next(), null);
+        final Iterator<Future<SourceResponse>> futureIter = futureKeys.iterator();
+
+        when(completionService.poll(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenAnswer(new Answer<Future>() {
+                    @Override
+                    public Future answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        return futureIter.next();
+                    }
+                });
+        queryMonitor.run();
+        verify(completionService, times(3)).poll(anyLong(), eq(TimeUnit.MILLISECONDS));
+        verify(completionService, never()).take();
+
+        assertThat(queryResponse.getResults().size()).isEqualTo(3);
+        assertThat(queryResponse.getHits()).isEqualTo(3);
+        assertThat(queryResponse.getProcessingDetails()).extracting(byName("exception"))
+                .extracting(byName("class")).contains(NullPointerException.class,
+                TimeoutException.class, TimeoutException.class);
+    }
+
+    @Test
+    public void interruptThirdFuture() throws Exception {
+        when(query.getTimeoutMillis()).thenReturn(5000L);
+        when(queryRequest.getQuery()).thenReturn(query);
+
+        Iterator<Future<SourceResponse>> iter = futures.keySet().iterator();
+        iter.next(); // Source-0
+        iter.next(); // Source-1
+        Future<SourceResponse> future = iter.next();
+        when(future.get()).thenThrow(new InterruptedException("neener-neener"));
+
+        SortedQueryMonitor queryMonitor = new SortedQueryMonitor(cachingFederationStrategy,
+                completionService, futures, queryResponse, queryRequest);
+
+        final Iterator<Future<SourceResponse>> futureIter = getFutureIterator();
+        when(completionService.poll(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenAnswer(new Answer<Future>() {
+                    @Override
+                    public Future answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        return futureIter.next();
+                    }
+                });
+        queryMonitor.run();
+        verify(completionService, times(3)).poll(anyLong(), eq(TimeUnit.MILLISECONDS));
+        verify(completionService, never()).take();
+
+        assertThat(queryResponse.getResults().size()).isEqualTo(3);
+        assertThat(queryResponse.getProcessingDetails()).extracting(byName("exception"))
+                .extracting(byName("class"))
+                .contains(NullPointerException.class, InterruptedException.class,
+                        InterruptedException.class);
+    }
+
+    public Iterator<Future<SourceResponse>> getFutureIterator() {
+        List<Future<SourceResponse>> futureKeys = new ArrayList<>();
+        futureKeys.addAll(futures.keySet());
+        return futureKeys.iterator();
+    }
+}


### PR DESCRIPTION
The old implementation calculated the timeout for each query at the time each source was checked. If a large number of queries against a large number of sources were queued up, this could lead to source being queried long past the time they should have timed out.

@pklinef 
@tbatie 
@roelens8 Hero this, please
@jckilmer

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/222)
<!-- Reviewable:end -->
