### PR TITLE
DDF-1510 Web Context Policy Manager settings are complex and require a one-to-one mapping between all fields

### DIFF
--- a/platform/security/filter/security-filter-authorization/src/test/java/org/codice/ddf/security/filter/authorization/AuthorizationFilterTest.java
+++ b/platform/security/filter/security-filter-authorization/src/test/java/org/codice/ddf/security/filter/authorization/AuthorizationFilterTest.java
@@ -226,8 +226,8 @@ public class AuthorizationFilterTest {
         }
 
         @Override
-        public void setAllowedAttributes(Collection<ContextAttributeMapping> attributes) {
-
+        public Collection<ContextAttributeMapping> getAllowedAttributes() {
+            return null;
         }
 
         @Override

--- a/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/ContextPolicy.java
+++ b/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/ContextPolicy.java
@@ -73,9 +73,9 @@ public interface ContextPolicy {
     public Collection<String> getAllowedAttributeNames();
 
     /**
-     * Sets the attribute mappings.
+     * Returns a{@link java.util.Collection} of attributes
      *
-     * @param attributes
+     * @return all attributes the policy uses
      */
-    public void setAllowedAttributes(Collection<ContextAttributeMapping> attributes);
+    public Collection<ContextAttributeMapping> getAllowedAttributes();
 }

--- a/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/attributes/ContextAttributeMapping.java
+++ b/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/attributes/ContextAttributeMapping.java
@@ -31,25 +31,11 @@ public interface ContextAttributeMapping {
     public String getAttributeName();
 
     /**
-     * Sets the attribute name for this mapping
-     *
-     * @param name
-     */
-    public void setAttributeName(String name);
-
-    /**
      * Gets the attribute value for this mapping. This should return the raw, un-parsed value.
      *
      * @return attribute value
      */
     public String getAttributeValue();
-
-    /**
-     * Sets the attribute value for this mapping.
-     *
-     * @param value
-     */
-    public void setAttributeValue(String value);
 
     /**
      * Returns a {@link ddf.security.permission.KeyValuePermission} object that has been created
@@ -58,4 +44,11 @@ public interface ContextAttributeMapping {
      * @return permission
      */
     public KeyValuePermission getAttributePermission();
+
+    /**
+     * Returns the context of the attribute
+     *
+     * @return context
+     */
+    public String getContext();
 }

--- a/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/attributes/DefaultContextAttributeMapping.java
+++ b/platform/security/policy/security-policy-api/src/main/java/org/codice/ddf/security/policy/context/attributes/DefaultContextAttributeMapping.java
@@ -43,18 +43,8 @@ public class DefaultContextAttributeMapping implements ContextAttributeMapping {
     }
 
     @Override
-    public void setAttributeName(String name) {
-        this.attributeName = name;
-    }
-
-    @Override
     public String getAttributeValue() {
         return attributeValue;
-    }
-
-    @Override
-    public void setAttributeValue(String value) {
-        this.attributeValue = value;
     }
 
     @Override
@@ -66,11 +56,8 @@ public class DefaultContextAttributeMapping implements ContextAttributeMapping {
         return keyValuePermission;
     }
 
+    @Override
     public String getContext() {
         return context;
-    }
-
-    public void setContext(String context) {
-        this.context = context;
     }
 }

--- a/platform/security/policy/security-policy-context/src/main/java/org/codice/ddf/security/policy/context/impl/Policy.java
+++ b/platform/security/policy/security-policy-context/src/main/java/org/codice/ddf/security/policy/context/impl/Policy.java
@@ -84,7 +84,10 @@ public class Policy implements ContextPolicy {
     }
 
     @Override
-    public void setAllowedAttributes(Collection<ContextAttributeMapping> attributes) {
-        this.attributeMappings = attributes;
+    public Collection<ContextAttributeMapping> getAllowedAttributes() {
+        if (attributeMappings == null) {
+            return new ArrayList<ContextAttributeMapping>();
+        }
+        return new ArrayList<ContextAttributeMapping>(attributeMappings);
     }
 }

--- a/platform/security/policy/security-policy-context/src/main/java/org/codice/ddf/security/policy/context/impl/PolicyManager.java
+++ b/platform/security/policy/security-policy-context/src/main/java/org/codice/ddf/security/policy/context/impl/PolicyManager.java
@@ -16,8 +16,8 @@ package org.codice.ddf.security.policy.context.impl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,9 +46,11 @@ public class PolicyManager implements ContextPolicyManager {
 
     private static final String WHITE_LIST = "whiteListContexts";
 
-    private static final String DEFAULT_REALM = "DDF";
+    public static final String DEFAULT_REALM = "DDF";
 
-    private static final String DEFAULT_REALM_CONTEXTS = "/=karaf";
+    public static final String DEFAULT_REALM_CONTEXT_VALUE = "karaf";
+
+    private static final String DEFAULT_REALM_CONTEXTS = "/=" + DEFAULT_REALM_CONTEXT_VALUE;
 
     private Map<String, ContextPolicy> policyStore = new HashMap<>();
 
@@ -59,28 +61,28 @@ public class PolicyManager implements ContextPolicyManager {
 
     private Map<String, Object> policyProperties = new HashMap<>();
 
-    private Collection<ContextPolicy> currentPolicies;
-
     public PolicyManager() {
         policyStore.put("/", defaultPolicy);
-        currentPolicies = Collections.unmodifiableCollection(new ArrayList<>(policyStore.values()));
     }
 
     @Override
     public ContextPolicy getContextPolicy(String path) {
-        ContextPolicy entry = policyStore.get(path);
+        return getContextPolicy(path, getPolicyStore(), getWhiteListContexts());
+    }
+
+    private ContextPolicy getContextPolicy(String path, Map<String, ContextPolicy> policyStore,
+            List<String> whiteListContexts) {
+        ContextPolicy entry;
+        entry = policyStore.get(path);
+
         if (entry != null) {
             return entry;
         } else if (whiteListContexts.contains(path)) {
             return null;
         } else {
-            int idx = path.lastIndexOf("/");
-            if (idx <= 0) {
-                idx++;
-            }
-            String pathFragment = path.substring(0, idx);
+            String pathFragment = rollbackPath(path);
             if (StringUtils.isNotEmpty(pathFragment)) {
-                return getContextPolicy(pathFragment);
+                return getContextPolicy(pathFragment, policyStore, whiteListContexts);
             } else {
                 //this is just here for safety
                 //if we get down to the point where we can never get an entry, return the default
@@ -91,24 +93,59 @@ public class PolicyManager implements ContextPolicyManager {
 
     @Override
     public Collection<ContextPolicy> getAllContextPolicies() {
-        return currentPolicies;
+        return getPolicyStore().values();
     }
 
     @Override
-    public synchronized void setContextPolicy(String path, ContextPolicy contextPolicy) {
+    public void setContextPolicy(String path, ContextPolicy newContextPolicy) {
         if (path == null) {
             throw new IllegalArgumentException("Context path cannot be null.");
         }
         if (!path.startsWith("/")) {
             throw new IllegalArgumentException("Context path must start with /");
         }
-        if (contextPolicy == null) {
+        if (newContextPolicy == null) {
             throw new IllegalArgumentException("Context policy cannot be null.");
         }
+        
         LOGGER.debug("setContextPolicy called with path = {}", path);
-        policyStore.put(path, contextPolicy);
 
-        currentPolicies = Collections.unmodifiableCollection(new ArrayList<>(policyStore.values()));
+        //gather all context realms, authorization types, & required attributes
+        Map<String, String> contextsToRealms = new HashMap<String, String>();
+        Map<String, List<ContextAttributeMapping>> contextsToAttrs = new HashMap<>();
+        Map<String, List<String>> contextsToAuths = new HashMap<>();
+
+        for (ContextPolicy contextPolicy : getPolicyStore().values()) {
+            contextsToRealms.put(contextPolicy.getContextPath(), contextPolicy.getRealm());
+            contextsToAttrs.put(contextPolicy.getContextPath(),
+                    new ArrayList(contextPolicy.getAllowedAttributes()));
+            contextsToAuths.put(contextPolicy.getContextPath(),
+                    new ArrayList(contextPolicy.getAuthenticationMethods()));
+        }
+
+        //duplicate and add the new context policy
+        String newContextRealm = newContextPolicy.getRealm();
+
+        List<ContextAttributeMapping> newContextAttrs = new ArrayList<>();
+        for (ContextAttributeMapping contextAttribute : newContextPolicy.getAllowedAttributes()) {
+            newContextAttrs.add(new DefaultContextAttributeMapping(contextAttribute.getContext(),
+                    contextAttribute.getAttributeName(), contextAttribute.getAttributeValue()));
+        }
+
+        Collection<String> newContextAuths = new ArrayList<>();
+        newContextAuths.addAll(newContextPolicy.getAuthenticationMethods());
+
+        if (StringUtils.isNotEmpty(newContextRealm)) {
+            contextsToRealms.put(path, newContextRealm);
+        }
+        if (newContextAttrs != null) {
+            contextsToAttrs.put(path, new ArrayList(newContextAttrs));
+        }
+        if (newContextAuths != null) {
+            contextsToAuths.put(path, new ArrayList(newContextAuths));
+        }
+
+        setPolicyStore(contextsToRealms, contextsToAuths, contextsToAttrs);
     }
 
     /**
@@ -124,7 +161,7 @@ public class PolicyManager implements ContextPolicyManager {
      *                   Since there is no configuration file bound to these properties by default,
      *                   this map may be {@code null}.
      */
-    public synchronized void setPolicies(Map<String, Object> properties) {
+    public void setPolicies(Map<String, Object> properties) {
         if (properties == null) {
             LOGGER.debug("setPolicies() called with null properties map. "
                     + "Policy store should have already been initialized so ignoring.");
@@ -133,9 +170,6 @@ public class PolicyManager implements ContextPolicyManager {
         }
 
         LOGGER.debug("setPolicies called: {}", properties);
-        policyStore.clear();
-        policyStore.put("/", defaultPolicy);
-
         Object realmsObj = properties.get(REALMS);
         String[] realmContexts = null;
         Object authTypesObj = properties.get(AUTH_TYPES);
@@ -176,9 +210,7 @@ public class PolicyManager implements ContextPolicyManager {
             Map<String, List<ContextAttributeMapping>> contextToAttr = new HashMap<>();
 
             List<String> realmContextList = expandStrings(realmContexts);
-
             List<String> authContextList = expandStrings(authContexts);
-
             List<String> attrContextList = expandStrings(attrContexts);
 
             for (String realm : realmContextList) {
@@ -216,30 +248,179 @@ public class PolicyManager implements ContextPolicyManager {
                     for (String attribute : attributes) {
                         String[] parts = attribute.split("=");
                         if (parts.length == 2) {
-                            attrMaps.add(new DefaultContextAttributeMapping(context, parts[0],
-                                    parts[1]));
+                            attrMaps.add(new DefaultContextAttributeMapping(context, parts[0], parts[1]));
                         }
                     }
                     contextToAttr.put(context, attrMaps);
                 }
             }
 
-            Set<Map.Entry<String, List<String>>> contexts = contextToAuth.entrySet();
+            setPolicyStore(contextToRealm, contextToAuth, contextToAttr);
+        }
+        LOGGER.debug("Policy store initialized, now contains {} entries", policyStore.size());
+    }
 
-            for (Map.Entry<String, List<String>> context : contexts) {
-                List<ContextAttributeMapping> mappings = contextToAttr.get(context.getKey());
-                if (mappings == null) {
-                    mappings = new ArrayList<>();
-                }
-                policyStore.put(context.getKey(),
-                        new Policy(context.getKey(), contextToRealm.get(context.getKey()),
-                                context.getValue(), mappings));
-            }
+    private void setPolicyStore(Map<String, String> allContextsToRealms,
+            Map<String, List<String>> allContextsToAuths,
+            Map<String, List<ContextAttributeMapping>> allContextsToAttrs) {
+
+        //add default context values if they do not exist
+        if (allContextsToRealms.get("/") == null) {
+            allContextsToRealms.put("/", DEFAULT_REALM_CONTEXT_VALUE);
         }
 
-        currentPolicies = Collections.unmodifiableCollection(new ArrayList<>(policyStore.values()));
+        if (allContextsToAttrs.get("/") == null) {
+            allContextsToAttrs.put("/", new ArrayList<ContextAttributeMapping>());
+        }
 
-        LOGGER.debug("Policy store initialized, now contains {} entries", policyStore.size());
+        if (allContextsToAuths.get("/") == null) {
+            allContextsToAuths.put("/", new ArrayList<String>());
+        }
+
+        //gather all given context paths
+        Set<String> allContextPaths = new HashSet<>();
+        allContextPaths.addAll(allContextsToRealms.keySet());
+        allContextPaths.addAll(allContextsToAuths.keySet());
+        allContextPaths.addAll(allContextsToAttrs.keySet());
+
+        Map<String, ContextPolicy> newPolicyStore = new HashMap<>();
+        newPolicyStore.put("/", defaultPolicy);
+
+        //resolve all realms, authorization types & required attributes
+        for (String path : allContextPaths) {
+            String contextRealm = getContextRealm(path, allContextsToRealms);
+            List<String> contextAuthTypes = getContextAuthTypes(path, allContextsToAuths);
+            List<ContextAttributeMapping> contextReqAttrs = getContextReqAttrs(path,
+                    allContextsToAttrs);
+
+            newPolicyStore
+                    .put(path, new Policy(path, contextRealm, contextAuthTypes, contextReqAttrs));
+        }
+
+        policyStore = newPolicyStore;
+    }
+
+    /**
+     * Returns a duplicate of the current policy store.
+     * @return duplicate policy store
+     */
+    public Map<String, ContextPolicy> getPolicyStore() {
+        Map<String, ContextPolicy> copiedPolicyStore = new HashMap<>();
+
+        for (ContextPolicy contextPolicy : policyStore.values()) {
+            copiedPolicyStore.put(contextPolicy.getContextPath(), copyContextPolicy(contextPolicy));
+        }
+
+        return copiedPolicyStore;
+    }
+
+    /**
+     * Returns a duplicate of the current white list contexts
+     * @return
+     */
+    public List<String> getWhiteListContexts() {
+        List<String> copiedWhiteListContexts = new ArrayList<>();
+        copiedWhiteListContexts.addAll(whiteListContexts);
+        return copiedWhiteListContexts;
+    }
+
+    /**
+     * Duplicates the given context policy
+     * @param contextPolicy
+     * @return copy of contextPolicy
+     */
+    public ContextPolicy copyContextPolicy(ContextPolicy contextPolicy) {
+        Collection<ContextAttributeMapping> copiedContextAttributes = new ArrayList<>();
+        Collection<String> copiedAuthenticationMethods = new ArrayList<>();
+
+        copiedAuthenticationMethods.addAll(contextPolicy.getAuthenticationMethods());
+
+        for (ContextAttributeMapping contextAttribute : contextPolicy.getAllowedAttributes()) {
+            copiedContextAttributes
+                    .add(new DefaultContextAttributeMapping(contextAttribute.getContext(),
+                                    contextAttribute.getAttributeName(),
+                                    contextAttribute.getAttributeValue()));
+        }
+
+        return new Policy(contextPolicy.getContextPath(), contextPolicy.getRealm(),
+                copiedAuthenticationMethods, copiedContextAttributes);
+    }
+
+    /**
+     * Gets the context realm of the given path. If context realm of given path does not exist it rolls back until a parent path exists with a context realm
+     * If no parent path exists, the context defaults to "/" realm
+     *
+     * @param path           - Path associated to context
+     * @param contextToRealm - Map of all paths and their context realms
+     * @return context - Realm associated to path
+     */
+    public String getContextRealm(String path, Map<String, String> contextToRealm) {
+        String entry = contextToRealm.get(path);
+        if (entry != null) {
+            return entry;
+        } else {
+            String pathFragment = rollbackPath(path);
+            if (StringUtils.isNotEmpty(pathFragment)) {
+                return getContextRealm(pathFragment, contextToRealm);
+            } else {
+                return DEFAULT_REALM_CONTEXT_VALUE;
+            }
+        }
+    }
+
+    /**
+     * Gets the authorization types of the given path. If authorization types of given path do not exist it rolls back until a parent path exists with such authorization types is found
+     * If no parent path exists, the authorization types defaults to an empty list
+     *
+     * @param path               - Path associated with context
+     * @param contextToAuthTypes - Map of all paths and their context authorization types
+     * @return List of authorization types
+     */
+    public List<String> getContextAuthTypes(String path,
+            Map<String, List<String>> contextToAuthTypes) {
+        List<String> entry = contextToAuthTypes.get(path);
+        if (entry != null) {
+            return entry;
+        } else {
+            String pathFragment = rollbackPath(path);
+            if (StringUtils.isNotEmpty(pathFragment)) {
+                return getContextAuthTypes(pathFragment, contextToAuthTypes);
+            } else {
+                return new ArrayList<String>();
+            }
+        }
+    }
+
+    /**
+     * Gets the required attributes of the context associated to the given path. If required attributes of given path do not exist it rolls back until a parent context path exists with such required attributes is found
+     * If no parent path exists, the context defaults to empty list
+     *
+     * @param -                 Path associated to context
+     * @param contextToReqAttrs - Map of all paths to contexts and their associated required attributes
+     * @return List of required attributes
+     */
+    public List<ContextAttributeMapping> getContextReqAttrs(String path,
+            Map<String, List<ContextAttributeMapping>> contextToReqAttrs) {
+        List<ContextAttributeMapping> entry = contextToReqAttrs.get(path);
+        if (entry != null) {
+            return entry;
+        } else {
+            String pathFragment = rollbackPath(path);
+            if (StringUtils.isNotEmpty(pathFragment)) {
+                return getContextReqAttrs(pathFragment, contextToReqAttrs);
+            } else {
+                return new ArrayList<ContextAttributeMapping>();
+            }
+        }
+    }
+
+    public String rollbackPath(String path) {
+        //Continue splitting by last "/"  down path until value found,
+        int idx = path.lastIndexOf("/");
+        if (idx <= 0) {
+            idx++;
+        }
+        return path.substring(0, idx);
     }
 
     private List<String> expandStrings(String[] itemArr) {
@@ -306,8 +487,7 @@ public class PolicyManager implements ContextPolicyManager {
     public void setWhiteListContexts(List<String> contexts) {
         LOGGER.debug("setWhiteListContexts(List<String>) called with {}", contexts);
         if (contexts != null && !contexts.isEmpty()) {
-            whiteListContexts.clear();
-            whiteListContexts.addAll(expandStrings(contexts));
+            whiteListContexts = expandStrings(contexts);
         }
     }
 
@@ -315,8 +495,7 @@ public class PolicyManager implements ContextPolicyManager {
         LOGGER.debug("setWhiteListContexts(String) called with {}", contexts);
         if (StringUtils.isNotEmpty(contexts)) {
             String[] contextsArr = contexts.split(",");
-            whiteListContexts.clear();
-            whiteListContexts.addAll(Arrays.asList(contextsArr));
+            whiteListContexts = Arrays.asList(contextsArr);
         }
     }
 

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
         <property name="authenticationTypes"
                   value="/=SAML|ANON,/admin=SAML|basic,/jolokia=SAML|basic,/system=basic,/solr=SAML|PKI|basic,/sources=SAML|basic,/security-config=SAML|basic"/>
         <property name="realms"
-                  value="/=karaf,/admin=karaf,/system=karaf,/solr=karaf,/jolokia=karaf,/sources=karaf,/security-config=karaf"/>
+                  value="/=karaf"/>
         <property name="requiredAttributes"
                   value="/=,/admin={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin},/solr={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin},/jolokia={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin},/system={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin},/sources={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin},/security-config={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=admin}"/>
         <property name="whiteListContexts"

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,7 +22,7 @@
         <AD description="List of realms supporting each context. Provided realms are: DDF, karaf. Example: /=DDF"
             name="Context Realms" id="realms" required="true" cardinality="100"
             type="String"
-            default="/=karaf,/admin=karaf,/system=karaf,/solr=karaf,/jolokia=karaf,/sources=karaf,/security-config=karaf"/>
+            default="/=karaf"/>
 
         <AD description="List of authentication types required for each context. List of default valid authentication types are: SAML, BASIC, PKI, ANON. Example: /context=AUTH1|AUTH2|AUTH3"
             name="Authentication Types" id="authenticationTypes" required="true" cardinality="100"

--- a/platform/security/policy/security-policy-context/src/test/java/org/codice/security/policy/context/PolicyManagerTest.java
+++ b/platform/security/policy/security-policy-context/src/test/java/org/codice/security/policy/context/PolicyManagerTest.java
@@ -13,6 +13,8 @@
  */
 package org.codice.security.policy.context;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -25,6 +27,8 @@ import org.codice.ddf.security.policy.context.impl.PolicyManager;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 import junit.framework.Assert;
 
 /**
@@ -32,23 +36,143 @@ import junit.framework.Assert;
  */
 public class PolicyManagerTest {
 
+
+    private static final String REALMS = "realms";
+
+    private static final String DEFAULT_REALM_CONTEXT_VALUE = "karaf";
+
+    private static final String AUTH_TYPES = "authenticationTypes";
+
+    private static final String REQ_ATTRS = "requiredAttributes";
+
+    private static final List<String> DEFAULT_AUTH_TYPES = Arrays.asList(new String[] {"SAML", "ANON"});
     private PolicyManager manager;
+
+    private PolicyManager rollBackTestManager;
+
+    private String rollBackRealmValues =
+            "/=" + DEFAULT_REALM_CONTEXT_VALUE + ","
+            + "/A=a,"
+            + "/A/B/C/testContext4=abcTestContext4,"
+            + "/testContext5=karaf,"
+            + "/1/2/3/testContext6=" + DEFAULT_REALM_CONTEXT_VALUE + ","
+            + "/A/B/C/testContext7=" + DEFAULT_REALM_CONTEXT_VALUE + ",";
+
+    private String rollBackAuthTypesValues =
+            "/=SAML|ANON,"
+            + "/A=a,"
+            + "/A/B/C/testContext4=abcTestContext4";
+
+    private String rollBackReqAttrValues =
+            "/=,"
+            + "/A={A=a},"
+            + "/testContext=,"
+            + "/1/2/3/testContext2=,"
+            + "/A/B/C/testContext3=,"
+            + "/A/B/C/testContext4=,"
+            + "/A/B/C/testContext8={AbcTestContext8=abcTestContext8}";
+
+    private final Map<String, String> expectedRollBackRealms = new ImmutableMap.Builder<String, String>()
+            .put("/testContext", DEFAULT_REALM_CONTEXT_VALUE)
+            .put("/1/2/3/testContext2", DEFAULT_REALM_CONTEXT_VALUE)
+            .put("/A/B/C/testContext3", "a")
+            .put("/A/B/C/testContext4", "abcTestContext4").build();
+
+    private final Map<String, List<String>> expectedRollBackAuthTypes = new ImmutableMap.Builder<String, List<String>>()
+            .put("/testContext", DEFAULT_AUTH_TYPES)
+            .put("/1/2/3/testContext2", Arrays.asList(new String[] {"SAML", "ANON"}))
+            .put("/A/B/C/testContext3", Arrays.asList(new String[] {"a"}))
+            .put("/A/B/C/testContext4", Arrays.asList(new String[] {"abcTestContext4"}))
+            .build();
+
+    private  final Map<String, List<String>> expectedRollBackReqAttrs = new ImmutableMap.Builder<String, List<String>>()
+            .put("/testContext5", Arrays.asList(new String[] {}))
+            .put("/1/2/3/testContext6", Arrays.asList(new String[] {}))
+            .put("/A/B/C/testContext7", Arrays.asList(new String[] {"A"}))
+            .put("/A/B/C/testContext8", Arrays.asList(new String[] {"AbcTestContext8"}))
+            .build();
+
+
 
     @Before
     public void setup() {
         manager = new PolicyManager();
-        manager.setContextPolicy("/", new Policy("/", null, null, null));
-        manager.setContextPolicy("/search", new Policy("/search", null, null, null));
-        manager.setContextPolicy("/admin", new Policy("/admin", null, null, null));
-        manager.setContextPolicy("/search/standard",
-                new Policy("/search/standard", null, null, null));
-        manager.setContextPolicy("/cometd", new Policy("/cometd", null, null, null));
-        manager.setContextPolicy("/search/simple", new Policy("/search/simple", null, null, null));
-        manager.setContextPolicy("/aaaaaa", new Policy("/aaaaaa", null, null, null));
-        manager.setContextPolicy("/aaa", new Policy("/aaa", null, null, null));
-        manager.setContextPolicy("/aaa/aaa", new Policy("/aaa/aaa", null, null, null));
-        manager.setContextPolicy("/foo/bar", new Policy("/foo/bar", null, null, null));
+        manager.setContextPolicy("/", new Policy("/", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/search", new Policy("/search", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/admin", new Policy("/admin", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/search/standard", new Policy("/search/standard", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/cometd", new Policy("/cometd", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/search/simple", new Policy("/search/simple", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/aaaaaa", new Policy("/aaaaaa", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/aaa", new Policy("/aaa", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/aaa/aaa", new Policy("/aaa/aaa", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/foo/bar", new Policy("/foo/bar", null, new ArrayList<String>(), null));
         manager.setWhiteListContexts("/foo");
+
+        Map<String, Object> contextPolicies = new HashMap<>();
+        contextPolicies.put(REALMS, rollBackRealmValues);
+        contextPolicies.put(AUTH_TYPES, rollBackAuthTypesValues);
+        contextPolicies.put(REQ_ATTRS, rollBackReqAttrValues);
+
+        rollBackTestManager = new PolicyManager();
+        rollBackTestManager.setPolicies(contextPolicies);
+    }
+
+    /**
+     * Tests context rollbacks to the specified realms
+     * / <- /testContext - single rollback to default
+     * / <- /1/2/3/testContext2 - several rollbacks to default
+     * /A <- /A/B/C/testContext3 - several rollback to parent
+     * /A/B/C/testContext4 <- /A/B/C/testContext4 - no rollback
+     */
+    @Test
+    public void testContextRealmRollBack() {
+        for (String contextPath : expectedRollBackRealms.keySet()) {
+            Assert.assertEquals(expectedRollBackRealms.get(contextPath),
+                    rollBackTestManager.getContextPolicy(contextPath).getRealm());
+        }
+
+    }
+
+    /**
+     * Tests context rollbacks to the specified authorization types
+     * / <- /testContext - single rollback to default
+     * / <- /1/2/3/testContext2 - several rollbacks to default
+     * /A <- /A/B/C/testContext3 - several rollback to parent
+     * /A/B/C/testContext4 <- /A/B/C/testContext4 - no rollback
+     */
+    @Test
+    public void testAuthTypesRollBack() {
+        for (String contextPath : expectedRollBackAuthTypes.keySet()) {
+            for (String authType : rollBackTestManager.getContextPolicy(contextPath)
+                    .getAuthenticationMethods()) {
+                Assert.assertTrue(expectedRollBackAuthTypes.get(contextPath).contains(authType));
+            }
+        }
+    }
+
+    /**
+     * Tests context rollbacks to the specified required attributes
+     * / <- /testContext5 - single rollback to default
+     * / <- /1/2/3/testContext6 - several rollbacks to default
+     * /A <- /A/B/C/testContext7 - several rollback to parent
+     * /A/B/C/testContext8 <- /A/B/C/testContext8 - no rollback
+     */
+    @Test
+    public void testReqAttrRollBack() {
+        for (String contextPath : expectedRollBackReqAttrs.keySet()) {
+            for (String authType : rollBackTestManager.getContextPolicy(contextPath)
+                    .getAllowedAttributeNames()) {
+                Assert.assertTrue(expectedRollBackReqAttrs.get(contextPath).contains(authType));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidEntry() {
+        Assert.assertEquals(rollBackTestManager.getContextPolicy("invalidContextPathEntry").getRealm(), PolicyManager.DEFAULT_REALM_CONTEXT_VALUE);
+        Assert.assertEquals(rollBackTestManager.getContextPolicy("invalidContextPathEntry").getAllowedAttributeNames(), Arrays.asList(new String[] {}));
+        Assert.assertEquals(rollBackTestManager.getContextPolicy("invalidContextPathEntry").getAuthenticationMethods(), DEFAULT_AUTH_TYPES);
     }
 
     @Test


### PR DESCRIPTION
Web Context Policy Manager settings are complex and require a one-to-one mapping between all fields

 - Created maps for attributes, context realms and authorizations to perform roll backs if necessary before setting the policy manager
- Made policy manager thread safe by returning a copy of the policy store and by creating copies of any policy to be added
@jckilmer @rzwiefel  @roelens8 @coyotesqrl @ryeats

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/238)
<!-- Reviewable:end -->
