### PR TITLE
DDF-1571 Adds integration tests for persisting to workspace.

### DIFF
--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -52,6 +52,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ddf.persistence.core</groupId>
+            <artifactId>persistence-core-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>


### PR DESCRIPTION
An issue has been found during a demo in a production environment where attempting to save a large workspace fails with an error. This is caused by Lucene, which changed its behavior from logging and ignoring a too-large field to throwing an error if a field of >32776 bytes is indexed. We should not be indexing the data we put in the persistent store, but are for now. Two tests are added here: one with a small data size and one too large; the latter has been marked Ignored for now.

@kcwire 
@tbatie - Please hero this
@jckilmer
@ryeats

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/264)
<!-- Reviewable:end -->
