### PR TITLE
DDF-1321 Use specific XML Transformer Factory.

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -120,6 +120,11 @@
             <version>1.2-pre-dr-b04-2014-09-13</version>
         </dependency>
 
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -134,7 +139,8 @@
                             imgscalr-lib,
                             guava,
                             jai-imageio-core-standalone,
-                            jai-imageio-jpeg2000
+                            jai-imageio-jpeg2000,
+                            Saxon-HE
                         </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.transformer.input.tika,

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -67,10 +67,12 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 
+import net.sf.saxon.TransformerFactoryImpl;
+
 public class TikaInputTransformer implements InputTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(TikaInputTransformer.class);
 
-    private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+    private static final TransformerFactory TRANSFORMER_FACTORY = new TransformerFactoryImpl();
 
     private static final String XSLT = "/metadata.xslt";
 


### PR DESCRIPTION
@kcwire @jrnorth @bdeining 

- TikaInputTransformer should not rely on JRE/JDK implementation
  of javax.xml.transform.TransformerFactory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/233)
<!-- Reviewable:end -->
