### PR TITLE
DDF-1519 Encode relay state before sending to IdP

### DIFF
--- a/platform/security/idp/security-idp-client/pom.xml
+++ b/platform/security/idp/security-idp-client/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>opensaml</artifactId>
             <version>2.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -103,7 +108,8 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             common-system,
-                            ddf-security-common
+                            ddf-security-common,
+                            guava
                         </Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -91,14 +91,18 @@ public class IdpHandler implements AuthenticationHandler {
 
     private final SystemBaseUrl baseUrl;
 
-    public IdpHandler(SimpleSign simpleSign, IdpMetadata metadata, SystemBaseUrl baseUrl)
-            throws IOException {
+    private final RelayStates relayStates;
+
+    public IdpHandler(SimpleSign simpleSign, IdpMetadata metadata, SystemBaseUrl baseUrl,
+            RelayStates relayStates) throws IOException {
         LOGGER.debug("Creating IdP handler.");
 
         this.simpleSign = simpleSign;
         idpMetadata = metadata;
 
         this.baseUrl = baseUrl;
+
+        this.relayStates = relayStates;
 
         postBindingTemplate = IOUtils
                 .toString(IdpHandler.class.getResourceAsStream("/post-binding.html"));
@@ -247,11 +251,7 @@ public class IdpHandler implements AuthenticationHandler {
     }
 
     private String createRelayState(HttpServletRequest request) {
-        String requestUrl = recreateFullRequestUrl(request);
-        if (requestUrl.length() > 80) {
-            LOGGER.warn("AuthN relay state exceeds 80 characters: {}", requestUrl);
-        }
-        return requestUrl;
+        return relayStates.encode(recreateFullRequestUrl(request));
     }
 
     private String encodeRedirectRequest(String request) throws WSSecurityException, IOException {

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/RelayStates.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/RelayStates.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.client;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+public class RelayStates {
+
+    Cache<String, String> encodedRelayStates = CacheBuilder.newBuilder()
+            .expireAfterWrite(10, TimeUnit.MINUTES).build();
+
+    public String encode(String relayState) {
+        String id = UUID.randomUUID().toString();
+        encodedRelayStates.put(id, relayState);
+
+        return id;
+    }
+
+    public String decode(String relayState) {
+        String decodedRelayState = encodedRelayStates.getIfPresent(relayState);
+
+        if (decodedRelayState != null) {
+            encodedRelayStates.invalidate(relayState);
+        }
+
+        return decodedRelayState;
+    }
+
+}

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,12 +41,15 @@
         <argument ref="crypto" />
     </bean>
 
+    <bean id="relayStates" class="org.codice.ddf.security.idp.client.RelayStates" />
+
     <bean id="idpHandler" class="org.codice.ddf.security.idp.client.IdpHandler">
         <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpHandler"
                                update-strategy="container-managed"/>
         <argument ref="simpleSign" />
         <argument ref="idpMetadata" />
         <argument ref="baseUrl" />
+        <argument ref="relayStates" />
     </bean>
 
     <service ref="idpHandler" interface="org.codice.ddf.security.handler.api.AuthenticationHandler" />
@@ -58,6 +61,7 @@
                 <argument ref="idpMetadata" />
                 <argument ref="crypto" />
                 <argument ref="baseUrl" />
+                <argument ref="relayStates" />
                 <property name="loginFilter">
                     <reference interface="javax.servlet.Filter"
                                filter="(filter-name=login-filter)"/>


### PR DESCRIPTION
Relay state cannot exceed 80 characters and it should not leak
information about the user action.  Relay state is now a GUID that
can be used to lookup the original redirect url after the user has
successfully logged into the IdP.  Relay state will expire if the
user does not return.

@coyotesqrl @rzwiefel @ryeats

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/265)
<!-- Reviewable:end -->
