### PR TITLE
DDF-1555: Implement solution for cardinality issues that cause unpredictable configuration

### DIFF
--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -46,6 +46,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.security.policy</groupId>
             <artifactId>security-policy-context</artifactId>
             <version>${project.version}</version>

--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -46,12 +46,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-util</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>ddf.security.policy</groupId>
             <artifactId>security-policy-context</artifactId>
             <version>${project.version}</version>

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -32,7 +32,9 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.useOwnExa
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -42,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.karaf.features.FeaturesService;
 import org.junit.Rule;
 import org.ops4j.pax.exam.Option;
@@ -330,6 +333,23 @@ public abstract class AbstractIntegrationTest {
      */
     protected Option[] configureCustom() {
         return null;
+    }
+
+    /**
+     * Copies the content of a JAR resource to the destination specified before the container
+     * starts up. Useful to add test configuration files before tests are run.
+     *
+     * @param resourceInputStream input stream to te he JAR resource to copy
+     * @param destination         destination relative to DDF_HOME
+     * @return option object to include in a {@link #configureCustom()} method
+     * @throws IOException thrown if a problem occurs while copying the resource
+     */
+    protected Option installStartupFile(InputStream resourceInputStream, String destination)
+            throws IOException {
+        File tempFile = Files.createTempFile("StartupFile", ".temp").toFile();
+        tempFile.deleteOnExit();
+        FileUtils.copyInputStreamToFile(resourceInputStream, tempFile);
+        return replaceConfigurationFile(destination, tempFile);
     }
 
     /**

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -107,6 +107,10 @@ public abstract class AbstractIntegrationTest {
 
     protected static final String CSW_SOURCE_ID = "cswSource";
 
+    protected static final String DDF_HOME_PROPERTY = "ddf.home";
+
+    protected static String ddfHome;
+
     static {
         // Make Pax URL use the maven.repo.local setting if present
         if (System.getProperty("maven.repo.local") != null) {
@@ -144,6 +148,7 @@ public abstract class AbstractIntegrationTest {
 
     @PostTestConstruct
     public void initFacades() {
+        ddfHome = System.getProperty(DDF_HOME_PROPERTY);
         adminConfig = new AdminConfig(configAdmin);
         serviceManager = new ServiceManager(bundleCtx, metatype, adminConfig);
         catalogBundle = new CatalogBundle(serviceManager, adminConfig);

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestPlatform.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestPlatform.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.util.Dictionary;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.felix.cm.file.ConfigurationHandler;
+import org.codice.ddf.platform.util.ConfigurationPropertiesComparator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.service.cm.Configuration;
+import org.slf4j.LoggerFactory;
+import org.slf4j.ext.XLogger;
+
+import ddf.common.test.BeforeExam;
+import ddf.common.test.config.ConfigurationPredicate;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class TestPlatform extends AbstractIntegrationTest {
+
+    private static final XLogger LOGGER = new XLogger(LoggerFactory.getLogger(TestPlatform.class));
+
+    private static final String TRACKED_PID = "ddf.catalog.test.TestPlatform";
+
+    private static final String UNTRACKED_PID = TRACKED_PID + ".untracked";
+
+    private static final String TRACKED_CONFIG_FILE = "/" + TRACKED_PID + ".config";
+
+    private static final String STARTUP_CONFIG_FILE = "/" + TRACKED_PID + ".startup.config";
+
+    private static final String MODIFIED_TRACKED_CONFIG_FILE =
+            "/" + TRACKED_PID + ".modified.config";
+
+    private static final String UNTRACKED_CONFIG_FILE = "/" + UNTRACKED_PID + ".config";
+
+    /* This value is derived from SensitivityWatchEventModifier class.
+       The default sensitivity for the watch service is Medium, so we should
+       use the medium wait time (10 seconds) + 2 second buffer which is 12 seconds total.
+     */
+    private static final long POLLER_WAIT_TIME = TimeUnit.SECONDS.toMillis(12);
+
+    private static final ConfigurationPropertiesComparator CONFIGURATION_PROPERTIES_COMPARATOR = new ConfigurationPropertiesComparator();
+
+    private static Dictionary<String, Object> configProperties;
+
+    private static Dictionary<String, Object> modifiedConfigProperties;
+
+    private static Dictionary<String, Object> untrackedConfigProperties;
+
+    private static Dictionary<String, Object> startupConfigProperties;
+
+    @BeforeExam
+    @SuppressWarnings("unchecked")
+    public void beforeExam() throws Exception {
+        configProperties = ConfigurationHandler
+                .read(getClass().getResourceAsStream(TRACKED_CONFIG_FILE));
+        modifiedConfigProperties = ConfigurationHandler
+                .read(getClass().getResourceAsStream(MODIFIED_TRACKED_CONFIG_FILE));
+        untrackedConfigProperties = ConfigurationHandler
+                .read(getClass().getResourceAsStream(UNTRACKED_CONFIG_FILE));
+        startupConfigProperties = ConfigurationHandler
+                .read(getClass().getResourceAsStream(STARTUP_CONFIG_FILE));
+        getAdminConfig().setLogLevels();
+        getServiceManager().waitForAllBundles();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        copyConfigToFileSystem();
+
+        getAdminConfig().waitForConfiguration(TRACKED_PID,
+                new ConfigurationPropertiesMatch(configProperties), POLLER_WAIT_TIME);
+    }
+
+    @Override
+    protected Option[] configureCustom() {
+        String fileName = String.format("/%s.startup.config", TRACKED_PID);
+
+        try {
+            File tempFile = Files.createTempFile(TRACKED_PID, ".config").toFile();
+            tempFile.deleteOnExit();
+            FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(fileName), tempFile);
+            return options(replaceConfigurationFile("/etc" + fileName, tempFile),
+                    wrappedBundle(mavenBundle("ddf.platform", "platform-configuration-listener")));
+        } catch (Exception e) {
+            LOGGER.error("Could not copy file [{}]", fileName);
+            return null;
+        }
+    }
+
+    @Test
+    public void testStartUpWithExistingConfigFile() throws Exception {
+        assertThat("Did not startup with config",
+                configAdmin.getConfiguration(TRACKED_PID + ".startup", null), is(notNullValue()));
+        assertThat("Config properties did not match", CONFIGURATION_PROPERTIES_COMPARATOR
+                .equal(configAdmin.getConfiguration(TRACKED_PID + ".startup", null).getProperties(),
+                        startupConfigProperties), is(true));
+    }
+
+    @Test
+    public void testModifyConfigFileFromAdmin() throws Exception {
+        LOGGER.debug("Starting test");
+        getAdminConfig().getConfiguration(TRACKED_PID, null).update(modifiedConfigProperties);
+        waitForConfigurationFilePoller();
+        LOGGER.debug("Checking file properties");
+        Dictionary<String, Object> fileProperties = ConfigurationHandler
+                .read(new FileInputStream(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)));
+        assertThat("File does not match modification from config admin",
+                CONFIGURATION_PROPERTIES_COMPARATOR.equal(fileProperties, modifiedConfigProperties),
+                is(true));
+    }
+
+    @Test
+    public void testDeleteConfigFileFromAdmin() throws Exception {
+        getAdminConfig().getConfiguration(TRACKED_PID, null).delete();
+        waitForConfigurationFilePoller();
+        assertThat("Files was not deleted ",
+                new File(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)).exists(),
+                is(false));
+    }
+
+    @Test
+    public void testCreateUntrackedConfigFileFromAdmin() throws Exception {
+        getAdminConfig().getConfiguration(UNTRACKED_PID, null).update(untrackedConfigProperties);
+        waitForConfigurationFilePoller();
+        assertThat("File was created for untracked pid",
+                new File(String.format("%s/etc%s", ddfHome, UNTRACKED_CONFIG_FILE)).exists(),
+                is(false));
+    }
+
+    @Test
+    public void testRecreationOfTrackedFile() throws Exception {
+        deleteConfigFileFromFileSystem();
+
+        getAdminConfig()
+                .waitForConfiguration(TRACKED_PID, new ConfigurationDeleted(), POLLER_WAIT_TIME);
+        LOGGER.debug("Configuration deleted!");
+        getAdminConfig().getConfiguration(TRACKED_PID, null).update(configProperties);
+        long timeoutLimit = System.currentTimeMillis() + POLLER_WAIT_TIME;
+        while (!(new File(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)).exists())) {
+            Thread.sleep(1000);
+            if (System.currentTimeMillis() > timeoutLimit) {
+                fail(String.format("Configuration file wasn't recreated within %d seconds.",
+                        TimeUnit.MILLISECONDS.toSeconds(POLLER_WAIT_TIME)));
+            }
+        }
+        LOGGER.debug("Wait to Delete!");
+        waitForConfigurationFilePoller();
+        LOGGER.debug("Start the Delete!");
+    }
+
+    @Test
+    public void testModifyConfigFromFileSystem() throws Exception {
+
+        overwriteExistingConfigOnFileSystem();
+
+        getAdminConfig().waitForConfiguration(TRACKED_PID,
+                new ConfigurationPropertiesMatch(modifiedConfigProperties), POLLER_WAIT_TIME);
+    }
+
+    @Test
+    public void testDeleteConfigFromFileSystem() throws Exception {
+        // this is accomplished by teardown
+    }
+
+    @Test
+    public void testCreateTrackedConfigFileFromFileSystem() throws Exception {
+        // this is accomplished by setup
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deleteConfigFileFromFileSystem();
+
+        getAdminConfig()
+                .waitForConfiguration(TRACKED_PID, new ConfigurationDeleted(), POLLER_WAIT_TIME);
+        getAdminConfig().getConfiguration(TRACKED_PID, null).delete();
+    }
+
+    public void overwriteExistingConfigOnFileSystem() throws Exception {
+        FileUtils
+                .copyInputStreamToFile(getClass().getResourceAsStream(MODIFIED_TRACKED_CONFIG_FILE),
+                        new File(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)));
+    }
+
+    public void copyConfigToFileSystem() throws Exception {
+        FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(TRACKED_CONFIG_FILE),
+                new File(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)));
+    }
+
+    public void deleteConfigFileFromFileSystem() throws Exception {
+        new File(String.format("%s/etc%s", ddfHome, TRACKED_CONFIG_FILE)).delete();
+    }
+
+    private void waitForConfigurationFilePoller() throws Exception {
+        Thread.sleep(POLLER_WAIT_TIME);
+    }
+
+    private static class ConfigurationDeleted implements ConfigurationPredicate {
+        @Override
+        public boolean test(Configuration configuration) {
+            if ((configuration == null) || (configuration.getProperties() == null)) {
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private static class ConfigurationPropertiesMatch implements ConfigurationPredicate {
+        private final Dictionary<String, Object> expectedProperties;
+
+        public ConfigurationPropertiesMatch(Dictionary<String, Object> expectedProperties) {
+            this.expectedProperties = expectedProperties;
+        }
+
+        @Override
+        public boolean test(Configuration configuration) {
+            if ((configuration == null) || (configuration.getProperties() == null)) {
+                return false;
+            }
+
+            return CONFIGURATION_PROPERTIES_COMPARATOR
+                    .equal(expectedProperties, configuration.getProperties());
+        }
+    }
+
+}
+

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.config
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.config
@@ -1,0 +1,10 @@
+service.pid="ddf.catalog.test.TestPlatform"
+property.string="string"
+property.boolean.true=B"true"
+property.boolean.false=B"false"
+property.int=I"10"
+property.float=F"10"
+property.double=D"10"
+property.long=L"10"
+property.list.strings=["A","B","C"]
+property.list.int=I["10","20","30"]

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.modified.config
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.modified.config
@@ -1,0 +1,10 @@
+service.pid="ddf.catalog.test.TestPlatform"
+property.string="string"
+property.boolean.true=B"true"
+property.boolean.false=B"false"
+property.int=I"10"
+property.float=F"10"
+property.double=D"10"
+property.long=L"10"
+property.list.strings=["D","B","C"]
+property.list.int=I["10","20","30"]

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.startup.config
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.startup.config
@@ -1,0 +1,2 @@
+service.pid="ddf.catalog.test.TestPlatform.startup"
+property.string="string"

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.untracked.config
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.catalog.test.TestPlatform.untracked.config
@@ -1,0 +1,4 @@
+enableBackupPlugin=B"false"
+rootBackupDir="data/backup"
+service.pid="ddf.catalog.test.TestPlatform.untracked"
+subDirLevels=I"2"

--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>admin-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
@@ -85,14 +85,14 @@ public class AdminConfig {
         LOGGER.debug("Waiting for condition {} in Configuration object [{}] to be true",
                 predicate.toString(), pid);
 
-        Configuration configuration = configAdmin.getConfiguration(pid);
+        Configuration configuration = configAdmin.getConfiguration(pid, null);
 
         int waitPeriod = 0;
 
         while ((waitPeriod < timeoutMs) && !predicate.test(configuration)) {
             TimeUnit.MILLISECONDS.sleep(CONFIG_WAIT_POLLING_INTERVAL);
             waitPeriod += CONFIG_WAIT_POLLING_INTERVAL;
-            configuration = configAdmin.getConfiguration(pid);
+            configuration = configAdmin.getConfiguration(pid, null);
         }
 
         LOGGER.debug("Waited for {}ms", waitPeriod);

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationDeleted.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationDeleted.java
@@ -1,7 +1,27 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
 package ddf.common.test.config;
 
+import org.osgi.service.cm.Configuration;
+
 /**
- * Created by elessard on 10/21/15.
+ * Configuration predicate class that checks to see if a {@link Configuration} property has been
+ * deleted.
  */
-public class ConfigurationDeleted {
+public class ConfigurationDeleted implements ConfigurationPredicate {
+    @Override
+    public boolean test(Configuration configuration) {
+        return configuration == null;
+    }
 }

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationDeleted.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationDeleted.java
@@ -1,0 +1,7 @@
+package ddf.common.test.config;
+
+/**
+ * Created by elessard on 10/21/15.
+ */
+public class ConfigurationDeleted {
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertiesMatch.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertiesMatch.java
@@ -1,0 +1,7 @@
+package ddf.common.test.config;
+
+/**
+ * Created by elessard on 10/21/15.
+ */
+public class ConfigurationPropertiesMatch {
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertiesMatch.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/config/ConfigurationPropertiesMatch.java
@@ -1,7 +1,48 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
 package ddf.common.test.config;
 
+import java.util.Dictionary;
+
+import org.codice.ddf.platform.util.ConfigurationPropertiesComparator;
+import org.osgi.service.cm.Configuration;
+
 /**
- * Created by elessard on 10/21/15.
+ * Configuration predicate class that checks to see if a {@link Configuration} object's properties
+ * match the properties provided.
  */
-public class ConfigurationPropertiesMatch {
+public class ConfigurationPropertiesMatch implements ConfigurationPredicate {
+    private static final ConfigurationPropertiesComparator CONFIGURATION_PROPERTIES_COMPARATOR = new ConfigurationPropertiesComparator();
+
+    private final Dictionary<String, Object> expectedProperties;
+
+    /**
+     * Constructor.
+     *
+     * @param expectedProperties properties to match
+     */
+    public ConfigurationPropertiesMatch(Dictionary<String, Object> expectedProperties) {
+        this.expectedProperties = expectedProperties;
+    }
+
+    @Override
+    public boolean test(Configuration configuration) {
+        if ((configuration == null) || (configuration.getProperties() == null)) {
+            return false;
+        }
+
+        return CONFIGURATION_PROPERTIES_COMPARATOR
+                .equal(expectedProperties, configuration.getProperties());
+    }
 }

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -528,6 +528,11 @@
     </feature>
     <!-- End CXF Features -->
 
+    <feature name ="platform-configuration-listener" install="manual" version="${project.version}"
+             description="Listens for changes to config admin and updates their configuration files">
+        <bundle>mvn:ddf.platform/platform-configuration-listener/${project.version}</bundle>
+    </feature>
+
     <feature name="platform-scheduler" install="manual" version="${project.version}"
              description="Schedules tasks">
         <bundle>mvn:ddf.platform/platform-scheduler/${project.version}</bundle>
@@ -834,6 +839,11 @@
 
     <feature name="platform-app" install="auto" version="${project.version}"
              description="Installs the DDF platform boot features which all other applications depend upon.\nPlatform features installed by default include Apache CXF, Apache Camel, Action Framework, MIME Framework, Metrics, Security Core API and Security Encryption::DDF Platform">
+        <!-- This feature handles Felix style configuration files for DDF and MUST be the first
+             one in the platform-app feature
+             NOTE: It is currently disabled until the implementation is ready for production.
+        <feature>platform-configuration-listener</feature>
+        -->
         <feature>platform-security-session</feature>
         <feature>cxf</feature>
         <feature>camel</feature>

--- a/platform/platform-configuration-listener/pom.xml
+++ b/platform/platform-configuration-listener/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<!-- 
 /**
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
+ * version 3 of the License, or any later version. 
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
--->
+
+ -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
+        <groupId>ddf.platform</groupId>
         <version>2.8.0-SNAPSHOT</version>
     </parent>
-
-    <artifactId>platform-util</artifactId>
-    <name>DDF Platform Util</name>
+    <artifactId>platform-configuration-listener</artifactId>
+    <name>DDF :: Platform :: Configuration :: Listener</name>
+    <description>Listens for configuration changes and writes them to configuration files
+    </description>
     <packaging>bundle</packaging>
 
     <dependencies>
@@ -37,12 +38,42 @@
             <artifactId>org.osgi.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -52,13 +83,10 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package>
-                            org.codice.ddf.platform.util
-                        </Export-Package>
+                        <Embed-Dependency>commons-lang,validation-api,guava</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>
@@ -76,26 +104,32 @@
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>
+                                    <!-- Because of some JaCoCo limitations related to
+                                         try-with-resources, the branch and complexity coverage
+                                         thresholds have to be set lower than 75% even though all
+                                         the exception paths are being covered and the actual
+                                         coverage is much higher.
+                                         See https://github.com/jacoco/jacoco/issues/82 -->
                                     <limits>
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.1</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.4</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.1</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.1</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationAdminListener.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationAdminListener.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.listener;
+
+import java.io.IOException;
+import java.util.Dictionary;
+
+import org.codice.ddf.configuration.store.FileHandler;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class listens for changes in configAdmin and calls FileHandler to write out changes to a
+ * configuration file.
+ */
+public class ConfigurationAdminListener implements ConfigurationListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationAdminListener.class);
+
+    private BundleContext bundleContext;
+
+    private FileHandler fileHandler;
+
+    public ConfigurationAdminListener(BundleContext bundleContext, FileHandler fileHandler) {
+        this.bundleContext = bundleContext;
+        this.fileHandler = fileHandler;
+        LOGGER.debug("{} is using the {} file handler.", ConfigurationAdminListener.class.getName(),
+                fileHandler.getClass().getName());
+    }
+
+    /**
+     * This method is invoked when a configuration event occurs (modification of configAdmin)
+     *
+     * @param event object containing configuration event data
+     */
+    @Override
+    public void configurationEvent(ConfigurationEvent event) {
+        if (event == null) {
+            return;
+        }
+
+        String pid = event.getPid();
+        int eventType = event.getType();
+        String factoryPid = event.getFactoryPid();
+        LOGGER.debug("Factory pid: {}", factoryPid);
+        LOGGER.debug("Event type: {}", eventType);
+        LOGGER.debug("Received configuration event for bundle with pid [{}].", pid);
+        try {
+            Configuration configuration = getConfiguration(pid, event);
+            Dictionary<String, Object> properties = configuration.getProperties();
+            switch (eventType) {
+            case ConfigurationEvent.CM_UPDATED:
+                fileHandler.write(pid, properties);
+                break;
+            case ConfigurationEvent.CM_DELETED:
+                fileHandler.delete(pid);
+                break;
+            default:
+                LOGGER.debug("Unsupported ConfigurationEvent [{}]. No action taken for pid [{}].",
+                        eventType, pid);
+            }
+        } catch (RuntimeException | IOException e) {
+            LOGGER.error("Failed to process ConfigurationEvent [{}] for pid [{}].", eventType, pid,
+                    e);
+        }
+    }
+
+    /*
+     * Returns the configuration object associated with a specific PID and configuration event.
+     */
+    private Configuration getConfiguration(String pid, ConfigurationEvent event)
+            throws IOException {
+        ServiceReference<ConfigurationAdmin> configAdminServiceReference = event.getReference();
+        ConfigurationAdmin configAdmin = bundleContext.getService(configAdminServiceReference);
+        return configAdmin.getConfiguration(pid, null);
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationFileListener.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationFileListener.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.listener;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Dictionary;
+
+import org.codice.ddf.configuration.store.ChangeListener;
+import org.codice.ddf.configuration.store.FileHandler;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class listens for changes in configuration files and updates configAdmin with the changes
+ */
+public class ConfigurationFileListener implements ChangeListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationFileListener.class);
+
+    private final FileHandler fileHandler;
+
+    private final ConfigurationAdmin configAdmin;
+
+    public ConfigurationFileListener(FileHandler fileHandler, ConfigurationAdmin configAdmin) {
+        this.fileHandler = fileHandler;
+        this.configAdmin = configAdmin;
+    }
+
+    /**
+     * Iterates over the entire configuration directory at the beginning to push all the files through ConfigAdmin
+     */
+    public void init() {
+        Collection<String> filePids = fileHandler.getConfigurationPids();
+
+        for (String filePid : filePids) {
+            updateConfig(filePid);
+        }
+
+        fileHandler.registerForChanges(this);
+    }
+
+    /**
+     * Called by the ConfigurationFilesPoller when there is an update to a config file.
+     * Determines what action to take based on the change type.
+     *
+     * @param filePid pid of the configuration file
+     * @param changeType whether the change was an update, creation, or deletion
+     */
+    @Override
+    public void update(String filePid, ChangeType changeType) {
+        try {
+            switch (changeType) {
+            case CREATED:
+            case UPDATED:
+                updateConfig(filePid);
+                break;
+            case DELETED:
+                deleteConfig(filePid);
+                break;
+            }
+        } catch (RuntimeException e) {
+            LOGGER.error("A runtime exception occured", e);
+        }
+
+    }
+
+    /*
+     * Reads the properties from the config file and makes the same change in configAdmin
+     */
+    private void updateConfig(String filePid) {
+        Dictionary<String, Object> props;
+        props = fileHandler.read(filePid);
+        LOGGER.debug("Updating configuration for file PID [{}].", filePid);
+
+        try {
+            Configuration configuration = configAdmin.getConfiguration(filePid, null);
+            configuration.update(props);
+        } catch (IOException ex) {
+            LOGGER.error("[{}] configuration could not be found, or failed to update.", filePid,
+                    ex);
+        }
+    }
+
+    /*
+     * Deletes configuration from configAdmin when the config file is deleted
+     */
+    private void deleteConfig(String filePid) {
+        try {
+            configAdmin.getConfiguration(filePid, null).delete();
+            LOGGER.debug("[{}] was deleted successfully.", filePid);
+        } catch (IOException ex) {
+            LOGGER.error("There was an issue deleting [{}].", filePid, ex);
+        }
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationFileListener.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/listener/ConfigurationFileListener.java
@@ -74,7 +74,6 @@ public class ConfigurationFileListener implements ChangeListener {
         } catch (RuntimeException e) {
             LOGGER.error("A runtime exception occured", e);
         }
-
     }
 
     /*

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ChangeListener.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ChangeListener.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.store;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Interface configuration file change listener must implement.
+ *
+ * @see FileHandler#registerForChanges(ChangeListener)
+ */
+public interface ChangeListener {
+
+    /**
+     * Update types enumeration
+     */
+    enum ChangeType {
+        CREATED, UPDATED, DELETED
+    }
+
+    /**
+     * Method called when the properties associated with a configuration PID have changed.
+     *
+     * @param configurationPid persistence identifier (PID) of the configuration that has changed
+     * @param changeType       type of change that occurred
+     */
+    void update(@NotNull String configurationPid, @NotNull ChangeType changeType);
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFileDirectory.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFileDirectory.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.store;
+
+import static org.apache.commons.lang.Validate.isTrue;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Class that provides utility methods to access the configuration files in the configuration
+ * directory.
+ * <p/>
+ * Note: Since this class is meant to only be used by {@link FileHandlerImpl} and is package
+ * private, it assumes that all input validation has already been performed.
+ */
+public class ConfigurationFileDirectory {
+
+    private File configurationDirectory;
+
+    private String fileExtension;
+
+    /**
+     * Constructor.
+     *
+     * @param configurationDirectory directory that contains the configuration files.
+     *                               The directory must exist and be readable and writable.
+     * @param fileExtension          configuration files extension with preceding period, e.g.,
+     *                               ".cfg"
+     * @throws IllegalArgumentException thrown if any of the arguments is invalid
+     */
+    public ConfigurationFileDirectory(@NotNull File configurationDirectory,
+            @NotNull @Min(2) String fileExtension) {
+        notNull(configurationDirectory, "Configuration directory cannot be null");
+        notNull(fileExtension, "File extension is required");
+        isTrue(fileExtension.length() >= 2, "Invalid file extension: ", fileExtension);
+        isTrue(configurationDirectory.exists() && configurationDirectory.canRead()
+                        && configurationDirectory.canWrite(),
+                "Directory does not exist or is not readable/writable: ", configurationDirectory);
+
+        this.configurationDirectory = configurationDirectory;
+        this.fileExtension = fileExtension;
+    }
+
+    /**
+     * Creates a {@link FileInputStream} that can be used to read the configuration file associated
+     * with a specific PID.
+     *
+     * @param pid persistent ID of the configuration file to read
+     * @return input stream
+     * @throws FileNotFoundException thrown if the {@link FileInputStream} couldn't be created
+     */
+    public FileInputStream createFileInputStream(String pid) throws FileNotFoundException {
+        return new FileInputStream(getFileNameFromPid(pid));
+    }
+
+    /**
+     * Creates a {@link FileOutputStream} that can be used to write to the configuration file
+     * associated with a specific PID.
+     *
+     * @param pid persistent ID of the configuration file to write
+     * @return output stream
+     * @throws FileNotFoundException thrown if the {@link FileOutputStream} couldn't be created
+     */
+    public FileOutputStream createFileOutputStream(String pid) throws FileNotFoundException {
+        return new FileOutputStream(getFileNameFromPid(pid));
+    }
+
+    /**
+     * Gets the list of configuration file PIDs in the configuration directory.
+     *
+     * @return list of configuration file PIDs
+     */
+    public Collection<String> listFiles() {
+        final Collection<String> pids = new ArrayList<>();
+
+        configurationDirectory.listFiles(createFilenameFilter(pids));
+
+        return pids;
+    }
+
+    /**
+     * Tells whether a configuration file exists for a specific PID
+     *
+     * @param pid persistence ID of the configuration file
+     * @return {@code true} if a configuration file exists for the PID provided, {@code false}
+     * otherwise
+     */
+    public boolean exists(String pid) {
+        return getFileNameFromPid(pid).exists();
+    }
+
+    /**
+     * Deletes the configuration file associated with a persistence ID.
+     *
+     * @param pid persistence ID of the configuration file to delete
+     * @return {@code true} if the file was successfully deleted, {@code false} otherwise
+     */
+    public boolean delete(String pid) {
+        return getFileNameFromPid(pid).delete();
+    }
+
+    // Package-private for unit testing purposes
+    ConfigurationFileFilter createFilenameFilter(Collection<String> pids) {
+        return new ConfigurationFileFilter(pids, fileExtension);
+    }
+
+    private File getFileNameFromPid(String pid) {
+        return new File(
+                configurationDirectory.getAbsolutePath() + File.separator + pid + fileExtension);
+    }
+
+    /**
+     * Filter used to get the list of configuration files that have a specific extension.
+     * <p/>
+     * Package-private for unit testing purposes.
+     */
+    static class ConfigurationFileFilter implements FilenameFilter {
+        private final Collection<String> pids;
+
+        private String fileExtension;
+
+        /**
+         * Constructor.
+         *
+         * @param pids          collection that will contain the list of PIDs for which a
+         *                      configuration file exists
+         * @param fileExtension configuration file extension to look for
+         */
+        public ConfigurationFileFilter(Collection<String> pids, String fileExtension) {
+            this.pids = pids;
+            this.fileExtension = fileExtension;
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p/>
+         * Returns {@code true} only if the file has the proper file extension.
+         */
+        @Override
+        public boolean accept(File dir, String name) {
+            if (name.endsWith(fileExtension)) {
+                pids.add(getPidFromFileName(name));
+                return true;
+            }
+            return false;
+        }
+
+        private String getPidFromFileName(String fileName) {
+            return fileName.substring(0, fileName.lastIndexOf("."));
+        }
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFileException.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFileException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.store;
+
+/**
+ * Exception thrown when a configuration file processing error occurs.
+ */
+public class ConfigurationFileException extends RuntimeException {
+
+    public ConfigurationFileException(String message) {
+        super(message);
+    }
+
+    public ConfigurationFileException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFilesPoller.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFilesPoller.java
@@ -113,10 +113,13 @@ public class ConfigurationFilesPoller implements Runnable {
                         listener.update(pid, KIND_CHANGE_TYPE_MAP.get(kind));
                     } catch (RuntimeException e) {
                         LOGGER.error(
-                                "A runtime exception occured"); // TODO is this try catch needed anymore?
+                                "Runtime exception occurred when calling listener.update() for PID [{}], filename [{}]",
+                                pid, filename, e);
                     }
                 }
-                // reset key, shutdown watcher if directory no able to be observed (possibly deleted, who knows)
+
+                // Reset key, shutdown watcher if directory no able to be observed
+                // (possibly deleted)
                 if (!key.reset()) {
                     LOGGER.warn("Configurations in [{}] are no longer able to be observed.",
                             configurationDirectory);

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFilesPoller.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/ConfigurationFilesPoller.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.store;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+import static org.codice.ddf.configuration.store.ChangeListener.ChangeType.CREATED;
+import static org.codice.ddf.configuration.store.ChangeListener.ChangeType.DELETED;
+import static org.codice.ddf.configuration.store.ChangeListener.ChangeType.UPDATED;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.configuration.listener.ConfigurationFileListener;
+import org.codice.ddf.configuration.store.ChangeListener.ChangeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+public class ConfigurationFilesPoller implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationFilesPoller.class);
+
+    private static final Map<Kind, ChangeType> KIND_CHANGE_TYPE_MAP = ImmutableMap
+            .of(ENTRY_CREATE, CREATED, ENTRY_MODIFY, UPDATED, ENTRY_DELETE, DELETED);
+
+    private final WatchService watchService;
+
+    private final ExecutorService watchThread;
+
+    private final Path configurationDirectory;
+
+    private final String fileExtension;
+
+    private ChangeListener listener;
+
+    public ConfigurationFilesPoller(Path configurationDirectory, String fileExtension,
+            WatchService watchService, ExecutorService watchThread) {
+        this.configurationDirectory = configurationDirectory;
+        this.watchService = watchService;
+        this.watchThread = watchThread;
+        this.fileExtension = fileExtension;
+        this.listener = null;
+        LOGGER.debug(
+                "Configuration directory for [{}] is [{}].  Files with an extension of [{}] will be observed.",
+                ConfigurationFileListener.class.getName(), configurationDirectory, fileExtension);
+    }
+
+    public void register(ChangeListener listener) throws IOException {
+        LOGGER.debug(
+                "{} initializing by reading/updating all the configurations in [{}] with the file extension of [{}]",
+                getClass().getSimpleName(), configurationDirectory, fileExtension);
+
+        this.listener = listener;
+        this.configurationDirectory
+                .register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        watchThread.execute(this);
+
+        LOGGER.debug(
+                "Starting the Configuration Observer.  From this point onward, any updates to files with the extension of [{}] in [{}] will be detected and acted on.",
+                fileExtension, configurationDirectory);
+    }
+
+    @Override
+    public void run() {
+        try {
+            WatchKey key;
+            while (!Thread.currentThread().isInterrupted()) {
+                key = watchService.take();  //blocking
+                LOGGER.debug("Key has been signalled.  Looping over events.");
+
+                for (WatchEvent<?> genericEvent : key.pollEvents()) {
+                    WatchEvent.Kind<?> kind = genericEvent.kind();
+
+                    if (kind.equals(OVERFLOW)) {
+                        LOGGER.debug("Skipping event due to overflow");
+                        continue;
+                    }
+
+                    String filename = genericEvent.context().toString();
+
+                    if (!filename.endsWith(fileExtension)) {
+                        LOGGER.debug("Skipping event for [{}] due to file extension.", filename);
+                        continue;  //just skip to the next event
+                    }
+
+                    LOGGER.debug("Processing [{}] event for for [{}].", kind, filename);
+
+                    String pid = filename.substring(0, filename.lastIndexOf("."));
+
+                    try {
+                        listener.update(pid, KIND_CHANGE_TYPE_MAP.get(kind));
+                    } catch (RuntimeException e) {
+                        LOGGER.error(
+                                "A runtime exception occured"); // TODO is this try catch needed anymore?
+                    }
+                }
+                // reset key, shutdown watcher if directory no able to be observed (possibly deleted, who knows)
+                if (!key.reset()) {
+                    LOGGER.warn("Configurations in [{}] are no longer able to be observed.",
+                            configurationDirectory);
+                    break;
+                }
+            }
+        } catch (InterruptedException | RuntimeException ex) {
+            LOGGER.error("The Configuration Observer was interrupted.", ex);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void destroy() {
+        try {
+            watchService.close();
+            watchThread.shutdown();
+
+            if (!watchThread.awaitTermination(10, TimeUnit.SECONDS)) {
+                watchThread.shutdownNow();
+                if (!watchThread.awaitTermination(10, TimeUnit.SECONDS)) {
+                    LOGGER.error("[{}] did not terminate correctly.", getClass().getName());
+                }
+            }
+        } catch (IOException | InterruptedException ex) {
+            watchThread.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FelixPersistenceStrategy.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FelixPersistenceStrategy.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.store;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Dictionary;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+/**
+ * Class that persists configuration properties using the Felix' file format.
+ */
+public class FelixPersistenceStrategy implements PersistenceStrategy {
+    @Override
+    @SuppressWarnings("unchecked")
+    public Dictionary<String, Object> read(InputStream inputStream) throws IOException {
+        return ConfigurationHandler.read(inputStream);
+    }
+
+    @Override
+    public void write(OutputStream outputStream, Dictionary<String, Object> properties)
+            throws IOException {
+        ConfigurationHandler.write(outputStream, properties);
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FileHandler.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FileHandler.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.store;
+
+import java.util.Collection;
+import java.util.Dictionary;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Interface implemented by classes used to manage and persist configuration files.
+ */
+public interface FileHandler {
+
+    /**
+     * Gets the list of configuration Persistent Identifiers (PID) for which configuration files
+     * exist.
+     *
+     * @return collection of PIDs for which a configuration file exists
+     * @throws ConfigurationFileException thrown if the list of PIDs couldn't be retrieved.
+     */
+    @NotNull
+    Collection<String> getConfigurationPids() throws ConfigurationFileException;
+
+    /**
+     * Reads the properties associated with a specific PID.
+     *
+     * @param pid configuration PID of the properties to read
+     * @return properties associated with the configuration PID provided
+     * @throws ConfigurationFileException thrown if the properties couldn't be read
+     * @throws IllegalArgumentException   thrown if no file exists for the configuration PID
+     *                                    provided
+     */
+    @NotNull
+    Dictionary<String, Object> read(@NotNull String pid)
+            throws ConfigurationFileException, IllegalArgumentException;
+
+    /**
+     * Writes the properties associated with a configuration PID. The properties will only be
+     * written if a file existed at startup.
+     *
+     * @param pid        configuration PID of the properties to write
+     * @param properties properties to write
+     * @throws ConfigurationFileException thrown if the properties couldn't be written
+     */
+    void write(@NotNull String pid, @NotNull Dictionary<String, Object> properties)
+            throws ConfigurationFileException;
+
+    /**
+     * Deletes the file and properties associated with a configuration PID. Nothing will happen if
+     * no file exists for the configuration PID provided.
+     *
+     * @param pid configuration PID of the properties to delete.
+     * @throws ConfigurationFileException thrown if the properties couldn't be deleted
+     */
+    void delete(@NotNull String pid) throws ConfigurationFileException;
+
+    /**
+     * Registers a listener that will be called when any file associated with a configuration PID
+     * changes. Only one listener can be registered at any given time, i.e., calling this method
+     * will replace any listener previously registered.
+     *
+     * @param listener listener to call when a configuration file is created, changed or deleted
+     */
+    void registerForChanges(@NotNull ChangeListener listener);
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FileHandlerImpl.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/FileHandlerImpl.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.store;
+
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileLock;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import javax.validation.constraints.NotNull;
+
+import org.codice.ddf.platform.util.ConfigurationPropertiesComparator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class used to manage configuration property files.
+ */
+public class FileHandlerImpl implements FileHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileHandlerImpl.class);
+
+    private final ConfigurationPropertiesComparator propertiesComparator = new ConfigurationPropertiesComparator();
+
+    private final ReadWriteLock readWriteLock;
+
+    private final Lock readLock;
+
+    private final Lock writeLock;
+
+    private final Map<String, Dictionary<String, Object>> propertiesCache = new HashMap<>();
+
+    private final ConfigurationFilesPoller configurationFilesPoller;
+
+    private final PersistenceStrategy persistenceStrategy;
+
+    private final ConfigurationFileDirectory configurationFileDirectory;
+
+    /**
+     * Constructor.
+     *
+     * @param configurationFileDirectory object to use to access the configuration file directory
+     * @param configurationFilesPoller   object to use to monitor file changes
+     * @param persistenceStrategy        object to use to persist files to disk
+     * @throws IllegalArgumentException thrown if any of the arguments is invalid
+     */
+    public FileHandlerImpl(@NotNull ConfigurationFileDirectory configurationFileDirectory,
+            @NotNull ConfigurationFilesPoller configurationFilesPoller,
+            @NotNull PersistenceStrategy persistenceStrategy) {
+        notNull(configurationFileDirectory, "ConfigurationFileDirectory cannot be null");
+        notNull(configurationFilesPoller, "ConfigurationFilesPoller cannot be null");
+        notNull(persistenceStrategy, "PersistenceStrategy cannot be null");
+
+        this.configurationFileDirectory = configurationFileDirectory;
+        this.configurationFilesPoller = configurationFilesPoller;
+        this.persistenceStrategy = persistenceStrategy;
+        this.readWriteLock = createLock();
+        this.readLock = readWriteLock.readLock();
+        this.writeLock = readWriteLock.writeLock();
+    }
+
+    @Override
+    public Collection<String> getConfigurationPids() throws ConfigurationFileException {
+        return configurationFileDirectory.listFiles();
+    }
+
+    @Override
+    public Dictionary<String, Object> read(String pid) {
+        notNull(pid, "Configuration persistence ID cannot be null");
+
+        readLock.lock();
+
+        try (InputStream inputStream = configurationFileDirectory.createFileInputStream(pid)) {
+            Dictionary<String, Object> properties = persistenceStrategy.read(inputStream);
+            propertiesCache.put(pid, properties);
+            return properties;
+        } catch (IOException e) {
+            LOGGER.error("Unable to read configuration file for pid {}", pid, e);
+            throw new ConfigurationFileException("Unable to read configuration for pid " + pid, e);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public void write(String pid, Dictionary<String, Object> properties) {
+        notNull(pid, "Configuration persistence ID cannot be null");
+        notNull(properties, "Properties map cannot be null");
+
+        writeLock.lock();
+
+        try {
+            if (!propertiesCache.containsKey(pid)) {
+                LOGGER.debug("Did not find custom configuration file for pid [{}]. "
+                        + "The configuration will not be written.", pid);
+                return;
+            }
+
+            if (doesPropertyNeedToBeWrittenToFile(pid, properties)) {
+                writeFile(pid, properties);
+                propertiesCache.put(pid, properties);
+            } else {
+                LOGGER.debug(
+                        "Cached properties for configuration pid [{}] are equal to the incoming properties. "
+                                + "Not updating configuration file.", pid);
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void delete(String pid) {
+        notNull(pid, "Configuration persistence ID cannot be null");
+
+        writeLock.lock();
+
+        try {
+
+            if (configurationFileDirectory.delete(pid)) {
+                LOGGER.warn("Tried to delete configuration file for PID {} but it did not exist.",
+                        pid);
+            }
+
+            propertiesCache.put(pid, null);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void registerForChanges(ChangeListener listener) {
+        notNull(listener, "Change listener cannot be null");
+
+        try {
+            configurationFilesPoller.register(listener);
+        } catch (IOException e) {
+            throw new ConfigurationFileException("Unable to register listener for changes");
+        }
+    }
+
+    ReadWriteLock createLock() {
+        return new ReentrantReadWriteLock();
+    }
+
+    private void writeFile(String pid, Dictionary<String, Object> properties) {
+
+        try (FileOutputStream out = configurationFileDirectory.createFileOutputStream(pid);
+                FileLock fileLock = out.getChannel().tryLock()) {
+
+            if (fileLock == null) {
+                LOGGER.error("Failed to update configuration file for PID {}: "
+                        + "file locked by another application", pid);
+                throw new ConfigurationFileException("Unable to obtain file lock on " + pid);
+            }
+
+            persistenceStrategy.write(out, properties);
+        } catch (IOException e) {
+            throw new ConfigurationFileException("Unable to write to " + pid);
+        }
+    }
+
+    private boolean doesPropertyNeedToBeWrittenToFile(String pid,
+            Dictionary<String, Object> properties) {
+
+        return !propertiesComparator.equal(propertiesCache.get(pid), properties);
+    }
+}

--- a/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/PersistenceStrategy.java
+++ b/platform/platform-configuration-listener/src/main/java/org/codice/ddf/configuration/store/PersistenceStrategy.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.store;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Dictionary;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Interface implemented by classes that can read and write configuration properties.
+ */
+public interface PersistenceStrategy {
+    /**
+     * Reads the configuration properties from an {@link InputStream}.
+     *
+     * @param inputStream input stream to read the properties from
+     * @return {@link Dictionary} of properties
+     * @throws IOException thrown if the properties couldn't be read
+     */
+    @NotNull
+    Dictionary<String, Object> read(@NotNull InputStream inputStream) throws IOException;
+
+    /**
+     * Writes the configuration properties to an {@link OutputStream}.
+     *
+     * @param outputStream output stream where the properties will be written
+     * @param properties   properties to write
+     * @throws IOException thrown if the properties couldn't be written
+     */
+    void write(@NotNull OutputStream outputStream, @NotNull Dictionary<String, Object> properties)
+            throws IOException;
+}

--- a/platform/platform-configuration-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <!--ext:property-placeholder/-->
+
+    <ext:property-placeholder>
+        <ext:default-properties>
+            <ext:property name="configFileExtension" value=".config"/>
+            <ext:property name="configFileDirectory" value="${ddf.home}/etc"/>
+        </ext:default-properties>
+    </ext:property-placeholder>
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+
+    <bean id="watchThread" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadExecutor">
+    </bean>
+
+    <bean id="defaultFileSystem" class="java.nio.file.FileSystems" factory-method="getDefault">
+    </bean>
+
+    <bean id="watchService" factory-ref="defaultFileSystem" factory-method="newWatchService">
+    </bean>
+
+    <bean id="persistenceStrategy"
+          class="org.codice.ddf.configuration.store.FelixPersistenceStrategy">
+    </bean>
+
+    <bean id="configDirectoryPath" class="java.nio.file.Paths" factory-method="get">
+        <argument value="file://${configFileDirectory}"/>
+    </bean>
+
+    <bean id="configurationFilesPoller"
+          class="org.codice.ddf.configuration.store.ConfigurationFilesPoller"
+          destroy-method="destroy">
+        <argument ref="configDirectoryPath"/>
+        <argument value="${configFileExtension}"/>
+        <argument ref="watchService"/>
+        <argument ref="watchThread"/>
+    </bean>
+
+    <bean id="configDirectory" class="java.io.File">
+        <argument value="${configFileDirectory}"/>
+    </bean>
+
+    <bean id="configurationFileDirectory"
+          class="org.codice.ddf.configuration.store.ConfigurationFileDirectory">
+        <argument ref="configDirectory"/>
+        <argument value="${configFileExtension}"/>
+    </bean>
+
+    <bean id="fileHandler" class="org.codice.ddf.configuration.store.FileHandlerImpl"
+          scope="singleton">
+        <argument ref="configurationFileDirectory"/>
+        <argument ref="configurationFilesPoller"/>
+        <argument ref="persistenceStrategy"/>
+    </bean>
+
+    <bean id="configurationFileListener"
+          class="org.codice.ddf.configuration.listener.ConfigurationFileListener"
+          init-method="init">
+        <argument ref="fileHandler"/>
+        <argument ref="configurationAdmin"/>
+    </bean>
+
+    <bean id="configurationAdminListener"
+          class="org.codice.ddf.configuration.listener.ConfigurationAdminListener">
+        <argument ref="blueprintBundleContext"/>
+        <argument ref="fileHandler"/>
+    </bean>
+
+
+    <service ref="configurationAdminListener"
+             interface="org.osgi.service.cm.ConfigurationListener"/>
+
+</blueprint>

--- a/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationAdminListenerTest.java
+++ b/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationAdminListenerTest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.listener;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.codice.ddf.configuration.store.FileHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationAdminListenerTest {
+
+    private static final String PID = "my.pid";
+
+    private static final int INVALID_CM_EVENT = 999;
+
+    private static final Dictionary<String, Object> PROPERTIES = new Hashtable<String, Object>(1);
+
+    @Mock
+    private FileHandler mockFileHandler;
+
+    static {
+        PROPERTIES.put("myKey", "myValue");
+    }
+
+    @Test
+    public void testCmUpdateEvent() throws Exception {
+        // Setup
+        Configuration mockConfiguration = getMockConfiguration(PROPERTIES);
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration);
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = getMockConfigurationAdminServiceReference();
+        BundleContext mockBundleContext = getMockBundleContext(mockConfigurationAdmin,
+                mockConfigurationAdminServiceReference);
+        ConfigurationEvent mockConfigurationEvent = getMockConfigurationEvent(
+                mockConfigurationAdminServiceReference, ConfigurationEvent.CM_UPDATED);
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(
+                mockBundleContext, mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(mockConfigurationEvent);
+
+        // Verify
+        verify(mockFileHandler, times(1)).write(PID, PROPERTIES);
+    }
+
+    @Test
+    public void testCmDeletedEvent() throws Exception {
+        // Setup
+        Configuration mockConfiguration = getMockConfiguration(PROPERTIES);
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration);
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = getMockConfigurationAdminServiceReference();
+        BundleContext mockBundleContext = getMockBundleContext(mockConfigurationAdmin,
+                mockConfigurationAdminServiceReference);
+        ConfigurationEvent mockConfigurationEvent = getMockConfigurationEvent(
+                mockConfigurationAdminServiceReference, ConfigurationEvent.CM_DELETED);
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(
+                mockBundleContext, mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(mockConfigurationEvent);
+
+        // Verify
+        verify(mockFileHandler, times(1)).delete(PID);
+    }
+
+    @Test
+    public void testCmLocationChangedEvent() throws Exception {
+        // Setup
+        Configuration mockConfiguration = getMockConfiguration(PROPERTIES);
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration);
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = getMockConfigurationAdminServiceReference();
+        BundleContext mockBundleContext = getMockBundleContext(mockConfigurationAdmin,
+                mockConfigurationAdminServiceReference);
+        ConfigurationEvent mockConfigurationEvent = getMockConfigurationEvent(
+                mockConfigurationAdminServiceReference, ConfigurationEvent.CM_LOCATION_CHANGED);
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(
+                mockBundleContext, mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(mockConfigurationEvent);
+
+        // Verify
+        verify(mockFileHandler, times(0)).write(PID, PROPERTIES);
+        verify(mockFileHandler, times(0)).delete(PID);
+
+    }
+
+    @Test
+    public void testInvalidCmEvent() throws Exception {
+        // Setup
+        Configuration mockConfiguration = getMockConfiguration(PROPERTIES);
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration);
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = getMockConfigurationAdminServiceReference();
+        BundleContext mockBundleContext = getMockBundleContext(mockConfigurationAdmin,
+                mockConfigurationAdminServiceReference);
+        ConfigurationEvent mockConfigurationEvent = getMockConfigurationEvent(
+                mockConfigurationAdminServiceReference, INVALID_CM_EVENT);
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(
+                mockBundleContext, mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(mockConfigurationEvent);
+
+        // Verify
+        verify(mockFileHandler, times(0)).write(PID, PROPERTIES);
+        verify(mockFileHandler, times(0)).delete(PID);
+    }
+
+    @Test
+    public void testIOExceptionWhenRetrievingConfiguration() throws Exception {
+        // Setup
+        Configuration mockConfiguration = getMockConfiguration(PROPERTIES);
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration);
+        doThrow(new IOException()).when(mockConfigurationAdmin).getConfiguration(PID, null);
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = getMockConfigurationAdminServiceReference();
+        BundleContext mockBundleContext = getMockBundleContext(mockConfigurationAdmin,
+                mockConfigurationAdminServiceReference);
+        ConfigurationEvent mockConfigurationEvent = getMockConfigurationEvent(
+                mockConfigurationAdminServiceReference, ConfigurationEvent.CM_UPDATED);
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(
+                mockBundleContext, mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(mockConfigurationEvent);
+
+        // Verify
+        verify(mockFileHandler, times(0)).write(PID, PROPERTIES);
+        verify(mockFileHandler, times(0)).delete(PID);
+    }
+
+    @Test
+    public void testNullConfigurationEvent() throws Exception {
+        // Setup
+        ConfigurationAdminListener configurationAdminListener = new ConfigurationAdminListener(null,
+                mockFileHandler);
+
+        // Perform Test
+        configurationAdminListener.configurationEvent(null);
+    }
+
+    private Configuration getMockConfiguration(Dictionary<String, Object> properties) {
+        Configuration mockConfiguration = mock(Configuration.class);
+        when(mockConfiguration.getProperties()).thenReturn(properties);
+        return mockConfiguration;
+    }
+
+    private ConfigurationAdmin getMockConfigurationAdmin(Configuration mockConfiguration)
+            throws Exception {
+        ConfigurationAdmin mockConfigurationAdmin = mock(ConfigurationAdmin.class);
+        when(mockConfigurationAdmin.getConfiguration(PID, null)).thenReturn(mockConfiguration);
+        return mockConfigurationAdmin;
+    }
+
+    private BundleContext getMockBundleContext(ConfigurationAdmin mockConfigurationAdmin,
+            ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference) {
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        when(mockBundleContext.getService(mockConfigurationAdminServiceReference))
+                .thenReturn(mockConfigurationAdmin);
+        return mockBundleContext;
+    }
+
+    private ServiceReference<ConfigurationAdmin> getMockConfigurationAdminServiceReference() {
+        @SuppressWarnings("unchecked")
+        ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference = mock(
+                ServiceReference.class);
+        return mockConfigurationAdminServiceReference;
+    }
+
+    private ConfigurationEvent getMockConfigurationEvent(
+            ServiceReference<ConfigurationAdmin> mockConfigurationAdminServiceReference,
+            int configurationEvent) {
+        ConfigurationEvent mockConfigurationEvent = mock(ConfigurationEvent.class);
+        when(mockConfigurationEvent.getPid()).thenReturn(PID);
+        when(mockConfigurationEvent.getFactoryPid()).thenReturn(null);
+        when(mockConfigurationEvent.getType()).thenReturn(configurationEvent);
+        when(mockConfigurationEvent.getReference())
+                .thenReturn(mockConfigurationAdminServiceReference);
+        return mockConfigurationEvent;
+    }
+}

--- a/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationFileListenerTest.java
+++ b/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationFileListenerTest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.listener;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.codice.ddf.configuration.store.ChangeListener.ChangeType;
+import org.codice.ddf.configuration.store.FileHandler;
+import org.junit.Test;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+public class ConfigurationFileListenerTest {
+
+    private static final String PID = "my.pid";
+
+    private static final Dictionary<String, Object> PROPERTIES = new Hashtable<String, Object>(1);
+
+    static {
+        PROPERTIES.put("myKey", "myValue");
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                false);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.init();
+
+        // Verify
+        verify(mockFileHandler).read(PID);
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration).update(PROPERTIES);
+        verify(mockFileHandler).registerForChanges(configurationFileListener);
+    }
+
+    @Test
+    public void testUpdateCreatedChangeType() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                false);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.CREATED);
+
+        // Verify
+        verify(mockFileHandler).read(PID);
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration).update(PROPERTIES);
+    }
+
+    @Test
+    public void testUpdateUpdatedChangeType() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                false);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.UPDATED);
+
+        // Verify
+        verify(mockFileHandler).read(PID);
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration).update(PROPERTIES);
+    }
+
+    @Test
+    public void testUpdateUpdatedChangeTypeConfigAdminThrowsIOException() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                true);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.UPDATED);
+
+        // Verify
+        verify(mockFileHandler).read(PID);
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration, times(0)).update(PROPERTIES);
+    }
+
+    @Test
+    public void testUpdateUpdatedChangeTypeFileHandlerThrowsRuntimeException() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(true);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                false);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.UPDATED);
+
+        // Verify
+        verify(mockFileHandler).read(PID);
+    }
+
+    @Test
+    public void testUpdateDeletedChangeType() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                false);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.DELETED);
+
+        // Verify
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration).delete();
+    }
+
+    @Test
+    public void testUpdateDeletedChangeTypeConfigAdminThrowsIOException() throws Exception {
+        // Setup
+        FileHandler mockFileHandler = getMockFileHandler(false);
+        Configuration mockConfiguration = getMockConfiguration();
+        ConfigurationAdmin mockConfigurationAdmin = getMockConfigurationAdmin(mockConfiguration,
+                true);
+
+        ConfigurationFileListener configurationFileListener = new ConfigurationFileListener(
+                mockFileHandler, mockConfigurationAdmin);
+
+        // Perform Test
+        configurationFileListener.update(PID, ChangeType.DELETED);
+
+        // Verify
+        verify(mockConfigurationAdmin).getConfiguration(PID, null);
+        verify(mockConfiguration, times(0)).delete();
+    }
+
+    private FileHandler getMockFileHandler(boolean throwRuntimeException) {
+        Collection<String> pids = new ArrayList<String>(1);
+        pids.add(PID);
+        FileHandler mockFileHandler = mock(FileHandler.class);
+        when(mockFileHandler.getConfigurationPids()).thenReturn(pids);
+        if (throwRuntimeException) {
+            doThrow(new RuntimeException()).when(mockFileHandler).read(PID);
+        } else {
+            when(mockFileHandler.read(PID)).thenReturn(PROPERTIES);
+        }
+        return mockFileHandler;
+    }
+
+    private ConfigurationAdmin getMockConfigurationAdmin(Configuration mockConfiguration,
+            boolean throwIOException) throws Exception {
+        ConfigurationAdmin mockConfigurationAdmin = mock(ConfigurationAdmin.class);
+        if (throwIOException) {
+            doThrow(new IOException()).when(mockConfigurationAdmin).getConfiguration(PID, null);
+        } else {
+            when(mockConfigurationAdmin.getConfiguration(PID, null)).thenReturn(mockConfiguration);
+        }
+        return mockConfigurationAdmin;
+    }
+
+    private Configuration getMockConfiguration() {
+        Configuration mockConfiguration = mock(Configuration.class);
+        return mockConfiguration;
+    }
+}

--- a/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationFilesPollerTest.java
+++ b/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/listener/ConfigurationFilesPollerTest.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.configuration.listener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.configuration.store.ChangeListener;
+import org.codice.ddf.configuration.store.ConfigurationFilesPoller;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class ConfigurationFilesPollerTest {
+
+    private static final String FILE_EXT = ".config";
+
+    private static final String INVALID_FILE_EXT = ".xml";
+
+    private static final String PID = "my.pid";
+
+    @Test
+    public void testRunFileModified() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_MODIFY);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+        ChangeListener mockChangeListener = getMockChangeListener();
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Perform Test
+        configurationFilesPoller.run();
+
+        // Verify
+        verify(mockChangeListener).update(PID, ChangeListener.ChangeType.UPDATED);
+    }
+
+    @Test
+    public void testRunOverflow() throws Exception {
+        // Setup
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(new Object(),
+                StandardWatchEventKinds.OVERFLOW);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+        ChangeListener mockChangeListener = getMockChangeListener();
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Perform Test
+        configurationFilesPoller.run();
+
+        // Verify
+        verify(mockChangeListener, times(0)).update(PID, ChangeListener.ChangeType.UPDATED);
+    }
+
+    @Test
+    public void testRunFileCreated() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_CREATE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+        ChangeListener mockChangeListener = getMockChangeListener();
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Perform Test
+        configurationFilesPoller.run();
+
+        // Verify
+        verify(mockChangeListener).update(PID, ChangeListener.ChangeType.CREATED);
+    }
+
+    @Test
+    public void testRunFileDeleted() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_DELETE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+        ChangeListener mockChangeListener = getMockChangeListener();
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Perform Test
+        configurationFilesPoller.run();
+
+        // Verify
+        verify(mockChangeListener).update(PID, ChangeListener.ChangeType.DELETED);
+    }
+
+    @Test
+    public void testDestroyShutsdownAfterFirstAwaitTermination() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_DELETE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(true);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+
+        // Perform Test
+        configurationFilesPoller.destroy();
+
+        // verify
+        verify(mockWatchService).close();
+        verify(mockExecutorService).shutdown();
+        verify(mockExecutorService, times(1)).awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testDestroyShutsdownAfterSecondAwaitTermination() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_DELETE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(false, true);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+
+        // Perform Test
+        configurationFilesPoller.destroy();
+
+        // verify
+        verify(mockWatchService).close();
+        verify(mockExecutorService).shutdown();
+        verify(mockExecutorService).shutdownNow();
+        verify(mockExecutorService, times(2)).awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testDestroyFailsToShutdownAfterSecondAwaitTermination() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_DELETE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(false, false);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+
+        // Perform Test
+        configurationFilesPoller.destroy();
+
+        // verify
+        verify(mockWatchService).close();
+        verify(mockExecutorService).shutdown();
+        verify(mockExecutorService).shutdownNow();
+        verify(mockExecutorService, times(2)).awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testRunInvalidFileExtension() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, INVALID_FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_MODIFY);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        Path mockConfigurationDirectory = mock(Path.class);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory, FILE_EXT, mockWatchService, mockExecutorService);
+        ChangeListener mockChangeListener = getMockChangeListener();
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Perform Test
+        configurationFilesPoller.run();
+
+        // Verify
+        verify(mockChangeListener, times(0)).update(PID, ChangeListener.ChangeType.UPDATED);
+    }
+
+    private Path getMockPath(String baseFileName, String extension) {
+        Path mockPath = mock(Path.class);
+        when(mockPath.toString()).thenReturn(baseFileName + extension);
+        return mockPath;
+    }
+
+    private <T> WatchEvent<?> getMockWatchEvent(T mockPath, Kind<?> mockKind) {
+        WatchEvent<?> mockWatchEvent = mock(WatchEvent.class);
+        when(mockWatchEvent.context()).thenAnswer(createAnswer(mockPath));
+        when(mockWatchEvent.kind()).thenAnswer(createAnswer(mockKind));
+        return mockWatchEvent;
+    }
+
+    private WatchKey getMockWatchKey(List<WatchEvent<?>> watchEvents) {
+        WatchKey mockWatchKey = mock(WatchKey.class);
+        when(mockWatchKey.pollEvents()).thenReturn(watchEvents);
+        when(mockWatchKey.reset()).thenReturn(false);
+        return mockWatchKey;
+    }
+
+    private WatchService getMockWatchService(WatchKey mockWatchKey) throws Exception {
+        WatchService mockWatchService = mock(WatchService.class);
+        when(mockWatchService.take()).thenReturn(mockWatchKey);
+        return mockWatchService;
+    }
+
+    private List<WatchEvent<?>> getSingleMockWatchEvent(WatchEvent<?> mockWatchEvent) {
+        List<WatchEvent<?>> watchEvents = new ArrayList<>(1);
+        watchEvents.add(mockWatchEvent);
+        return watchEvents;
+    }
+
+    private ChangeListener getMockChangeListener() {
+        ChangeListener mockChangeListener = mock(ChangeListener.class);
+        return mockChangeListener;
+    }
+
+    private <T> Answer<T> createAnswer(T value) {
+        Answer<T> answer = new Answer<T>() {
+            @Override
+            public T answer(InvocationOnMock invocation) throws Throwable {
+                return value;
+            }
+        };
+        return answer;
+    }
+}

--- a/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/store/ConfigurationFileDirectoryTest.java
+++ b/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/store/ConfigurationFileDirectoryTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.store;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationFileDirectoryTest {
+
+    private static final String FILE_EXT = ".cfg";
+
+    private static final String PID = "org.codice.ddf.ConfigurationTest";
+
+    @Mock
+    private File directory;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullDirectory() {
+        new ConfigurationFileDirectory(null, FILE_EXT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNonExistentConfigurationDirectory() {
+        setupConfigurationDirectoryExpectations(false, true, true);
+        new ConfigurationFileDirectory(directory, FILE_EXT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNonReadableDirectory() {
+        setupConfigurationDirectoryExpectations(true, false, true);
+        new ConfigurationFileDirectory(directory, FILE_EXT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNonWritableDirectory() {
+        setupConfigurationDirectoryExpectations(true, true, false);
+        new ConfigurationFileDirectory(directory, FILE_EXT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullExtension() {
+        setupConfigurationDirectoryExpectations(true, true, true);
+        new ConfigurationFileDirectory(directory, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithExtensionTooShort() {
+        setupConfigurationDirectoryExpectations(true, true, true);
+        new ConfigurationFileDirectory(directory, ".");
+    }
+
+    @Test
+    public void createFileInputStream() throws IOException {
+        Path tempDirectory = createTempConfigFile();
+
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        FileInputStream fileInputStream = configurationFileDirectory.createFileInputStream(PID);
+
+        assertThat(fileInputStream, is(not(nullValue())));
+        assertThat(fileInputStream.getFD().valid(), is(true));
+        assertThat(fileInputStream.getChannel().size(), equalTo(0L));
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void createFileInputStreamWithNonExistingFile() throws IOException {
+        Path tempDirectory = createTempDir();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        configurationFileDirectory.createFileInputStream(PID);
+    }
+
+    @Test
+    public void createFileOutputStream() throws IOException {
+        Path tempDirectory = createTempDir();
+
+        try {
+            ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                    tempDirectory.toFile(), FILE_EXT);
+            FileOutputStream fileOutputStream = configurationFileDirectory
+                    .createFileOutputStream(PID);
+            fileOutputStream.write(new byte[] {32});
+
+            assertThat(fileOutputStream, is(not(nullValue())));
+            assertThat(fileOutputStream.getFD().valid(), is(true));
+            assertThat(fileOutputStream.getChannel().size(), equalTo(1L));
+        } finally {
+            getTempConfigFileName(tempDirectory).toFile().delete();
+        }
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void createFileOutputStreamInReadOnlyDirectory() throws IOException {
+        Path tempDirectory = createTempDir();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        assertThat("Failing the test because we couldn't make the temporary directory read-only.",
+                tempDirectory.toFile().setReadOnly(), is(true));
+        configurationFileDirectory.createFileOutputStream(PID);
+    }
+
+    @Test
+    public void fileExists() throws IOException {
+        Path tempDirectory = createTempConfigFile();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        assertThat(configurationFileDirectory.exists(PID), is(true));
+    }
+
+    @Test
+    public void fileDoesNotExist() throws IOException {
+        Path tempDirectory = createTempDir();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        assertThat(configurationFileDirectory.exists(PID), is(false));
+    }
+
+    @Test
+    public void deleteExistingFile() throws IOException {
+        Path tempDirectory = createTempConfigFile();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        assertThat(configurationFileDirectory.delete(PID), is(true));
+        assertThat(getTempConfigFileName(tempDirectory).toFile().exists(), is(false));
+    }
+
+    @Test
+    public void deleteNonExistingFile() throws IOException {
+        Path tempDirectory = createTempDir();
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                tempDirectory.toFile(), FILE_EXT);
+        assertThat(configurationFileDirectory.delete(PID), is(false));
+        assertThat(getTempConfigFileName(tempDirectory).toFile().exists(), is(false));
+    }
+
+    @Test
+    public void listFiles() throws IOException {
+        setupConfigurationDirectoryExpectations(true, true, true);
+        ConfigurationFileDirectory configurationFileDirectory = new ConfigurationFileDirectory(
+                directory, FILE_EXT);
+
+        Collection<String> pids = configurationFileDirectory.listFiles();
+        assertThat(pids, is(notNullValue()));
+        assertThat(pids.size(), equalTo(0));
+        verify(directory)
+                .listFiles(Matchers.any(ConfigurationFileDirectory.ConfigurationFileFilter.class));
+    }
+
+    @Test
+    public void fileFilterMatches() {
+        Collection<String> pids = new ArrayList<>();
+        ConfigurationFileDirectory.ConfigurationFileFilter fileFilter = new ConfigurationFileDirectory.ConfigurationFileFilter(
+                pids, FILE_EXT);
+        assertThat(fileFilter.accept(new File("/"), PID + FILE_EXT), is(true));
+        assertThat(pids, hasItems(PID));
+    }
+
+    @Test
+    public void fileFilterDoesNotMatche() {
+        Collection<String> pids = new ArrayList<>();
+        ConfigurationFileDirectory.ConfigurationFileFilter fileFilter = new ConfigurationFileDirectory.ConfigurationFileFilter(
+                pids, FILE_EXT);
+        assertThat(fileFilter.accept(new File("/"), PID + ".config"), is(false));
+        assertThat(pids, is(empty()));
+    }
+
+    private Path createTempDir() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("configTest");
+        tempDirectory.toFile().deleteOnExit();
+        return tempDirectory;
+    }
+
+    private Path createTempConfigFile() throws IOException {
+        Path tempDirectory = createTempDir();
+
+        Path configFile = getTempConfigFileName(tempDirectory);
+        configFile.toFile().createNewFile();
+        configFile.toFile().deleteOnExit();
+
+        return tempDirectory;
+    }
+
+    private Path getTempConfigFileName(Path tempDirectory) {
+        return tempDirectory.resolve(PID + FILE_EXT);
+    }
+
+    private void setupConfigurationDirectoryExpectations(boolean exists, boolean canRead,
+            boolean canWrite) {
+        when(directory.exists()).thenReturn(exists);
+        when(directory.canRead()).thenReturn(canRead);
+        when(directory.canWrite()).thenReturn(canWrite);
+    }
+}

--- a/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/store/FileHandlerImplTest.java
+++ b/platform/platform-configuration-listener/src/test/java/org/codice/ddf/configuration/store/FileHandlerImplTest.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.store;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import org.apache.felix.cm.impl.CaseInsensitiveDictionary;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Unit test class for {@link FileHandlerImpl}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FileHandlerImplTest {
+
+    private static final String FILE_EXT = ".cfg";
+
+    private static final String FILE_PATH = "/some/valid/path";
+
+    private static final String CONFIG_PID = "org.codice.ddf.MyConfig";
+
+    @Mock
+    private ConfigurationFilesPoller configurationFilesPoller;
+
+    @Mock
+    private PersistenceStrategy persistenceStrategy;
+
+    @Mock
+    private ConfigurationFileDirectory configurationFileDirectory;
+
+    @Mock
+    private FileInputStream inputStream;
+
+    @Mock
+    private FileOutputStream outputStream;
+
+    @Mock
+    private FileChannel fileChannel;
+
+    @Mock
+    private FileLock fileLock;
+
+    @Mock
+    private ReadWriteLock lock;
+
+    @Mock
+    private Lock readLock;
+
+    @Mock
+    private Lock writeLock;
+
+    @Mock
+    private ChangeListener changeListener;
+
+    private Dictionary<String, Object> expectedProperties = new CaseInsensitiveDictionary();
+
+    private Dictionary<String, Object> properties1 = new CaseInsensitiveDictionary();
+
+    private Dictionary<String, Object> properties2 = new CaseInsensitiveDictionary();
+
+    @Before
+    public void setup() {
+        expectedProperties.put("key1", "value1");
+        expectedProperties.put("key2", "value2");
+        properties1.put("A", "1");
+        properties1.put("B", "2");
+        properties2.put("C", "3");
+        properties2.put("D", "4");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullFileDirectory() {
+        new FileHandlerImpl(null, configurationFilesPoller, persistenceStrategy);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullFilePoller() {
+        new FileHandlerImpl(configurationFileDirectory, null, persistenceStrategy);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullPersistenceStrategy() {
+        new FileHandlerImpl(configurationFileDirectory, configurationFilesPoller, null);
+    }
+
+    @Test
+    public void getConfigurationPids() {
+        Collection<String> pids = new ArrayList<>();
+        pids.add("pid1");
+
+        when(configurationFileDirectory.listFiles()).thenReturn(pids);
+        FileHandlerImpl fileHandler = new FileHandlerImpl(configurationFileDirectory,
+                configurationFilesPoller, persistenceStrategy);
+
+        assertThat(fileHandler.getConfigurationPids(), equalTo(pids));
+        verify(configurationFileDirectory).listFiles();
+    }
+
+    @Test
+    public void readConfigurationFile() throws IOException {
+        when(configurationFileDirectory.createFileInputStream(CONFIG_PID)).thenReturn(inputStream);
+        when(persistenceStrategy.read(inputStream)).thenReturn(expectedProperties);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        Dictionary<String, Object> properties = fileHandler.read(CONFIG_PID);
+
+        assertThat(properties, equalTo(expectedProperties));
+
+        verify(configurationFileDirectory).createFileInputStream(CONFIG_PID);
+        verify(persistenceStrategy, times(1)).read(inputStream);
+        verify(inputStream).close();
+        verifyReadLockUsed();
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void readConfigurationFileWhenInputStreamCannotBeCreated() throws FileNotFoundException {
+        when(configurationFileDirectory.createFileInputStream(CONFIG_PID))
+                .thenThrow(new FileNotFoundException());
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.read(CONFIG_PID);
+
+        verify(configurationFileDirectory).createFileInputStream(CONFIG_PID);
+        verifyReadLockUsed();
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void readConfigurationFileWhenReadFails() throws IOException {
+        when(configurationFileDirectory.createFileInputStream(CONFIG_PID)).thenReturn(inputStream);
+        when(persistenceStrategy.read(inputStream)).thenThrow(new IOException());
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.read(CONFIG_PID);
+
+        verify(configurationFileDirectory).createFileInputStream(CONFIG_PID);
+        verify(inputStream).close();
+        verifyReadLockUsed();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void readWithNullPid() {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.read(null);
+    }
+
+    @Test
+    public void writeKnownConfigurationFile() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        readFile(fileHandler);
+        writeFile(fileHandler, properties1);
+
+        verify(fileChannel).tryLock();
+        verify(persistenceStrategy).write(outputStream, properties1);
+        verify(outputStream).close();
+        verify(fileLock).close();
+        verifyLocksUsed(1, 1);
+    }
+
+    @Test
+    public void writeUnknownConfigurationFile() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        fileHandler.write(CONFIG_PID, properties1);
+
+        verify(fileChannel, never()).tryLock();
+        verify(persistenceStrategy, never()).write(outputStream, properties1);
+        verifyLocksUsed(0, 1);
+    }
+
+    @Test
+    public void writeConfigurationFileWithSameProperties() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        readFile(fileHandler);
+        writeFile(fileHandler, properties1);
+        fileHandler.write(CONFIG_PID, properties1);
+
+        verify(fileChannel).tryLock();
+        verify(persistenceStrategy).write(outputStream, properties1);
+        verify(outputStream).close();
+        verify(fileLock).close();
+        verifyLocksUsed(1, 2);
+    }
+
+    @Test
+    public void writeConfigurationFileWithDifferentProperties() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        readFile(fileHandler);
+        writeFile(fileHandler, properties1);
+        fileHandler.write(CONFIG_PID, properties2);
+
+        verify(fileChannel, times(2)).tryLock();
+        verify(persistenceStrategy).write(outputStream, properties1);
+        verify(persistenceStrategy).write(outputStream, properties2);
+        verify(outputStream, times(2)).close();
+        verify(fileLock, times(2)).close();
+        verifyLocksUsed(1, 2);
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void writeConfigurationFileWhenOutputStreamCannotBeCreated() throws IOException {
+        when(configurationFileDirectory.createFileOutputStream(CONFIG_PID))
+                .thenThrow(new FileNotFoundException());
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        readFile(fileHandler);
+
+        try {
+            fileHandler.write(CONFIG_PID, properties1);
+        } finally {
+            verify(persistenceStrategy, never()).write(outputStream, properties1);
+            verifyLocksUsed(1, 1);
+        }
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void writeConfigurationWhenFileLockFails() throws IOException {
+        when(configurationFileDirectory.createFileOutputStream(CONFIG_PID))
+                .thenReturn(outputStream);
+        when(outputStream.getChannel()).thenReturn(fileChannel);
+        when(fileChannel.tryLock()).thenThrow(new IOException());
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        readFile(fileHandler);
+
+        try {
+            fileHandler.write(CONFIG_PID, properties1);
+        } finally {
+            verify(fileChannel).tryLock();
+            verify(persistenceStrategy, never()).write(outputStream, properties1);
+            verify(outputStream).close();
+            verifyLocksUsed(1, 1);
+        }
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void writeConfigurationWhenFileIsLocked() throws IOException {
+        when(configurationFileDirectory.createFileOutputStream(CONFIG_PID))
+                .thenReturn(outputStream);
+        when(outputStream.getChannel()).thenReturn(fileChannel);
+        when(fileChannel.tryLock()).thenReturn(null);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        readFile(fileHandler);
+
+        try {
+            fileHandler.write(CONFIG_PID, properties1);
+        } finally {
+            verify(fileChannel).tryLock();
+            verify(persistenceStrategy, never()).write(outputStream, properties1);
+            verify(outputStream).close();
+            verifyLocksUsed(1, 1);
+        }
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void writeConfigurationFileWhenWriteFails() throws IOException {
+        when(configurationFileDirectory.createFileOutputStream(CONFIG_PID))
+                .thenReturn(outputStream);
+        when(outputStream.getChannel()).thenReturn(fileChannel);
+        when(fileChannel.tryLock()).thenReturn(fileLock);
+        doThrow(new IOException()).when(persistenceStrategy).write(outputStream, properties1);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        readFile(fileHandler);
+
+        try {
+            fileHandler.write(CONFIG_PID, properties1);
+        } finally {
+            verify(fileChannel).tryLock();
+            verify(outputStream).close();
+            verifyLocksUsed(1, 1);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeWithNullPid() {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.write(null, expectedProperties);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeWithNullProperties() {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.write(CONFIG_PID, null);
+    }
+
+    @Test
+    public void deleteExistingFile() {
+        when(configurationFileDirectory.delete(CONFIG_PID)).thenReturn(true);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.delete(CONFIG_PID);
+
+        verify(configurationFileDirectory).delete(CONFIG_PID);
+        verifyLocksUsed(0, 1);
+    }
+
+    @Test
+    public void deleteExistingFileAndRecreateFile() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        readFile(fileHandler);
+
+        when(configurationFileDirectory.delete(CONFIG_PID)).thenReturn(true);
+
+        fileHandler.delete(CONFIG_PID);
+
+        writeFile(fileHandler, properties1);
+
+        verify(configurationFileDirectory).delete(CONFIG_PID);
+        verify(fileChannel).tryLock();
+        verify(persistenceStrategy).write(outputStream, properties1);
+        verify(outputStream).close();
+        verify(fileLock).close();
+        verifyLocksUsed(1, 2);
+    }
+
+    @Test
+    public void deleteNonExistingFile() {
+        when(configurationFileDirectory.delete(CONFIG_PID)).thenReturn(false);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.delete(CONFIG_PID);
+
+        verify(configurationFileDirectory).delete(CONFIG_PID);
+        verifyLocksUsed(0, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void deleteWithNullPid() {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.delete(null);
+    }
+
+    @Test
+    public void registerListener() throws IOException {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        fileHandler.registerForChanges(changeListener);
+
+        verify(configurationFilesPoller).register(changeListener);
+    }
+
+    @Test(expected = ConfigurationFileException.class)
+    public void registerListenerFails() throws IOException {
+        doThrow(new IOException()).when(configurationFilesPoller).register(changeListener);
+
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+
+        fileHandler.registerForChanges(changeListener);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void registerNullListener() {
+        FileHandlerImplUnderTest fileHandler = new FileHandlerImplUnderTest(
+                configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        fileHandler.registerForChanges(null);
+    }
+
+    private void readFile(FileHandlerImplUnderTest fileHandler) throws IOException {
+        when(configurationFileDirectory.createFileInputStream(CONFIG_PID)).thenReturn(inputStream);
+        when(persistenceStrategy.read(inputStream)).thenReturn(expectedProperties);
+        fileHandler.read(CONFIG_PID);
+    }
+
+    private void writeFile(FileHandlerImplUnderTest fileHandler,
+            Dictionary<String, Object> properties) throws IOException {
+        when(configurationFileDirectory.createFileOutputStream(CONFIG_PID))
+                .thenReturn(outputStream);
+        when(outputStream.getChannel()).thenReturn(fileChannel);
+        when(fileChannel.tryLock()).thenReturn(fileLock);
+        fileHandler.write(CONFIG_PID, properties);
+    }
+
+    private void verifyLocksUsed(int readTimes, int writeTimes) {
+        verify(writeLock, times(writeTimes)).lock();
+        verify(writeLock, times(writeTimes)).unlock();
+        verify(readLock, times(readTimes)).lock();
+        verify(readLock, times(readTimes)).unlock();
+    }
+
+    private void verifyReadLockUsed() {
+        verify(readLock).lock();
+        verify(readLock).unlock();
+        verify(writeLock, never()).lock();
+        verify(writeLock, never()).unlock();
+    }
+
+    private class FileHandlerImplUnderTest extends FileHandlerImpl {
+
+        public FileHandlerImplUnderTest(ConfigurationFileDirectory configurationFileDirectory,
+                ConfigurationFilesPoller configurationFilesPoller,
+                PersistenceStrategy persistenceStrategy) {
+            super(configurationFileDirectory, configurationFilesPoller, persistenceStrategy);
+        }
+
+        @Override
+        ReadWriteLock createLock() {
+            when(lock.readLock()).thenReturn(readLock);
+            when(lock.writeLock()).thenReturn(writeLock);
+            return lock;
+        }
+    }
+}

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -321,6 +321,7 @@
 
     <modules>
         <module>platform-configuration</module>
+        <module>platform-configuration-listener</module>
         <module>parser</module>
         <module>action</module>
         <module>compression</module>

--- a/platform/util/src/main/java/org/codice/ddf/platform/util/ConfigurationPropertiesComparator.java
+++ b/platform/util/src/main/java/org/codice/ddf/platform/util/ConfigurationPropertiesComparator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Enumeration;
+
+/**
+ * Compares two {@code Dictionary} objects returned by OSGi's
+ * {@link org.osgi.service.cm.Configuration} objects for equality.
+ */
+public class ConfigurationPropertiesComparator {
+    /**
+     * Compares two {link org.osgi.service.cm.Configuration} {@link Dictionary} for equality.
+     *
+     * @param configProperties1 first dictionary to compare
+     * @param configProperties2 second dictionary to compare
+     * @return {@code true} if both dictionaries contain the exact same key-value pairs
+     */
+    public boolean equal(Dictionary<String, Object> configProperties1,
+            Dictionary<String, Object> configProperties2) {
+
+        if (configProperties1 == null && configProperties2 == null) {
+            return true;
+        }
+
+        if (configProperties1 == null || configProperties2 == null) {
+            return false;
+        }
+
+        if (configProperties1.size() != configProperties2.size()) {
+            return false;
+        }
+
+        for (Enumeration<String> keys = configProperties1.keys(); keys.hasMoreElements();) {
+            String key = keys.nextElement();
+            Object value1 = configProperties1.get(key);
+            Object value2 = configProperties2.get(key);
+
+            if (value1 instanceof Object[] && value2 instanceof Object[]) {
+                if (!Arrays.equals((Object[]) value1, (Object[]) value2)) {
+                    return false;
+                }
+            } else if (!value1.equals(value2)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/platform/util/src/test/java/org/codice/ddf/platform/util/ConfigurationPropertiesComparatorTest.java
+++ b/platform/util/src/test/java/org/codice/ddf/platform/util/ConfigurationPropertiesComparatorTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Dictionary;
+
+import org.apache.felix.cm.impl.CaseInsensitiveDictionary;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigurationPropertiesComparatorTest {
+    private ConfigurationPropertiesComparator configurationPropertiesComparator;
+
+    @Before
+    public void setUp() {
+        configurationPropertiesComparator = new ConfigurationPropertiesComparator();
+    }
+
+    @Test
+    public void equalWithBothArgumentsNull() {
+        assertThat(configurationPropertiesComparator.equal(null, null), is(true));
+    }
+
+    @Test
+    public void equalWithFirstArgumentNull() {
+        assertThat(configurationPropertiesComparator.equal(null, newDictionary("Key", "Value")),
+                is(false));
+    }
+
+    @Test
+    public void equalWithSecondArgumentNull() {
+        assertThat(configurationPropertiesComparator.equal(newDictionary("Key", "Value"), null),
+                is(false));
+    }
+
+    @Test
+    public void equalDictionaryWithItself() {
+        Dictionary<String, Object> dictionary = newDictionary("Key", "Value");
+        assertThat(configurationPropertiesComparator.equal(dictionary, dictionary), is(true));
+    }
+
+    @Test
+    public void equalWithEmptyDictionaries() {
+        Dictionary<String, Object> dictionary = newDictionary();
+        assertThat(configurationPropertiesComparator.equal(dictionary, dictionary), is(true));
+    }
+
+    @Test
+    public void equalWithEmptyAndNonEmptyDictionaries() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary(), newDictionary("Key", "Value")), is(false));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveTheSameKeysAndValues() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("Key", "Value"), newDictionary("Key", "Value")), is(true));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveDifferentKeys() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("K1", "V1", "K2", "V2", "K3", "V3"),
+                        newDictionary("K1", "V1", "Different", "V2", "K3", "V3")), is(false));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveDifferentSizes() {
+        assertThat(configurationPropertiesComparator
+                        .equal(newDictionary("K1", "V1"), newDictionary("K1", "V1", "K2", "V2")),
+                is(false));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveDifferentValues() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("K1", "V1", "K2", "V2", "K3", "V3"),
+                        newDictionary("K1", "V1", "K2", "Different", "K3", "V3")), is(false));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveDifferentValueTypes() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("K1", "V1", "K2", "10", "K3", "V3"),
+                        newDictionary("K1", "V1", "K2", 10, "K3", "V3")), is(false));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveSameKeysAndArrayValues() {
+        assertThat(configurationPropertiesComparator
+                        .equal(newDictionary("K1", new String[] {"V1", "V2"}, "K2",
+                                new String[] {"V3", "V4"}),
+                                newDictionary("K1", new String[] {"V1", "V2"}, "K2",
+                                        new String[] {"V3", "V4"})), is(true));
+    }
+
+    @Test
+    public void equalWithDictionariesThatHaveDifferentArrayValues() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("K1", new String[] {"V1"}, "K2",
+                                new String[] {"V1", "V2", "V3"}, "K3", new String[] {"V3"}),
+                        newDictionary("K1", new String[] {"V1"}, "K2",
+                                new String[] {"V1", "Different", "V3"}, "K3", new String[] {"V3"})),
+                is(false));
+    }
+
+    @Test
+    public void equalWithDictionaryThatHasArrayValueAndAnotherThatHasSimpleValue() {
+        assertThat(configurationPropertiesComparator
+                .equal(newDictionary("K1", "V1", "K2", new String[] {"V2"}, "K3", "V3"),
+                        newDictionary("K1", "V1", "K2", "V2", "K3", "V3")), is(false));
+    }
+
+    @Test
+    public void equalWithDictionaryThatHasSimpleValueAndAnotherThatHasArrayValue() {
+        assertThat(configurationPropertiesComparator
+                        .equal(newDictionary("K1", "V1", "K2", "V2", "K3", "V3"),
+                                newDictionary("K1", "V1", "K2", new String[] {"V2"}, "K3", "V3")),
+                is(false));
+    }
+
+    private Dictionary<String, Object> newDictionary(Object... keyValuePairs) {
+        assertThat("List of key/value arguments must be even", keyValuePairs.length % 2,
+                equalTo(0));
+
+        @SuppressWarnings("unchecked")
+        Dictionary<String, Object> dictionary = new CaseInsensitiveDictionary();
+
+        for (int i = 0; i < keyValuePairs.length; i += 2) {
+            dictionary.put((String) keyValuePairs[i], keyValuePairs[i + 1]);
+        }
+
+        return dictionary;
+    }
+}


### PR DESCRIPTION
 - Added a configuration admin listener that reads and writes custom configuration
   files that properly support cardinality. The current implementation uses
   Felix' ConfigurationHandler class to read and write the files.
 - Added a file watcher to configuration directory. Previously, there
   wasn't a way to get changes that were made directly in the
   filesystem as opposed to the given administration ui or commands.
   With this change, ddf will pick up any changes to config files that are
   made (created, modified, deleted) and propagate them to the Config Admin.
 - Listeners added as a feature that installs at Karaf start up.
 - Added ConfigurationPropertiesComparator class in platform-util to compare
   OSGi Configuration properties and removed equal() method from FileHandlerImpl
   class.
 - Removed cardinality workaround in policy manager.

Hero:
@brendan-hofmann

Reviewers:
@pklinef 
@figliold 
@andrewkfiedler 
@garrettfreibott 
@oconnormi 
@clockard 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/261)
<!-- Reviewable:end -->
