### PR TITLE
DDF-1572 Shuts off periodic bundlefile backups for itest exam folders.

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -249,6 +249,12 @@ public abstract class AbstractIntegrationTest {
                 editConfigurationFilePut("etc/system.properties", "org.codice.ddf.system.httpsPort",
                         HTTPS_PORT),
 
+                // DDF-1572: Disables the periodic backups of .bundlefile. In itests, having those
+                // backups serves no purpose and it appears that intermittent failures have occurred
+                // when the background thread attempts to create the backup before the exam bundle
+                // is completely exploded.
+                editConfigurationFilePut("etc/system.properties", "eclipse.enableStateSaver",
+                        Boolean.FALSE.toString()),
 
                 editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", SSH_PORT),
                 editConfigurationFilePut("etc/ddf.platform.config.cfg", "port", HTTPS_PORT),


### PR DESCRIPTION
We see an intermittent failure with itests where the entire pax exam setup fails, causing all tests in a class to fail. Errors have been seen in the osgi code when it attempts to create periodic backups of the `.bundlefile` in `${ddf.home}/data/cache/org.eclipse.osgi`.

Working on the supposition that pax can explode the exam directly successfully but that on slow boxes the background backup thread may start too soon, this will turn off those periodic backups. They are not necessary for itests; this will have either a positive or neutral effect.

It is possible that this is only a symptom of a more basic problem exploding the exam folder in which case this will merely shift the error.

===
Assuming this passes Bamboo without exam setup failures...I'll re-run the CI build multiple times to increase confidence that this is resolving the problem. If it fails a Bamboo build with exam setup, then this PR will be canceled.

@kcwire 
@lessarderic 
@pklinef

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/266)
<!-- Reviewable:end -->
