### PR TITLE
Upgraded npm to 2.14.7

### DIFF
--- a/platform/error/platform-error-impl/package.json
+++ b/platform/error/platform-error-impl/package.json
@@ -26,7 +26,7 @@
     "grunt-cli": "0.1.13",
     "bower": "~1.4.1",
     "grunt-bower-task": "0.4.0",
-    "grunt-casperjs": "git+https://github.com/codice/grunt-casperjs.git",
+    "grunt-casperjs": "git+https://github.com/djblue/grunt-casperjs.git",
     "grunt-contrib-jshint": "0.3.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-watch": "0.4.4",
@@ -44,7 +44,7 @@
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9",
-    "casperjs": "~1.1.0",
+    "casperjs": "^1.1.0-beta3",
     "request": "2.49.0"
   }
 }

--- a/platform/security/handler/security-handler-anonymous/package.json
+++ b/platform/security/handler/security-handler-anonymous/package.json
@@ -26,7 +26,7 @@
     "grunt-cli": "0.1.13",
     "bower": "~1.4.1",
     "grunt-bower-task": "0.4.0",
-    "grunt-casperjs": "git+https://github.com/codice/grunt-casperjs.git",
+    "grunt-casperjs": "git+https://github.com/djblue/grunt-casperjs.git",
     "grunt-contrib-jshint": "0.3.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-watch": "0.4.4",
@@ -44,6 +44,6 @@
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9",
-    "casperjs": "~1.1.0"
+    "casperjs": "^1.1.0-beta3"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- Properties for the frontend-maven-plugin -->
         <node.version>v0.10.30</node.version>
-        <npm.version>1.4.12</npm.version>
+        <npm.version>2.14.7</npm.version>
 
         <camel.version>2.14.2</camel.version>
         <commons-io.version>2.1</commons-io.version>
@@ -461,7 +461,7 @@
                             <configuration>
                                 <nodeVersion>${node.version}</nodeVersion>
                                 <npmVersion>${npm.version}</npmVersion>
-                                <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
+                           <!--     <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot> -->
                             </configuration>
                         </execution>
                         <execution>


### PR DESCRIPTION
Testing out the npm version. Would need to update the grunt-casperjs url. It is temporarily pointing to @djblue's fork at the moment to test it out. Also would need to upload this version of npm to Nexus. The downloadRoot is commented out temporarily.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/260)
<!-- Reviewable:end -->
