### PR TITLE
DDF-1523 Remove use of ConfigurationWatcher

### DIFF
--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -75,6 +75,11 @@
             <version>0.9.24</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -85,6 +90,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package>
                             ddf.catalog*;version=2.0.12
                         </Export-Package>

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/CatalogFrameworkImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -32,8 +32,7 @@ import java.util.concurrent.Executors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemInfo;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -114,8 +113,7 @@ import ddf.catalog.util.SourcePoller;
  *
  */
 @Deprecated
-public class CatalogFrameworkImpl extends DescribableImpl
-        implements ConfigurationWatcher, CatalogFramework {
+public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFramework {
 
     // TODO make this private
     protected static final String PRE_INGEST_ERROR = "Error during pre-ingest service invocation:\n\n";
@@ -222,6 +220,8 @@ public class CatalogFrameworkImpl extends DescribableImpl
     private Masker masker;
 
     private SourcePoller poller;
+
+    private SystemInfo systemInfo;
 
     /**
      * Instantiates a new CatalogFrameworkImpl
@@ -2109,38 +2109,14 @@ public class CatalogFrameworkImpl extends DescribableImpl
         }
     }
 
-    @Override
-    public void configurationUpdateCallback(Map<String, String> properties) {
-        String methodName = "configurationUpdateCallback";
-        logger.debug("ENTERING: " + methodName);
-
-        if (properties != null && !properties.isEmpty()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(properties.toString());
-            }
-
-            String ddfSiteName = properties.get(ConfigurationManager.SITE_NAME);
-            if (StringUtils.isNotBlank(ddfSiteName)) {
-                logger.debug("ddfSiteName = " + ddfSiteName);
-                this.setId(ddfSiteName);
-            }
-
-            String ddfVersion = properties.get(ConfigurationManager.VERSION);
-            if (StringUtils.isNotBlank(ddfVersion)) {
-                logger.debug("ddfVersion = " + ddfVersion);
-                this.setVersion(ddfVersion);
-            }
-
-            String ddfOrganization = properties.get(ConfigurationManager.ORGANIZATION);
-            if (StringUtils.isNotBlank(ddfOrganization)) {
-                logger.debug("ddfOrganization = " + ddfOrganization);
-                this.setOrganization(ddfOrganization);
-            }
-        } else {
-            logger.debug("properties are NULL or empty");
-        }
-
-        logger.debug("EXITING: " + methodName);
+    public SystemInfo getSystemInfo() {
+        return systemInfo;
     }
 
+    public void setSystemInfo(SystemInfo systemInfo) {
+        this.systemInfo = systemInfo;
+        setId(systemInfo.getSiteName());
+        setVersion(systemInfo.getVersion());
+        setOrganization(systemInfo.getOrganization());
+    }
 }

--- a/catalog/core/catalog-core-api/src/main/resources/META-INF/spring/beans.xml
+++ b/catalog/core/catalog-core-api/src/main/resources/META-INF/spring/beans.xml
@@ -52,14 +52,16 @@ NOTE:
 	
     <list id="ddfManagedServiceList" interface="ddf.catalog.util.DdfConfigurationWatcher"
           cardinality="0..N"/>
+
+    <beans:bean name="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+    <beans:bean name="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 	
 	<beans:bean name="ddfConfigurationManager" class="ddf.catalog.util.DdfConfigurationManager">
 		<beans:constructor-arg ref="ddfManagedServiceList"/>
 		<beans:constructor-arg ref="configurationAdmin"/>
+        <beans:constructor-arg ref="urlHelper"/>
+        <beans:constructor-arg ref="systemInfo"/>
  	</beans:bean>
-  
-    <service ref="ddfConfigurationManager"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 	
 </beans:beans>
 

--- a/catalog/core/catalog-core-metricsplugin/pom.xml
+++ b/catalog/core/catalog-core-metricsplugin/pom.xml
@@ -68,6 +68,11 @@
             <version>0.9.24</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,7 +86,8 @@
                         <Embed-Dependency>
                             metrics-core,
                             metrics-collector,
-                            rrd4j;scope=compile|runtime;artifactId=!slf4j-api
+                            rrd4j;scope=compile|runtime;artifactId=!slf4j-api,
+                            common-system
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Import-Package>

--- a/catalog/core/catalog-core-metricsplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-metricsplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,16 +11,17 @@
  *
  **/
 -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-        >
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
     
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
 	<bean id="catalogMetrics" class="ddf.catalog.metrics.CatalogMetrics">
         <argument ref="filterAdapter"/>
+        <argument ref="systemInfo"/>
     </bean>
 
-    <service ref="catalogMetrics" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
     <service ref="catalogMetrics" interface="ddf.catalog.plugin.PreQueryPlugin"/>
 	<service ref="catalogMetrics" interface="ddf.catalog.plugin.PostQueryPlugin"/>
     <service ref="catalogMetrics" interface="ddf.catalog.plugin.PostIngestPlugin"/>

--- a/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
+++ b/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -21,13 +21,11 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import org.codice.ddf.configuration.ConfigurationManager;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +59,6 @@ import ddf.catalog.source.UnsupportedQueryException;
  *
  * @author Phillip Klinefelter
  * @author ddf.isgs@lmco.com
- *
  */
 public class CatalogMetricsTest {
 
@@ -76,7 +73,8 @@ public class CatalogMetricsTest {
 
     @Before
     public void setup() {
-        underTest = new CatalogMetrics(filterAdapter);
+        underTest = new CatalogMetrics(filterAdapter, new SystemInfo());
+        System.setProperty(SystemInfo.SITE_NAME, "testSite");
     }
 
     @After
@@ -145,17 +143,11 @@ public class CatalogMetricsTest {
         query = new QueryRequestImpl(new QueryImpl(idFilter), Arrays.asList((String) null));
         underTest.process(query);
 
-        setLocalCatalogId("localSourceId");
+        System.setProperty(SystemInfo.SITE_NAME, "localSourceId");
         query = new QueryRequestImpl(new QueryImpl(idFilter), Arrays.asList("localSourceId"));
         underTest.process(query);
 
         assertThat(underTest.federatedQueries.getCount(), is(0L));
-    }
-
-    private void setLocalCatalogId(String catalogId) {
-        Map<String, String> settings = new HashMap<String, String>();
-        settings.put(ConfigurationManager.SITE_NAME, catalogId);
-        underTest.configurationUpdateCallback(settings);
     }
 
     @Test

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -149,6 +149,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -171,6 +176,7 @@
                             commons-cli,
                             commons-fileupload,
                             commons-codec,
+                            common-system,
                             spatial4j,
                             solr-core,
                             solr-solrj,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -30,8 +30,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemInfo;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -122,8 +121,7 @@ import ddf.catalog.util.impl.SourcePoller;
  * @author ddf.isgs@lmco.com
  */
 @SuppressWarnings("deprecation")
-public class CatalogFrameworkImpl extends DescribableImpl
-        implements ConfigurationWatcher, CatalogFramework {
+public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFramework {
 
     protected static final String FAILED_BY_GET_RESOURCE_PLUGIN = "Error during Pre/PostResourcePlugin.";
 
@@ -244,6 +242,8 @@ public class CatalogFrameworkImpl extends DescribableImpl
     private boolean fanoutEnabled = false;
 
     private QueryResponsePostProcessor queryResponsePostProcessor;
+
+    private SystemInfo systemInfo;
 
     /**
      * Instantiates a new CatalogFrameworkImpl
@@ -470,7 +470,7 @@ public class CatalogFrameworkImpl extends DescribableImpl
     /**
      * Invoked by blueprint when a {@link CatalogProvider} is created and bound to this
      * CatalogFramework instance.
-     * <p/>
+     * <p>
      * The local catalog provider will be set to the first item in the {@link List} of
      * {@link CatalogProvider}s bound to this CatalogFramework.
      *
@@ -491,7 +491,7 @@ public class CatalogFrameworkImpl extends DescribableImpl
     /**
      * Invoked by blueprint when a {@link CatalogProvider} is deleted and unbound from this
      * CatalogFramework instance.
-     * <p/>
+     * <p>
      * The local catalog provider will be reset to the new first item in the {@link List} of
      * {@link CatalogProvider}s bound to this CatalogFramework. If this list of catalog providers is
      * currently empty, then the local catalog provider will be set to <code>null</code>.
@@ -632,7 +632,7 @@ public class CatalogFrameworkImpl extends DescribableImpl
      * Retrieves the {@link SourceDescriptor} info for all {@link FederatedSource}s in the fanout
      * configuration, but the all of the source info, e.g., content types, for all of the available
      * {@link FederatedSource}s is packed into one {@SourceDescriptor
-     * <p/>
+     * <p>
      * } for the
      * fanout configuration with the fanout's site name in it. This keeps the individual
      * {@link FederatedSource}s' source info hidden from the external client.
@@ -1651,7 +1651,7 @@ public class CatalogFrameworkImpl extends DescribableImpl
 
     /**
      * Retrieves a resource by URI.
-     * <p/>
+     * <p>
      * The {@link ResourceRequest} can specify either the product's URI or ID. If the product ID is
      * specified, then the matching {@link Metacard} must first be retrieved and the product URI
      * extracted from this {@link Metacard}.
@@ -1796,7 +1796,7 @@ public class CatalogFrameworkImpl extends DescribableImpl
 
     /**
      * Retrieves a resource by URI.
-     * <p/>
+     * <p>
      * The {@link ResourceRequest} can specify either the product's URI or ID. If the product ID is
      * specified, then the matching {@link Metacard} must first be retrieved and the product URI
      * extracted from this {@link Metacard}.
@@ -2565,40 +2565,6 @@ public class CatalogFrameworkImpl extends DescribableImpl
         }
     }
 
-    @Override
-    public void configurationUpdateCallback(Map<String, String> properties) {
-        String methodName = "configurationUpdateCallback";
-        LOGGER.debug("ENTERING: " + methodName);
-
-        if (properties != null && !properties.isEmpty()) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(properties.toString());
-            }
-
-            String ddfSiteName = properties.get(ConfigurationManager.SITE_NAME);
-            if (StringUtils.isNotBlank(ddfSiteName)) {
-                LOGGER.debug("ddfSiteName = " + ddfSiteName);
-                this.setId(ddfSiteName);
-            }
-
-            String ddfVersion = properties.get(ConfigurationManager.VERSION);
-            if (StringUtils.isNotBlank(ddfVersion)) {
-                LOGGER.debug("ddfVersion = " + ddfVersion);
-                this.setVersion(ddfVersion);
-            }
-
-            String ddfOrganization = properties.get(ConfigurationManager.ORGANIZATION);
-            if (StringUtils.isNotBlank(ddfOrganization)) {
-                LOGGER.debug("ddfOrganization = " + ddfOrganization);
-                this.setOrganization(ddfOrganization);
-            }
-        } else {
-            LOGGER.debug("properties are NULL or empty");
-        }
-
-        LOGGER.debug("EXITING: " + methodName);
-    }
-
     protected static class ResourceInfo {
         private Metacard metacard;
 
@@ -2618,4 +2584,14 @@ public class CatalogFrameworkImpl extends DescribableImpl
         }
     }
 
+    public SystemInfo getSystemInfo() {
+        return systemInfo;
+    }
+
+    public void setSystemInfo(SystemInfo systemInfo) {
+        this.systemInfo = systemInfo;
+        setId(systemInfo.getSiteName());
+        setVersion(systemInfo.getVersion());
+        setOrganization(systemInfo.getOrganization());
+    }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -235,6 +235,8 @@
         <argument ref="downloadThreadPool"/>
     </bean>
 
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
     <!-- create the ddf bean -->
     <bean id="ddf" class="ddf.catalog.impl.CatalogFrameworkImpl">
 		<cm:managed-properties persistent-id="ddf.catalog.CatalogFrameworkImpl"
@@ -257,9 +259,8 @@
 		<argument ref="productCache"/>
 		<argument ref="retrieveStatusEventPublisher"/>
 		<argument ref="reliableResourceDownloadManager"/>
-		<property name="id" value="ddf"/>
-		<property name="version" value="DDF v2.0"/>
-		<property name="organization" value="Codice"/>
+		<property name="poolSize" value="0"/>
+		<property name="systemInfo" ref="systemInfo"/>
 		<property name="masker" ref="sourceListener"/>
 		<property name="cacheEnabled" value="true"/>
 		<property name="delayBetweenRetryAttempts" value="10"/>
@@ -281,8 +282,6 @@
     <service ref="ddf" interface="ddf.catalog.CatalogFramework">
 		<registration-listener ref="sourcePoller"
                                registration-method="start" unregistration-method="cancel"/>
-	</service>
-	<service ref="ddf" interface="org.codice.ddf.configuration.ConfigurationWatcher">
 	</service>
 
     <!-- Events -->

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -259,7 +259,6 @@
 		<argument ref="productCache"/>
 		<argument ref="retrieveStatusEventPublisher"/>
 		<argument ref="reliableResourceDownloadManager"/>
-		<property name="poolSize" value="0"/>
 		<property name="systemInfo" ref="systemInfo"/>
 		<property name="masker" ref="sourceListener"/>
 		<property name="cacheEnabled" value="true"/>

--- a/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
@@ -119,6 +119,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Wanted to use this in JUnit tests to be able to get SQL representation
            of an OGC filter, but it caused class loader problems.
            No idea why ...
@@ -136,6 +142,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Spring-Context>*;wait-for-dependencies:=true;timeout:=604800</Spring-Context>
+              <Embed-Dependency>common-system</Embed-Dependency>
             <Import-Package>
               META-INF.cxf,
               org.joda.time;version="[1.6.0,3.0.0)",

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,12 +36,12 @@
         </jaxrs:outInterceptors>
     </jaxrs:server>
 
-    <service id="OsOsgiSvc" ref="OsSvc"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
     <bean id="OsSvc" class="org.codice.ddf.endpoints.OpenSearchEndpoint">
         <argument ref="ddf"/>
         <argument ref="filterBuilder"/>
+        <argument ref="systemInfo"/>
     </bean>
 
 </blueprint>

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/endpoints/OpenSearchEndpointTest.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/endpoints/OpenSearchEndpointTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -25,12 +25,11 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
+import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.opensearch.query.OpenSearchQuery;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,7 +57,7 @@ public class OpenSearchEndpointTest {
      * Test method for
      * {@link org.codice.ddf.endpoints.OpenSearchEndpoint#processQuery(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, javax.ws.rs.core.UriInfo, java.lang.String, java.lang.String)}
      * .
-     *
+     * <p>
      * This test will verify that the string "local" in the sources passed to
      * OpenSearchEndpoint.processQuery is replaced with the local site name (in this case the mocked
      * name "TestSiteName"). The QueryRequest object is checked when the framework.query is called
@@ -137,13 +136,10 @@ public class OpenSearchEndpointTest {
         when(mockFramework.transform(any(QueryResponse.class), anyString(), anyMap()))
                 .thenReturn(mockBinaryContent);
 
-        OpenSearchEndpoint osEndPoint = new OpenSearchEndpoint(mockFramework, mockFilterBuilder);
+        OpenSearchEndpoint osEndPoint = new OpenSearchEndpoint(mockFramework, mockFilterBuilder,
+                new SystemInfo());
 
-        // Call ddfConfigurationUpdated to set the id values to the site name we want
-        // local to be replaced with
-        Map<String, String> ddfProperties = new HashMap<String, String>();
-        ddfProperties.put("id", testSiteName);
-        osEndPoint.configurationUpdateCallback(ddfProperties);
+        System.setProperty(SystemInfo.SITE_NAME, testSiteName);
 
         // ***Test Execution***
         osEndPoint

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -116,7 +121,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>json-smart,catalog-core-api-impl,guava</Embed-Dependency>
+                        <Embed-Dependency>json-smart,catalog-core-api-impl,common-system,guava</Embed-Dependency>
                         <Import-Package>
                             org.joda.time;version="[1.6.0,3.0.0)",
                             *

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,12 +15,11 @@ package org.codice.ddf.endpoints.rest.action;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Map;
 
 import org.apache.commons.lang.CharEncoding;
 import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +27,7 @@ import ddf.action.Action;
 import ddf.action.ActionProvider;
 import ddf.catalog.data.Metacard;
 
-public abstract class AbstractMetacardActionProvider
-        implements ActionProvider, ConfigurationWatcher {
+public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     static final String UNKNOWN_TARGET = "0.0.0.0";
 
@@ -38,52 +36,18 @@ public abstract class AbstractMetacardActionProvider
     private static final Logger LOGGER = LoggerFactory
             .getLogger(AbstractMetacardActionProvider.class);
 
-    protected String protocol;
-
-    protected String host;
-
-    protected String port;
-
-    protected String contextRoot;
-
     protected String actionProviderId;
 
-    protected String currentSourceName;
+    protected SystemBaseUrl systemBaseUrl;
+
+    protected SystemInfo systemInfo;
+
+    protected AbstractMetacardActionProvider(SystemBaseUrl sbu, SystemInfo info) {
+        this.systemBaseUrl = sbu;
+        this.systemInfo = info;
+    }
 
     protected abstract Action getAction(String metacardId, String metacardSource);
-
-    @Override
-    public void configurationUpdateCallback(Map<String, String> configuration) {
-
-        if (configuration != null) {
-            String protocolMapValue = configuration.get(ConfigurationManager.PROTOCOL);
-            String hostMapValue = configuration.get(ConfigurationManager.HOST);
-            String portMapValue = configuration.get(ConfigurationManager.PORT);
-            String serviceContextMapValue = configuration
-                    .get(ConfigurationManager.SERVICES_CONTEXT_ROOT);
-            String sourceNameValue = configuration.get(ConfigurationManager.SITE_NAME);
-
-            if (StringUtils.isNotBlank(configuration.get(ConfigurationManager.PROTOCOL))) {
-                this.host = hostMapValue;
-            }
-
-            if (StringUtils.isNotBlank(portMapValue)) {
-                this.port = portMapValue;
-            }
-
-            if (StringUtils.isNotBlank(serviceContextMapValue)) {
-                this.contextRoot = serviceContextMapValue;
-            }
-
-            if (StringUtils.isNotBlank(protocolMapValue)) {
-                this.protocol = protocolMapValue;
-            }
-
-            if (StringUtils.isNotBlank(sourceNameValue)) {
-                this.currentSourceName = sourceNameValue;
-            }
-        }
-    }
 
     @Override
     public <T> Action getAction(T input) {
@@ -103,7 +67,7 @@ public abstract class AbstractMetacardActionProvider
                 return null;
             }
 
-            if (isHostUnset(this.host)) {
+            if (systemBaseUrl == null || isHostUnset(systemBaseUrl.getHost())) {
                 LOGGER.info("Host name/ip not set. Cannot create link for metacard.");
                 return null;
             }
@@ -137,7 +101,7 @@ public abstract class AbstractMetacardActionProvider
             return metacard.getSourceId();
         }
 
-        return this.currentSourceName;
+        return systemInfo.getSiteName();
     }
 
     @Override

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -18,6 +18,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +46,11 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
      * @param actionProviderId
      * @param metacardTransformerId
      */
-    public MetacardTransformerActionProvider(String actionProviderId,
-            String metacardTransformerId) {
-
+    public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId,
+            SystemBaseUrl sbu, SystemInfo info) {
+        super(sbu, info);
         this.actionProviderId = actionProviderId;
         this.metacardTransformerId = metacardTransformerId;
-
     }
 
     @Override
@@ -58,9 +59,9 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
         URL url = null;
         try {
 
-            URI uri = new URI(
-                    protocol + host + ':' + port + contextRoot + PATH + "/" + metacardSource + "/"
-                            + metacardId + "?transform=" + metacardTransformerId);
+            URI uri = new URI(systemBaseUrl.constructUrl(
+                    systemBaseUrl.getRootContext() + PATH + "/" + metacardSource + "/" + metacardId
+                            + "?transform=" + metacardTransformerId));
             url = uri.toURL();
 
         } catch (MalformedURLException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
@@ -60,8 +60,8 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
         try {
 
             URI uri = new URI(systemBaseUrl.constructUrl(
-                    systemBaseUrl.getRootContext() + PATH + "/" + metacardSource + "/" + metacardId
-                            + "?transform=" + metacardTransformerId));
+                    PATH + "/" + metacardSource + "/" + metacardId + "?transform="
+                            + metacardTransformerId, true));
             url = uri.toURL();
 
         } catch (MalformedURLException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.endpoints.rest.action;
+
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
+
+public class MetacardTransformerActionProviderFactory {
+
+    private SystemBaseUrl systemBaseUrl;
+
+    private SystemInfo systemInfo;
+
+    public MetacardTransformerActionProviderFactory(SystemBaseUrl sbu, SystemInfo info) {
+        this.systemBaseUrl = sbu;
+        this.systemInfo = info;
+    }
+
+    public MetacardTransformerActionProvider createActionProvider(String id, String transformer) {
+        return new MetacardTransformerActionProvider(id, transformer, systemBaseUrl, systemInfo);
+    }
+
+    public SystemInfo getSystemInfo() {
+        return systemInfo;
+    }
+
+    public SystemBaseUrl getSystemBaseUrl() {
+        return systemBaseUrl;
+    }
+}

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
@@ -45,9 +45,8 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
         URL url = null;
         try {
 
-            URI uri = new URI(systemBaseUrl.constructUrl(
-                    systemBaseUrl.getRootContext() + PATH + "/" + metacardSource + "/"
-                            + metacardId));
+            URI uri = new URI(systemBaseUrl
+                    .constructUrl(PATH + "/" + metacardSource + "/" + metacardId, true));
             url = uri.toURL();
 
         } catch (MalformedURLException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -18,6 +18,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +34,8 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewMetacardActionProvider.class);
 
-    public ViewMetacardActionProvider(String id) {
+    public ViewMetacardActionProvider(String id, SystemBaseUrl sbu, SystemInfo info) {
+        super(sbu, info);
         this.actionProviderId = id;
     }
 
@@ -42,9 +45,9 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
         URL url = null;
         try {
 
-            URI uri = new URI(
-                    protocol + host + ':' + port + contextRoot + PATH + "/" + metacardSource + "/"
-                            + metacardId);
+            URI uri = new URI(systemBaseUrl.constructUrl(
+                    systemBaseUrl.getRootContext() + PATH + "/" + metacardSource + "/"
+                            + metacardId));
             url = uri.toURL();
 
         } catch (MalformedURLException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,20 +14,27 @@
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-
-  http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
+		http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
 
 	<reference id="transformerMapper" interface="ddf.mime.MimeTypeToTransformerMapper"/>
 	<reference id="catalog" interface="ddf.catalog.CatalogFramework"/>
 	<reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver"/>
-    
+
+	<bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"></bean>
+	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"></bean>
+
+	<bean id="actionFactory" class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory">
+		<argument ref="urlHelper"/>
+		<argument ref="systemInfo"/>
+	</bean>
 
 	<reference-list id="metacardTransformerRefList"
                     interface="ddf.catalog.transform.MetacardTransformer" availability="optional">
 		<reference-listener bind-method="bind" unbind-method="unbind">
 			<bean class="org.codice.ddf.endpoints.rest.action.ActionProviderRegistryProxy">
 				<argument ref="blueprintBundleContext"/>
+				<argument ref="actionFactory"/>
 			</bean>
 		</reference-listener>
 	</reference-list>
@@ -58,6 +65,8 @@
 	<bean id="viewActionProvider"
           class="org.codice.ddf.endpoints.rest.action.ViewMetacardActionProvider">
 		<argument value="catalog.data.metacard.view"/>
+		<argument ref="urlHelper"/>
+		<argument ref="systemInfo"/>
 	</bean>
 
 	<service ref="viewActionProvider" interface="ddf.action.ActionProvider">
@@ -65,8 +74,5 @@
 			<entry key="id" value="catalog.data.metacard.view"/>
 		</service-properties>
 	</service>
-
-	<service ref="viewActionProvider"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/AbstractActionProviderTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/AbstractActionProviderTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -12,11 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package org.codice.ddf.endpoints.rest.action;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.codice.ddf.configuration.ConfigurationManager;
 
 public class AbstractActionProviderTest {
 
@@ -40,47 +35,33 @@ public class AbstractActionProviderTest {
 
     protected static final String ACTION_PROVIDER_ID = "catalog.view.metacard";
 
-    protected AbstractMetacardActionProvider configureActionProvider(
-            AbstractMetacardActionProvider actionProvider) {
-
-        actionProvider.configurationUpdateCallback(getDefaultSettings());
-
-        return actionProvider;
-    }
-
-    protected AbstractMetacardActionProvider configureSecureActionProvider() {
-        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
-
-        actionProvider.configurationUpdateCallback(getDefaultSecureSettings());
-
-        return actionProvider;
-    }
-
-    protected Map<String, String> getDefaultSettings() {
-
-        return createMap(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+    protected void configureActionProvider() {
+        configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
     }
 
-    private Map<String, String> getDefaultSecureSettings() {
+    protected void configureSecureActionProvider() {
 
-        return createMap(SAMPLE_SECURE_PROTOCOL, SAMPLE_IP, SAMPLE_SECURE_PORT,
+        configureActionProvider(SAMPLE_SECURE_PROTOCOL, SAMPLE_IP, SAMPLE_SECURE_PORT,
                 SAMPLE_SERVICES_ROOT, SAMPLE_SOURCE_NAME);
     }
 
-    protected Map<String, String> createMap(String protocol, String ip, String port,
-            String contextRoot, String sourceName) {
+    protected void configureActionProvider(String protocol, String host, String port,
+            String contextRoot, String siteName) {
 
-        Map<String, String> settings = new HashMap<String, String>();
-
-        settings.put(ConfigurationManager.PROTOCOL, protocol);
-        settings.put(ConfigurationManager.HOST, ip);
-        settings.put(ConfigurationManager.PORT, port);
-        settings.put(ConfigurationManager.SERVICES_CONTEXT_ROOT, contextRoot);
-        settings.put(ConfigurationManager.SITE_NAME, sourceName);
-
-        return settings;
+        setProperty("org.codice.ddf.system.hostname", host);
+        setProperty("org.codice.ddf.system.httpPort", port);
+        setProperty("org.codice.ddf.system.httpsPort", port);
+        setProperty("org.codice.ddf.system.protocol", protocol);
+        setProperty("org.codice.ddf.system.rootContext", contextRoot);
+        setProperty("org.codice.ddf.system.siteName", siteName);
     }
 
+    private void setProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -23,6 +21,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Dictionary;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -44,7 +44,7 @@ public class TestActionProviderRegistryProxy {
 
         BundleContext bundleContext = givenBundleContext(answer);
 
-        ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext);
+        ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext, null);
 
         ServiceReference reference = mock(ServiceReference.class);
 
@@ -65,7 +65,10 @@ public class TestActionProviderRegistryProxy {
 
         BundleContext bundleContext = givenBundleContext(answer);
 
-        ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext);
+        MetacardTransformerActionProviderFactory mtapf = new MetacardTransformerActionProviderFactory(
+                new SystemBaseUrl(), new SystemInfo());
+
+        ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext, mtapf);
 
         ServiceReference reference = mock(ServiceReference.class);
 
@@ -76,30 +79,21 @@ public class TestActionProviderRegistryProxy {
         proxy.unbind(reference);
 
         // then
-        verify(bundleContext, times(2))
+        verify(bundleContext, times(1))
                 .registerService(isA(String.class), isA(Object.class), isA(Dictionary.class));
 
-        Dictionary actionProperties = (Dictionary) (answer.getArguments()[2]);
-        LOGGER.info("actionproperties:" + actionProperties);
-
-        String actionProviderId = actionProperties.get(ddf.catalog.Constants.SERVICE_ID).toString();
-
-        assertThat(actionProviderId,
-                is(ActionProviderRegistryProxy.ACTION_ID_PREFIX + SAMPLE_TRANSFORMER_ID));
-
         ServiceRegistration mockRegistration1 = answer.getIssuedServiceRegistrations().get(0);
-        ServiceRegistration mockRegistration2 = answer.getIssuedServiceRegistrations().get(1);
 
         verify(mockRegistration1, times(1)).unregister();
-        verify(mockRegistration2, times(1)).unregister();
 
     }
 
     private BundleContext givenBundleContext(ServiceRegistrationAnswer answer) {
         BundleContext bundleContext = mock(BundleContext.class);
 
-        when(bundleContext.registerService(isA(String.class), isA(Object.class),
-                        isA(Dictionary.class))).then(answer);
+        when(bundleContext
+                .registerService(isA(String.class), isA(Object.class), isA(Dictionary.class)))
+                .then(answer);
 
         return bundleContext;
     }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,11 +46,10 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap("badProtocol", SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider("badProtocol", SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
         assertNull("A bad url should have been caught and a null action returned.",
                 actionProvider.getAction(metacard));
@@ -62,11 +63,10 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
         assertNull("A bad url should have been caught and a null action returned.",
                 actionProvider.getAction(metacard));
@@ -81,8 +81,9 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         String noSource = null;
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new MetacardTransformerActionProvider(ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID));
+        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         Action action = actionProvider.getAction(metacard);
@@ -105,7 +106,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
     @Test
     public void testToString() {
         String toString = new MetacardTransformerActionProvider(ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID).toString();
+                SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo()).toString();
 
         LOGGER.info(toString);
 
@@ -136,8 +137,9 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
 
         metacard.setSourceId(newSourceName);
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new MetacardTransformerActionProvider(ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID));
+        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         Action action = actionProvider.getAction(metacard);

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,13 +13,17 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.Date;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 
 import ddf.action.Action;
@@ -29,7 +33,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
     @Test
     public void testMetacardNull() {
-        assertEquals(null, new ViewMetacardActionProvider(ACTION_PROVIDER_ID).getAction(null));
+        assertEquals(null,
+                new ViewMetacardActionProvider(ACTION_PROVIDER_ID, null, null).getAction(null));
     }
 
     @Test
@@ -40,11 +45,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
-
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
         assertNull("A bad url should have been caught and a null action returned.",
                 actionProvider.getAction(metacard));
@@ -59,8 +62,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId("abd ef");
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         String url = actionProvider.getAction(metacard).getUrl().toString();
@@ -78,8 +82,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId("abd&ef");
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         String url = actionProvider.getAction(metacard).getUrl().toString();
@@ -96,8 +101,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId(null);
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         assertNull("An action should not have been created when no id is provided.",
                 actionProvider.getAction(metacard));
@@ -112,7 +118,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, null, null);
 
         assertNull(actionProvider.getAction(metacard));
 
@@ -126,14 +132,13 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, null, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(SAMPLE_PROTOCOL, null, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
-        assertNull("An action should not have been created when ip is null.",
-                actionProvider.getAction(metacard));
+        assertThat(actionProvider.getAction(metacard).getUrl().toString(),
+                containsString("localhost"));
 
     }
 
@@ -145,15 +150,13 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, "0.0.0.0", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(SAMPLE_PROTOCOL, "0.0.0.0", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
         assertNull("An action should not have been created when ip is unknown (0.0.0.0).",
                 actionProvider.getAction(metacard));
-
     }
 
     @Test
@@ -164,15 +167,12 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, SAMPLE_IP, null, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, null, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
-        assertNull("An action should not have been created when port is null.",
-                actionProvider.getAction(metacard));
-
+        assertThat(actionProvider.getAction(metacard).getUrl().toString(), containsString("8181"));
     }
 
     @Test
@@ -183,21 +183,21 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, null, SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, null,
+                SAMPLE_SOURCE_NAME);
 
-        assertNull("An action should not have been created when context root is null.",
-                actionProvider.getAction(metacard));
-
+        assertThat(actionProvider.getAction(metacard).getUrl().toString(),
+                not(containsString("/services")));
     }
 
     @Test
     public void testNonMetacard() {
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         assertNull("An action when metacard was not provided.",
                 actionProvider.getAction(new Date()));
@@ -212,8 +212,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId(SAMPLE_ID);
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         Action action = actionProvider.getAction(metacard);
@@ -237,8 +238,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         String newSourceName = "newSource";
         metacard.setSourceId(newSourceName);
 
-        AbstractMetacardActionProvider actionProvider = configureActionProvider(
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID));
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureActionProvider();
 
         // when
         Action action = actionProvider.getAction(metacard);
@@ -258,8 +260,9 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         MetacardImpl metacard = new MetacardImpl();
 
         metacard.setId(SAMPLE_ID);
-
-        AbstractMetacardActionProvider actionProvider = configureSecureActionProvider();
+        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+        this.configureSecureActionProvider();
 
         Action action = actionProvider.getAction(metacard);
 
@@ -281,15 +284,16 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID);
+                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
 
-        actionProvider.configurationUpdateCallback(
-                createMap(null, SAMPLE_IP, SAMPLE_SECURE_PORT, SAMPLE_SERVICES_ROOT,
-                        SAMPLE_SOURCE_NAME));
+        this.configureActionProvider(null, SAMPLE_IP, SAMPLE_SECURE_PORT, SAMPLE_SERVICES_ROOT,
+                SAMPLE_SOURCE_NAME);
 
         Action action = actionProvider.getAction(metacard);
 
-        assertNull(action);
+        //when null protocal should default to https
+        assertThat(action.getUrl().toString(), containsString("https"));
+
     }
 
     private String expectedDefaultAddressWith(String id, String sourceName) {

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.0</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,7 +86,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>JavaAPIforKml, catalog-core-api-impl, handlebars,
-                            antlr4-runtime, commons-lang3
+                            antlr4-runtime, commons-lang3, common-system
                         </Embed-Dependency>
                         <Import-Package>!org.abego.treelayout.*, org.apache.felix.webconsole; version="[3.1.0,4.0.0)", *</Import-Package>
                     </instructions>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,15 +35,18 @@
         	</bean>
         </jaxrs:providers>
     </jaxrs:server>
-	
+
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
 	<bean id="kmlEndpoint" class="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint">
 		<argument ref="branding"/>
 		<argument ref="framework"/>
+        <argument ref="urlHelper"/>
+        <argument ref="systemInfo"/>
 		<cm:managed-properties persistent-id="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint"
                                update-strategy="container-managed"/>
 	</bean>
-	
-	<service id="kmlWatcher" ref="kmlEndpoint"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
+
 	
 </blueprint>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.kml.endpoint;
 
@@ -28,9 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.WebApplicationException;
@@ -41,7 +38,8 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.felix.webconsole.BrandingPlugin;
-import org.codice.ddf.configuration.ConfigurationManager;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -94,8 +92,6 @@ public class TestKmlEndpoint {
 
     private static String jetPath;
 
-    private static Map<String, String> config = new HashMap<String, String>();
-
     @BeforeClass
     public static void setUp() throws IOException, URISyntaxException, SourceUnavailableException {
         when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://example.com"));
@@ -108,11 +104,11 @@ public class TestKmlEndpoint {
         jetPath = jetLocation.getPath().replaceAll(JET_ICON, "");
         jetBtyes = IOUtils.toByteArray(jetLocation.openStream());
 
-        config = new HashMap<String, String>();
-        config.put(ConfigurationManager.HOST, TEST_HOST);
-        config.put(ConfigurationManager.PORT, TEST_PORT);
-        config.put(ConfigurationManager.SERVICES_CONTEXT_ROOT, "/services");
-        config.put(ConfigurationManager.CONTACT, "example@example.com");
+        System.setProperty(SystemBaseUrl.HOST, TEST_HOST);
+        System.setProperty(SystemBaseUrl.HTTPS_PORT, TEST_PORT);
+        System.setProperty(SystemBaseUrl.HTTP_PORT, TEST_PORT);
+        System.setProperty(SystemBaseUrl.ROOT_CONTEXT, "/services");
+        System.setProperty(SystemInfo.SITE_CONTACT, "example@example.com");
 
         when(mockFramework.getSourceInfo(any(SourceInfoRequest.class)))
                 .thenReturn(mockSourceInfoResponse);
@@ -127,8 +123,8 @@ public class TestKmlEndpoint {
     @Test
     public void testGetKmlNetworkLink() {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
-        kmlEndpoint.configurationUpdateCallback(config);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         kmlEndpoint.setDescription("This is some description.");
         kmlEndpoint.setLogo(
                 "https://tools.codice.org/wiki/download/attachments/3047457/DDF?version=1&modificationDate=1369422662164&api=v2");
@@ -149,11 +145,12 @@ public class TestKmlEndpoint {
     }
 
     @Test
-    public void testGetAvailableSources() throws UnknownHostException, MalformedURLException,
-            IllegalArgumentException, UriBuilderException, SourceUnavailableException {
+    public void testGetAvailableSources()
+            throws UnknownHostException, MalformedURLException, IllegalArgumentException,
+            UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
-        kmlEndpoint.configurationUpdateCallback(config);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
@@ -169,12 +166,12 @@ public class TestKmlEndpoint {
     }
 
     @Test
-    public void testGetAvailableSourcesVisibleByDefault() throws UnknownHostException,
-            MalformedURLException, IllegalArgumentException, UriBuilderException,
-            SourceUnavailableException {
+    public void testGetAvailableSourcesVisibleByDefault()
+            throws UnknownHostException, MalformedURLException, IllegalArgumentException,
+            UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
-        kmlEndpoint.configurationUpdateCallback(config);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
@@ -192,12 +189,12 @@ public class TestKmlEndpoint {
     }
 
     @Test
-    public void testGetAvailableSourcesWithCount() throws UnknownHostException,
-            MalformedURLException, IllegalArgumentException, UriBuilderException,
-            SourceUnavailableException {
+    public void testGetAvailableSourcesWithCount()
+            throws UnknownHostException, MalformedURLException, IllegalArgumentException,
+            UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
-        kmlEndpoint.configurationUpdateCallback(config);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         kmlEndpoint.setMaxResults(250);
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
@@ -220,7 +217,8 @@ public class TestKmlEndpoint {
      */
     @Test
     public void testGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         byte[] response = kmlEndpoint.getIcon(null, BOMBER_ICON);
         assertThat(response, is(bomberBytes));
     }
@@ -230,13 +228,15 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         kmlEndpoint.getIcon(null, JET_ICON);
     }
 
     @Test
     public void testGetIconCustomLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         kmlEndpoint.setIconLoc(jetPath);
         byte[] response = kmlEndpoint.getIcon(null, JET_ICON);
         assertThat(response, is(jetBtyes));
@@ -247,7 +247,8 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetCustomIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
+                new SystemInfo());
         kmlEndpoint.setIconLoc(bomberPath);
         kmlEndpoint.getIcon(null, JET_ICON);
     }

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KMLTransformer.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KMLTransformer.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.kml.transformer;
 
@@ -19,16 +18,13 @@ import java.util.Map;
 
 import javax.security.auth.Subject;
 
-import org.codice.ddf.configuration.ConfigurationWatcher;
-
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import ddf.catalog.transform.QueryResponseTransformer;
 import de.micromata.opengis.kml.v_2_2_0.Placemark;
 
-public interface KMLTransformer
-        extends QueryResponseTransformer, MetacardTransformer, ConfigurationWatcher {
+public interface KMLTransformer extends QueryResponseTransformer, MetacardTransformer {
     public Placemark transformEntry(Subject user, Metacard entry,
             Map<String, Serializable> arguments) throws CatalogTransformerException;
 }

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KMLTransformerImpl.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KMLTransformerImpl.java
@@ -120,8 +120,6 @@ public class KMLTransformerImpl implements KMLTransformer {
 
     private ClassPathTemplateLoader templateLoader;
 
-    private Map<String, String> platformConfiguration;
-
     private KmlStyleMap styleMapper;
 
     private DescriptionTemplateHelper templateHelper;
@@ -382,11 +380,6 @@ public class KMLTransformerImpl implements KMLTransformer {
         } else {
             return null;
         }
-    }
-
-    @Override
-    public void configurationUpdateCallback(Map<String, String> configuration) {
-        platformConfiguration = configuration;
     }
 
     @Override

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,6 +56,4 @@
 		</service-properties>
 	</service>
 
-	<service ref="kmlTransformerImpl"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 </blueprint>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/pom.xml
@@ -94,6 +94,12 @@
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -119,7 +125,8 @@
                             spatial-wfs-v1_0_0-common;scope=compile|runtime,
                             spatial-wfs-converter;scope=compile|runtime,
                             spatial-wfs-v1_0_0-converter;scope=compile|runtime,
-                            catalog-core-api-impl;scope=compile|runtime
+                            catalog-core-api-impl;scope=compile|runtime,
+                            common-system
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/FeatureCollectionMessageBodyWriter.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/FeatureCollectionMessageBodyWriter.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 
 package org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer;
@@ -19,7 +18,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Map;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -28,8 +26,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsFeatureCollection;
 import org.codice.ddf.spatial.ogc.wfs.catalog.converter.impl.EnhancedStaxDriver;
 import org.codice.ddf.spatial.ogc.wfs.catalog.converter.impl.GenericFeatureConverter;
@@ -42,18 +39,18 @@ import com.thoughtworks.xstream.io.naming.NoNameCoder;
 
 @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
 @Provider
-public class FeatureCollectionMessageBodyWriter
-        implements MessageBodyWriter<WfsFeatureCollection>, ConfigurationWatcher {
+public class FeatureCollectionMessageBodyWriter implements MessageBodyWriter<WfsFeatureCollection> {
 
     private XStream xstream;
 
     private FeatureCollectionConverterWfs10 featureCollectionConverter;
 
-    public FeatureCollectionMessageBodyWriter() {
+    public FeatureCollectionMessageBodyWriter(SystemBaseUrl sbu) {
         xstream = new XStream(new EnhancedStaxDriver(new NoNameCoder()));
         xstream.setClassLoader(xstream.getClass().getClassLoader());
 
         featureCollectionConverter = new FeatureCollectionConverterWfs10();
+        featureCollectionConverter.setContextRoot(sbu.getRootContext());
         xstream.registerConverter(featureCollectionConverter);
         xstream.registerConverter(new GenericFeatureConverter());
 
@@ -81,21 +78,6 @@ public class FeatureCollectionMessageBodyWriter
             Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> headers,
             OutputStream outStream) throws IOException, WebApplicationException {
         xstream.toXML(featureCollection, outStream);
-    }
-
-    @Override
-    public void configurationUpdateCallback(Map configuration) {
-        String contextRoot = null;
-        if (configuration != null) {
-            Object serviceContextMapValue = configuration
-                    .get(ConfigurationManager.SERVICES_CONTEXT_ROOT);
-
-            if (serviceContextMapValue != null) {
-                contextRoot = serviceContextMapValue.toString();
-            }
-
-            this.featureCollectionConverter.setContextRoot(contextRoot);
-        }
     }
 
 }

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,13 +33,16 @@
         <argument ref="ddf"/>
     </bean>
 
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+
     <bean id="WfsResourceComparator"
           class="org.codice.ddf.spatial.ogc.catalog.common.EndpointOperationInfoResourceComparator"/>
     <bean id="XmlSchemaWriter"
           class="org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer.XmlSchemaMessageBodyWriter"/>
     <bean id="FeatureCollectionWriter"
-          class="org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer.FeatureCollectionMessageBodyWriter"/>
-    <service ref="FeatureCollectionWriter" interface="ddf.catalog.util.DdfConfigurationWatcher"/>
+          class="org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer.FeatureCollectionMessageBodyWriter">
+        <argument ref="urlHelper"/>
+    </bean>
 
 
     <bean id="jaxbProvider" class="org.apache.cxf.jaxrs.provider.JAXBElementProvider">

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/TestFeatureCollectionMessageBodyWriter.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/TestFeatureCollectionMessageBodyWriter.java
@@ -38,6 +38,7 @@ import javax.xml.validation.SchemaFactory;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.xerces.dom.DOMInputImpl;
+import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsFeatureCollection;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
@@ -96,7 +97,7 @@ public class TestFeatureCollectionMessageBodyWriter {
     public void testWriteToGeneratesGMLConformantXml() throws IOException, WebApplicationException,
             SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getWfsFeatureCollection(), null, null, null, null, null, stream);
         String actual = stream.toString();
@@ -164,7 +165,7 @@ public class TestFeatureCollectionMessageBodyWriter {
     public void testWriteToGeneratesExpectedNonBasicMetacard() throws IOException,
             WebApplicationException, SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getWfsFeatureCollection(), null, null, null, null, null, stream);
 
@@ -180,7 +181,7 @@ public class TestFeatureCollectionMessageBodyWriter {
     public void testWriteToGeneratesExpectedBasicMetacard() throws IOException,
             WebApplicationException, SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getBasicWfsFeatureCollection(), null, null, null, null, null, stream);
 

--- a/catalog/transformer/catalog-transformer-service-atom/pom.xml
+++ b/catalog/transformer/catalog-transformer-service-atom/pom.xml
@@ -87,6 +87,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -98,6 +104,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.transformer.response.query.atom,
                             ddf.catalog.data.impl

--- a/catalog/transformer/catalog-transformer-service-atom/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-service-atom/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,11 +29,14 @@
 	<reference id="thumbnailActionProvider" interface="ddf.action.ActionProvider"
                filter="(id=catalog.data.metacard.thumbnail)" availability="optional"/>
 
+	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
 	<bean id="transformer" class="ddf.catalog.transformer.response.query.atom.AtomTransformer">
 		<property name="metacardTransformer" ref="metacardTransformer"/>
 		<property name="viewMetacardActionProvider" ref="viewMetacardActionProvider"/>
 		<property name="resourceActionProvider" ref="resourceActionProvider"/>
 		<property name="thumbnailActionProvider" ref="thumbnailActionProvider"/>
+		<argument ref="systemInfo"/>
 	</bean>
 
 	<service ref="transformer" interface="ddf.catalog.transform.QueryResponseTransformer">
@@ -43,7 +46,5 @@
 			<entry key="mime-type" value="application/atom+xml"/>
 		</service-properties>
 	</service>
-	
-	<service ref="transformer" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -49,7 +49,7 @@ import javax.xml.validation.Validator;
 
 import org.apache.abdera.model.Link;
 import org.apache.commons.io.IOUtils;
-import org.codice.ddf.configuration.ConfigurationManager;
+import org.codice.ddf.configuration.SystemInfo;
 import org.custommonkey.xmlunit.NamespaceContext;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -170,7 +170,7 @@ public class TestAtomTransformer {
     @Test(expected = CatalogTransformerException.class)
     public void testNullInput() throws CatalogTransformerException {
 
-        new AtomTransformer().transform(null, null);
+        new AtomTransformer(new SystemInfo()).transform(null, null);
     }
 
     /**
@@ -187,7 +187,7 @@ public class TestAtomTransformer {
         // given
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, null);
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, false);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -220,8 +220,7 @@ public class TestAtomTransformer {
         // given
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response1 = mock(SourceResponse.class);
 
@@ -268,8 +267,7 @@ public class TestAtomTransformer {
     public void testNoMetacardTransformer()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = getConfiguredAtomTransformer(null,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(null, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -300,8 +298,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenThrow(CatalogTransformerException.class);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -336,8 +333,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenThrow(RuntimeException.class);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -370,8 +366,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenReturn(metacardTransformation);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -404,8 +399,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenReturn(metacardTransformation);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -438,8 +432,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenReturn(metacardTransformation);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -469,8 +462,7 @@ public class TestAtomTransformer {
         when(metacardTransformer.transform(isA(Metacard.class), isNull(Map.class)))
                 .thenReturn(null);
 
-        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer,
-                getDefaultSystemConfiguration());
+        AtomTransformer transformer = getConfiguredAtomTransformer(metacardTransformer, true);
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -496,10 +488,10 @@ public class TestAtomTransformer {
     public void testTotalResultsNegative()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -543,10 +535,10 @@ public class TestAtomTransformer {
     public void testItemsPerPageNegativeInteger()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -590,10 +582,10 @@ public class TestAtomTransformer {
     public void testNoCreatedDate()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -634,10 +626,10 @@ public class TestAtomTransformer {
     public void testNoModifiedDate()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -738,12 +730,11 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer();
-
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -793,12 +784,11 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer();
-
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -894,12 +884,11 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer();
-
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -948,13 +937,13 @@ public class TestAtomTransformer {
         ActionProvider viewActionProvider = mock(ActionProvider.class);
         when(viewActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
 
         transformer.setViewMetacardActionProvider(viewActionProvider);
 
         transformer.setMetacardTransformer(metacardTransformer);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response1 = mock(SourceResponse.class);
 
@@ -1047,7 +1036,7 @@ public class TestAtomTransformer {
         ActionProvider thumbnailActionProvider = mock(ActionProvider.class);
         when(thumbnailActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
-        AtomTransformer transformer = new AtomTransformer();
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
 
         transformer.setViewMetacardActionProvider(viewActionProvider);
 
@@ -1057,7 +1046,7 @@ public class TestAtomTransformer {
 
         transformer.setThumbnailActionProvider(thumbnailActionProvider);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response1 = mock(SourceResponse.class);
 
@@ -1143,11 +1132,11 @@ public class TestAtomTransformer {
     public void testGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer();
+        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
-        atomTransformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID,
                 "POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))");
@@ -1175,11 +1164,11 @@ public class TestAtomTransformer {
     public void testNoGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer();
+        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
-        atomTransformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
@@ -1199,11 +1188,11 @@ public class TestAtomTransformer {
     public void testBadGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer();
+        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
-        atomTransformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = getSourceResponseStub(SAMPLE_ID, BAD_WKT);
 
@@ -1237,10 +1226,12 @@ public class TestAtomTransformer {
     }
 
     protected AtomTransformer getConfiguredAtomTransformer(MetacardTransformer metacardTransformer,
-            Map systemConfiguration) {
-        AtomTransformer transformer = new AtomTransformer();
+            boolean setProperties) {
+        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
         transformer.setMetacardTransformer(metacardTransformer);
-        transformer.configurationUpdateCallback(systemConfiguration);
+        if (setProperties) {
+            setDefaultSystemConfiguration();
+        }
         return transformer;
     }
 
@@ -1274,7 +1265,7 @@ public class TestAtomTransformer {
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
-        transformer.configurationUpdateCallback(getDefaultSystemConfiguration());
+        setDefaultSystemConfiguration();
 
         SourceResponse response = mock(SourceResponse.class);
 
@@ -1423,12 +1414,10 @@ public class TestAtomTransformer {
         return metacardTransformer;
     }
 
-    protected Map<String, String> getDefaultSystemConfiguration() {
-        Map<String, String> configuration = new HashMap<String, String>();
-        configuration.put(ConfigurationManager.ORGANIZATION, DEFAULT_TEST_ORGANIZATION);
-        configuration.put(ConfigurationManager.SITE_NAME, DEFAULT_TEST_SITE);
-        configuration.put(ConfigurationManager.VERSION, DEFAULT_TEST_VERSION);
-        return configuration;
+    protected void setDefaultSystemConfiguration() {
+        System.setProperty(SystemInfo.ORGANIZATION, DEFAULT_TEST_ORGANIZATION);
+        System.setProperty(SystemInfo.SITE_NAME, DEFAULT_TEST_SITE);
+        System.setProperty(SystemInfo.VERSION, DEFAULT_TEST_VERSION);
     }
 
     private String getMethodName() {

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.cxf.osgi.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.cxf.osgi.cfg
@@ -1,2 +1,2 @@
-org.apache.cxf.servlet.context=/services
+org.apache.cxf.servlet.context=${org.codice.ddf.system.rootContext}
 org.apache.cxf.servlet.disable-address-updates=true

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -6,7 +6,7 @@
 org.osgi.service.http.enabled=false
 
 # Default port for the OSGI HTTP Service
-org.osgi.service.http.port=8181
+org.osgi.service.http.port=${org.codice.ddf.system.httpPort}
 
 ######################
 # HTTPS settings
@@ -19,7 +19,7 @@ org.osgi.service.http.secure.enabled=true
 # (Verify this port does not conflict with any other secure ports being used in your
 # network. For example, JBoss and other application servers use port 8443 by default)
 
-org.osgi.service.http.port.secure=8993
+org.osgi.service.http.port.secure=${org.codice.ddf.system.httpsPort}
 
 # They keystore and passwords pull from the Java System Properties which are set
 # in the system.properties file.  It is recommended that the keystore values are changed 

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -35,6 +35,7 @@ org.codice.ddf.system.protocol=https://
 org.codice.ddf.system.hostname=localhost
 org.codice.ddf.system.httpsPort=8993
 org.codice.ddf.system.httpPort=8181
+org.codice.ddf.system.port=8993
 org.codice.ddf.system.rootContext=/services
 
 # Set the system information properties

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -243,6 +243,13 @@ public abstract class AbstractIntegrationTest {
                 editConfigurationFilePut("etc/system.properties", "jetty.port", HTTPS_PORT),
                 editConfigurationFilePut("etc/system.properties", "hostContext", "/solr"),
                 editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
+
+                editConfigurationFilePut("etc/system.properties", "org.codice.ddf.system.httpPort",
+                        HTTP_PORT),
+                editConfigurationFilePut("etc/system.properties", "org.codice.ddf.system.httpsPort",
+                        HTTPS_PORT),
+
+
                 editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", SSH_PORT),
                 editConfigurationFilePut("etc/ddf.platform.config.cfg", "port", HTTPS_PORT),
                 editConfigurationFilePut("etc/ddf.platform.config.cfg", "host", "localhost"),

--- a/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
+++ b/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
@@ -23,6 +23,8 @@ public final class SystemBaseUrl {
 
     public static final String HTTPS_PORT = "org.codice.ddf.system.httpsPort";
 
+    public static final String PORT = "org.codice.ddf.system.port";
+
     public static final String HOST = "org.codice.ddf.system.hostname";
 
     public static final String PROTOCOL = "org.codice.ddf.system.protocol";
@@ -47,7 +49,11 @@ public final class SystemBaseUrl {
      * @return
      */
     public String getPort() {
-        return getPort(getProtocol());
+        String port = System.getProperty(PORT);
+        if (port == null) {
+            port = getPort(getProtocol());
+        }
+        return port;
     }
 
     /**
@@ -81,6 +87,18 @@ public final class SystemBaseUrl {
     }
 
     /**
+     * Construct a url for the given context
+     *
+     * @param context The context path to be appened to the end of the base url
+     * @param includeRootContext Flag to indicated whether the rootcontext should be
+     *                           included in the url.
+     * @return
+     */
+    public String constructUrl(String context, boolean includeRootContext) {
+        return constructUrl(getProtocol(), context, includeRootContext);
+    }
+
+    /**
      * Construct a url based on the protocol and context
      *
      * @param proto   Protocol to use during url construction. A null value will
@@ -89,6 +107,20 @@ public final class SystemBaseUrl {
      * @return
      */
     public String constructUrl(String proto, String context) {
+        return constructUrl(proto, context, false);
+    }
+
+    /**
+     * Construct a url based on the protocol and context
+     *
+     * @param proto   Protocol to use during url construction. A null value will
+     *                cause the system default protocol to be used
+     * @param context The context path to be appened to the end of the base url
+     * @param includeRootContext Flag to indicated whether the rootcontext should be
+     *                           included in the url.
+     * @return
+     */
+    public String constructUrl(String proto, String context, boolean includeRootContext) {
         StringBuilder sb = new StringBuilder();
         String protocol = proto;
         if (protocol == null) {
@@ -101,7 +133,15 @@ public final class SystemBaseUrl {
         }
         sb.append(getHost());
         sb.append(":");
+
         sb.append(getPort(protocol));
+
+        if (includeRootContext) {
+            if (!getRootContext().startsWith("/")) {
+                sb.append("/");
+            }
+            sb.append(getRootContext());
+        }
 
         if (context != null) {
             if (!context.startsWith("/")) {

--- a/libs/common-system/src/test/java/org/codice/ddf/configuration/SystemBaseUrlTest.java
+++ b/libs/common-system/src/test/java/org/codice/ddf/configuration/SystemBaseUrlTest.java
@@ -106,6 +106,12 @@ public class SystemBaseUrlTest {
         assertThat(sbu.getRootContext(), equalTo(""));
         System.setProperty("org.codice.ddf.system.rootContext", "/services");
         assertThat(sbu.getRootContext(), equalTo("/services"));
+
+        assertThat(sbu.constructUrl("/some/path", true),
+                equalTo("https://localhost:8993/services/some/path"));
+        System.setProperty("org.codice.ddf.system.rootContext", "services");
+        assertThat(sbu.constructUrl("/some/path", true),
+                equalTo("https://localhost:8993/services/some/path"));
     }
 
 }

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -42,7 +42,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${org.slf4j.version}</version>
             <scope>test</scope>
+        </dependency><dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
         </dependency>
+
     </dependencies>
 
     <build>
@@ -63,6 +68,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
+++ b/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,79 +13,54 @@
  */
 package org.codice.ddf.configuration.impl;
 
-import java.util.Collections;
-import java.util.Map;
-
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
-import org.slf4j.LoggerFactory;
-import org.slf4j.ext.XLogger;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 
 /**
- * Implementation of {@link ConfigurationWatcher} that allows bundles that need to use the
+ * Implementation of {@link org.codice.ddf.configuration.ConfigurationWatcher} that allows bundles that need to use the
  * Configuration values and easy way to do so by injecting an instance of this class into the Object
  * via Blueprint (or similar).
+ * <p>
+ * This allows Objects to easily use a {@link org.codice.ddf.configuration.ConfigurationWatcher} instead of be a
+ * {@link org.codice.ddf.configuration.ConfigurationWatcher}
  *
- * This allows Objects to easily use a {@link ConfigurationWatcher} instead of be a
- * {@link ConfigurationWatcher}
- *
+ * @deprecated As of 2.8.0, Use SystemBaseUrl and SystemInfo instead
  */
-public class ConfigurationWatcherImpl implements ConfigurationWatcher {
+public class ConfigurationWatcherImpl {
 
-    private static final XLogger LOGGER = new XLogger(
-            LoggerFactory.getLogger(ConfigurationWatcherImpl.class));
+    private SystemBaseUrl systemBaseUrl;
 
-    private Map<String, String> propertyMap = null;
+    private SystemInfo systemInfo;
 
-    // Pull out variables for the more common properties and properties that have to be massaged
-    // before they are returned
-    private String hostname = null;
-
-    private Integer port = null;
-
-    private String protocol = null;
-
-    private String schemeFromProtocol = null;
-
-    private String siteName = null;
-
-    private String version = null;
-
-    private String organization = null;
-
-    private String contactInfo = null;
-
-    @SuppressWarnings("unchecked")
     public ConfigurationWatcherImpl() {
-        propertyMap = Collections.EMPTY_MAP;
+
     }
 
     /**
      * Helper method to get the hostname or IP from the configuration
      *
-     * @return the value associated with {@link ConfigurationManager#HOST} property name
+     * @return the value associated with {@link SystemBaseUrl#HOST} property name
      */
     public String getHostname() {
-        return hostname;
+        return systemBaseUrl.getHost();
     }
 
     /**
      * Helper method to get the port from the configuration
      *
-     * @return the Integer value associated with the {@link ConfigurationManager#PORT} property name
-     *         if it is an Integer, otherwise null
+     * @return the Integer value associated with the {@link SystemBaseUrl#HTTP_PORT} or {@link SystemBaseUrl#HTTPS_PORT} property depending on the protocol
      */
     public Integer getPort() {
-        return port;
+        return Integer.parseInt(systemBaseUrl.getPort());
     }
 
     /**
      * Helper method to get the Protocol which includes the slashes (e.g. http:// or https://)
      *
-     * @return the value associated with the {@link ConfigurationManager#PROTOCOL} property name
+     * @return the value associated with the {@link SystemBaseUrl#PROTOCOL} property name
      */
     public String getProtocol() {
-        return protocol;
+        return systemBaseUrl.getProtocol();
     }
 
     /**
@@ -93,131 +68,72 @@ public class ConfigurationWatcherImpl implements ConfigurationWatcher {
      * the first ':' (e.g. http or https)
      *
      * @return the String value before the first ':' character associated with the
-     *         {@link ConfigurationManager#PROTOCOL} property name
+     * {@link SystemBaseUrl#PROTOCOL} property name
      */
     public String getSchemeFromProtocol() {
-        return schemeFromProtocol;
+        return systemBaseUrl.getProtocol().split(":")[0];
     }
 
     /**
      * Helper method to get the site name from the configuration
      *
-     * @return the value associated with {@link ConfigurationManager#SITE_NAME} property name
+     * @return the value associated with {@link SystemInfo#SITE_NAME} property name
      */
     public String getSiteName() {
-        return siteName;
+        return systemInfo.getSiteName();
     }
 
     /**
      * Helper method to get the version from the configuration
      *
-     * @return the value associated with {@link ConfigurationManager#VERSION} property name
+     * @return the value associated with {@link SystemInfo#VERSION} property name
      */
     public String getVersion() {
-        return version;
+        return systemInfo.getVersion();
     }
 
     /**
      * Helper method to get the version from the configuration
      *
-     * @return the value associated with {@link ConfigurationManager#ORGANIZATION property name
+     * @return the value associated with {@link SystemInfo#ORGANIZATION property name
      */
     public String getOrganization() {
-        return organization;
+        return systemInfo.getOrganization();
     }
 
     /**
      * Helper method to get the contact info from the configuration
      *
-     * @return the value associated with {@link ConfigurationManager#CONTACT} property name
+     * @return the value associated with {@link SystemInfo#SITE_CONTACT} property name
      */
     public String getContactEmailAddress() {
-        return contactInfo;
+        return systemInfo.getSiteContatct();
     }
 
     /**
-     * Method to get property values from the configuration. Refer to the Constants in the
-     * {@link ConfigurationManager} class for a list of property names
+     * Method to get property values from the configuration.
      *
      * @return the value associated with property name passed in, null if the property name does not
-     *         exist in the configuration
+     * exist in the configuration
+     * @deprecated will always return null
      */
     public String getConfigurationValue(String name) {
-        return propertyMap.get(name);
+        return null;
     }
 
-    @Override
-    public void configurationUpdateCallback(Map<String, String> properties) {
-        LOGGER.entry("configurationUpdateCallback");
-
-        if (properties != null && !properties.isEmpty()) {
-            propertyMap = properties;
-
-            LOGGER.debug("Configuration values: {}", properties);
-
-            String oldValue = hostname;
-            hostname = properties.get(ConfigurationManager.HOST);
-            logConfigurationValue(ConfigurationManager.HOST, oldValue, hostname);
-
-            String portString = properties.get(ConfigurationManager.PORT);
-            try {
-                if (portString != null && !portString.isEmpty()) {
-                    port = Integer.parseInt(portString);
-                } else {
-                    port = null;
-                }
-                logConfigurationValue(ConfigurationManager.PORT, oldValue, port);
-            } catch (NumberFormatException e) {
-                LOGGER.warn(
-                        "Error Updating Configuration value for '{}', not a valid Integer [{}] reverting back to old value [{}]",
-                        new Object[] {ConfigurationManager.PORT, portString, port});
-            }
-
-            oldValue = protocol;
-            protocol = properties.get(ConfigurationManager.PROTOCOL);
-            logConfigurationValue(ConfigurationManager.PROTOCOL, oldValue, protocol);
-            if (protocol != null) {
-                int index = protocol.indexOf(':');
-                schemeFromProtocol = index > -1 ? protocol.substring(0, index) : protocol;
-            } else {
-                schemeFromProtocol = null;
-            }
-
-            oldValue = siteName;
-            siteName = properties.get(ConfigurationManager.SITE_NAME);
-            logConfigurationValue(ConfigurationManager.SITE_NAME, oldValue, siteName);
-
-            oldValue = version;
-            version = properties.get(ConfigurationManager.VERSION);
-            logConfigurationValue(ConfigurationManager.VERSION, oldValue, version);
-
-            oldValue = organization;
-            organization = properties.get(ConfigurationManager.ORGANIZATION);
-            logConfigurationValue(ConfigurationManager.ORGANIZATION, oldValue, organization);
-
-            oldValue = contactInfo;
-            contactInfo = properties.get(ConfigurationManager.CONTACT);
-            logConfigurationValue(ConfigurationManager.CONTACT, oldValue, contactInfo);
-
-        } else {
-            propertyMap.clear();
-            hostname = null;
-            port = null;
-            protocol = null;
-            schemeFromProtocol = null;
-            siteName = null;
-            version = null;
-            organization = null;
-            contactInfo = null;
-            LOGGER.debug(
-                    "Platform Configuration Properties are NULL or empty, setting all values to null");
-        }
-        LOGGER.exit();
+    public SystemBaseUrl getSystemBaseUrl() {
+        return systemBaseUrl;
     }
 
-    protected void logConfigurationValue(String propertyName, Object oldValue, Object newValue) {
-        LOGGER.debug("Updating Configuration value '{}' oldValue = [{}], newValue = [{}]",
-                new Object[] {propertyName, oldValue, newValue});
+    public void setSystemBaseUrl(SystemBaseUrl systemBaseUrl) {
+        this.systemBaseUrl = systemBaseUrl;
     }
 
+    public SystemInfo getSystemInfo() {
+        return systemInfo;
+    }
+
+    public void setSystemInfo(SystemInfo systemInfo) {
+        this.systemInfo = systemInfo;
+    }
 }

--- a/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
+++ b/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,24 +14,20 @@
 package org.codice.ddf.configuration.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.codice.ddf.configuration.ConfigurationManager;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 
 public class ConfigurationWatcherImpTest {
 
     @Test
     public void testGetters() {
-        Map<String, String> properties = getProperties();
         ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-        configWatcher.configurationUpdateCallback(properties);
-
+        configWatcher.setSystemBaseUrl(new SystemBaseUrl());
+        configWatcher.setSystemInfo(new SystemInfo());
+        configureProperties("http://", "hostValue", "8888", "/services", "siteNameValue",
+                "orgValue", "contactValue", "versionValue");
         assertEquals(configWatcher.getContactEmailAddress(), "contactValue");
         assertEquals(configWatcher.getHostname(), "hostValue");
         assertEquals(configWatcher.getPort(), Integer.valueOf("8888"));
@@ -40,19 +36,11 @@ public class ConfigurationWatcherImpTest {
         assertEquals(configWatcher.getSchemeFromProtocol(), "http");
         assertEquals(configWatcher.getSiteName(), "siteNameValue");
         assertEquals(configWatcher.getVersion(), "versionValue");
-        assertEquals(configWatcher.getConfigurationValue("BlahKey"), "BlahValue");
+        assertEquals(configWatcher.getConfigurationValue("BlahKey"), null);
 
-        Map<String, String> updatedProperties = new HashMap<String, String>();
-        updatedProperties.put(ConfigurationManager.CONTACT, "updatedcontactValue");
-        updatedProperties.put(ConfigurationManager.HOST, "updatedhostValue");
-        updatedProperties.put(ConfigurationManager.PORT, "9999");
-        updatedProperties.put(ConfigurationManager.ORGANIZATION, "updatedorgValue");
-        updatedProperties.put(ConfigurationManager.PROTOCOL, "https://");
-        updatedProperties.put(ConfigurationManager.SITE_NAME, "updatedsiteNameValue");
-        updatedProperties.put(ConfigurationManager.VERSION, "updatedversionValue");
-        updatedProperties.put("BlahKey", "UpdatedBlahValue");
-        configWatcher.configurationUpdateCallback(updatedProperties);
-
+        configureProperties("https://", "updatedhostValue", "9999", "/services",
+                "updatedsiteNameValue", "updatedorgValue", "updatedcontactValue",
+                "updatedversionValue");
         assertEquals(configWatcher.getContactEmailAddress(), "updatedcontactValue");
         assertEquals(configWatcher.getHostname(), "updatedhostValue");
         assertEquals(configWatcher.getPort(), Integer.valueOf("9999"));
@@ -61,125 +49,20 @@ public class ConfigurationWatcherImpTest {
         assertEquals(configWatcher.getSchemeFromProtocol(), "https");
         assertEquals(configWatcher.getSiteName(), "updatedsiteNameValue");
         assertEquals(configWatcher.getVersion(), "updatedversionValue");
-        assertEquals(configWatcher.getConfigurationValue("BlahKey"), "UpdatedBlahValue");
+        assertEquals(configWatcher.getConfigurationValue("BlahKey"), null);
     }
 
-    @Test
-    public void testPortValues() {
-        Map<String, String> invalidProps = new HashMap<String, String>();
-        ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
+    protected void configureProperties(String protocol, String host, String port,
+            String contextRoot, String siteName, String org, String contact, String version) {
 
-        invalidProps.put(ConfigurationManager.PORT, "Blah");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertNull(configWatcher.getPort());
-
-        invalidProps.put(ConfigurationManager.PORT, null);
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertNull(configWatcher.getPort());
-
-        invalidProps.put(ConfigurationManager.PORT, "5555");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getPort(), Integer.valueOf("5555"));
-
-        // If set to an invalid value, it will keep the last known good port value
-        invalidProps.put(ConfigurationManager.PORT, "Blah");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getPort(), Integer.valueOf("5555"));
+        System.setProperty(SystemBaseUrl.HTTP_PORT, port);
+        System.setProperty(SystemBaseUrl.HTTPS_PORT, port);
+        System.setProperty(SystemBaseUrl.HOST, host);
+        System.setProperty(SystemBaseUrl.PROTOCOL, protocol);
+        System.setProperty(SystemBaseUrl.ROOT_CONTEXT, contextRoot);
+        System.setProperty(SystemInfo.SITE_NAME, siteName);
+        System.setProperty(SystemInfo.SITE_CONTACT, contact);
+        System.setProperty(SystemInfo.VERSION, version);
+        System.setProperty(SystemInfo.ORGANIZATION, org);
     }
-
-    @Test
-    public void testSchemeValues() {
-        Map<String, String> invalidProps = new HashMap<String, String>();
-        ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-
-        invalidProps.put(ConfigurationManager.PROTOCOL, "Blah");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getSchemeFromProtocol(), "Blah");
-        assertEquals(configWatcher.getProtocol(), "Blah");
-
-        invalidProps.put(ConfigurationManager.PROTOCOL, null);
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertNull(configWatcher.getSchemeFromProtocol());
-        assertNull(configWatcher.getProtocol());
-
-        invalidProps.put(ConfigurationManager.PROTOCOL, "http://");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getSchemeFromProtocol(), "http");
-        assertEquals(configWatcher.getProtocol(), "http://");
-
-        invalidProps.put(ConfigurationManager.PROTOCOL, "Blah");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getSchemeFromProtocol(), "Blah");
-        assertEquals(configWatcher.getProtocol(), "Blah");
-
-        invalidProps.put(ConfigurationManager.PROTOCOL, "https://");
-        configWatcher.configurationUpdateCallback(invalidProps);
-        assertEquals(configWatcher.getSchemeFromProtocol(), "https");
-        assertEquals(configWatcher.getProtocol(), "https://");
-    }
-
-    @Test
-    public void testNonGetterValues() {
-        Map<String, String> properties = new HashMap<String, String>();
-        ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-
-        properties.put("custom1", "custom1Value");
-        properties.put("custom2", "custom2Value");
-        configWatcher.configurationUpdateCallback(properties);
-
-        assertEquals(configWatcher.getConfigurationValue("custom1"), "custom1Value");
-        assertEquals(configWatcher.getConfigurationValue("custom2"), "custom2Value");
-
-        properties.put("custom1", null);
-        properties.put("custom2", "updatedcustom2Value");
-
-        assertNull(configWatcher.getConfigurationValue("custom1"));
-        assertEquals(configWatcher.getConfigurationValue("custom2"), "updatedcustom2Value");
-
-    }
-
-    @Test
-    public void testUpdateWithEmptyMap() {
-        setNullOrEmptyMapThenTest(new HashMap<String, String>());
-    }
-
-    @Test
-    public void testUpdateWithNullMap() {
-        setNullOrEmptyMapThenTest(null);
-    }
-
-    private void setNullOrEmptyMapThenTest(Map<String, String> emptyProps) {
-        Map<String, String> properties = getProperties();
-        ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-        configWatcher.configurationUpdateCallback(properties);
-
-        configWatcher.configurationUpdateCallback(emptyProps);
-
-        // This will fail if new getters are added and the values are not set to null
-        Method[] methods = configWatcher.getClass().getDeclaredMethods();
-        for (Method method : methods) {
-            if (method.getParameterTypes().length == 0 && method.getName().startsWith("get")) {
-                try {
-                    assertNull(method.invoke(configWatcher, null));
-                } catch (Exception e) {
-                    fail(e.getMessage());
-                }
-            }
-        }
-        assertNull(configWatcher.getConfigurationValue("BlahKey"));
-    }
-
-    private Map<String, String> getProperties() {
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put(ConfigurationManager.CONTACT, "contactValue");
-        properties.put(ConfigurationManager.HOST, "hostValue");
-        properties.put(ConfigurationManager.PORT, "8888");
-        properties.put(ConfigurationManager.ORGANIZATION, "orgValue");
-        properties.put(ConfigurationManager.PROTOCOL, "http://");
-        properties.put(ConfigurationManager.SITE_NAME, "siteNameValue");
-        properties.put(ConfigurationManager.VERSION, "versionValue");
-        properties.put("BlahKey", "BlahValue");
-        return properties;
-    }
-
 }

--- a/platform/metrics/platform-metrics-reporting/pom.xml
+++ b/platform/metrics/platform-metrics-reporting/pom.xml
@@ -88,6 +88,12 @@
             <version>2.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -98,7 +104,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>rrd4j,joda-time, commons-math</Embed-Dependency>
+                        <Embed-Dependency>rrd4j,joda-time, commons-math, common-system</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Import-Package>
                             !com.mongodb,

--- a/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,13 +23,16 @@
 			<ref component-id="MetricsService"/>
 		</jaxrs:serviceBeans>
 	</jaxrs:server>
-	
+
+	<bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
 	<bean id="MetricsService" class="ddf.metrics.reporting.internal.rest.MetricsEndpoint">
 		<cm:managed-properties persistent-id="MetricsReporting"
                                update-strategy="container-managed"/>
+		<argument ref="urlHelper"/>
+		<argument ref="systemInfo"/>
 		<property name="metricsMaxThreshold" value="4000000000"/>
 	</bean>
-
-	<service ref="MetricsService" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
+++ b/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
@@ -49,6 +49,8 @@ import org.apache.poi.hslf.usermodel.SlideShow;
 import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 import org.custommonkey.xmlunit.XMLTestCase;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -86,7 +88,7 @@ public class MetricsEndpointTest extends XMLTestCase {
 
     @Test
     public void testParseDate() {
-        long time = new MetricsEndpoint().parseDate("1998-07-09T09:00:00-07:00");
+        long time = getEndpoint().parseDate("1998-07-09T09:00:00-07:00");
         assertThat(time, equalTo(900000000L));
     }
 
@@ -115,7 +117,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics list from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         Response response = endpoint.getMetricsList(uriInfo);
         String metricsList = (String) response.getEntity();
@@ -195,7 +197,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics graph from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         Response response = endpoint.getMetricsData("uptime", "png", "2013-03-25T06:00:00-07:00",
                 "2013-03-25T07:10:00-07:00", null, "my label", "my title", uriInfo);
@@ -220,7 +222,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics graph from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         Response response = endpoint
                 .getMetricsData("uptime", "png", null, null, null, null, null, uriInfo);
@@ -237,7 +239,7 @@ public class MetricsEndpointTest extends XMLTestCase {
     public void testGetMetricsGraphWithDateOffsetAndDates() throws Exception {
         UriInfo uriInfo = createUriInfo();
 
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         try {
             endpoint.getMetricsData("uptime", "png", "2013-03-25T06:00:00-07:00",
@@ -259,7 +261,7 @@ public class MetricsEndpointTest extends XMLTestCase {
                 .createGraph(anyString(), anyString(), anyLong(), anyLong(), anyString(),
                         anyString())).thenThrow(IOException.class);
 
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         endpoint.setMetricsRetriever(metricsRetriever);
 
@@ -283,7 +285,7 @@ public class MetricsEndpointTest extends XMLTestCase {
                 .createGraph(anyString(), anyString(), anyLong(), anyLong(), anyString(),
                         anyString())).thenThrow(MetricsGraphException.class);
 
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         endpoint.setMetricsRetriever(metricsRetriever);
 
@@ -304,7 +306,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint
@@ -337,7 +339,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint
@@ -372,7 +374,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint
@@ -426,7 +428,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint
@@ -452,7 +454,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint
@@ -495,7 +497,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint.getMetricsReport("xls", null, null,
@@ -525,7 +527,7 @@ public class MetricsEndpointTest extends XMLTestCase {
         UriInfo uriInfo = createUriInfo();
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
 
         Response response = endpoint.getMetricsReport("ppt", null, null,
@@ -549,7 +551,7 @@ public class MetricsEndpointTest extends XMLTestCase {
     public void testSummaryFormat() throws URISyntaxException {
         boolean pass = false;
         try {
-            MetricsEndpoint endpoint = new MetricsEndpoint();
+            MetricsEndpoint endpoint = getEndpoint();
             endpoint.setMetricsDir(TEST_DIR);
 
             Response response = endpoint
@@ -703,7 +705,7 @@ public class MetricsEndpointTest extends XMLTestCase {
                 .thenThrow(exceptionClass);
 
         // Get the metrics data from the endpoint
-        MetricsEndpoint endpoint = new MetricsEndpoint();
+        MetricsEndpoint endpoint = getEndpoint();
         endpoint.setMetricsDir(TEST_DIR);
         endpoint.setMetricsRetriever(metricsRetriever);
 
@@ -756,5 +758,12 @@ public class MetricsEndpointTest extends XMLTestCase {
         }
 
         return String.valueOf(value);
+    }
+
+    private MetricsEndpoint getEndpoint() {
+        MetricsEndpoint me = new MetricsEndpoint(new SystemBaseUrl(), new SystemInfo());
+        System.setProperty(SystemBaseUrl.ROOT_CONTEXT, "/services");
+        System.setProperty(SystemInfo.SITE_NAME, "siteName");
+        return me;
     }
 }

--- a/platform/metrics/platform-metrics-webconsole-plugin/pom.xml
+++ b/platform/metrics/platform-metrics-webconsole-plugin/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>org.osgi.core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
     </dependencies>
 
@@ -92,7 +97,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>joda-time</Embed-Dependency>
+                        <Embed-Dependency>joda-time,common-system</Embed-Dependency>
                         <Import-Package>
                             javax.servlet;version="[2.5,3)",
                             javax.servlet.http;version="[2.5,3)",

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
@@ -76,7 +76,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author rodgersh
  * @author ddf.isgs@lmco.com
- *
  */
 public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
     public static final String NAME = "metrics";
@@ -162,8 +161,7 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
         final PrintWriter pw = response.getWriter();
 
-        String metricsServiceUrl = systemBaseUrl
-                .constructUrl(systemBaseUrl.getRootContext() + METRICS_SERVICE_BASE_URL);
+        String metricsServiceUrl = systemBaseUrl.constructUrl(METRICS_SERVICE_BASE_URL, true);
 
         // Call Metrics Endpoint REST service to get list of all of the monitored
         // metrics and their associated hyperlinks to graph their historical data.

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -50,8 +50,7 @@ import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.felix.webconsole.AbstractWebConsolePlugin;
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemBaseUrl;
 import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
@@ -79,8 +78,7 @@ import org.slf4j.LoggerFactory;
  * @author ddf.isgs@lmco.com
  *
  */
-public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin
-        implements ConfigurationWatcher {
+public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
     public static final String NAME = "metrics";
 
     public static final String LABEL = "Metrics";
@@ -107,15 +105,11 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin
 
     private static final String KEYSTORE_DEFAULT_PASS = "changeit";
 
-    private String trustStore;
+    private SystemBaseUrl systemBaseUrl;
 
-    private String trustStorePassword;
-
-    private String keyStore;
-
-    private String keyStorePassword;
-
-    private String servicesContextRoot = "/services";
+    public MetricsWebConsolePlugin(SystemBaseUrl sbu) {
+        this.systemBaseUrl = sbu;
+    }
 
     private static String urlEncodeDate(DateMidnight date) throws UnsupportedEncodingException {
         return urlEncodeDate(date.toDateTime());
@@ -168,9 +162,8 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin
 
         final PrintWriter pw = response.getWriter();
 
-        String metricsServiceUrl =
-                request.getScheme() + "://" + request.getServerName() + ":" + request
-                        .getServerPort() + servicesContextRoot + METRICS_SERVICE_BASE_URL;
+        String metricsServiceUrl = systemBaseUrl
+                .constructUrl(systemBaseUrl.getRootContext() + METRICS_SERVICE_BASE_URL);
 
         // Call Metrics Endpoint REST service to get list of all of the monitored
         // metrics and their associated hyperlinks to graph their historical data.
@@ -343,6 +336,14 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin
             FileInputStream ksFIS = null;
             try {
                 keyStoreJks = KeyStore.getInstance("JKS");
+                String trustStore = System
+                        .getProperty("javax.net.ssl.trustStore", TRUSTSTORE_DEFAULT_LOC);
+                String trustStorePassword = System
+                        .getProperty("javax.net.ssl.trustStorePassword", TRUSTSTORE_DEFAULT_PASS);
+                String keyStore = System
+                        .getProperty("javax.net.ssl.keyStore", KEYSTORE_DEFAULT_LOC);
+                String keyStorePassword = System
+                        .getProperty("javax.net.ssl.keyStorePassword", KEYSTORE_DEFAULT_PASS);
 
                 File trustStoreFile = new File(trustStore);
                 tsFIS = new FileInputStream(trustStoreFile);
@@ -536,29 +537,5 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin
 
     private void endTableRow(PrintWriter pw) {
         pw.println("</tr>");
-    }
-
-    @Override
-    public void configurationUpdateCallback(Map<String, String> configuration) {
-        synchronized (this) {
-            servicesContextRoot = configuration.get(ConfigurationManager.SERVICES_CONTEXT_ROOT);
-            String trustStoreLoc = configuration.get(ConfigurationManager.TRUST_STORE);
-            if (StringUtils.isNotBlank(trustStoreLoc)) {
-                trustStore = trustStoreLoc;
-                trustStorePassword = configuration.get(ConfigurationManager.TRUST_STORE_PASSWORD);
-            } else {
-                trustStore = TRUSTSTORE_DEFAULT_LOC;
-                trustStorePassword = TRUSTSTORE_DEFAULT_PASS;
-            }
-
-            String keystoreLoc = configuration.get(ConfigurationManager.KEY_STORE);
-            if (StringUtils.isNotBlank(keystoreLoc)) {
-                keyStore = keystoreLoc;
-                keyStorePassword = configuration.get(ConfigurationManager.KEY_STORE_PASSWORD);
-            } else {
-                keyStore = KEYSTORE_DEFAULT_LOC;
-                keyStorePassword = KEYSTORE_DEFAULT_PASS;
-            }
-        }
     }
 }

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,9 +15,12 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <reference id="MetricsAdminPluginService" interface="javax.servlet.Servlet"/>
+
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
     
     <bean id="metricsWebConsolePlugin" class="ddf.metrics.plugin.webconsole.MetricsWebConsolePlugin"
           init-method="start" destroy-method="stop">
+        <argument ref="urlHelper"/>
     </bean>
     
     <service ref="metricsWebConsolePlugin" interface="javax.servlet.Servlet">
@@ -25,8 +28,5 @@
             <entry key="felix.webconsole.label" value="metrics"/>
         </service-properties>
     </service>
-    
-    <service ref="metricsWebConsolePlugin"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/test/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePluginTest.java
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/test/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePluginTest.java
@@ -28,6 +28,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
 import org.custommonkey.xmlunit.HTMLDocumentBuilder;
 import org.custommonkey.xmlunit.TolerantSaxDocumentBuilder;
 import org.custommonkey.xmlunit.XMLTestCase;
@@ -65,19 +66,19 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
 
     @Test
     public void testTitle() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
         assertEquals("Metrics", metricsPlugin.getTitle());
     }
 
     @Test
     public void testLabel() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
         assertEquals("metrics", metricsPlugin.getLabel());
     }
 
     @Test
     public void testConvertCamelCase() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
         assertEquals("Foo", metricsPlugin.convertCamelCase("foo"));
         assertEquals("Foo", metricsPlugin.convertCamelCase("Foo"));
         assertEquals("Foobar", metricsPlugin.convertCamelCase("foobar"));
@@ -147,7 +148,7 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
         Locale.setDefault(new Locale(language, country));
         StringWriter sw = new StringWriter();
 
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
         PrintWriter pw = new PrintWriter(sw);
 
         int numWeeklyReports = 3;
@@ -168,7 +169,7 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
         DateTimeZone.setDefault(DateTimeZone.forID(dateTimeZoneId));
         Locale.setDefault(new Locale(language, country));
 
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
 
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);

--- a/platform/platform-commands/pom.xml
+++ b/platform/platform-commands/pom.xml
@@ -41,6 +41,11 @@
             <groupId>ddf.platform</groupId>
             <artifactId>platform-configuration</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -52,6 +57,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package/>
                         <Import-Package>
                             org.apache.felix.service.command,

--- a/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
+++ b/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,28 +13,35 @@
  */
 package org.codice.ddf.commands.platform;
 
-import java.util.Map;
-import java.util.TreeSet;
-
 import org.apache.felix.gogo.commands.Command;
-import org.codice.ddf.configuration.ConfigurationWatcher;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
 
 @Command(scope = PlatformCommands.NAMESPACE, name = "describe", description = "Provides a description of the platform")
-public class DescribeCommand extends PlatformCommands implements ConfigurationWatcher {
+public class DescribeCommand extends PlatformCommands {
 
-    private static Map<String, String> configurationMap;
+    private SystemBaseUrl systemBaseUrl;
 
-    @Override
-    protected Object doExecute() throws Exception {
-        TreeSet<String> keys = new TreeSet<String>(configurationMap.keySet());
-        for (String key : keys) {
-            System.out.printf("%s=%s%n", key, configurationMap.get(key));
-        }
-        return null;
+    private SystemInfo systemInfo;
+
+    public DescribeCommand(SystemBaseUrl sbu, SystemInfo info) {
+        this.systemBaseUrl = sbu;
+        this.systemInfo = info;
     }
 
     @Override
-    public void configurationUpdateCallback(Map<String, String> configuration) {
-        configurationMap = configuration;
+    protected Object doExecute() throws Exception {
+        System.out.printf("%s=%s%n", "Protocol", systemBaseUrl.getProtocol());
+        System.out.printf("%s=%s%n", "Host", systemBaseUrl.getHost());
+        System.out.printf("%s=%s%n", "Port", systemBaseUrl.getPort());
+        System.out.printf("%s=%s%n", "Root Context", systemBaseUrl.getRootContext());
+        System.out.printf("%s=%s%n", "Http Port", systemBaseUrl.getHttpPort());
+        System.out.printf("%s=%s%n", "Https Port", systemBaseUrl.getHttpsPort());
+
+        System.out.printf("%s=%s%n", "Site Name", systemInfo.getSiteName());
+        System.out.printf("%s=%s%n", "Organization", systemInfo.getOrganization());
+        System.out.printf("%s=%s%n", "Contact", systemInfo.getSiteContatct());
+        System.out.printf("%s=%s%n", "Version", systemInfo.getVersion());
+        return null;
     }
 }

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,11 +24,13 @@
 
     </command-bundle>
 
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
+
     <bean id="platformDescribeCommand" class="org.codice.ddf.commands.platform.DescribeCommand">
         <property name="bundleContext" ref="blueprintBundleContext"/>
+        <argument ref="urlHelper"/>
+        <argument ref="systemInfo"/>
     </bean>
-
-    <service id="platformDescribeCommandWatcher" ref="platformDescribeCommand"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/platform/platform-configuration/pom.xml
+++ b/platform/platform-configuration/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>common-system</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.utils</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -64,7 +69,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>json-smart,common-system</Embed-Dependency>
+                        <Embed-Dependency>json-smart,common-system,org.apache.felix.utils</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/platform-configuration/pom.xml
+++ b/platform/platform-configuration/pom.xml
@@ -49,7 +49,11 @@
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -60,7 +64,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>json-smart</Embed-Dependency>
+                        <Embed-Dependency>json-smart,common-system</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationWatcher.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationWatcher.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -19,10 +19,12 @@ import java.util.Map;
  * This interface is used to specify a source as a watcher of updates to the DDF system
  * configuration settings. Whenever the source is configured, or updates are made to the DDF System
  * Settings, the source will receive the entire list of the most current DDF system settings.
- *
+ * <p>
  * It is up to the ConfigurationWatcher to determine which DDF system settings are of interest,
  * if their values have changed, and how to react to their values.
  *
+ * @deprecated As of 2.8.0, replaced by using system properties.
+ * See {@link org.codice.ddf.configuration.SystemBaseUrl} and {@link org.codice.ddf.configuration.SystemInfo}
  */
 public interface ConfigurationWatcher {
 
@@ -31,8 +33,9 @@ public interface ConfigurationWatcher {
      * configuration properties contains the entire list of system settings, not just the ones that
      * have changed.
      *
-     * @param configuration
-     *            the entire list of DDF system settings
+     * @param configuration the entire list of DDF system settings
+     * @deprecated As of 2.8.0, replaced by using system properties.
+     * See {@link org.codice.ddf.configuration.SystemBaseUrl} and {@link org.codice.ddf.configuration.SystemInfo}
      */
     public void configurationUpdateCallback(Map<String, String> configuration);
 

--- a/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,12 +29,15 @@
     DDF started up.
     -->
     <reference-list id="managedServiceList"
-                    interface="org.codice.ddf.configuration.ConfigurationWatcher">
+                    interface="org.codice.ddf.configuration.ConfigurationWatcher" availability="optional">
         <reference-listener bind-method="bind" unbind-method="bind" ref="ConfigurationManager"/>
     </reference-list>
 
-    <reference-list id="initialManagedServiceList"
+    <reference-list id="initialManagedServiceList" availability="optional"
                     interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
+
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
     <bean id="ConfigurationManager" class="org.codice.ddf.configuration.ConfigurationManager"
           init-method="init">
@@ -42,6 +45,8 @@
                                update-strategy="component-managed" update-method="updated"/>
         <argument ref="initialManagedServiceList"/>
         <argument ref="configurationAdmin"/>
+        <argument ref="urlHelper"/>
+        <argument ref="systemInfo"/>
     </bean>
 
     <bean id="PlatformUiConfiguration" class="org.codice.ddf.configuration.PlatformUiConfiguration">

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -55,11 +55,13 @@ public class ConfigurationManagerTest {
 
     @Before
     public void setUp() throws Exception {
+        SystemBaseUrl sbu = new SystemBaseUrl();
+        SystemInfo info = new SystemInfo();
         key = ConfigurationManagerTest.class.getSimpleName() + "Key";
         mockWatcher = new MockConfigurationWatcher();
         List<ConfigurationWatcher> watchers = new ArrayList<ConfigurationWatcher>();
         watchers.add(mockWatcher);
-        ddfConfigMgr = new ConfigurationManager(watchers, null);
+        ddfConfigMgr = new ConfigurationManager(watchers, null, sbu, info);
         config1 = new HashMap<String, String>();
         config1.put(key, "config1");
         config2 = new HashMap<String, String>();
@@ -118,6 +120,7 @@ public class ConfigurationManagerTest {
 
     @Test
     public void testInit() {
+
         ddfConfigMgr.setProtocol(PROTOCOL);
         ddfConfigMgr.setHost(HOST);
         ddfConfigMgr.setPort(PORT);

--- a/platform/security/cas/security-cas-tokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/cas/security-cas-tokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,7 +26,6 @@
     
     <service ref="webSsoTokenValidator">
         <interfaces>
-            <value>org.codice.ddf.configuration.ConfigurationWatcher</value>
             <value>org.apache.cxf.sts.token.validator.TokenValidator</value>
         </interfaces>
     </service>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,8 +58,5 @@
         <property name="propertyFileLocation" value="etc/ws-security/attributeMap.properties"/>
     </bean>
 
-    <service ref="claimsHandlerManager"
-             interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
-
 </blueprint>
 

--- a/platform/security/sts/security-sts-ldaplogin/pom.xml
+++ b/platform/security/sts/security-sts-ldaplogin/pom.xml
@@ -81,7 +81,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.13</minimum>
+                                            <minimum>0.08</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
@@ -172,6 +172,10 @@
             <artifactId>powermock-module-junit4-rule-agent</artifactId>
             <version>${powermock.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/KeystoreManager.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/KeystoreManager.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,13 +14,9 @@
 package ddf.ldap.ldaplogin;
 
 import java.io.File;
-import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.jaas.config.KeystoreInstance;
 import org.apache.karaf.jaas.config.impl.ResourceKeystoreInstance;
-import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -32,9 +28,8 @@ import ddf.security.encryption.EncryptionService;
 
 /**
  * Registers keystores based on the platform configuration.
- *
  */
-public class KeystoreManager implements ConfigurationWatcher {
+public class KeystoreManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeystoreManager.class);
 
@@ -44,10 +39,6 @@ public class KeystoreManager implements ConfigurationWatcher {
 
     private ServiceRegistration<KeystoreInstance> truststoreRegistration = null;
 
-    private String keystoreLoc, keystorePass;
-
-    private String truststoreLoc, truststorePass;
-
     private String keyAlias;
 
     private EncryptionService encryptService;
@@ -55,80 +46,48 @@ public class KeystoreManager implements ConfigurationWatcher {
     /**
      * Creates a new instance of the KeystoreManager class.
      *
-     * @param encryptService
-     *            Service that can encrypt and decrypt passwords.
+     * @param encryptService Service that can encrypt and decrypt passwords.
      */
-    public KeystoreManager(EncryptionService encryptService) {
+    public KeystoreManager(EncryptionService encryptService, String alias) {
         this.encryptService = encryptService;
+        this.keyAlias = alias;
+        configure();
     }
 
     /**
      * Sets the alias that should be used in the keystore for encrypted
      * communication.
      *
-     * @param keyAlias
-     *            alias located inside of the keystore.
+     * @param keyAlias alias located inside of the keystore.
      */
     public void setKeyAlias(String keyAlias) {
         LOGGER.debug("Updating the keyAlias from {} to {}", this.keyAlias, keyAlias);
         this.keyAlias = keyAlias;
     }
 
-    @Override
-    public void configurationUpdateCallback(Map<String, String> props) {
-        LOGGER.debug("Got a new configuration.");
-        String keystoreLocation = props.get(ConfigurationManager.KEY_STORE);
-        String keystorePassword = encryptService
-                .decryptValue(props.get(ConfigurationManager.KEY_STORE_PASSWORD));
-
-        String truststoreLocation = props.get(ConfigurationManager.TRUST_STORE);
-        String truststorePassword = encryptService
-                .decryptValue(props.get(ConfigurationManager.TRUST_STORE_PASSWORD));
-
-        if (StringUtils.isNotBlank(keystoreLocation) && (
-                !StringUtils.equals(this.keystoreLoc, keystoreLocation) || !StringUtils
-                        .equals(this.keystorePass, keystorePassword))) {
-            if (new File(keystoreLocation).exists()) {
-                LOGGER.debug(
-                        "Detected a change in the values for the keystore, registering new keystore instance.");
-                keystoreRegistration = registerKeystore("ks", keystoreLocation, keystorePassword,
-                        keystoreRegistration);
-                this.keystoreLoc = keystoreLocation;
-                this.keystorePass = keystorePassword;
-            } else {
-                LOGGER.debug(
-                        "Keystore file does not exist at location {}, not updating keystore values.");
-            }
+    private void configure() {
+        String truststoreLoc = System.getProperty("javax.net.ssl.trustStore");
+        String truststorePass = System.getProperty("javax.net.ssl.trustStorePassword");
+        String keystoreLoc = System.getProperty("javax.net.ssl.keyStore");
+        String keystorePass = System.getProperty("javax.net.ssl.keyStorePassword");
+        if (encryptService != null) {
+            keystorePass = encryptService.decryptValue(keystorePass);
+            truststorePass = encryptService.decryptValue(truststorePass);
         }
-        if (StringUtils.isNotBlank(truststoreLocation) && (
-                !StringUtils.equals(this.truststoreLoc, truststoreLocation) || !StringUtils
-                        .equals(this.truststorePass, truststorePassword))) {
-            if (new File(truststoreLocation).exists()) {
-                LOGGER.debug(
-                        "Detected a change in the values for the truststore, registering new keystore instance.");
-                truststoreRegistration = registerKeystore("ts", truststoreLocation,
-                        truststorePassword, truststoreRegistration);
-                this.truststoreLoc = truststoreLocation;
-                this.truststorePass = truststorePassword;
-            } else {
-                LOGGER.debug(
-                        "Truststore file does not exist at location {}, not updating truststore values.");
-            }
-        }
+        keystoreRegistration = registerKeystore("ks", keystoreLoc, keystorePass,
+                keystoreRegistration);
 
+        truststoreRegistration = registerKeystore("ts", truststoreLoc, truststorePass,
+                truststoreRegistration);
     }
 
     /**
      * Registers a keystore instance to the OSGi registry.
      *
-     * @param name
-     *            Name of the keystore to use.
-     * @param location
-     *            relative file location
-     * @param password
-     *            Password of the keystore and private key
-     * @param keystoreReg
-     *            Previous registration instance
+     * @param name        Name of the keystore to use.
+     * @param location    relative file location
+     * @param password    Password of the keystore and private key
+     * @param keystoreReg Previous registration instance
      * @return
      */
     private ServiceRegistration<KeystoreInstance> registerKeystore(String name, String location,

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -42,9 +42,8 @@
         <cm:managed-properties persistent-id="ddf.security.sts.ldap"
                                update-strategy="container-managed"/>
         <argument ref="encryptionService"/>
-        <property name="keyAlias" value="localhost"/>
+        <argument value="${org.codice.ddf.system.hostname}"/>
     </bean>
 
-    <service ref="keystoreManager" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
 </blueprint>

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/KeystoreManagerTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/KeystoreManagerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -16,18 +16,14 @@ package ddf.ldap.ldaplogin;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.karaf.jaas.config.KeystoreInstance;
-import org.codice.ddf.configuration.ConfigurationManager;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +35,6 @@ import ddf.security.encryption.EncryptionService;
 
 /**
  * Tests out KeystoreManager functionality.
- *
  */
 public class KeystoreManagerTest {
 
@@ -56,6 +51,7 @@ public class KeystoreManagerTest {
 
     /**
      * Sets up a new context and encryptservice before each test.
+     *
      * @throws IOException
      */
     @Before
@@ -70,39 +66,41 @@ public class KeystoreManagerTest {
      * Verifies the keystore instances are properly registered as services.
      */
     @Test
-    public void testKeystoreChanged() {
-        KeystoreManager manager = new KeystoreManager(encryptService) {
+    public void testKeystore() {
+
+        System.setProperty("javax.net.ssl.keyStore", "/test/keystore.jks");
+        System.setProperty("javax.net.ssl.keyStorePassword", "password");
+        System.setProperty("javax.net.ssl.trustStore", "/test/truststore.jks");
+        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+
+        KeystoreManager manager = new KeystoreManager(encryptService, "localhost") {
             protected BundleContext getContext() {
                 return context;
             }
         };
-        Map<String, String> updateMap = new HashMap<String, String>();
-        updateMap.put(ConfigurationManager.KEY_STORE, "/test/keystore.jks");
-        updateMap.put(ConfigurationManager.KEY_STORE_PASSWORD, "password");
-        updateMap.put(ConfigurationManager.TRUST_STORE, "/test/truststore.jks");
-        updateMap.put(ConfigurationManager.TRUST_STORE_PASSWORD, "password");
 
-        manager.configurationUpdateCallback(updateMap);
-
-        // register keystore and truststore with INVALID file
-        verify(context, never())
-                .registerService(eq(KeystoreInstance.class), any(KeystoreInstance.class),
-                        Matchers.<Dictionary<String, Object>>any());
-
-        // only keystore changed to be valid
-        updateMap.put(ConfigurationManager.KEY_STORE, keystore.getAbsolutePath());
-        manager.configurationUpdateCallback(updateMap);
-        verify(context, times(1))
-                .registerService(eq(KeystoreInstance.class), any(KeystoreInstance.class),
-                        Matchers.<Dictionary<String, Object>>any());
-
-        // only truststore changed to be valid
-        updateMap.put(ConfigurationManager.TRUST_STORE, truststore.getAbsolutePath());
-        manager.configurationUpdateCallback(updateMap);
         verify(context, times(2))
                 .registerService(eq(KeystoreInstance.class), any(KeystoreInstance.class),
                         Matchers.<Dictionary<String, Object>>any());
+    }
 
+    @Test
+    public void testKeystoreNullEncrypt() {
+
+        System.setProperty("javax.net.ssl.keyStore", "/test/keystore.jks");
+        System.setProperty("javax.net.ssl.keyStorePassword", "password");
+        System.setProperty("javax.net.ssl.trustStore", "/test/truststore.jks");
+        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+
+        KeystoreManager manager = new KeystoreManager(null, "localhost") {
+            protected BundleContext getContext() {
+                return context;
+            }
+        };
+
+        verify(context, times(2))
+                .registerService(eq(KeystoreInstance.class), any(KeystoreInstance.class),
+                        Matchers.<Dictionary<String, Object>>any());
     }
 
 }

--- a/platform/security/sts/security-sts-realm/src/main/java/ddf/security/realm/sts/AbstractStsRealm.java
+++ b/platform/security/sts/security-sts-realm/src/main/java/ddf/security/realm/sts/AbstractStsRealm.java
@@ -64,7 +64,6 @@ import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.subject.SimplePrincipalCollection;
-import org.codice.ddf.configuration.ConfigurationManager;
 import org.codice.ddf.security.handler.api.BaseAuthenticationToken;
 import org.codice.ddf.security.handler.api.SAMLAuthenticationToken;
 import org.codice.ddf.security.policy.context.ContextPolicy;
@@ -333,21 +332,6 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
     }
 
     /**
-     * Log properties from DDF configuration updates.
-     */
-    private void logIncomingProperties(@SuppressWarnings("rawtypes") Map properties) {
-        @SuppressWarnings("unchecked")
-        Set<String> keys = properties.keySet();
-        StringBuilder builder = new StringBuilder();
-        builder.append("\nIncoming properties:\n");
-        for (String key : keys) {
-            builder.append("key: " + key + "; value: " + properties.get(key) + "\n");
-        }
-
-        LOGGER.debug(builder.toString());
-    }
-
-    /**
      * Logs the current STS client configuration.
      */
     private void logStsClientConfiguration() {
@@ -366,24 +350,6 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
         }
 
         LOGGER.debug(builder.toString());
-    }
-
-    /**
-     * Determines if the received update is a DDF System Settings update.
-     */
-    private boolean isDdfConfigurationUpdate(@SuppressWarnings("rawtypes") Map properties) {
-        boolean updated = false;
-
-        if (properties.containsKey(ConfigurationManager.TRUST_STORE) && properties
-                .containsKey(ConfigurationManager.TRUST_STORE_PASSWORD) && properties
-                .containsKey(ConfigurationManager.KEY_STORE) && properties
-                .containsKey(ConfigurationManager.KEY_STORE_PASSWORD)) {
-            updated = true;
-        } else {
-            updated = false;
-        }
-
-        return updated;
     }
 
     /**

--- a/platform/security/sts/security-sts-realm/src/main/java/ddf/security/realm/sts/AbstractStsRealm.java
+++ b/platform/security/sts/security-sts-realm/src/main/java/ddf/security/realm/sts/AbstractStsRealm.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -65,7 +65,6 @@ import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.codice.ddf.configuration.ConfigurationManager;
-import org.codice.ddf.configuration.ConfigurationWatcher;
 import org.codice.ddf.security.handler.api.BaseAuthenticationToken;
 import org.codice.ddf.security.handler.api.SAMLAuthenticationToken;
 import org.codice.ddf.security.policy.context.ContextPolicy;
@@ -90,7 +89,7 @@ import ddf.security.encryption.EncryptionService;
 import ddf.security.sts.client.configuration.STSClientConfiguration;
 
 public abstract class AbstractStsRealm extends AuthenticatingRealm
-        implements ConfigurationWatcher, STSClientConfiguration {
+        implements STSClientConfiguration {
     private static final XLogger LOGGER = new XLogger(
             LoggerFactory.getLogger(AbstractStsRealm.class));
 
@@ -174,37 +173,6 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
 
     public void setContextPolicyManager(ContextPolicyManager contextPolicyManager) {
         this.contextPolicyManager = contextPolicyManager;
-    }
-
-    /**
-     * Watch for changes in System Settings and STS Client Settings from the configuration page in
-     * the DDF console.
-     */
-    @Override
-    public void configurationUpdateCallback(Map<String, String> properties) {
-        settingsConfigured = false;
-
-        if (properties != null && !properties.isEmpty()) {
-
-            if (LOGGER.isDebugEnabled()) {
-                logIncomingProperties(properties);
-            }
-
-            if (isDdfConfigurationUpdate(properties)) {
-                LOGGER.debug("Got system configuration update.");
-                setDdfPropertiesFromConfigAdmin(properties);
-                try {
-                    configureStsClient();
-                    settingsConfigured = true;
-                } catch (Exception e) {
-                    LOGGER.debug(
-                            "STS was not available during configuration update, will try again when realm is called. Full stack trace is available at the TRACE level.");
-                    LOGGER.trace("Could not create STS client", e);
-                }
-            }
-        } else {
-            LOGGER.debug("properties are NULL or empty");
-        }
     }
 
     /**
@@ -535,16 +503,16 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
     }
 
     /**
-     * Set properties based on DDF System Setting updates.
+     * Set properties based on DDF System Properties.
      */
-    private void setDdfPropertiesFromConfigAdmin(Map<String, String> properties) {
-        String setTrustStorePath = properties.get(ConfigurationManager.TRUST_STORE);
+    private void setDdfPropertiesFromSystemProperties() {
+        String setTrustStorePath = System.getProperty("javax.net.ssl.trustStore");
         if (StringUtils.isNotBlank(setTrustStorePath)) {
             LOGGER.debug("Setting trust store path: " + setTrustStorePath);
             this.trustStorePath = setTrustStorePath;
         }
 
-        String setTrustStorePassword = properties.get(ConfigurationManager.TRUST_STORE_PASSWORD);
+        String setTrustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
         if (StringUtils.isNotBlank(setTrustStorePassword)) {
             if (encryptionService == null) {
                 LOGGER.error(
@@ -558,13 +526,13 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
             }
         }
 
-        String setKeyStorePath = properties.get(ConfigurationManager.KEY_STORE);
+        String setKeyStorePath = System.getProperty("javax.net.ssl.keyStore");
         if (StringUtils.isNotBlank(setKeyStorePath)) {
             LOGGER.debug("Setting key store path: " + setKeyStorePath);
             this.keyStorePath = setKeyStorePath;
         }
 
-        String setKeyStorePassword = properties.get(ConfigurationManager.KEY_STORE_PASSWORD);
+        String setKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
         if (StringUtils.isNotBlank(setKeyStorePassword)) {
             if (encryptionService == null) {
                 LOGGER.error(
@@ -665,7 +633,7 @@ public abstract class AbstractStsRealm extends AuthenticatingRealm
      */
     protected void configureStsClient() {
         LOGGER.debug("Configuring the STS client.");
-
+        setDdfPropertiesFromSystemProperties();
         try {
             if (trustStorePath != null && trustStorePassword != null && keyStorePath != null
                     && keyStorePassword != null) {

--- a/platform/security/sts/security-sts-realm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-realm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,8 +58,6 @@
         </service-properties>
     </service>
 
-    <service ref="stsRealm" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
-
     <service ref="stsRealm" interface="org.apache.shiro.realm.Realm"/>
 
     <bean id="wssStsRealm" class="ddf.security.realm.sts.WssStsRealm">
@@ -97,8 +95,6 @@
             <entry key="id" value="wss"/>
         </service-properties>
     </service>
-
-    <service ref="wssStsRealm" interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
     <service ref="wssStsRealm" interface="org.apache.shiro.realm.Realm"/>
 


### PR DESCRIPTION
 - Updated ConfigurationManager to pull its values from the system properties
 - Replaced ConfigurationWatchers by injecting SystemBaseUrl and SystemInfo beans

@pklinef @ricklarsen @vinamartin

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/227)
<!-- Reviewable:end -->
