### PR TITLE
DDF-1543 Fix USNG to LL switch and search bug

### DIFF
--- a/catalog/ui/search-ui/standard/bower.json
+++ b/catalog/ui/search-ui/standard/bower.json
@@ -33,7 +33,7 @@
     "pnotify": "1.3.1",
     "lato": "v0.2.1",
     "strapdown": "arturadib/strapdown#509f99f9c00e6b40f208a39e2a2c980331642fe5",
-    "usng.js": "codice/usng.js#394458bf77f4c8ac47ffc37ab208e54111e6cb8b",
+    "usng.js": "codice/usng.js#aa6f25217a84a0ef864ea44299f269ec92adac7f",
     "openlayers3": "codice/ol3#27933cf5dd10b31af2817d212ec518eb525f97a6",
     "jquery-file-upload": "9.5.7",
     "cesium-drawhelper": "leforthomas/cesium-drawhelper#4fbe1776f50a8b9dee0252725eab93a8e68fb539",

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -103,14 +103,16 @@ define([
             },
 
             setLatLon: function() {
-                var north = this.get('north'),
-                    south = this.get('south'),
-                    west = this.get('west'),
-                    east = this.get('east');
-                if (!(north && south && west && east)) {
-                    var result = converter.USNGtoLL(this.get('usngbb'));
-                    this.set(result);
+                var result = {};
+                result.north = this.get('mapNorth');
+                result.south = this.get('mapSouth');
+                result.west = this.get('mapWest');
+                result.east = this.get('mapEast');
+                if (!(result.north && result.south && result.west && result.east)) {
+                    result = converter.USNGtoLL(this.get('usngbb'));
+
                 }
+                this.set(result);
             },
 
             setBboxLatLon: function () {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -202,7 +202,6 @@ define([
 
             swapLocationTypeLatLon: function() {
                 this.model.set('locationType', 'latlon');
-                this.model.setLatLon();
                 this.updateLocationFields();
             },
 
@@ -539,6 +538,10 @@ define([
                 if (_.isUndefined(this.model.get('src'))) {
                     this.model.setSources(this.sources);
                 }
+                view.model.set({"north" : view.model.get('mapNorth')}, {silent: true});
+                view.model.set({"west" : view.model.get('mapWest')}, {silent: true});
+                view.model.set({"south" : view.model.get('mapSouth')}, {silent: true});
+                view.model.set({"east" : view.model.get('mapEast')}, {silent: true});
 
                 // disable the whole form
                 this.$('button').addClass('disabled');

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
@@ -212,22 +212,22 @@
                     <div class="col-lg-10">
                         <div id="westdiv" class="input-group input-group-sm">
                             <span class="input-group-addon">West&nbsp;</span>
-                            <input class="form-control" id="west" name="west" type="number" min="-180" max="180" step="any" placeholder=""/>
+                            <input class="form-control" id="mapWest" name="mapWest" type="number" min="-180" max="180" step="any" placeholder=""/>
                             <label class="input-group-addon">&deg;</label>
                         </div>
                         <div id="southdiv" class="input-group input-group-sm">
                             <span class="input-group-addon">South&nbsp;</span>
-                            <input class="form-control" id="south" name="south" type="number" min="-90" max="90" step="any" placeholder=""/>
+                            <input class="form-control" id="mapSouth" name="mapSouth" type="number" min="-90" max="90" step="any" placeholder=""/>
                             <label class="input-group-addon">&deg;</label>
                         </div>
                         <div id="eastdiv" class="input-group input-group-sm">
                             <span class="input-group-addon">East&nbsp;</span>
-                            <input class="form-control" id="east" name="east" type="number" min="-180" max="180" step="any" placeholder=""/>
+                            <input class="form-control" id="mapEast" name="mapEast" type="number" min="-180" max="180" step="any" placeholder=""/>
                             <label class="input-group-addon">&deg;</label>
                         </div>
                         <div id="northdiv" class="input-group input-group-sm">
                             <span class="input-group-addon">North&nbsp;</span>
-                            <input class="form-control" id="north" name="north" type="number" min="-90" max="90" step="any" placeholder=""/>
+                            <input class="form-control" id="mapNorth" name="mapNorth" type="number" min="-90" max="90" step="any" placeholder=""/>
                             <label class="input-group-addon">&deg;</label>
                         </div>
 

--- a/catalog/ui/search-ui/standard/src/test/js/wd/usng.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/usng.js
@@ -8,10 +8,10 @@ var convertLLtoUSNG = function(browser,lat1, lon1, lat2, lon2) {
     return browser
         .waitForElementById('latlon', shared.timeout).click()
         .waitForElementById('locationBbox', shared.timeout).click()
-        .waitForElementById('north', shared.timeout).clear().type(lat1)
-        .waitForElementById('south', shared.timeout).clear().type(lat2)
-        .waitForElementById('east', shared.timeout).clear().type(lon1)
-        .waitForElementById('west', shared.timeout).clear().type(lon2)
+        .waitForElementById('mapNorth', shared.timeout).clear().type(lat1)
+        .waitForElementById('mapSouth', shared.timeout).clear().type(lat2)
+        .waitForElementById('mapEast', shared.timeout).clear().type(lon1)
+        .waitForElementById('mapWest', shared.timeout).clear().type(lon2)
         .waitForElementById('usng', shared.timeout).click()
         .waitForElementById('usngbb', shared.timeout);
 };
@@ -125,10 +125,10 @@ describe('USNG Search', function () {
             var east = -77.0351;
             var west = -77.0351;
             return convertUSNGtoLL(this.browser, "18S UJ 23487 06483")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 38.8895 -77.0351 38.8894 -77.0350", function () {
@@ -137,10 +137,10 @@ describe('USNG Search', function () {
             var east = -77.0350;
             var west = -77.0351;
             return convertUSNGtoLL(this.browser, "18S UJ 2349 0648")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 38.8896 -77.0361 38.8887 -77.0350", function () {
@@ -149,10 +149,10 @@ describe('USNG Search', function () {
             var east = -77.0350;
             var west = -77.0361;
             return convertUSNGtoLL(this.browser, "18S UJ 234 064")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 38.8942 -77.0406 38.8850 -77.0294", function () {
@@ -161,10 +161,10 @@ describe('USNG Search', function () {
             var east = -77.0294;
             var west = -77.0406;
             return convertUSNGtoLL(this.browser, "18S UJ 23 06")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 38.9224 -77.0736 38.8304 -76.9610", function () {
@@ -173,10 +173,10 @@ describe('USNG Search', function () {
             var east = -76.9610;
             var west = -77.0736;
             return convertUSNGtoLL(this.browser, "18S UJ 2 0")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 39.7440 -77.3039 38.8260 -76.1671", function () {
@@ -185,10 +185,10 @@ describe('USNG Search', function () {
             var east = -76.1671;
             var west = -77.3039;
             return convertUSNGtoLL(this.browser, "18S UJ")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
 
         it("should convert to 40 -84 32 -84", function () {
@@ -197,10 +197,10 @@ describe('USNG Search', function () {
             var east = -78;
             var west = -84;
             return convertUSNGtoLL(this.browser, "17S")
-                .waitForConditionInBrowser("document.getElementById('west').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('east').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('north').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('south').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
+                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
+                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
         });
     });
 });


### PR DESCRIPTION
-Switching from USNG to Lat Lon would not properly update the Lat Lon values.
The template now looks to the 'map' version of these variables as opposed to
the raw versions. This continues the migration from 'north' -> 'mapNorth'
that was started in these USNG changes. The raw variables just track where the
cursor is and does not decide what is shown on the map or what is searched.

-Updated search function to use the 'map' versions of variables. Silently sets
the raw variables to the 'map' variables to not trigger a redraw but to affect
other code as little as possible - best not to percolate the 'map' change, except
where needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/274)
<!-- Reviewable:end -->
