### PR TITLE
DDF-1532:Makes Subject DN Constraints Configurable

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -154,3 +154,5 @@ karaf.secured.services=(&(osgi.command.scope=*)(osgi.command.function=*))
 #java.security.policy=${karaf.home}/etc/all.policy
 #org.osgi.framework.security=osgi
 #org.osgi.framework.trust.repositories=${karaf.home}/etc/trustStore.ks
+ws-security.subject.cert.constraints = .*
+

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -11,24 +11,26 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>ddf.test</groupId>
-		<artifactId>test</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.test</groupId>
+        <artifactId>test</artifactId>
         <version>2.8.0-SNAPSHOT</version>
-	</parent>
-	<groupId>ddf.test.itests</groupId>
-	<artifactId>itests</artifactId>
-	<name>DDF Integration Tests</name>
-	<packaging>pom</packaging>
+    </parent>
+    <groupId>ddf.test.itests</groupId>
+    <artifactId>itests</artifactId>
+    <name>DDF Integration Tests</name>
+    <packaging>pom</packaging>
 
-	<modules>
-		<module>test-itests-common</module>
-		<module>test-itests-catalog</module>
-	</modules>
-    
+    <modules>
+        <module>test-itests-common</module>
+        <module>test-itests-catalog</module>
+    </modules>
+
     <properties>
         <pax.exam.version>4.4.0</pax.exam.version>
     </properties>
@@ -129,55 +131,55 @@
             <artifactId>javax.inject</artifactId>
             <scope>test</scope>
         </dependency>
-
         <!-- End of pax exam dependencies -->
+
     </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.servicemix.tooling</groupId>
-				<artifactId>depends-maven-plugin</artifactId>
-				<version>1.2</version>
-				<executions>
-					<execution>
-						<id>generate-depends-file</id>
-						<goals>
-							<goal>generate-depends-file</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.servicemix.tooling</groupId>
-										<artifactId>depends-maven-plugin</artifactId>
-										<versionRange>[1.2,)</versionRange>
-										<goals>
-											<goal>generate-depends-file</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.servicemix.tooling</groupId>
+                                        <artifactId>depends-maven-plugin</artifactId>
+                                        <versionRange>[1.2,)</versionRange>
+                                        <goals>
+                                            <goal>generate-depends-file</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>

--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -76,6 +76,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>com.springsource.org.apache.httpcomponents.httpcore</artifactId>
+            <version>4.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>com.springsource.org.apache.httpcomponents.httpclient</artifactId>
+            <version>4.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.distribution</groupId>
             <artifactId>sdk-app</artifactId>
             <version>${project.version}</version>

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -223,6 +223,18 @@ public abstract class AbstractIntegrationTest {
         return options(junitBundles(),
                 // HACK: incorrect version exported to override hamcrest-core from exam
                 // feature which causes a split package issue for rest-assured
+                wrappedBundle(mavenBundle("org.apache.httpcomponents",
+                        "com.springsource.org.apache.httpcomponents.httpclient")
+                        .versionAsInProject()), wrappedBundle(
+                        mavenBundle("org.apache.httpcomponents",
+                                "com.springsource.org.apache.httpcomponents.httpcore")
+                                .versionAsInProject()), wrappedBundle(
+                        mavenBundle("org.apache.httpcomponents", "httpclient")
+                                .versionAsInProject()), wrappedBundle(
+                        mavenBundle("org.apache.httpcomponents", "httpcore").versionAsInProject()),
+                wrappedBundle(mavenBundle("commons-codec", "commons-codec").versionAsInProject()),
+                wrappedBundle(
+                        mavenBundle("commons-logging", "commons-logging").versionAsInProject()),
                 wrappedBundle(mavenBundle("org.hamcrest", "hamcrest-all").versionAsInProject())
                         .exports("*;version=1.3.0.10"), wrappedBundle(
                         mavenBundle("org.apache.karaf.itests", "itests").classifier("tests")

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
+import static com.jayway.restassured.authentication.CertificateAuthSettings.certAuthSettings;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,6 +33,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.hamcrest.xml.HasXPath;
 import org.junit.Before;
@@ -51,6 +53,12 @@ import ddf.security.SecurityConstants;
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class TestSecurity extends AbstractIntegrationTest {
+
+    protected static final String TRUST_STORE_PATH = System.getProperty("javax.net.ssl.trustStore");
+
+    protected static final String KEY_STORE_PATH = System.getProperty("javax.net.ssl.keyStore");
+
+    protected static final String PASSWORD = System.getProperty("javax.net.ssl.trustStorePassword");
 
     protected static final String SOAP_ENV =
             "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -365,7 +373,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
+                .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
@@ -382,7 +392,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory())).
+                log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
@@ -396,7 +408,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory())).
+                log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
@@ -412,7 +426,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + GOOD_X509_TOKEN + "</wsse:BinarySecurityToken>\n" + "</wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
+                .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
@@ -429,7 +445,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + GOOD_X509_PATH_TOKEN + "</wsse:BinarySecurityToken>\n" + "</wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
+        given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
+                .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
@@ -479,8 +497,9 @@ public class TestSecurity extends AbstractIntegrationTest {
                 + "                </wst:OnBehalfOf>\n";
         String body = getSoapEnvelope(onBehalfOf);
 
-        String assertionHeader = given().log().all().body(body)
-                .header("Content-Type", "text/xml; charset=utf-8")
+        String assertionHeader = given().auth().certificate(KEY_STORE_PATH, PASSWORD,
+                certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
+                .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
                 .post(SERVICE_ROOT + "/SecurityTokenService").then().extract().response()

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -12,44 +12,46 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<parent>
-		<groupId>ddf</groupId>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>ddf</groupId>
         <artifactId>distribution</artifactId>
         <version>2.8.0-SNAPSHOT</version>
-	</parent>
+    </parent>
 
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>ddf.test</groupId>
-	<artifactId>test</artifactId>
-	<packaging>pom</packaging>
-	<name>DDF Test</name>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ddf.test</groupId>
+    <artifactId>test</artifactId>
+    <packaging>pom</packaging>
+    <name>DDF Test</name>
 
-	<modules>
-		<module>features-xml</module>
-		<module>test-input-transformer-stubs</module>
-		<module>thirdparty</module>
-		<module>itests</module>
-	</modules>
+    <modules>
+        <module>features-xml</module>
+        <module>test-input-transformer-stubs</module>
+        <module>thirdparty</module>
+        <module>itests</module>
+    </modules>
 
-	<repositories>
-		<repository>
-			<id>codice</id>
-			<name>Codice Repository</name>
-			<url>http://artifacts.codice.org/content/groups/public/</url>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>codice</id>
+            <name>Codice Repository</name>
+            <url>http://artifacts.codice.org/content/groups/public/</url>
+        </repository>
+    </repositories>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
 
     <dependencyManagement>
         <dependencies>

--- a/distribution/test/thirdparty/rest-assured/pom.xml
+++ b/distribution/test/thirdparty/rest-assured/pom.xml
@@ -11,22 +11,24 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>ddf.test.thirdparty</groupId>
-		<artifactId>thirdparty</artifactId>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.test.thirdparty</groupId>
+        <artifactId>thirdparty</artifactId>
         <version>2.8.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>rest-assured</artifactId>
-	<name>DDF :: Test :: Thirdparty :: REST-assured</name>
-	<packaging>bundle</packaging>
-	
-	<dependencies>
-		<dependency>
-			<groupId>com.jayway.restassured</groupId>
-			<artifactId>rest-assured</artifactId>
-			<version>${restassured.version}</version>
+    </parent>
+    <artifactId>rest-assured</artifactId>
+    <name>DDF :: Test :: Thirdparty :: REST-assured</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${restassured.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
@@ -36,60 +38,86 @@
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-library</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>com.springsource.org.apache.httpcomponents.httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>com.springsource.org.apache.httpcomponents.httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
             </exclusions>
-		</dependency>
-	</dependencies>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Bundle-SymbolicName>
-							${project.groupId}.${project.artifactId}
-						</Bundle-SymbolicName>
-						<Bundle-Name>${project.name}</Bundle-Name>
-						
-						<Embed-Transitive>true</Embed-Transitive>
-						<Embed-Dependency>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.groupId}.${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Embed-Dependency>
                             *;artifactId=!hamcrest-core|hamcrest-library|hamcrest-all|
-                                junit|mockito-all
+                            junit|mockito-all
                         </Embed-Dependency>
 
-						<Export-Package>						
-							com.jayway.restassured;version="${restassured.version}",
-							com.jayway.restassured.assertion;version="${restassured.version}",
-							com.jayway.restassured.authentication;version="${restassured.version}",
-							com.jayway.restassured.builder;version="${restassured.version}",
-							com.jayway.restassured.config;version="${restassured.version}",
-							com.jayway.restassured.exception;version="${restassured.version}",
-							com.jayway.restassured.filter;version="${restassured.version}",
-							com.jayway.restassured.filter.log;version="${restassured.version}",
-							com.jayway.restassured.http;version="${restassured.version}",
-							com.jayway.restassured.internal;version="${restassured.version}",
-							com.jayway.restassured.internal.filter;version="${restassured.version}",
-							com.jayway.restassured.internal.http;version="${restassured.version}",
-							com.jayway.restassured.internal.mapping;version="${restassured.version}",
-							com.jayway.restassured.internal.matcher.xml;version="${restassured.version}",
-							com.jayway.restassured.internal.path;version="${restassured.version}",
-							com.jayway.restassured.internal.path.xml;version="${restassured.version}",
-							com.jayway.restassured.internal.support;version="${restassured.version}",
-							com.jayway.restassured.mapper;version="${restassured.version}",
-							com.jayway.restassured.mapper.factory;version="${restassured.version}",
-							com.jayway.restassured.mapper.resolver;version="${restassured.version}",
-							com.jayway.restassured.matcher;version="${restassured.version}",
-							com.jayway.restassured.parsing;version="${restassured.version}",
-							com.jayway.restassured.path.json;version="${restassured.version}",
-							com.jayway.restassured.path.xml;version="${restassured.version}",
-							com.jayway.restassured.path.xml.element;version="${restassured.version}",
-							com.jayway.restassured.response;version="${restassured.version}",
-							com.jayway.restassured.specification;version="${restassured.version}",
-							com.jayway.restassured.spi;version="${restassured.version}"
-						</Export-Package>
+                        <Export-Package>
+                            com.jayway.restassured;version="${restassured.version}",
+                            com.jayway.restassured.assertion;version="${restassured.version}",
+                            com.jayway.restassured.authentication;version="${restassured.version}",
+                            com.jayway.restassured.builder;version="${restassured.version}",
+                            com.jayway.restassured.config;version="${restassured.version}",
+                            com.jayway.restassured.exception;version="${restassured.version}",
+                            com.jayway.restassured.filter;version="${restassured.version}",
+                            com.jayway.restassured.filter.log;version="${restassured.version}",
+                            com.jayway.restassured.http;version="${restassured.version}",
+                            com.jayway.restassured.internal;version="${restassured.version}",
+                            com.jayway.restassured.internal.filter;version="${restassured.version}",
+                            com.jayway.restassured.internal.http;version="${restassured.version}",
+                            com.jayway.restassured.internal.mapping;version="${restassured.version}",
+                            com.jayway.restassured.internal.matcher.xml;version="${restassured.version}",
+                            com.jayway.restassured.internal.path;version="${restassured.version}",
+                            com.jayway.restassured.internal.path.xml;version="${restassured.version}",
+                            com.jayway.restassured.internal.support;version="${restassured.version}",
+                            com.jayway.restassured.mapper;version="${restassured.version}",
+                            com.jayway.restassured.mapper.factory;version="${restassured.version}",
+                            com.jayway.restassured.mapper.resolver;version="${restassured.version}",
+                            com.jayway.restassured.matcher;version="${restassured.version}",
+                            com.jayway.restassured.parsing;version="${restassured.version}",
+                            com.jayway.restassured.path.json;version="${restassured.version}",
+                            com.jayway.restassured.path.xml;version="${restassured.version}",
+                            com.jayway.restassured.path.xml.element;version="${restassured.version}",
+                            com.jayway.restassured.response;version="${restassured.version}",
+                            com.jayway.restassured.specification;version="${restassured.version}",
+                            com.jayway.restassured.spi;version="${restassured.version}"
+                            com.springsource.org.apache.httpcomponents.httpcore;version=4.2.1,
+                            com.springsource.org.apache.httpcomponents.httpclient;version=4.2.1
+                        </Export-Package>
 
-						<Import-Package>
+                        <Import-Package>
                             org.hamcrest,
                             org.hamcrest.core,
                             org.hamcrest.internal,
@@ -99,14 +127,14 @@
                             org.hamcrest.object,
                             org.hamcrest.text,
                             org.hamcrest.xml,
-							javax.xml.bind,
-							javax.xml.bind.annotation,
-							*;resolution:=optional
-						</Import-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                            javax.xml.bind,
+                            javax.xml.bind.annotation,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -44,6 +44,7 @@
         <property name="realms">
             <list value-type="java.lang.String">
                 <value>karaf</value>
+                <value>ldap</value>
             </list>
         </property>
 

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -84,9 +84,14 @@
         </dependency>
 
         <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>common-system</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>2.4.0</version>
         </dependency>
 
     </dependencies>

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/SubjectDNConstraintsInterceptor.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/SubjectDNConstraintsInterceptor.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.sts;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.security.AccessDeniedException;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.ws.security.wss4j.AbstractWSS4JInterceptor;
+import org.apache.wss4j.dom.handler.WSHandlerConstants;
+import org.eclipse.jetty.server.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SubjectDNConstraintsInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    private Logger logger = LoggerFactory.getLogger(SubjectDNConstraintsInterceptor.class);
+
+    public SubjectDNConstraintsInterceptor() {
+        super(Phase.PRE_INVOKE);
+        addAfter(AbstractWSS4JInterceptor.class.getName());
+    }
+
+    /**
+     * Return true if the provided certificate matches the regular expression
+     * defined in the Subject DN Certificate Constraints.
+     *
+     * @param message
+     * @return true if the certificate matches the constraints
+     */
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        if (message != null) {
+            String subjectDNConstraints = (String) message
+                    .get(WSHandlerConstants.SIG_SUBJECT_CERT_CONSTRAINTS);
+            if (subjectDNConstraints == null) {
+                logger.warn(
+                        "No Subject DN Certificate Constraints were defined. This could be a security issue");
+            }
+            Collection<Pattern> subjectDNPatterns = setSubjectDNPatterns(subjectDNConstraints);
+            X509Certificate[] cert;
+            cert = ((X509Certificate[]) (((Request) message.get("HTTP.REQUEST"))
+                    .getAttribute("javax.servlet.request.X509Certificate")));
+            if (cert == null) {
+                throw new AccessDeniedException("No certificate provided.");
+            }
+            if (!(matches(cert[0], subjectDNPatterns))) {
+                logger.warn("Certificate does not match Subject DN Certificate Constraints");
+                throw new AccessDeniedException(
+                        "Certificate DN does not match allowed pattern(s).");
+            }
+        }
+    }
+
+    public Collection<Pattern> setSubjectDNPatterns(String subjectDNConstraints) {
+        ArrayList<Pattern> subjectDNPatterns = new ArrayList<>();
+
+        String[] patterns = subjectDNConstraints.split(",");
+        for (String pattern : patterns) {
+            Pattern p = Pattern.compile(pattern);
+            subjectDNPatterns.add(p);
+        }
+
+        return subjectDNPatterns;
+    }
+
+    /**
+     * Checks the certificate against the list of regular expressions given.
+     * Only matching one of the regular expressions is necessary.
+     *
+     * @param cert
+     * @param subjectDNPatterns
+     * @return true if the certificate matches the constraints
+     */
+    protected boolean matches(final X509Certificate cert,
+            final Collection<Pattern> subjectDNPatterns) {
+        if (subjectDNPatterns == null || subjectDNPatterns.isEmpty()) {
+            logger.warn(
+                    "No Subject DN Certificate Constraints were defined. This could be a security issue");
+        } else {
+            if (cert == null) {
+                logger.debug("The certificate is null so no constraints matching was possible");
+                return false;
+            }
+            String subjectName = cert.getSubjectX500Principal().getName();
+
+            for (Pattern subjectDNPattern : subjectDNPatterns) {
+                final Matcher matcher = subjectDNPattern.matcher(subjectName);
+                if (matcher.matches()) {
+                    logger.debug("Subject DN " + subjectName + " matches with pattern "
+                            + subjectDNPattern);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/platform/security/sts/security-sts-server/src/main/resources/META-INF/sts/wsdl/ws-trust-1.4-service.wsdl
+++ b/platform/security/sts/security-sts-server/src/main/resources/META-INF/sts/wsdl/ws-trust-1.4-service.wsdl
@@ -12,178 +12,187 @@
         xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
         targetNamespace="http://docs.oasis-open.org/ws-sx/ws-trust/200512/">
 
-  <wsdl:types>
-    <xs:schema elementFormDefault="qualified"
-               targetNamespace='http://docs.oasis-open.org/ws-sx/ws-trust/200512'>
+    <wsdl:types>
+        <xs:schema elementFormDefault="qualified"
+                   targetNamespace='http://docs.oasis-open.org/ws-sx/ws-trust/200512'>
 
-      <xs:element name='RequestSecurityToken' type='wst:AbstractRequestSecurityTokenType'/>
-      <xs:element name='RequestSecurityTokenResponse' type='wst:AbstractRequestSecurityTokenType'/>
+            <xs:element name='RequestSecurityToken' type='wst:AbstractRequestSecurityTokenType'/>
+            <xs:element name='RequestSecurityTokenResponse'
+                        type='wst:AbstractRequestSecurityTokenType'/>
 
-      <xs:complexType name='AbstractRequestSecurityTokenType'>
-        <xs:sequence>
-          <xs:any namespace='##any' processContents='lax' minOccurs='0' maxOccurs='unbounded'/>
-        </xs:sequence>
-        <xs:attribute name='Context' type='xs:anyURI' use='optional'/>
-        <xs:anyAttribute namespace='##other' processContents='lax'/>
-      </xs:complexType>
-      <xs:element name='RequestSecurityTokenCollection'
-                  type='wst:RequestSecurityTokenCollectionType'/>
-      <xs:complexType name='RequestSecurityTokenCollectionType'>
-        <xs:sequence>
-          <xs:element name='RequestSecurityToken' type='wst:AbstractRequestSecurityTokenType'
-                      minOccurs='2' maxOccurs='unbounded'/>
-        </xs:sequence>
-      </xs:complexType>
+            <xs:complexType name='AbstractRequestSecurityTokenType'>
+                <xs:sequence>
+                    <xs:any namespace='##any' processContents='lax' minOccurs='0'
+                            maxOccurs='unbounded'/>
+                </xs:sequence>
+                <xs:attribute name='Context' type='xs:anyURI' use='optional'/>
+                <xs:anyAttribute namespace='##other' processContents='lax'/>
+            </xs:complexType>
+            <xs:element name='RequestSecurityTokenCollection'
+                        type='wst:RequestSecurityTokenCollectionType'/>
+            <xs:complexType name='RequestSecurityTokenCollectionType'>
+                <xs:sequence>
+                    <xs:element name='RequestSecurityToken'
+                                type='wst:AbstractRequestSecurityTokenType'
+                                minOccurs='2' maxOccurs='unbounded'/>
+                </xs:sequence>
+            </xs:complexType>
 
-      <xs:element name='RequestSecurityTokenResponseCollection'
-                  type='wst:RequestSecurityTokenResponseCollectionType'/>
-      <xs:complexType name='RequestSecurityTokenResponseCollectionType'>
-        <xs:sequence>
-          <xs:element ref='wst:RequestSecurityTokenResponse' minOccurs='1' maxOccurs='unbounded'/>
-        </xs:sequence>
-        <xs:anyAttribute namespace='##other' processContents='lax'/>
-      </xs:complexType>
+            <xs:element name='RequestSecurityTokenResponseCollection'
+                        type='wst:RequestSecurityTokenResponseCollectionType'/>
+            <xs:complexType name='RequestSecurityTokenResponseCollectionType'>
+                <xs:sequence>
+                    <xs:element ref='wst:RequestSecurityTokenResponse' minOccurs='1'
+                                maxOccurs='unbounded'/>
+                </xs:sequence>
+                <xs:anyAttribute namespace='##other' processContents='lax'/>
+            </xs:complexType>
 
-    </xs:schema>
-  </wsdl:types>
+        </xs:schema>
+    </wsdl:types>
 
     <!-- WS-Trust defines the following GEDs -->
     <wsdl:message name="RequestSecurityTokenMsg">
-    <wsdl:part name="request" element="wst:RequestSecurityToken"/>
-  </wsdl:message>
-  <wsdl:message name="RequestSecurityTokenResponseMsg">
-    <wsdl:part name="response"
-               element="wst:RequestSecurityTokenResponse"/>
-  </wsdl:message>
-  <wsdl:message name="RequestSecurityTokenCollectionMsg">
-    <wsdl:part name="requestCollection"
-               element="wst:RequestSecurityTokenCollection"/>
-  </wsdl:message>
-  <wsdl:message name="RequestSecurityTokenResponseCollectionMsg">
-    <wsdl:part name="responseCollection"
-               element="wst:RequestSecurityTokenResponseCollection"/>
-  </wsdl:message>
+        <wsdl:part name="request" element="wst:RequestSecurityToken"/>
+    </wsdl:message>
+    <wsdl:message name="RequestSecurityTokenResponseMsg">
+        <wsdl:part name="response"
+                   element="wst:RequestSecurityTokenResponse"/>
+    </wsdl:message>
+    <wsdl:message name="RequestSecurityTokenCollectionMsg">
+        <wsdl:part name="requestCollection"
+                   element="wst:RequestSecurityTokenCollection"/>
+    </wsdl:message>
+    <wsdl:message name="RequestSecurityTokenResponseCollectionMsg">
+        <wsdl:part name="responseCollection"
+                   element="wst:RequestSecurityTokenResponseCollection"/>
+    </wsdl:message>
 
     <!-- This portType an example of a Requestor (or other) endpoint that
            Accepts SOAP-based challenges from a Security Token Service -->
     <wsdl:portType name="WSSecurityRequestor">
-    <wsdl:operation name="Challenge">
-      <wsdl:input message="tns:RequestSecurityTokenResponseMsg"/>
-      <wsdl:output message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-  </wsdl:portType>
+        <wsdl:operation name="Challenge">
+            <wsdl:input message="tns:RequestSecurityTokenResponseMsg"/>
+            <wsdl:output message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+    </wsdl:portType>
 
     <!-- This portType is an example of an STS supporting full protocol -->
     <wsdl:portType name="STS">
-    <wsdl:operation name="Cancel">
-      <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Cancel"
-                  message="tns:RequestSecurityTokenMsg"/>
-      <wsdl:output wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/CancelFinal"
-                   message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-    <wsdl:operation name="Issue">
-      <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
-                  message="tns:RequestSecurityTokenMsg"/>
-      <wsdl:output wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal"
-                   message="tns:RequestSecurityTokenResponseCollectionMsg"/>
-    </wsdl:operation>
-    <wsdl:operation name="Renew">
-      <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Renew"
-                  message="tns:RequestSecurityTokenMsg"/>
-      <wsdl:output wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/RenewFinal"
-                   message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-    <wsdl:operation name="Validate">
-      <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Validate"
-                  message="tns:RequestSecurityTokenMsg"/>
-      <wsdl:output wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/ValidateFinal"
-                   message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-    <wsdl:operation name="KeyExchangeToken">
-      <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/KET"
-                  message="tns:RequestSecurityTokenMsg"/>
-      <wsdl:output wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/KETFinal"
-                   message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-    <wsdl:operation name="RequestCollection">
-      <wsdl:input message="tns:RequestSecurityTokenCollectionMsg"/>
-      <wsdl:output message="tns:RequestSecurityTokenResponseCollectionMsg"/>
-    </wsdl:operation>
-  </wsdl:portType>
+        <wsdl:operation name="Cancel">
+            <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Cancel"
+                        message="tns:RequestSecurityTokenMsg"/>
+            <wsdl:output
+                    wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/CancelFinal"
+                    message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+        <wsdl:operation name="Issue">
+            <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"
+                        message="tns:RequestSecurityTokenMsg"/>
+            <wsdl:output
+                    wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal"
+                    message="tns:RequestSecurityTokenResponseCollectionMsg"/>
+        </wsdl:operation>
+        <wsdl:operation name="Renew">
+            <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Renew"
+                        message="tns:RequestSecurityTokenMsg"/>
+            <wsdl:output
+                    wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/RenewFinal"
+                    message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+        <wsdl:operation name="Validate">
+            <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Validate"
+                        message="tns:RequestSecurityTokenMsg"/>
+            <wsdl:output
+                    wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/ValidateFinal"
+                    message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+        <wsdl:operation name="KeyExchangeToken">
+            <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/KET"
+                        message="tns:RequestSecurityTokenMsg"/>
+            <wsdl:output
+                    wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTR/KETFinal"
+                    message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+        <wsdl:operation name="RequestCollection">
+            <wsdl:input message="tns:RequestSecurityTokenCollectionMsg"/>
+            <wsdl:output message="tns:RequestSecurityTokenResponseCollectionMsg"/>
+        </wsdl:operation>
+    </wsdl:portType>
 
     <!-- This portType is an example of an endpoint that accepts
            Unsolicited RequestSecurityTokenResponse messages -->
     <wsdl:portType name="SecurityTokenResponseService">
-    <wsdl:operation name="RequestSecurityTokenResponse">
-      <wsdl:input message="tns:RequestSecurityTokenResponseMsg"/>
-    </wsdl:operation>
-  </wsdl:portType>
+        <wsdl:operation name="RequestSecurityTokenResponse">
+            <wsdl:input message="tns:RequestSecurityTokenResponseMsg"/>
+        </wsdl:operation>
+    </wsdl:portType>
 
-  <wsdl:binding name="STS_Binding" type="wstrust:STS">
-    <wsp:PolicyReference URI="#STS_policy"/>
-  	<soap:binding style="document"
-                  transport="http://schemas.xmlsoap.org/soap/http"/>
-  	<wsdl:operation name="Issue">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  	<wsdl:operation name="Validate">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Validate"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  	<wsdl:operation name="Cancel">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Cancel"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  	<wsdl:operation name="Renew">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Renew"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  	<wsdl:operation name="KeyExchangeToken">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/KeyExchangeToken"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  	<wsdl:operation name="RequestCollection">
-  		<soap:operation
-                soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/RequestCollection"/>
-  		<wsdl:input>
-  			<soap:body use="literal"/>
-  		</wsdl:input>
-  		<wsdl:output>
-  			<soap:body use="literal"/>
-  		</wsdl:output>
-  	</wsdl:operation>
-  </wsdl:binding>
+    <wsdl:binding name="STS_Binding" type="wstrust:STS">
+        <wsp:PolicyReference URI="#STS_policy"/>
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="Issue">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Validate">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Validate"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Cancel">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Cancel"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Renew">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Renew"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="KeyExchangeToken">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/KeyExchangeToken"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="RequestCollection">
+            <soap:operation
+                    soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/RequestCollection"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
 
     <wsp:Policy wsu:Id="STS_policy">
         <wsp:ExactlyOne>
@@ -196,7 +205,9 @@
                             <sp:TransportToken>
                                 <wsp:Policy>
                                     <sp:HttpsToken>
-                                        <wsp:Policy/>
+                                        <wsp:Policy>
+                                            <sp:RequireClientCertificate/>
+                                        </wsp:Policy>
                                     </sp:HttpsToken>
                                 </wsp:Policy>
                             </sp:TransportToken>
@@ -234,69 +245,69 @@
             </wsp:All>
         </wsp:ExactlyOne>
     </wsp:Policy>
-   
-   <wsp:Policy wsu:Id="Input_policy">
-      <wsp:ExactlyOne>
-         <wsp:All>
-            <sp:SignedParts
-                    xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
-               <sp:Body/>
-               <sp:Header Name="To"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="From"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="FaultTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="ReplyTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="MessageID"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="RelatesTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="Action"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-            </sp:SignedParts>
-            <sp:EncryptedParts
-                    xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
-               <sp:Body/>
-            </sp:EncryptedParts>
-         </wsp:All>
-      </wsp:ExactlyOne>
-   </wsp:Policy>
-   
-   <wsp:Policy wsu:Id="Output_policy">
-      <wsp:ExactlyOne>
-         <wsp:All>
-            <sp:SignedParts
-                    xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
-               <sp:Body/>
-               <sp:Header Name="To"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="From"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="FaultTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="ReplyTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="MessageID"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="RelatesTo"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-               <sp:Header Name="Action"
-                          Namespace="http://www.w3.org/2005/08/addressing"/>
-            </sp:SignedParts>
-            <sp:EncryptedParts
-                    xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
-               <sp:Body/>
-            </sp:EncryptedParts>
-         </wsp:All>
-      </wsp:ExactlyOne>
-   </wsp:Policy>
-   
-   <wsdl:service name="SecurityTokenService">
-      <wsdl:port name="STS_Port" binding="tns:STS_Binding">
-         <soap:address location="http://localhost:8181/services/SecurityTokenService"/>
-      </wsdl:port>
-  </wsdl:service>
+
+    <wsp:Policy wsu:Id="Input_policy">
+        <wsp:ExactlyOne>
+            <wsp:All>
+                <sp:SignedParts
+                        xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                    <sp:Body/>
+                    <sp:Header Name="To"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="From"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="FaultTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="ReplyTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="MessageID"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="RelatesTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="Action"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                </sp:SignedParts>
+                <sp:EncryptedParts
+                        xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                    <sp:Body/>
+                </sp:EncryptedParts>
+            </wsp:All>
+        </wsp:ExactlyOne>
+    </wsp:Policy>
+
+    <wsp:Policy wsu:Id="Output_policy">
+        <wsp:ExactlyOne>
+            <wsp:All>
+                <sp:SignedParts
+                        xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                    <sp:Body/>
+                    <sp:Header Name="To"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="From"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="FaultTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="ReplyTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="MessageID"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="RelatesTo"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                    <sp:Header Name="Action"
+                               Namespace="http://www.w3.org/2005/08/addressing"/>
+                </sp:SignedParts>
+                <sp:EncryptedParts
+                        xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+                    <sp:Body/>
+                </sp:EncryptedParts>
+            </wsp:All>
+        </wsp:ExactlyOne>
+    </wsp:Policy>
+
+    <wsdl:service name="SecurityTokenService">
+        <wsdl:port name="STS_Port" binding="tns:STS_Binding">
+            <soap:address location="http://localhost:8181/services/SecurityTokenService"/>
+        </wsdl:port>
+    </wsdl:service>
 
 </wsdl:definitions>

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -169,6 +169,11 @@
                                update-strategy="container-managed"/>
     </bean>
 
+    <bean id="SubjectDNConstraintsInterceptor"
+          class="ddf.security.sts.SubjectDNConstraintsInterceptor">
+
+    </bean>
+
     <bean id="service"
           class="org.apache.cxf.sts.service.StaticService">
         <property name="endpoints">
@@ -221,6 +226,7 @@
                     depends-on="propertyWrapper">
         <jaxws:inInterceptors>
             <ref component-id="crlInterceptor"/>
+            <ref component-id="SubjectDNConstraintsInterceptor"/>
         </jaxws:inInterceptors>
         <jaxws:properties>
             <entry key="ws-security.signature.properties" value-ref="signatureProps"/>
@@ -230,6 +236,8 @@
             <entry key="ws-security.is-bsp-compliant" value="false"/>
             <entry key="ws-security.role.classifier" value="RolePrincipal"/>
             <entry key="ws-security.role.classifier.type" value="classname"/>
+            <entry key="ws-security.subject.cert.constraints"
+                   value="${ws-security.subject.cert.constraints}"/>
         </jaxws:properties>
     </jaxws:endpoint>
 
@@ -237,7 +245,7 @@
                     interface="org.apache.cxf.sts.token.validator.TokenValidator"
                     availability="optional"/>
 
-    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
+    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl"/>
 
     <bean id="propertyWrapper" class="ddf.security.sts.PropertyPlaceholderWrapper">
         <argument ref="SAMLConditionsProvider"/>


### PR DESCRIPTION
-Added a system property that allow admins to set the STS Subject DN Constraints. By default it is ".*".
-Some of the security itests now use authorization

Reviewers: 
@stustison @djblue @clockard @ricklarsen @gordocanchola

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/267)
<!-- Reviewable:end -->
