### PR TITLE
DDF-1519 Add support to authenticate with any SAML SSO IDP

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/ws-security/issuer/encryption.properties
+++ b/distribution/ddf-common/src/main/resources/etc/ws-security/issuer/encryption.properties
@@ -2,5 +2,6 @@
 org.apache.ws.security.crypto.provider=org.apache.wss4j.common.crypto.Merlin
 org.apache.ws.security.crypto.merlin.keystore.type=jks
 org.apache.ws.security.crypto.merlin.keystore.password=changeit
+org.apache.ws.security.crypto.merlin.keystore.private.password=changeit
 org.apache.ws.security.crypto.merlin.keystore.alias=localhost
 org.apache.ws.security.crypto.merlin.keystore.file=etc/keystores/serverKeystore.jks

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -276,6 +276,12 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <classifier>tests</classifier>
+                <version>4.3.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>4.3.5</version>
             </dependency>

--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -25,7 +25,7 @@
     <groupId>ddf.security</groupId>
     <artifactId>ddf-security-common</artifactId>
     <name>DDF :: Security :: Common</name>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/SecurityAssertionImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/SecurityAssertionImpl.java
@@ -19,12 +19,14 @@ import java.io.Serializable;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.x500.X500Principal;
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -46,6 +48,7 @@ import org.opensaml.saml2.core.AuthnContextDecl;
 import org.opensaml.saml2.core.AuthnContextDeclRef;
 import org.opensaml.saml2.core.AuthnStatement;
 import org.opensaml.saml2.core.AuthzDecisionStatement;
+import org.opensaml.saml2.core.Conditions;
 import org.opensaml.saml2.core.EncryptedAttribute;
 import org.opensaml.saml2.core.Issuer;
 import org.opensaml.saml2.core.NameID;
@@ -114,6 +117,10 @@ public class SecurityAssertionImpl implements SecurityAssertion {
 
     private transient List<AuthnStatement> authenticationStatements;
 
+    private Date notBefore;
+
+    private Date notOnOrAfter;
+
     /**
      * Uninitialized Constructor
      */
@@ -157,7 +164,7 @@ public class SecurityAssertionImpl implements SecurityAssertion {
     private void init() {
         attributeStatements = new ArrayList<>();
         authenticationStatements = new ArrayList<>();
-        this.usernameAttributeList = new ArrayList<>();
+        usernameAttributeList = new ArrayList<>();
     }
 
     /**
@@ -242,6 +249,18 @@ public class SecurityAssertionImpl implements SecurityAssertion {
                         break;
                     case Issuer.DEFAULT_ELEMENT_LOCAL_NAME:
                         issuer = xmlStreamReader.getElementText();
+                        break;
+                    case Conditions.DEFAULT_ELEMENT_LOCAL_NAME:
+                        attrs = xmlStreamReader.getAttributeCount();
+                        for (int i = 0; i < attrs; i++) {
+                            String name = xmlStreamReader.getAttributeLocalName(i);
+                            String value = xmlStreamReader.getAttributeValue(i);
+                            if (Conditions.NOT_BEFORE_ATTRIB_NAME.equals(name)) {
+                                notBefore = DatatypeConverter.parseDateTime(value).getTime();
+                            } else if (Conditions.NOT_ON_OR_AFTER_ATTRIB_NAME.equals(name)) {
+                                notOnOrAfter = DatatypeConverter.parseDateTime(value).getTime();
+                            }
+                        }
                         break;
                     }
                     break;
@@ -373,7 +392,7 @@ public class SecurityAssertionImpl implements SecurityAssertion {
      * Checks if the NameIDFormat is of the following formats below, if not, the name is changed
      * to the value of the first matching usernameAttribute.
      */
-    public void identifyNameIDFormat() {
+    private void identifyNameIDFormat() {
         if (!((StringUtils.containsIgnoreCase(nameIDFormat, SAML2Constants.NAMEID_FORMAT_PERSISTENT)
                 || StringUtils
                 .containsIgnoreCase(nameIDFormat, SAML2Constants.NAMEID_FORMAT_X509_SUBJECT_NAME)
@@ -394,13 +413,23 @@ public class SecurityAssertionImpl implements SecurityAssertion {
         }
     }
 
-    public boolean listContainsIgnoreCase(List<String> list, String string) {
+    private boolean listContainsIgnoreCase(List<String> list, String string) {
         for (String next : list) {
             if (next.equalsIgnoreCase(string)) {
                 return true;
             }
         }
         return false;
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return notBefore;
+    }
+
+    @Override
+    public Date getNotOnOrAfter() {
+        return notOnOrAfter;
     }
 
     /*

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/assertion/impl/SecurityAssertionImplTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/assertion/impl/SecurityAssertionImplTest.java
@@ -15,10 +15,12 @@ package ddf.security.assertion.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -41,6 +43,10 @@ public class SecurityAssertionImplTest {
     private static final int NUM_NAUTH = 1;
 
     private static final int NUM_AUTHZ = 0;
+
+    public static final String BEFORE = "2013-04-23T23:39:54.788Z";
+
+    public static final String AFTER = "2013-04-24T00:09:54.788Z";
 
     public static Document readXml(InputStream is)
             throws SAXException, IOException, ParserConfigurationException {
@@ -65,11 +71,13 @@ public class SecurityAssertionImplTest {
     @Test
     public void testEmptyAssertion() {
         SecurityAssertionImpl assertion = new SecurityAssertionImpl();
-        assertEquals(null, assertion.getIssuer());
+        assertNull(assertion.getIssuer());
         assertEquals(0, assertion.getAttributeStatements().size());
         assertEquals(0, assertion.getAuthnStatements().size());
         assertEquals(0, assertion.getAuthzDecisionStatements().size());
-        assertEquals(null, assertion.getPrincipal());
+        assertNull(assertion.getPrincipal());
+        assertNull(assertion.getNotBefore());
+        assertNull(assertion.getNotOnOrAfter());
     }
 
     @Test
@@ -85,6 +93,10 @@ public class SecurityAssertionImplTest {
         assertEquals(PRINCIPAL, assertion.getPrincipal().toString());
         assertEquals(NUM_ATTRIBUTES, assertion.getAttributeStatements().size());
         assertEquals(NUM_NAUTH, assertion.getAuthnStatements().size());
+        assertEquals(DatatypeConverter.parseDateTime(BEFORE).getTimeInMillis(),
+                assertion.getNotBefore().getTime());
+        assertEquals(DatatypeConverter.parseDateTime(AFTER).getTimeInMillis(),
+                assertion.getNotOnOrAfter().getTime());
         //we don't currently parse these
         //        assertEquals(NUM_AUTHZ, assertion.getAuthzDecisionStatements().size());
         assertNotNull(assertion.toString());

--- a/platform/security/encryption/platform-security-encryption-api/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-api/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.wss4j</groupId>
+            <artifactId>wss4j-ws-security-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
         </dependency>

--- a/platform/security/encryption/platform-security-encryption-api/src/main/java/ddf/security/encryption/EncryptionService.java
+++ b/platform/security/encryption/platform-security-encryption-api/src/main/java/ddf/security/encryption/EncryptionService.java
@@ -13,22 +13,9 @@
  */
 package ddf.security.encryption;
 
-public interface EncryptionService {
-    /**
-     * Encrypts a plain text value.
-     *
-     * @param value
-     *            The value to encrypt.
-     */
-    String encrypt(String value);
+import org.apache.wss4j.common.crypto.PasswordEncryptor;
 
-    /**
-     * Decrypts a plain text value.
-     *
-     * @param value
-     *            The value to decrypt.
-     */
-    String decrypt(String value);
+public interface EncryptionService extends PasswordEncryptor {
 
     /**
      * Decrypts the unwrapped encrypted value

--- a/platform/security/filter/security-filter-login/pom.xml
+++ b/platform/security/filter/security-filter-login/pom.xml
@@ -42,6 +42,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -116,7 +121,11 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>ddf-security-common, guava</Embed-Dependency>
+                        <Embed-Dependency>
+                            common-system,
+                            ddf-security-common,
+                            guava
+                        </Embed-Dependency>
                         <Import-Package>
                             org.apache.log4j,
                             javax.servlet; version="[2.5.0,3.0.0)",

--- a/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,11 +19,14 @@
 
     <ext:property-placeholder/>
 
+    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
+
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
     <bean id="filter" class="org.codice.ddf.security.filter.login.LoginFilter">
         <cm:managed-properties persistent-id="org.codice.ddf.security.filter.login.Session"
                                update-strategy="container-managed"/>
+        <argument ref="baseUrl" />
         <property name="securityManager" ref="securityManager"/>
         <property name="signaturePropertiesFile"
                   value="${ddf.home}/etc/ws-security/server/signature.properties"/>

--- a/platform/security/filter/security-filter-login/src/test/resources/good_saml.xml
+++ b/platform/security/filter/security-filter-login/src/test/resources/good_saml.xml
@@ -40,7 +40,7 @@
         Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
         NameQualifier="http://cxf.apache.org/sts">admin</saml2:NameID><saml2:SubjectConfirmation
         Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/></saml2:Subject><saml2:Conditions
-        NotBefore="2015-03-02T19:30:33.626Z" NotOnOrAfter="2015-03-02T20:00:33.626Z"/><saml2:AuthnStatement
+        NotBefore="2015-03-02T19:30:33.626Z" NotOnOrAfter="2115-03-02T20:00:33.626Z"/><saml2:AuthnStatement
         AuthnInstant="2015-03-02T19:30:33.626Z"><saml2:AuthnContext><saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef></saml2:AuthnContext></saml2:AuthnStatement><saml2:AttributeStatement><saml2:Attribute
         Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"
         NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified"><saml2:AttributeValue

--- a/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
+++ b/platform/security/filter/security-filter-web-sso/src/main/java/org/codice/ddf/security/filter/websso/WebSSOFilter.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class WebSSOFilter implements Filter {
 
-    private static final String DDF_AUTHENTICATION_TOKEN = "ddf.security.token";
+    public static final String DDF_AUTHENTICATION_TOKEN = "ddf.security.token";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSSOFilter.class);
 

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -26,6 +26,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -41,6 +42,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import ddf.security.SecurityConstants;
+import ddf.security.common.util.SecurityTokenHolder;
 
 public class SAMLAssertionHandlerTest {
 
@@ -158,6 +160,29 @@ public class SAMLAssertionHandlerTest {
 
         assertNotNull(result);
         assertEquals(HandlerResult.Status.NO_ACTION, result.getStatus());
+    }
+
+    @Test
+    public void testGetNormalizedTokenFromSession() throws Exception {
+        SAMLAssertionHandler handler = new SAMLAssertionHandler();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(request.getCookies()).thenReturn(null);
+        HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        SecurityTokenHolder tokenHolder = mock(SecurityTokenHolder.class);
+        when(session.getAttribute(SecurityConstants.SAML_ASSERTION)).thenReturn(tokenHolder);
+        SecurityToken securityToken = mock(SecurityToken.class);
+        when(tokenHolder.getSecurityToken()).thenReturn(securityToken);
+        when(securityToken.getToken()).thenReturn(readDocument("/saml.xml").getDocumentElement());
+
+        HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
+
+        assertNotNull(result);
+        assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
     }
 
     /**

--- a/platform/security/handler/security-handler-saml/src/test/resources/saml.xml
+++ b/platform/security/handler/security-handler-saml/src/test/resources/saml.xml
@@ -88,7 +88,7 @@
             </saml2:SubjectConfirmationData>
         </saml2:SubjectConfirmation>
     </saml2:Subject>
-    <saml2:Conditions NotBefore="2013-04-23T23:39:54.788Z" NotOnOrAfter="2013-04-24T00:09:54.788Z">
+    <saml2:Conditions NotBefore="2013-04-23T23:39:54.788Z" NotOnOrAfter="2113-04-24T00:09:54.788Z">
         <saml2:AudienceRestriction>
             <saml2:Audience>https://localhost:8993/services</saml2:Audience>
         </saml2:AudienceRestriction>

--- a/platform/security/idp/pom.xml
+++ b/platform/security/idp/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security</artifactId>
+        <groupId>ddf.platform.security</groupId>
+        <version>2.8.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ddf.security.idp</groupId>
+    <artifactId>idp</artifactId>
+    <name>DDF :: Security :: IDP</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>security-idp-client</module>
+    </modules>
+
+</project>

--- a/platform/security/idp/security-idp-client/pom.xml
+++ b/platform/security/idp/security-idp-client/pom.xml
@@ -11,33 +11,27 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
--->
+
+ -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>handler</artifactId>
-        <groupId>ddf.security.handler</groupId>
+        <artifactId>idp</artifactId>
+        <groupId>ddf.security.idp</groupId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>DDF :: Security :: Handler :: SAML</name>
-    <artifactId>security-handler-saml</artifactId>
+    <name>DDF :: Security :: IdP :: Client</name>
+    <artifactId>security-idp-client</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>ddf.security.handler</groupId>
-            <artifactId>security-handler-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security.core</groupId>
-            <artifactId>security-core-api</artifactId>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -48,10 +42,6 @@
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
         </dependency>
@@ -60,13 +50,46 @@
             <artifactId>cxf-services-sts-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-security-xml</artifactId>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.encryption</groupId>
+            <artifactId>security-encryption-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.handler</groupId>
+            <artifactId>security-handler-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.handler</groupId>
+            <artifactId>security-handler-saml</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.filter</groupId>
+            <artifactId>security-filter-login</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.filter</groupId>
+            <artifactId>security-filter-web-sso</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.security.policy</groupId>
             <artifactId>security-policy-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml</artifactId>
+            <version>2.6.1</version>
         </dependency>
     </dependencies>
 
@@ -79,12 +102,9 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
+                            common-system,
                             ddf-security-common
                         </Embed-Dependency>
-                        <Import-Package>
-                            org.apache.cxf.common.util,
-                            *
-                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -106,22 +126,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.22</minimum>
+                                            <minimum>0.0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.21</minimum>
+                                            <minimum>0.0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.0</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -132,6 +152,5 @@
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.crypto.CryptoType;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.apache.wss4j.common.util.DOM2Writer;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.security.common.jaxrs.RestSecurity;
+import org.codice.ddf.security.filter.websso.WebSSOFilter;
+import org.codice.ddf.security.handler.api.HandlerResult;
+import org.codice.ddf.security.handler.saml.SAMLAssertionHandler;
+import org.codice.ddf.security.policy.context.ContextPolicy;
+import org.opensaml.saml2.metadata.EntityDescriptor;
+import org.opensaml.xml.XMLObject;
+import org.opensaml.xml.validation.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+
+import ddf.security.samlp.SamlProtocol;
+
+@Path("sso")
+public class AssertionConsumerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdpHandler.class);
+
+    private static final String SAML_RESPONSE = "SAMLResponse";
+
+    private static final String RELAY_STATE = "RelayState";
+
+    private static final String SIG_ALG = "SigAlg";
+
+    private static final String SIGNATURE = "Signature";
+
+    private static final String UNABLE_TO_LOGIN = "Unable to login with provided AuthN response assertion.";
+
+    private final SimpleSign simpleSign;
+
+    private final IdpMetadata idpMetadata;
+
+    private final SystemBaseUrl baseUrl;
+
+    @Context
+    private HttpServletRequest request;
+
+    private Filter loginFilter;
+
+    private SystemCrypto systemCrypto;
+
+    public AssertionConsumerService(SimpleSign simpleSign, IdpMetadata metadata,
+            SystemCrypto crypto, SystemBaseUrl systemBaseUrl) {
+        this.simpleSign = simpleSign;
+        idpMetadata = metadata;
+        systemCrypto = crypto;
+        baseUrl = systemBaseUrl;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response postSamlResponse(@FormParam(SAML_RESPONSE) String encodedSamlResponse,
+            @FormParam(RELAY_STATE) String relayState) {
+
+        return processSamlResponse(decodeBase64(encodedSamlResponse), relayState);
+    }
+
+    @GET
+    public Response getSamlResponse(@QueryParam(SAML_RESPONSE) String deflatedSamlResponse,
+            @QueryParam(RELAY_STATE) String relayState,
+            @QueryParam(SIG_ALG) String signatureAlgorithm,
+            @QueryParam(SIGNATURE) String signature) {
+
+        if (validateSignature(deflatedSamlResponse, relayState, signatureAlgorithm, signature)) {
+            try {
+                return processSamlResponse(RestSecurity.inflateBase64(deflatedSamlResponse),
+                        relayState);
+            } catch (IOException e) {
+                String msg = "Unable to decode and inflate AuthN response.";
+                LOGGER.warn(msg, e);
+                return Response.serverError().entity(msg).build();
+            }
+        } else {
+            return Response.serverError().entity("Invalid AuthN response signature.").build();
+        }
+
+    }
+
+    private boolean validateSignature(String deflatedSamlResponse, String relayState,
+            String signatureAlgorithm, String signature) {
+        boolean signaturePasses = false;
+        if (signature != null) {
+            if (StringUtils.isNotBlank(deflatedSamlResponse) && StringUtils.isNotBlank(relayState)
+                    && StringUtils.isNotBlank(signatureAlgorithm)) {
+                try {
+                    String signedMessage = String.format("%s=%s&%s=%s&%s=%s", SAML_RESPONSE,
+                            URLEncoder.encode(deflatedSamlResponse, "UTF-8"), RELAY_STATE,
+                            URLEncoder.encode(relayState, "UTF-8"), SIG_ALG,
+                            URLEncoder.encode(signatureAlgorithm, "UTF-8"));
+                    signaturePasses = simpleSign.validateSignature(signedMessage, signature,
+                            idpMetadata.getSigningCertificate());
+                } catch (SimpleSign.SignatureException | UnsupportedEncodingException e) {
+                    LOGGER.debug("Failed to validate AuthN response signature.", e);
+                }
+            }
+        } else {
+            LOGGER.warn(
+                    "Received unsigned AuthN response.  Could not verify IDP identity or response integrity.");
+            signaturePasses = true;
+        }
+
+        return signaturePasses;
+    }
+
+    public Response processSamlResponse(String authnResponse, String relayState) {
+        LOGGER.trace(authnResponse);
+
+        org.opensaml.saml2.core.Response samlResponse = extractSamlResponse(authnResponse);
+        if (samlResponse == null) {
+            return Response.serverError().entity("Unable to parse AuthN response.").build();
+        }
+
+        if (!validateResponse(samlResponse)) {
+            return Response.serverError()
+                    .entity("AuthN response failed validation.").build();
+        }
+
+        if (!login(samlResponse)) {
+            return Response.serverError().entity(UNABLE_TO_LOGIN).build();
+        }
+
+        URI relayUri;
+        try {
+            relayUri = new URI(relayState);
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Unable to parse relay state.", e);
+            return Response.serverError().entity("Unable to redirect back to original location.")
+                    .build();
+        }
+
+        LOGGER.trace("Successfully logged in.  Redirecting to {}", relayUri.toString());
+        return Response.seeOther(relayUri).build();
+    }
+
+    private boolean validateResponse(org.opensaml.saml2.core.Response samlResponse) {
+        try {
+            samlResponse.registerValidator(new AuthnResponseValidator(simpleSign));
+            samlResponse.validate(false);
+        } catch (ValidationException e) {
+            LOGGER.warn("Invalid AuthN response received from " + samlResponse.getIssuer(), e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean login(org.opensaml.saml2.core.Response samlResponse) {
+        String assertionValue = DOM2Writer
+                .nodeToString(samlResponse.getAssertions().get(0).getDOM());
+
+        String encodedAssertion;
+        try {
+            encodedAssertion = RestSecurity.deflateAndBase64Encode(assertionValue);
+        } catch (IOException e) {
+            LOGGER.warn("Unable to deflate and encode assertion.", e);
+            return false;
+        }
+
+        final String authHeader = RestSecurity.SAML_HEADER_PREFIX + encodedAssertion;
+
+        HttpServletRequestWrapper wrappedRequest = new HttpServletRequestWrapper(request) {
+            @Override
+            public String getHeader(String name) {
+                if (RestSecurity.AUTH_HEADER.equals(name)) {
+                    return authHeader;
+                }
+                return super.getHeader(name);
+            }
+        };
+
+        SAMLAssertionHandler samlAssertionHandler = new SAMLAssertionHandler();
+
+        LOGGER.trace("Processing SAML assertion with SAML Handler.");
+        HandlerResult samlResult = samlAssertionHandler
+                .getNormalizedToken(wrappedRequest, null, null, false);
+
+        if (samlResult.getStatus() != HandlerResult.Status.COMPLETED) {
+            LOGGER.debug("Failed to handle SAML assertion.");
+            return false;
+        }
+
+        request.setAttribute(WebSSOFilter.DDF_AUTHENTICATION_TOKEN, samlResult);
+        request.removeAttribute(ContextPolicy.NO_AUTH_POLICY);
+
+        try {
+            LOGGER.trace("Trying to login with provided SAML assertion.");
+            loginFilter.doFilter(wrappedRequest, null, new FilterChain() {
+                @Override
+                public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse)
+                        throws IOException, ServletException {
+                }
+            });
+        } catch (IOException | ServletException e) {
+            LOGGER.debug("Failed to apply login filter to SAML assertion", e);
+            return false;
+        }
+
+        return true;
+    }
+
+    @GET
+    @Path("/metadata")
+    @Produces("application/xml")
+    public Response retrieveMetadata() throws WSSecurityException, CertificateEncodingException {
+        X509Certificate issuerCert = findCertificate(systemCrypto.getSignatureAlias(),
+                systemCrypto.getSignatureCrypto());
+        X509Certificate encryptionCert = findCertificate(systemCrypto.getEncryptionAlias(),
+                systemCrypto.getEncryptionCrypto());
+
+        String hostname = baseUrl.getHost();
+        String port = baseUrl.getPort();
+        String rootContext = baseUrl.getRootContext();
+
+        String entityId = String.format("https://%s:%s%s/saml", hostname, port, rootContext);
+        String logoutLocation = String.format("https://%s:%s/logout", hostname, port);
+        String assertionConsumerServiceLocation = String
+                .format("https://%s:%s%s/saml/sso", hostname, port, rootContext);
+
+        EntityDescriptor entityDescriptor = SamlProtocol
+                .createSpMetadata(entityId, Base64.encodeBase64String(issuerCert.getEncoded()),
+                        Base64.encodeBase64String(encryptionCert.getEncoded()), logoutLocation,
+                        assertionConsumerServiceLocation, assertionConsumerServiceLocation);
+
+        Document doc = DOMUtils.createDocument();
+        doc.appendChild(doc.createElement("root"));
+        return Response
+                .ok(DOM2Writer.nodeToString(OpenSAMLUtil.toDom(entityDescriptor, doc, false)))
+                .build();
+    }
+
+    private X509Certificate findCertificate(String alias, Crypto crypto)
+            throws WSSecurityException {
+        CryptoType cryptoType = new CryptoType(CryptoType.TYPE.ALIAS);
+        cryptoType.setAlias(alias);
+        X509Certificate[] certs = crypto.getX509Certificates(cryptoType);
+        return certs[0];
+    }
+
+    private org.opensaml.saml2.core.Response extractSamlResponse(String samlResponse) {
+        org.opensaml.saml2.core.Response response = null;
+        try {
+            Document responseDoc = StaxUtils
+                    .read(new ByteArrayInputStream(samlResponse.getBytes()));
+            XMLObject responseXmlObject = OpenSAMLUtil.fromDom(responseDoc.getDocumentElement());
+
+            if (responseXmlObject instanceof org.opensaml.saml2.core.Response) {
+                response = (org.opensaml.saml2.core.Response) responseXmlObject;
+            }
+        } catch (XMLStreamException | WSSecurityException e) {
+            LOGGER.debug("Failed to convert AuthN response string to object.", e);
+        }
+
+        return response;
+    }
+
+    private String decodeBase64(String encoded) {
+        return new String(Base64.decodeBase64(encoded.getBytes()));
+    }
+
+    public Filter getLoginFilter() {
+        return loginFilter;
+    }
+
+    public void setLoginFilter(Filter loginFilter) {
+        this.loginFilter = loginFilter;
+    }
+
+}

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AuthnResponseValidator.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AuthnResponseValidator.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import org.opensaml.saml2.core.Response;
+import org.opensaml.saml2.core.StatusCode;
+import org.opensaml.xml.XMLObject;
+import org.opensaml.xml.validation.ValidationException;
+import org.opensaml.xml.validation.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthnResponseValidator implements Validator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthnResponseValidator.class);
+
+    private final SimpleSign simpleSign;
+
+    public AuthnResponseValidator(SimpleSign simpleSign) {
+        this.simpleSign = simpleSign;
+    }
+
+    @Override
+    public void validate(XMLObject xmlObject) throws ValidationException {
+        if (!(xmlObject instanceof Response)) {
+            throw new ValidationException("Invalid AuthN response XML.");
+        }
+
+        Response authnResponse = (Response) xmlObject;
+
+        String status = authnResponse.getStatus().getStatusCode().getValue();
+        if (!StatusCode.SUCCESS_URI.equals(status)) {
+            throw new ValidationException(
+                    "AuthN request was unsuccessful.  Received status: " + status);
+        }
+
+        if (authnResponse.getAssertions().size() < 1) {
+            throw new ValidationException("Assertion missing in AuthN response.");
+        }
+
+        if (authnResponse.getAssertions().size() > 1) {
+            LOGGER.warn("Received multiple assertions in AuthN response.  Only using the first assertion.");
+        }
+
+        if (authnResponse.getSignature() != null) {
+            try {
+                simpleSign.validateSignature(authnResponse.getSignature(), authnResponse.getDOM().getOwnerDocument());
+            } catch (SimpleSign.SignatureException e) {
+                throw new ValidationException("Invalid or untrusted signature.");
+            }
+        }
+    }
+}

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.util.UUID;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.UriBuilder;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
+import org.apache.cxf.rs.security.saml.sso.SamlpRequestComponentBuilder;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.apache.wss4j.common.saml.builder.SAML2Constants;
+import org.apache.wss4j.common.util.DOM2Writer;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.security.common.jaxrs.RestSecurity;
+import org.codice.ddf.security.handler.api.AuthenticationHandler;
+import org.codice.ddf.security.handler.api.HandlerResult;
+import org.codice.ddf.security.policy.context.ContextPolicy;
+import org.joda.time.DateTime;
+import org.opensaml.Configuration;
+import org.opensaml.common.SAMLObjectBuilder;
+import org.opensaml.common.SAMLVersion;
+import org.opensaml.saml2.core.AuthnRequest;
+import org.opensaml.saml2.core.Issuer;
+import org.opensaml.xml.XMLObjectBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Handler for SAML 2.0 IdP based authentication. Unauthenticated clients will be redirected to the
+ * configured IdP for authentication.
+ */
+public class IdpHandler implements AuthenticationHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdpHandler.class);
+
+    /**
+     * IdP type to use when configuring context policy.
+     */
+    public static final String AUTH_TYPE = "IDP";
+
+    public static final String SOURCE = "IdpHandler";
+
+    public static final String UNABLE_TO_ENCODE_SAML_AUTHN_REQUEST = "Unable to encode SAML AuthnRequest";
+
+    public static final String UNABLE_TO_SIGN_SAML_AUTHN_REQUEST = "Unable to sign SAML Authn Request";
+
+    private static XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<AuthnRequest> authnRequestBuilder = (SAMLObjectBuilder<AuthnRequest>) builderFactory
+            .getBuilder(AuthnRequest.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<Issuer> issuerBuilder = (SAMLObjectBuilder<Issuer>)
+            builderFactory.getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
+
+    private final String postBindingTemplate;
+
+    private final SimpleSign simpleSign;
+
+    private final IdpMetadata idpMetadata;
+
+    private final SystemBaseUrl baseUrl;
+
+    public IdpHandler(SimpleSign simpleSign, IdpMetadata metadata, SystemBaseUrl baseUrl)
+            throws IOException {
+        LOGGER.debug("Creating IdP handler.");
+
+        this.simpleSign = simpleSign;
+        idpMetadata = metadata;
+
+        this.baseUrl = baseUrl;
+
+        postBindingTemplate = IOUtils
+                .toString(IdpHandler.class.getResourceAsStream("/post-binding.html"));
+    }
+
+    @Override
+    public String getAuthenticationType() {
+        return AUTH_TYPE;
+    }
+
+    /**
+     * Handler implementing SAML 2.0 IdP authentication. Supports HTTP-Redirect and HTTP-POST bindings.
+     *
+     * @param request  http request to obtain attributes from and to pass into any local filter chains required
+     * @param response http response to return http responses or redirects
+     * @param chain    original filter chain (should not be called from your handler)
+     * @param resolve  flag with true implying that credentials should be obtained, false implying return if no credentials are found.
+     * @return result of handling this request - status and optional tokens
+     * @throws ServletException
+     */
+    @Override
+    public HandlerResult getNormalizedToken(ServletRequest request, ServletResponse response,
+            FilterChain chain, boolean resolve) throws ServletException {
+
+        String realm = (String) request.getAttribute(ContextPolicy.ACTIVE_REALM);
+        HandlerResult handlerResult = new HandlerResult(HandlerResult.Status.REDIRECTED, null);
+        handlerResult.setSource(realm + "-" + SOURCE);
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String path = httpRequest.getServletPath();
+        LOGGER.debug("Doing IdP authentication and authorization for path {}", path);
+
+        // Default to HTTP-Redirect if binding is null
+        if (idpMetadata.getSingleSignOnBinding() == null || idpMetadata.getSingleSignOnBinding().endsWith("Redirect")) {
+            doHttpRedirectBinding((HttpServletRequest) request, (HttpServletResponse) response);
+        } else {
+            doHttpPostBinding((HttpServletRequest) request, (HttpServletResponse) response);
+        }
+
+        return handlerResult;
+    }
+
+    private void doHttpRedirectBinding(HttpServletRequest request, HttpServletResponse response) throws ServletException {
+
+        String redirectUrl;
+        String idpRequest = null;
+        String relayState = createRelayState(request);
+        try {
+            String queryParams = String.format("SAMLRequest=%s&RelayState=%s",
+                    createAuthnRequest(false), URLEncoder.encode(relayState, "UTF-8"));
+            idpRequest = idpMetadata.getSingleSignOnLocation() + "?" + queryParams;
+            UriBuilder idpUri = new UriBuilderImpl(new URI(idpRequest));
+
+            simpleSign.signUriString(queryParams, idpUri);
+
+            redirectUrl = idpUri.build().toString();
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.warn("Unable to encode relay state: " + relayState, e);
+            throw new ServletException("Unable to create return location");
+        } catch (SimpleSign.SignatureException e) {
+            String msg = "Unable to sign request";
+            LOGGER.warn(msg, e);
+            throw new ServletException(msg);
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Unable to parse IDP request location: " + idpRequest, e);
+            throw new ServletException("Unable to determine IDP location.");
+        }
+
+        try {
+            response.sendRedirect(redirectUrl);
+            response.flushBuffer();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to redirect AuthnRequest to " + redirectUrl, e);
+            throw new ServletException("Unable to redirect to IdP");
+        }
+    }
+
+    private void doHttpPostBinding(HttpServletRequest request, HttpServletResponse response) throws ServletException {
+        try {
+            response.getWriter().printf(postBindingTemplate, idpMetadata.getSingleSignOnLocation(), createAuthnRequest(true),
+                    createRelayState(request));
+            response.setStatus(200);
+            response.flushBuffer();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to post AuthnRequest to IdP", e);
+            throw new ServletException("Unable to post to IdP");
+        }
+    }
+
+    private String createAuthnRequest(boolean isPost) throws ServletException {
+
+        String spIssuerId = String.format("https://%s:%s%s/saml", baseUrl.getHost(),
+                baseUrl.getHttpsPort(), baseUrl.getRootContext());
+        String spAssertionConsumerServiceUrl = spIssuerId + "/sso";
+
+        AuthnRequest authnRequest = authnRequestBuilder.buildObject();
+
+        Issuer issuer = issuerBuilder.buildObject();
+        issuer.setValue(spIssuerId);
+        authnRequest.setIssuer(issuer);
+
+        authnRequest.setAssertionConsumerServiceURL(spAssertionConsumerServiceUrl);
+
+        authnRequest.setID("_" + UUID.randomUUID().toString());
+        authnRequest.setVersion(SAMLVersion.VERSION_20);
+        authnRequest.setIssueInstant(new DateTime());
+
+        authnRequest.setDestination(idpMetadata.getSingleSignOnLocation());
+
+        authnRequest.setProtocolBinding(idpMetadata.getSingleSignOnBinding());
+        authnRequest.setNameIDPolicy(SamlpRequestComponentBuilder
+                .createNameIDPolicy(true, SAML2Constants.NAMEID_FORMAT_PERSISTENT,
+                        spIssuerId));
+
+        return serializeAndSign(isPost, authnRequest);
+    }
+
+    private String serializeAndSign(boolean isPost, AuthnRequest authnRequest)
+            throws ServletException {
+        try {
+            if (isPost) {
+                simpleSign.signSamlObject(authnRequest);
+            }
+
+            Document doc = DOMUtils.createDocument();
+            doc.appendChild(doc.createElement("root"));
+
+            Element requestElement = OpenSAMLUtil.toDom(authnRequest, doc);
+
+            String requestMessage = DOM2Writer.nodeToString(requestElement);
+
+            LOGGER.trace(requestMessage);
+
+            if (isPost) {
+                return encodePostRequest(requestMessage);
+            } else {
+                return encodeRedirectRequest(requestMessage);
+            }
+        } catch (WSSecurityException | IOException e) {
+            LOGGER.warn(UNABLE_TO_ENCODE_SAML_AUTHN_REQUEST, e);
+            throw new ServletException(UNABLE_TO_ENCODE_SAML_AUTHN_REQUEST);
+        } catch (SimpleSign.SignatureException e) {
+            LOGGER.warn(UNABLE_TO_SIGN_SAML_AUTHN_REQUEST, e);
+            throw new ServletException(UNABLE_TO_SIGN_SAML_AUTHN_REQUEST);
+        }
+    }
+
+    private String createRelayState(HttpServletRequest request) {
+        String requestUrl = recreateFullRequestUrl(request);
+        if (requestUrl.length() > 80) {
+            LOGGER.warn("AuthN relay state exceeds 80 characters: {}", requestUrl);
+        }
+        return requestUrl;
+    }
+
+    private String encodeRedirectRequest(String request) throws WSSecurityException, IOException {
+        return URLEncoder.encode(RestSecurity.deflateAndBase64Encode(request), "UTF-8");
+    }
+
+    private String encodePostRequest(String request) throws WSSecurityException, IOException {
+        return new String(Base64.encodeBase64(request.getBytes()));
+    }
+
+    private String recreateFullRequestUrl(HttpServletRequest request) {
+        StringBuffer requestURL = request.getRequestURL();
+        String queryString = request.getQueryString();
+
+        if (queryString == null) {
+            return requestURL.toString();
+        } else {
+            return requestURL.append('?').append(queryString).toString();
+        }
+    }
+
+    @Override
+    public HandlerResult handleError(ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain chain) throws ServletException {
+        String realm = (String) servletRequest.getAttribute(ContextPolicy.ACTIVE_REALM);
+        HandlerResult result = new HandlerResult(HandlerResult.Status.NO_ACTION, null);
+        result.setSource(realm + "-" + SOURCE);
+        LOGGER.debug("In error handler for idp - no action taken.");
+        return result;
+    }
+
+}

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.opensaml.common.SAMLException;
+import org.opensaml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml2.metadata.SingleSignOnService;
+import org.opensaml.xml.security.credential.UsageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.security.samlp.MetadataConfigurationParser;
+
+public class IdpMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdpMetadata.class);
+
+    private static final String SAML_2_0_PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol";
+
+    private static final String BINDINGS_HTTP_POST = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+    private IDPSSODescriptor descriptor;
+
+    private String singleSignOnLocation;
+
+    private String singleSignOnBinding;
+
+    private String entityId;
+
+    private String signingCertificate;
+
+    private String encryptionCertificate;
+
+    public void setMetadata(String metadata)
+        throws WSSecurityException, XMLStreamException, SAMLException {
+        descriptor = null;
+        entityId = null;
+        singleSignOnLocation = null;
+        singleSignOnBinding = null;
+        signingCertificate = null;
+        encryptionCertificate = null;
+
+        if (StringUtils.isBlank(metadata)) {
+            return;
+        }
+
+        EntityDescriptor entity = null;
+        try {
+            entity = MetadataConfigurationParser.buildEntityDescriptor(metadata);
+        } catch (IOException e) {
+            LOGGER.error("Unable to parse IDP metadata.", e);
+            return;
+        }
+
+        descriptor = entity.getIDPSSODescriptor(SAML_2_0_PROTOCOL);
+
+        if (descriptor == null) {
+            throw new SAMLException("Unable to find SAML 2.0 IdP Entity Descriptor in metadata.");
+        }
+
+        entityId = entity.getEntityID();
+
+        for (SingleSignOnService service : descriptor.getSingleSignOnServices()) {
+            // Prefer HTTP-Redirect over HTTP-POST if both are present
+            if (singleSignOnBinding == null || BINDINGS_HTTP_POST.equals(singleSignOnBinding)) {
+                singleSignOnBinding = service.getBinding();
+                singleSignOnLocation = service.getLocation();
+            }
+        }
+
+        for (KeyDescriptor key : descriptor.getKeyDescriptors()) {
+            String certificate = null;
+            if (key.getKeyInfo().getX509Datas().size() > 0
+                    && key.getKeyInfo().getX509Datas().get(0).getX509Certificates().size() > 0) {
+                certificate = key.getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0)
+                        .getValue();
+            }
+
+            if (StringUtils.isBlank(certificate)) {
+                break;
+            }
+
+            if (UsageType.UNSPECIFIED.equals(key.getUse())) {
+                encryptionCertificate = certificate;
+                signingCertificate = certificate;
+            }
+
+            if (UsageType.ENCRYPTION.equals(key.getUse())) {
+                encryptionCertificate = certificate;
+            }
+
+            if (UsageType.SIGNING.equals(key.getUse())) {
+                signingCertificate = certificate;
+            }
+        }
+
+    }
+
+    public IDPSSODescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    public String getSingleSignOnLocation() {
+        return singleSignOnLocation;
+    }
+
+    public String getSingleSignOnBinding() {
+        return singleSignOnBinding;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public String getSigningCertificate() {
+        return signingCertificate;
+    }
+
+    public String getEncryptionCertificate() {
+        return encryptionCertificate;
+    }
+}

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/SimpleSign.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/SimpleSign.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import javax.ws.rs.core.UriBuilder;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.cxf.rs.security.saml.sso.SSOConstants;
+import org.apache.wss4j.common.crypto.CryptoType;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.apache.wss4j.common.saml.SAMLKeyInfo;
+import org.apache.wss4j.common.saml.SAMLUtil;
+import org.apache.wss4j.dom.WSDocInfo;
+import org.apache.wss4j.dom.WSSConfig;
+import org.apache.wss4j.dom.handler.RequestData;
+import org.apache.wss4j.dom.saml.WSSSAMLKeyInfoProcessor;
+import org.apache.wss4j.dom.validate.Credential;
+import org.apache.wss4j.dom.validate.SignatureTrustValidator;
+import org.apache.wss4j.dom.validate.Validator;
+import org.opensaml.common.SignableSAMLObject;
+import org.opensaml.common.impl.SAMLObjectContentReference;
+import org.opensaml.saml2.core.Assertion;
+import org.opensaml.saml2.core.Response;
+import org.opensaml.security.SAMLSignatureProfileValidator;
+import org.opensaml.xml.security.x509.BasicX509Credential;
+import org.opensaml.xml.security.x509.X509KeyInfoGeneratorFactory;
+import org.opensaml.xml.signature.KeyInfo;
+import org.opensaml.xml.signature.Signature;
+import org.opensaml.xml.signature.SignatureConstants;
+import org.opensaml.xml.signature.SignatureValidator;
+import org.opensaml.xml.validation.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+
+public class SimpleSign {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleSign.class);
+
+    private final SystemCrypto crypto;
+
+    public SimpleSign(SystemCrypto systemCrypto) {
+        crypto = systemCrypto;
+    }
+
+    public void signSamlObject(SignableSAMLObject samlObject) throws SignatureException {
+
+        X509Certificate[] certificates = getSignatureCertificates();
+        String sigAlgo = getSignatureAlgorithm(certificates[0]);
+        PrivateKey privateKey = getSignaturePrivateKey();
+
+        // Create the signature
+        Signature signature = OpenSAMLUtil.buildSignature();
+        signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+        signature.setSignatureAlgorithm(sigAlgo);
+
+        BasicX509Credential signingCredential = new BasicX509Credential();
+        signingCredential.setEntityCertificate(certificates[0]);
+        signingCredential.setPrivateKey(privateKey);
+
+        signature.setSigningCredential(signingCredential);
+
+        X509KeyInfoGeneratorFactory x509KeyInfoGeneratorFactory = new X509KeyInfoGeneratorFactory();
+        x509KeyInfoGeneratorFactory.setEmitEntityCertificate(true);
+
+        try {
+            KeyInfo keyInfo = x509KeyInfoGeneratorFactory.newInstance().generate(signingCredential);
+            signature.setKeyInfo(keyInfo);
+        } catch (org.opensaml.xml.security.SecurityException e) {
+            throw new SignatureException("Error generating KeyInfo from signing credential", e);
+        }
+
+        if (samlObject instanceof Response) {
+            List<Assertion> assertions = ((Response) samlObject).getAssertions();
+            for (Assertion assertion : assertions) {
+                assertion.getSignature().setSigningCredential(signingCredential);
+            }
+        }
+
+        samlObject.setSignature(signature);
+        SAMLObjectContentReference contentRef =
+                (SAMLObjectContentReference)signature.getContentReferences().get(0);
+        contentRef.setDigestAlgorithm(SignatureConstants.ALGO_ID_DIGEST_SHA1);
+        samlObject.releaseDOM();
+        samlObject.releaseChildrenDOM(true);
+    }
+
+    public void signUriString(String queryParams, UriBuilder uriBuilder)
+            throws SignatureException {
+        X509Certificate[] certificates = getSignatureCertificates();
+        String sigAlgo = getSignatureAlgorithm(certificates[0]);
+        PrivateKey privateKey = getSignaturePrivateKey();
+        java.security.Signature signature = getSignature(certificates[0], privateKey);
+
+        String requestToSign;
+        try {
+            requestToSign = queryParams + "&" + SSOConstants.SIG_ALG + "=" + URLEncoder
+                    .encode(sigAlgo, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new SignatureException(e);
+        }
+
+        try {
+            signature.update(requestToSign.getBytes("UTF-8"));
+        } catch (java.security.SignatureException | UnsupportedEncodingException e) {
+            throw new SignatureException(e);
+        }
+
+        byte[] signatureBytes;
+        try {
+            signatureBytes = signature.sign();
+        } catch (java.security.SignatureException e) {
+            throw new SignatureException(e);
+        }
+
+        try {
+            uriBuilder.queryParam(SSOConstants.SIG_ALG, URLEncoder.encode(sigAlgo, "UTF-8"));
+            uriBuilder.queryParam(SSOConstants.SIGNATURE,
+                    URLEncoder.encode(Base64.encodeBase64String(signatureBytes), "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new SignatureException(e);
+        }
+
+    }
+
+    private java.security.Signature getSignature(X509Certificate certificate, PrivateKey privateKey)
+            throws SignatureException {
+        String jceSigAlgo = "SHA1withRSA";
+        if ("DSA".equalsIgnoreCase(certificate.getPublicKey().getAlgorithm())) {
+            jceSigAlgo = "SHA1withDSA";
+        }
+
+        java.security.Signature signature;
+        try {
+            signature = java.security.Signature.getInstance(jceSigAlgo);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SignatureException(e);
+        }
+        try {
+            signature.initSign(privateKey);
+        } catch (InvalidKeyException e) {
+            throw new SignatureException(e);
+        }
+        return signature;
+    }
+
+    private String getSignatureAlgorithm(X509Certificate certificate) {
+        String sigAlgo = SSOConstants.RSA_SHA1;
+        String pubKeyAlgo = certificate.getPublicKey().getAlgorithm();
+
+        if (pubKeyAlgo.equalsIgnoreCase("DSA")) {
+            sigAlgo = SSOConstants.DSA_SHA1;
+        }
+
+        LOGGER.debug("Using Signature algorithm {}", sigAlgo);
+
+        return sigAlgo;
+    }
+
+    private X509Certificate[] getSignatureCertificates() throws SignatureException {
+        CryptoType cryptoType = new CryptoType(CryptoType.TYPE.ALIAS);
+        cryptoType.setAlias(crypto.getSignatureAlias());
+        X509Certificate[] issuerCerts;
+
+        try {
+            issuerCerts = crypto.getSignatureCrypto().getX509Certificates(cryptoType);
+        } catch (WSSecurityException e) {
+            throw new SignatureException(e);
+        }
+
+        if (issuerCerts == null) {
+            throw new SignatureException("No certs were found to sign the request using name: " + crypto.getSignatureAlias());
+        }
+
+        return issuerCerts;
+    }
+
+    private PrivateKey getSignaturePrivateKey() throws SignatureException {
+        PrivateKey privateKey;
+        try {
+            privateKey = crypto.getSignatureCrypto().getPrivateKey(crypto.getSignatureAlias(),
+                    crypto.getSignaturePassword());
+        } catch (WSSecurityException e) {
+            throw new SignatureException(e);
+        }
+        return privateKey;
+    }
+
+    public boolean validateSignature(String queryParamsToValidate, String encodedSignature,
+            String encodedPublicKey) throws SignatureException {
+        try {
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X509");
+            Certificate certificate = certificateFactory.generateCertificate(
+                    new ByteArrayInputStream(Base64.decodeBase64(encodedPublicKey)));
+
+            String jceSigAlgo = "SHA1withRSA";
+            if ("DSA".equalsIgnoreCase(certificate.getPublicKey().getAlgorithm())) {
+                jceSigAlgo = "SHA1withDSA";
+            }
+
+            java.security.Signature sig = java.security.Signature.getInstance(jceSigAlgo);
+            sig.initVerify(certificate.getPublicKey());
+            sig.update(queryParamsToValidate.getBytes("UTF-8"));
+            return sig.verify(Base64.decodeBase64(encodedSignature));
+        } catch (NoSuchAlgorithmException | InvalidKeyException | CertificateException | UnsupportedEncodingException
+                | java.security.SignatureException e) {
+            throw new SignatureException(e);
+        }
+    }
+
+    public void validateSignature(Signature signature, Document doc) throws SignatureException {
+        RequestData requestData = new RequestData();
+        requestData.setSigVerCrypto(crypto.getSignatureCrypto());
+        WSSConfig wssConfig = WSSConfig.getNewInstance();
+        requestData.setWssConfig(wssConfig);
+
+        SAMLKeyInfo samlKeyInfo = null;
+
+        KeyInfo keyInfo = signature.getKeyInfo();
+        if (keyInfo != null) {
+            try {
+                samlKeyInfo = SAMLUtil.getCredentialFromKeyInfo(keyInfo.getDOM(),
+                        new WSSSAMLKeyInfoProcessor(requestData, new WSDocInfo(doc)),
+                        crypto.getSignatureCrypto());
+            } catch (WSSecurityException e) {
+                throw new SignatureException("Unable to get KeyInfo.", e);
+            }
+        }
+        if (samlKeyInfo == null) {
+            throw new SignatureException("No KeyInfo supplied in the signature");
+        }
+
+        validateSignatureAndSamlKey(signature, samlKeyInfo);
+
+        Credential trustCredential = new Credential();
+        trustCredential.setPublicKey(samlKeyInfo.getPublicKey());
+        trustCredential.setCertificates(samlKeyInfo.getCerts());
+        Validator signatureValidator = new SignatureTrustValidator();
+
+        try {
+            signatureValidator.validate(trustCredential, requestData);
+        } catch (WSSecurityException e) {
+            throw new SignatureException("Error validating signature", e);
+        }
+    }
+
+    private void validateSignatureAndSamlKey(Signature signature, SAMLKeyInfo samlKeyInfo) throws SignatureException {
+        SAMLSignatureProfileValidator validator = new SAMLSignatureProfileValidator();
+        try {
+            validator.validate(signature);
+        } catch (ValidationException e) {
+            throw new SignatureException("Error validating the SAMLKey signature", e);
+        }
+
+        BasicX509Credential credential = new BasicX509Credential();
+        if (samlKeyInfo.getCerts() != null) {
+            credential.setEntityCertificate(samlKeyInfo.getCerts()[0]);
+        } else if (samlKeyInfo.getPublicKey() != null) {
+            credential.setPublicKey(samlKeyInfo.getPublicKey());
+        } else {
+            throw new SignatureException("Can't get X509Certificate or PublicKey to verify signature.");
+        }
+        SignatureValidator sigValidator = new SignatureValidator(credential);
+        try {
+            sigValidator.validate(signature);
+        } catch (ValidationException e) {
+            throw new SignatureException("Error validating the XML signature", e);
+        }
+    }
+
+    public static class SignatureException extends Exception {
+        public SignatureException() {
+        }
+
+        public SignatureException(Throwable cause) {
+            super(cause);
+        }
+
+        public SignatureException(String message) {
+            super(message);
+        }
+
+        public SignatureException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/SystemCrypto.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/SystemCrypto.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.crypto.CryptoFactory;
+import org.apache.wss4j.common.crypto.Merlin;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.security.PropertiesLoader;
+import ddf.security.encryption.EncryptionService;
+
+public class SystemCrypto {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemCrypto.class);
+
+    private final EncryptionService passwordEncryption;
+
+    private final Crypto signatureCrypto;
+
+    private final String signaturePassword;
+
+    private final String signatureAlias;
+
+    private final Crypto encryptionCrypto;
+
+    private final String encryptionPassword;
+
+    private final String encryptionAlias;
+
+    public SystemCrypto(String encryptionPropertiesPath, String signaturePropertiesPath,
+            EncryptionService passwordEncryption) {
+        this.passwordEncryption = passwordEncryption;
+
+        Properties sigProperties = PropertiesLoader.loadProperties(signaturePropertiesPath);
+        signatureCrypto = createCrypto(sigProperties);
+        signaturePassword = getPassword(sigProperties);
+        signatureAlias = getAlias(signatureCrypto, sigProperties);
+
+        Properties encProperties = PropertiesLoader.loadProperties(encryptionPropertiesPath);
+        encryptionCrypto = createCrypto(encProperties);
+        encryptionPassword = getPassword(encProperties);
+        encryptionAlias = getAlias(encryptionCrypto, encProperties);
+    }
+
+    private String getAlias(Crypto crypto, Properties cryptoProperties) {
+        String user = cryptoProperties
+                .getProperty(Merlin.PREFIX + Merlin.KEYSTORE_ALIAS);
+
+        if (user == null) {
+            try {
+                user = crypto.getDefaultX509Identifier();
+            } catch (WSSecurityException e) {
+                LOGGER.debug("Error in getting Crypto user: ", e);
+            }
+        }
+
+        return user;
+    }
+
+    private Crypto createCrypto(Properties cryptoProperties) {
+        Crypto crypto = null;
+        try {
+            crypto = CryptoFactory
+                    .getInstance(cryptoProperties, SystemCrypto.class.getClassLoader(),
+                            passwordEncryption);
+        } catch (WSSecurityException e) {
+            LOGGER.debug("Error in loading the Crypto object: ", e);
+        }
+        return crypto;
+    }
+
+    private String getPassword(Properties cryptoProperties) {
+        String password = cryptoProperties
+                .getProperty(Merlin.PREFIX + Merlin.KEYSTORE_PRIVATE_PASSWORD);
+
+        if (password == null) {
+            password = cryptoProperties
+                    .getProperty(Merlin.OLD_PREFIX + Merlin.KEYSTORE_PRIVATE_PASSWORD);
+        }
+
+        if (password != null) {
+            password = decryptPassword(password.trim());
+        }
+
+        return password;
+    }
+
+    private String decryptPassword(String password) {
+        if (password.startsWith(Merlin.ENCRYPTED_PASSWORD_PREFIX) && password
+                .endsWith(Merlin.ENCRYPTED_PASSWORD_SUFFIX)) {
+            return passwordEncryption.decrypt(StringUtils
+                    .substringBetween(password, Merlin.ENCRYPTED_PASSWORD_PREFIX,
+                            Merlin.ENCRYPTED_PASSWORD_SUFFIX));
+        }
+
+        return password;
+    }
+
+    public Crypto getSignatureCrypto() {
+        return signatureCrypto;
+    }
+
+    public String getSignaturePassword() {
+        return signaturePassword;
+    }
+
+    public Crypto getEncryptionCrypto() {
+        return encryptionCrypto;
+    }
+
+    public String getEncryptionPassword() {
+        return encryptionPassword;
+    }
+
+    public String getSignatureAlias() {
+        return signatureAlias;
+    }
+
+    public String getEncryptionAlias() {
+        return encryptionAlias;
+    }
+}

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.2.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="
+  http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <ext:property-placeholder/>
+
+    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
+
+    <bean id="idpMetadata" class="org.codice.ddf.security.idp.client.IdpMetadata">
+        <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpMetadata"
+                               update-strategy="container-managed"/>
+    </bean>
+
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
+
+    <bean id="crypto" class="org.codice.ddf.security.idp.client.SystemCrypto">
+        <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
+        <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <argument ref="encryptionService" />
+    </bean>
+
+    <bean id="simpleSign" class="org.codice.ddf.security.idp.client.SimpleSign">
+        <argument ref="crypto" />
+    </bean>
+
+    <bean id="idpHandler" class="org.codice.ddf.security.idp.client.IdpHandler">
+        <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpHandler"
+                               update-strategy="container-managed"/>
+        <argument ref="simpleSign" />
+        <argument ref="idpMetadata" />
+        <argument ref="baseUrl" />
+    </bean>
+
+    <service ref="idpHandler" interface="org.codice.ddf.security.handler.api.AuthenticationHandler" />
+
+    <jaxrs:server id="restService" address="/saml">
+        <jaxrs:serviceBeans>
+            <bean id="assertionConsumerService" class=" org.codice.ddf.security.idp.client.AssertionConsumerService">
+                <argument ref="simpleSign" />
+                <argument ref="idpMetadata" />
+                <argument ref="crypto" />
+                <argument ref="baseUrl" />
+                <property name="loginFilter">
+                    <reference interface="javax.servlet.Filter"
+                               filter="(filter-name=login-filter)"/>
+                </property>
+            </bean>
+        </jaxrs:serviceBeans>
+    </jaxrs:server>
+
+</blueprint>

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="IdP Client" id="org.codice.ddf.security.idp.client.IdpMetadata">
+        <AD
+                name="IdP Metadata" id="metadata" required="true" type="String"
+                default=""
+                description="Refer to metadata by HTTPS URL (https://), file URL (file:), or an XML block(<md:EntityDescriptor>...</md:EntityDescriptor>)."/>
+    </OCD>
+
+    <Designate pid="org.codice.ddf.security.idp.client.IdpMetadata">
+        <Object ocdref="org.codice.ddf.security.idp.client.IdpMetadata"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/platform/security/idp/security-idp-client/src/main/resources/post-binding.html
+++ b/platform/security/idp/security-idp-client/src/main/resources/post-binding.html
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+* Copyright (c) Codice Foundation
+*
+* This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+* version 3 of the License, or any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+* <http://www.gnu.org/licenses/lgpl.html>.
+*
+**/
+-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Sign-on Redirect</title>
+</head>
+<body>
+    <h2>Redirecting...</h2>
+    <form id="sso" method="post" action="%s">
+        <input type="hidden" name="SAMLRequest" value="%s" />
+        <input type="hidden" name="RelayState" value="%s" />
+        <input type="submit" value="Submit" style="display:none;" />
+    </form>
+    <script type="text/javascript">
+        window.onload = function() {
+            window.setTimeout(function () {
+                window.setInterval(function () {
+                    document.forms["sso"].submit();
+                }, 1000);
+            }, 100);
+        }
+    </script>
+</body>
+</html>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -71,6 +71,20 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,6 +95,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            httpclient;scope=!test,
+                            httpcore
+                        </Embed-Dependency>
                         <Export-Package>
                             ddf.security*;version=${project.version}
                         </Export-Package>

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/assertion/SecurityAssertion.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/assertion/SecurityAssertion.java
@@ -15,6 +15,7 @@ package ddf.security.assertion;
 
 import java.io.Serializable;
 import java.security.Principal;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -78,6 +79,20 @@ public interface SecurityAssertion extends Serializable {
      * @return SecurityToken
      */
     SecurityToken getSecurityToken();
+
+    /**
+     * Returns the earliest date that the assertion is valid
+     *
+     * @return Date
+     */
+    Date getNotBefore();
+
+    /**
+     * Returns the date that the assertion is invalid
+     *
+     * @return Date
+     */
+    Date getNotOnOrAfter();
 
     /**
      * Returns a String representation of this Assertion

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/MetadataConfigurationParser.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/MetadataConfigurationParser.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.samlp;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.opensaml.saml2.metadata.EntityDescriptor;
+import org.opensaml.xml.XMLObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+
+public class MetadataConfigurationParser {
+
+    public static final String METADATA_ROOT_FOLDER = "metadata";
+
+    public static final String ETC_FOLDER = "etc";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfigurationParser.class);
+
+    private static final String HTTPS = "https://";
+
+    private static final String HTTP = "http://";
+
+    private static final String FILE = "file:";
+
+    public static Map<String, EntityDescriptor> buildEntityDescriptors(
+            List<String> entityDescriptions) throws IOException {
+        String ddfHome = System.getProperty("ddf.home");
+        Map<String, EntityDescriptor> entityDescriptors = new HashMap<>();
+        for (String entityDescription : entityDescriptions) {
+            EntityDescriptor entityDescriptor = buildEntityDescriptor(entityDescription);
+            if (entityDescriptor != null) {
+                entityDescriptors.put(entityDescriptor.getEntityID(), entityDescriptor);
+            }
+        }
+        Path metadataFolder = Paths.get(ddfHome, ETC_FOLDER, METADATA_ROOT_FOLDER);
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(metadataFolder)) {
+            for (Path path : directoryStream) {
+                if (Files.isReadable(path)) {
+                    try (InputStream fileInputStream = Files.newInputStream(path)) {
+                        EntityDescriptor entityDescriptor = readEntityDescriptor(
+                                new InputStreamReader(fileInputStream, "UTF-8"));
+
+                        entityDescriptors.put(entityDescriptor.getEntityID(), entityDescriptor);
+                    }
+                }
+            }
+        } catch (NoSuchFileException e) {
+            LOGGER.debug("IDP metadata directory is not configured.", e);
+        }
+        return entityDescriptors;
+    }
+
+    public static EntityDescriptor buildEntityDescriptor(String entityDescription)
+            throws IOException {
+        EntityDescriptor entityDescriptor = null;
+        entityDescription = entityDescription.trim();
+        if (entityDescription.startsWith(HTTPS) || entityDescription.startsWith(HTTP)) {
+            if (entityDescription.startsWith(HTTP)) {
+                LOGGER.warn(
+                        "Retrieving metadata via HTTP instead of HTTPS. The metadata configuration is unsafe!!!");
+            }
+            try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+                String httpResponse = null;
+                HttpGet get = new HttpGet(entityDescription);
+                ResponseHandler responseHandler = new BasicResponseHandler();
+                try {
+                    httpResponse = (String) httpclient.execute(get, responseHandler);
+                } catch (IOException e) {
+                    LOGGER.warn("Incorrectly configured URL for metadata: {}", entityDescription,
+                            e);
+                }
+                if (httpResponse != null) {
+                    ByteArrayInputStream byteStream = new ByteArrayInputStream(
+                            httpResponse.getBytes());
+                    entityDescriptor = readEntityDescriptor(
+                            new InputStreamReader(byteStream, "UTF-8"));
+                }
+            }
+        } else if (entityDescription.startsWith(FILE + System.getProperty("ddf.home"))) {
+            String pathStr = StringUtils.substringAfter(entityDescription, FILE);
+            Path path = Paths.get(pathStr);
+            if (Files.isReadable(path)) {
+                try (InputStream fileInputStream = Files.newInputStream(path)) {
+                    entityDescriptor = readEntityDescriptor(
+                            new InputStreamReader(fileInputStream, "UTF-8"));
+                }
+            }
+        } else if (entityDescription.startsWith("<") && entityDescription.endsWith(">")) {
+            entityDescriptor = readEntityDescriptor(new StringReader(entityDescription));
+        } else {
+            LOGGER.warn("Skipping unknown metadata configuration value: " + entityDescription);
+        }
+
+        return entityDescriptor;
+    }
+
+    private static EntityDescriptor readEntityDescriptor(Reader reader) {
+        Document entityDoc;
+        try {
+            entityDoc = StaxUtils.read(reader);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Unable to read SAMLRequest as XML.");
+        }
+        XMLObject entityXmlObj;
+        try {
+            entityXmlObj = OpenSAMLUtil.fromDom(entityDoc.getDocumentElement());
+        } catch (WSSecurityException ex) {
+            throw new IllegalArgumentException(
+                    "Unable to convert EntityDescriptor document to XMLObject.");
+        }
+
+        return (EntityDescriptor) entityXmlObj;
+    }
+}

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.samlp;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.saml.SamlAssertionWrapper;
+import org.joda.time.DateTime;
+import org.opensaml.Configuration;
+import org.opensaml.common.SAMLObjectBuilder;
+import org.opensaml.common.SAMLVersion;
+import org.opensaml.saml2.core.Issuer;
+import org.opensaml.saml2.core.Response;
+import org.opensaml.saml2.core.Status;
+import org.opensaml.saml2.core.StatusCode;
+import org.opensaml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml2.metadata.NameIDFormat;
+import org.opensaml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml2.metadata.SingleLogoutService;
+import org.opensaml.saml2.metadata.SingleSignOnService;
+import org.opensaml.xml.XMLObjectBuilder;
+import org.opensaml.xml.XMLObjectBuilderFactory;
+import org.opensaml.xml.security.credential.UsageType;
+import org.opensaml.xml.signature.KeyInfo;
+import org.opensaml.xml.signature.X509Certificate;
+import org.opensaml.xml.signature.X509Data;
+import org.w3c.dom.Element;
+
+public class SamlProtocol {
+
+    public static final String SUPPORTED_PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol";
+
+    public static final String REDIRECT_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+
+    public static final String POST_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+    private static XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<Response> responseSAMLObjectBuilder = (SAMLObjectBuilder<org.opensaml.saml2.core.Response>) builderFactory
+            .getBuilder(org.opensaml.saml2.core.Response.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<Issuer> issuerBuilder = (SAMLObjectBuilder<Issuer>) builderFactory
+            .getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<Status> statusBuilder = (SAMLObjectBuilder<Status>) builderFactory
+            .getBuilder(Status.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<StatusCode> statusCodeBuilder = (SAMLObjectBuilder<StatusCode>) builderFactory
+            .getBuilder(StatusCode.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<EntityDescriptor> entityDescriptorBuilder = (SAMLObjectBuilder<EntityDescriptor>) builderFactory
+            .getBuilder(EntityDescriptor.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<IDPSSODescriptor> idpssoDescriptorBuilder = (SAMLObjectBuilder<IDPSSODescriptor>) builderFactory
+            .getBuilder(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<SPSSODescriptor> spSsoDescriptorBuilder = (SAMLObjectBuilder<SPSSODescriptor>) builderFactory
+            .getBuilder(SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<KeyDescriptor> keyDescriptorBuilder = (SAMLObjectBuilder<KeyDescriptor>) builderFactory
+            .getBuilder(KeyDescriptor.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<NameIDFormat> nameIdFormatBuilder = (SAMLObjectBuilder<NameIDFormat>) builderFactory
+            .getBuilder(NameIDFormat.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<SingleSignOnService> singleSignOnServiceBuilder = (SAMLObjectBuilder<SingleSignOnService>) builderFactory
+            .getBuilder(SingleSignOnService.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<SingleLogoutService> singleLogOutServiceBuilder = (SAMLObjectBuilder<SingleLogoutService>) builderFactory
+            .getBuilder(SingleLogoutService.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static SAMLObjectBuilder<AssertionConsumerService> assertionConsumerServiceBuilder = (SAMLObjectBuilder<AssertionConsumerService>) builderFactory
+            .getBuilder(AssertionConsumerService.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static XMLObjectBuilder<KeyInfo> keyInfoBuilder = (XMLObjectBuilder<KeyInfo>) builderFactory
+            .getBuilder(KeyInfo.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static XMLObjectBuilder<X509Data> x509DataBuilder = (XMLObjectBuilder<X509Data>) builderFactory
+            .getBuilder(X509Data.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static XMLObjectBuilder<X509Certificate> x509CertificateBuilder = (XMLObjectBuilder<X509Certificate>) builderFactory
+            .getBuilder(X509Certificate.DEFAULT_ELEMENT_NAME);
+
+    private SamlProtocol() {
+    }
+
+    public static Response createResponse(Issuer issuer, Status status, String requestId,
+            Element samlAssertion) throws WSSecurityException {
+        Response response = responseSAMLObjectBuilder.buildObject();
+        response.setIssuer(issuer);
+        response.setStatus(status);
+        response.setID("_" + UUID.randomUUID().toString());
+        response.setIssueInstant(new DateTime());
+        response.setInResponseTo(requestId);
+        response.setVersion(SAMLVersion.VERSION_20);
+        if (samlAssertion != null) {
+            SamlAssertionWrapper samlAssertionWrapper = new SamlAssertionWrapper(samlAssertion);
+            response.getAssertions().add(samlAssertionWrapper.getSaml2());
+        }
+        return response;
+    }
+
+    public static Issuer createIssuer(String issuerValue) {
+        Issuer issuer = issuerBuilder.buildObject();
+        issuer.setValue(issuerValue);
+
+        return issuer;
+    }
+
+    public static Status createStatus(String statusValue) {
+        Status status = statusBuilder.buildObject();
+        StatusCode statusCode = statusCodeBuilder.buildObject();
+        statusCode.setValue(statusValue);
+        status.setStatusCode(statusCode);
+
+        return status;
+    }
+
+    public static EntityDescriptor createIdpMetadata(String entityId, String signingCert,
+            String encryptionCert, List<String> nameIds, String singleSignOnLocationRedirect,
+            String singleSignOnLocationPost, String singleLogOutLocation) {
+        EntityDescriptor entityDescriptor = entityDescriptorBuilder.buildObject();
+        entityDescriptor.setEntityID(entityId);
+        IDPSSODescriptor idpssoDescriptor = idpssoDescriptorBuilder.buildObject();
+        //signing
+        KeyDescriptor signingKeyDescriptor = keyDescriptorBuilder.buildObject();
+        signingKeyDescriptor.setUse(UsageType.SIGNING);
+        KeyInfo signingKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
+        X509Data signingX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
+        X509Certificate signingX509Certificate = x509CertificateBuilder
+                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        signingX509Certificate.setValue(signingCert);
+        signingX509Data.getX509Certificates().add(signingX509Certificate);
+        signingKeyInfo.getX509Datas().add(signingX509Data);
+        signingKeyDescriptor.setKeyInfo(signingKeyInfo);
+        idpssoDescriptor.getKeyDescriptors().add(signingKeyDescriptor);
+        //encryption
+        KeyDescriptor encKeyDescriptor = keyDescriptorBuilder.buildObject();
+        encKeyDescriptor.setUse(UsageType.ENCRYPTION);
+        KeyInfo encKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
+        X509Data encX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
+        X509Certificate encX509Certificate = x509CertificateBuilder
+                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        encX509Certificate.setValue(encryptionCert);
+        encX509Data.getX509Certificates().add(encX509Certificate);
+        encKeyInfo.getX509Datas().add(encX509Data);
+        encKeyDescriptor.setKeyInfo(encKeyInfo);
+        idpssoDescriptor.getKeyDescriptors().add(encKeyDescriptor);
+
+        for (String nameId : nameIds) {
+            NameIDFormat nameIDFormat = nameIdFormatBuilder.buildObject();
+            nameIDFormat.setFormat(nameId);
+            idpssoDescriptor.getNameIDFormats().add(nameIDFormat);
+        }
+
+        if (StringUtils.isNotBlank(singleSignOnLocationRedirect)) {
+            SingleSignOnService singleSignOnServiceRedirect = singleSignOnServiceBuilder.buildObject();
+            singleSignOnServiceRedirect
+                    .setBinding(REDIRECT_BINDING);
+            singleSignOnServiceRedirect.setLocation(singleSignOnLocationRedirect);
+            idpssoDescriptor.getSingleSignOnServices().add(singleSignOnServiceRedirect);
+        }
+
+        if (StringUtils.isNotBlank(singleSignOnLocationPost)) {
+            SingleSignOnService singleSignOnServicePost = singleSignOnServiceBuilder.buildObject();
+            singleSignOnServicePost.setBinding(POST_BINDING);
+            singleSignOnServicePost.setLocation(singleSignOnLocationPost);
+            idpssoDescriptor.getSingleSignOnServices().add(singleSignOnServicePost);
+        }
+
+        if (StringUtils.isNotBlank(singleLogOutLocation)) {
+            SingleLogoutService singleLogoutServiceRedir = singleLogOutServiceBuilder.buildObject();
+            singleLogoutServiceRedir
+                    .setBinding(REDIRECT_BINDING);
+            singleLogoutServiceRedir.setLocation(singleLogOutLocation);
+            idpssoDescriptor.getSingleLogoutServices().add(singleLogoutServiceRedir);
+
+            SingleLogoutService singleLogoutServicePost = singleLogOutServiceBuilder.buildObject();
+            singleLogoutServicePost.setBinding(POST_BINDING);
+            singleLogoutServicePost.setLocation(singleLogOutLocation);
+            idpssoDescriptor.getSingleLogoutServices().add(singleLogoutServicePost);
+        }
+
+        idpssoDescriptor.setWantAuthnRequestsSigned(true);
+
+        idpssoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);
+
+        entityDescriptor.getRoleDescriptors().add(idpssoDescriptor);
+
+        return entityDescriptor;
+    }
+
+    public static EntityDescriptor createSpMetadata(String entityId, String signingCert,
+            String encryptionCert, String singleLogOutLocation,
+            String assertionConsumerServiceLocationRedirect,
+            String assertionConsumerServiceLocationPost) {
+        EntityDescriptor entityDescriptor = entityDescriptorBuilder.buildObject();
+        entityDescriptor.setEntityID(entityId);
+        SPSSODescriptor spSsoDescriptor = spSsoDescriptorBuilder.buildObject();
+        //signing
+        KeyDescriptor signingKeyDescriptor = keyDescriptorBuilder.buildObject();
+        signingKeyDescriptor.setUse(UsageType.SIGNING);
+        KeyInfo signingKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
+        X509Data signingX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
+        X509Certificate signingX509Certificate = x509CertificateBuilder
+                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        signingX509Certificate.setValue(signingCert);
+        signingX509Data.getX509Certificates().add(signingX509Certificate);
+        signingKeyInfo.getX509Datas().add(signingX509Data);
+        signingKeyDescriptor.setKeyInfo(signingKeyInfo);
+        spSsoDescriptor.getKeyDescriptors().add(signingKeyDescriptor);
+        //encryption
+        KeyDescriptor encKeyDescriptor = keyDescriptorBuilder.buildObject();
+        encKeyDescriptor.setUse(UsageType.ENCRYPTION);
+        KeyInfo encKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
+        X509Data encX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
+        X509Certificate encX509Certificate = x509CertificateBuilder
+                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        encX509Certificate.setValue(encryptionCert);
+        encX509Data.getX509Certificates().add(encX509Certificate);
+        encKeyInfo.getX509Datas().add(encX509Data);
+        encKeyDescriptor.setKeyInfo(encKeyInfo);
+        spSsoDescriptor.getKeyDescriptors().add(encKeyDescriptor);
+
+        if (StringUtils.isNotBlank(singleLogOutLocation)) {
+            SingleLogoutService singleLogoutServiceRedirect = singleLogOutServiceBuilder.buildObject();
+            singleLogoutServiceRedirect.setBinding(REDIRECT_BINDING);
+            singleLogoutServiceRedirect.setLocation(singleLogOutLocation);
+            spSsoDescriptor.getSingleLogoutServices().add(singleLogoutServiceRedirect);
+
+            SingleLogoutService singleLogoutServicePost = singleLogOutServiceBuilder.buildObject();
+            singleLogoutServicePost.setBinding(POST_BINDING);
+            singleLogoutServicePost.setLocation(singleLogOutLocation);
+            spSsoDescriptor.getSingleLogoutServices().add(singleLogoutServicePost);
+        }
+
+        if (StringUtils.isNotBlank(assertionConsumerServiceLocationRedirect)) {
+            AssertionConsumerService assertionConsumerService = assertionConsumerServiceBuilder
+                    .buildObject();
+            assertionConsumerService.setBinding(REDIRECT_BINDING);
+            assertionConsumerService.setLocation(assertionConsumerServiceLocationRedirect);
+            spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
+        }
+
+        if (StringUtils.isNotBlank(assertionConsumerServiceLocationPost)) {
+            AssertionConsumerService assertionConsumerService = assertionConsumerServiceBuilder
+                    .buildObject();
+            assertionConsumerService.setBinding(POST_BINDING);
+            assertionConsumerService.setLocation(assertionConsumerServiceLocationPost);
+            spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
+        }
+
+        spSsoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);
+
+        entityDescriptor.getRoleDescriptors().add(spSsoDescriptor);
+
+        return entityDescriptor;
+    }
+}

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/MetadataConfigurationParserTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/MetadataConfigurationParserTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.samlp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.localserver.LocalTestServer;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.opensaml.saml2.metadata.EntityDescriptor;
+
+public class MetadataConfigurationParserTest {
+
+    private Path descriptorPath;
+
+    private LocalTestServer server;
+
+    private String serverAddress;
+
+    @Mock
+    HttpRequestHandler handler;
+
+    @Before
+    public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        OpenSAMLUtil.initSamlEngine();
+
+        descriptorPath = Paths.get(getClass().getResource("/etc/metadata/entityDescriptor.xml").toURI());
+        System.setProperty("ddf.home", "");
+
+        server = new LocalTestServer(null, null);
+        server.register("/*", handler);
+        server.start();
+
+        serverAddress =
+                server.getServiceAddress().getHostString() + ":" + server.getServiceAddress()
+                        .getPort();
+    }
+
+    @After
+    public void after() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void testMetadataFolder() throws Exception {
+        System.setProperty("ddf.home",
+                descriptorPath.getParent().getParent().getParent().toString());
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser
+                .buildEntityDescriptors(Collections.<String>emptyList());
+
+        assertThat(entities.size(), is(1));
+    }
+
+    @Test
+    public void testMetadataFile() throws Exception {
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser.buildEntityDescriptors(
+                Collections.singletonList("file:" + descriptorPath.toString()));
+
+        assertThat(entities.size(), is(1));
+    }
+
+    @Test
+    public void testMetadataString() throws Exception {
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser.buildEntityDescriptors(
+                Collections.singletonList(IOUtils.toString(descriptorPath.toUri())));
+
+        assertThat(entities.size(), is(1));
+    }
+
+    @Test
+    public void testMetadataHttp() throws Exception {
+        serverRespondsWith(IOUtils.toString(descriptorPath.toUri()));
+
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser.buildEntityDescriptors(
+                Collections.singletonList("http://" + serverAddress));
+
+        assertThat(entities.size(), is(1));
+    }
+
+    @Test
+    public void testMetadataBadString() throws Exception {
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser.buildEntityDescriptors(
+                Collections.singletonList("bad xml"));
+
+        assertThat(entities.size(), is(0));
+    }
+
+    @Test
+    public void testMetadataBadFile() throws Exception {
+        Map<String, EntityDescriptor> entities = MetadataConfigurationParser.buildEntityDescriptors(
+                Collections.singletonList("file:bad path"));
+
+        assertThat(entities.size(), is(0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMetadataBadHttpResponse() throws Exception {
+        serverRespondsWith("bad xml");
+
+        MetadataConfigurationParser
+                .buildEntityDescriptors(Collections.singletonList("http://" + serverAddress));
+    }
+
+    private void serverRespondsWith(String message) throws HttpException, IOException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                HttpResponse response = (HttpResponse) invocationOnMock.getArguments()[1];
+                response.setEntity(new StringEntity(message));
+                return null;
+            }
+        }).when(handler).handle(any(), any(), any());
+    }
+
+}

--- a/platform/security/platform-security-core-api/src/test/resources/etc/metadata/entityDescriptor.xml
+++ b/platform/security/platform-security-core-api/src/test/resources/etc/metadata/entityDescriptor.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://localhost:8993/services/idp/login">
+    <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIDEzCCAnygAwIBAgIJAIzc4FYrIp9mMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJBWjEMMAoGA1UECgwDRERGMQwwCgYDVQQLDANEZXYxGTAXBgNVBAMMEERERiBEZW1vIFJvb3QgQ0ExJDAiBgkqhkiG9w0BCQEWFWRkZnJvb3RjYUBleGFtcGxlLm9yZzAeFw0xNDEyMTAyMTU4MThaFw0xNTEyMTAyMTU4MThaMIGDMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQVoxETAPBgNVBAcMCEdvb2R5ZWFyMQwwCgYDVQQKDANEREYxDDAKBgNVBAsMA0RldjESMBAGA1UEAwwJbG9jYWxob3N0MSQwIgYJKoZIhvcNAQkBFhVsb2NhbGhvc3RAZXhhbXBsZS5vcmcwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMeCyNZbCTZphHQfB5g8FrgBq1RYzV7ikVw/pVGkz8gx3l3A99s8WtA4mRAeb6n0vTR9yNBOekW4nYOiEOq//YTi/frI1kz0QbEH1s2cI5nFButabD3PYGxUSuapbc+AS7+Pklr0TDI4MRzPPkkTp4wlORQ/a6CfVsNr/mVgL2CfAgMBAAGjgZkwgZYwCQYDVR0TBAIwADAnBglghkgBhvhCAQ0EGhYYRk9SIFRFU1RJTkcgUFVSUE9TRSBPTkxZMB0GA1UdDgQWBBSA95QIMyBAHRsd0R4s7C3BreFrsDAfBgNVHSMEGDAWgBThVMeX3wrCv6lfeF47CyvkSBe9xjAgBgNVHREEGTAXgRVsb2NhbGhvc3RAZXhhbXBsZS5vcmcwDQYJKoZIhvcNAQEFBQADgYEAtRUp7fAxU/E6JD2Kj/+CTWqu8Elx13S0TxoIqv3gMoBW0ehyzEKjJi0bb1gUxO7n1SmOESp5sE3jGTnh0GtYV0D219z/09n90cd/imAEhknJlayyd0SjpnaL9JUd8uYxJexy8TJ2sMhsGAZ6EMTZCfT9m07XduxjsmDz0hlSGV0=
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:KeyDescriptor use="encryption">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIDEzCCAnygAwIBAgIJAIzc4FYrIp9mMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJBWjEMMAoGA1UECgwDRERGMQwwCgYDVQQLDANEZXYxGTAXBgNVBAMMEERERiBEZW1vIFJvb3QgQ0ExJDAiBgkqhkiG9w0BCQEWFWRkZnJvb3RjYUBleGFtcGxlLm9yZzAeFw0xNDEyMTAyMTU4MThaFw0xNTEyMTAyMTU4MThaMIGDMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQVoxETAPBgNVBAcMCEdvb2R5ZWFyMQwwCgYDVQQKDANEREYxDDAKBgNVBAsMA0RldjESMBAGA1UEAwwJbG9jYWxob3N0MSQwIgYJKoZIhvcNAQkBFhVsb2NhbGhvc3RAZXhhbXBsZS5vcmcwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMeCyNZbCTZphHQfB5g8FrgBq1RYzV7ikVw/pVGkz8gx3l3A99s8WtA4mRAeb6n0vTR9yNBOekW4nYOiEOq//YTi/frI1kz0QbEH1s2cI5nFButabD3PYGxUSuapbc+AS7+Pklr0TDI4MRzPPkkTp4wlORQ/a6CfVsNr/mVgL2CfAgMBAAGjgZkwgZYwCQYDVR0TBAIwADAnBglghkgBhvhCAQ0EGhYYRk9SIFRFU1RJTkcgUFVSUE9TRSBPTkxZMB0GA1UdDgQWBBSA95QIMyBAHRsd0R4s7C3BreFrsDAfBgNVHSMEGDAWgBThVMeX3wrCv6lfeF47CyvkSBe9xjAgBgNVHREEGTAXgRVsb2NhbGhvc3RAZXhhbXBsZS5vcmcwDQYJKoZIhvcNAQEFBQADgYEAtRUp7fAxU/E6JD2Kj/+CTWqu8Elx13S0TxoIqv3gMoBW0ehyzEKjJi0bb1gUxO7n1SmOESp5sE3jGTnh0GtYV0D219z/09n90cd/imAEhknJlayyd0SjpnaL9JUd8uYxJexy8TJ2sMhsGAZ6EMTZCfT9m07XduxjsmDz0hlSGV0=
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/logout"/>
+        <md:NameIDFormat>
+            urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+        </md:NameIDFormat>
+        <md:NameIDFormat>
+            urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+        </md:NameIDFormat>
+        <md:NameIDFormat>
+            urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
+        </md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/services/idp/login"/>
+    </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -36,7 +36,7 @@
 
         <AD description="List of contexts that will not use security. Note that sub-contexts to ones listed here will also skip security, unless authentication types are provided for it. For example: if /foo is listed here, then /foo/bar will also not require any sort of authentication. However, if /foo is listed and /foo/bar has authentication types provided in the 'Authentication Types' field, then that more specific policy will be used."
             name="White Listed Contexts" id="whiteListContexts" required="true" cardinality="100"
-            type="String" default="/services/SecurityTokenService,/services/internal,/proxy"/>
+            type="String" default="/services/SecurityTokenService,/services/internal/metrics,/services/saml,/proxy"/>
 
     </OCD>
 

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -202,9 +202,10 @@
         <module>interceptor</module>
         <module>certificate</module>
         <module>security-admin-module</module>
-        <module>docs</module>
+        <module>idp</module>
         <module>rest</module>
         <module>security-services-app</module>
+        <module>docs</module>
     </modules>
 
 </project>

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -263,4 +263,9 @@
         <bundle>mvn:ddf.security.servlet/security-servlet-logout/${project.version}</bundle>
     </feature>
 
+    <feature name="security-idp" install="manual" version="${project.version}"
+             description="IDP client">
+        <bundle>mvn:ddf.security.idp/security-idp-client/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServlet.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServlet.java
@@ -16,6 +16,7 @@ package org.codice.ddf.security.servlet.logout;
 import java.io.IOException;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -32,6 +33,7 @@ public class LogoutServlet extends HttpServlet {
         HttpSession session = request.getSession(false);
         if (session != null) {
             session.invalidate();
+            deleteJSessionId(response);
         }
 
         //This is just here to avoid a blank screen
@@ -41,5 +43,13 @@ public class LogoutServlet extends HttpServlet {
                 .print("You have successfully logged out. Please close your browser or tab.");
 
         response.getWriter().close();
+    }
+
+    private void deleteJSessionId(HttpServletResponse response) {
+        Cookie cookie = new Cookie("JSESSIONID", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
+        response.addCookie(cookie);
     }
 }

--- a/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutServlet.java
+++ b/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutServlet.java
@@ -43,6 +43,8 @@ public class TestLogoutServlet {
         }
         HttpSession httpSession = mock(HttpSession.class);
         when(request.getSession(anyBoolean())).thenReturn(httpSession);
+        when(request.getSession(anyBoolean()).getId()).thenReturn("id");
+        when(request.getRequestURL()).thenReturn(new StringBuffer("http://foo.bar"));
         try {
             logoutServlet.doGet(request, response);
         } catch (ServletException | IOException e) {

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -30,6 +30,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
             <scope>provided</scope>
@@ -87,7 +93,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>cxf-services-sts-core,
+                        <Embed-Dependency>
+                            common-system,
+                            cxf-services-sts-core,
                             security-sts-x509delegationhandler,
                             security-sts-bstdelegationhandler
                         </Embed-Dependency>

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/PropertyPlaceholderWrapper.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/PropertyPlaceholderWrapper.java
@@ -14,8 +14,10 @@
 
 package ddf.security.sts;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.sts.StaticSTSProperties;
 import org.apache.cxf.sts.token.provider.DefaultConditionsProvider;
+import org.codice.ddf.configuration.SystemBaseUrl;
 
 /**
  * property-placeholder misbehaves when set to reload, causing the bundle to bounce
@@ -34,21 +36,19 @@ public class PropertyPlaceholderWrapper {
 
     private static final int DEFAULT_LIFETIME = 1800;
 
-    private static final String DEFAULT_NAME = "localhost";
-
     private DefaultConditionsProvider samlConditionsProvider;
 
     private StaticSTSProperties stsProperties;
 
     public PropertyPlaceholderWrapper(DefaultConditionsProvider conditionsProvider,
-            StaticSTSProperties properties) {
+            StaticSTSProperties properties, SystemBaseUrl baseUrl) {
         samlConditionsProvider = conditionsProvider;
         stsProperties = properties;
         // set the default values in case there is no configuration
         samlConditionsProvider.setLifetime(DEFAULT_LIFETIME);
-        stsProperties.setSignatureUsername(DEFAULT_NAME);
-        stsProperties.setIssuer(DEFAULT_NAME);
-        stsProperties.setEncryptionUsername(DEFAULT_NAME);
+        stsProperties.setSignatureUsername(baseUrl.getHost());
+        stsProperties.setIssuer(baseUrl.getHost());
+        stsProperties.setEncryptionUsername(baseUrl.getHost());
     }
 
     public void setLifetime(Long lifetime) {
@@ -64,6 +64,8 @@ public class PropertyPlaceholderWrapper {
     }
 
     public void setIssuer(String issuer) {
-        stsProperties.setIssuer(issuer);
+        if (StringUtils.isNotBlank(issuer)) {
+            stsProperties.setIssuer(issuer);
+        }
     }
 }

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -231,9 +231,12 @@
                     interface="org.apache.cxf.sts.token.validator.TokenValidator"
                     availability="optional"/>
 
+    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
+
     <bean id="propertyWrapper" class="ddf.security.sts.PropertyPlaceholderWrapper">
         <argument ref="SAMLConditionsProvider"/>
         <argument ref="STSProperties"/>
+        <argument ref="baseUrl"/>
         <cm:managed-properties persistent-id="ddf.security.sts"
                                update-strategy="container-managed"/>
     </bean>

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,7 +21,7 @@
         </AD>
 	    
 	    <AD name="Token Issuer:" id="issuer" required="true" type="String"
-            default="localhost"
+            default=""
             description="The name of the server issuing tokens. Generally this is the cn or hostname of this machine on the network.">
 	    </AD>
 	    


### PR DESCRIPTION
- Added SAML IDP authentication handler that can connect to any IDP.
- Fixed logout servlet to properly delete JSESSIONID cookie.
- Fixed SAML handler to support SAML assertions that are missing the
  SAML namespace.
- Improved CXF server to read in configured hostname to use as issuer
  value when creating SAML assertions.
- Made SAML handler and login filter check if the SAML token saved to
  the session has expired before using it.
- Fixed thread safety of creating a new session for SAML handler and
  login filter.
- Encryption service extends PasswordEncryptor so it can be passed
  directly to WSS4J.
- Added before and after condition parsing to security assertion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/244)
<!-- Reviewable:end -->
