### PR TITLE
DDF-1545 Add BASIC authorization header directly to CXF client

### DIFF
--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -44,7 +44,9 @@ public final class RestSecurity {
 
     public static final String SAML_HEADER_PREFIX = "SAML ";
 
-    public static final String SAML_HEADER_NAME = "Authorization";
+    public static final String BASIC_HEADER_PREFIX = "BASIC ";
+
+    public static final String AUTH_HEADER = "Authorization";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RestSecurity.class);
 
@@ -65,7 +67,17 @@ public final class RestSecurity {
                 LOGGER.debug("SAML Header was null. Unable to set the header for the client.");
                 return;
             }
-            client.header(SAML_HEADER_NAME, encodedSamlHeader);
+            client.header(AUTH_HEADER, encodedSamlHeader);
+        }
+    }
+
+    public static void setUserOnClient(String username, String password, Client client) {
+        if (client != null && username != null && password != null && "https"
+                .equalsIgnoreCase(client.getCurrentURI().getScheme())) {
+            String basicCredentials = username + ":" + password;
+            String encodedHeader = BASIC_HEADER_PREFIX + new String(
+                    Base64.encodeBase64(basicCredentials.getBytes()));
+            client.header(AUTH_HEADER, encodedHeader);
         }
     }
 

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/jaxrs/RestSecurityTest.java
@@ -84,8 +84,8 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("https://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNotNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
-        ArrayList headers = (ArrayList) client.getHeaders().get(RestSecurity.SAML_HEADER_NAME);
+        assertNotNull(client.getHeaders().get(RestSecurity.AUTH_HEADER));
+        ArrayList headers = (ArrayList) client.getHeaders().get(RestSecurity.AUTH_HEADER);
         boolean containsSaml = false;
         for (Object header : headers) {
             if (StringUtils.contains(header.toString(), RestSecurity.SAML_HEADER_PREFIX)) {
@@ -106,7 +106,7 @@ public class RestSecurityTest {
         when(subject.getPrincipals()).thenReturn(new SimplePrincipalCollection(assertion, "sts"));
         WebClient client = WebClient.create("http://example.org");
         RestSecurity.setSubjectOnClient(subject, client);
-        assertNull(client.getHeaders().get(RestSecurity.SAML_HEADER_NAME));
+        assertNull(client.getHeaders().get(RestSecurity.AUTH_HEADER));
     }
 
     @Test

--- a/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/SecureCxfClientFactoryTest.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/SecureCxfClientFactoryTest.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 import javax.ws.rs.GET;
 import javax.ws.rs.core.Response;
 
-import org.apache.cxf.configuration.security.AuthorizationPolicy;
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.transport.http.HTTPConduit;
@@ -210,9 +209,6 @@ public class SecureCxfClientFactoryTest {
                 null, true).getClientForBasicAuth(USERNAME, PASSWORD);
         HTTPConduit httpConduit = WebClient.getConfig(WebClient.client(clientForSubject))
                 .getHttpConduit();
-        AuthorizationPolicy authorization = httpConduit.getAuthorization();
-        assertThat(authorization.getUserName(), is(USERNAME));
-        assertThat(authorization.getPassword(), is(PASSWORD));
         assertThat(httpConduit.getTlsClientParameters().isDisableCNCheck(), is(true));
     }
 


### PR DESCRIPTION
Setting the username and password on the HTTPConduit of the CXF client
periodically will not attach the authorization header to the outgoing
message. Adding the header directly to the client works.

@stustison @coyotesqrl @rzwiefel

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/231)
<!-- Reviewable:end -->
