### PR TITLE
DDF-1580: Remove notification parsing in CometD listener

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Notification.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Notification.js
@@ -29,13 +29,6 @@ define(["backbone", "moment", "underscore", "jquery"], function (Backbone, momen
                 return "Notification must have message.";
             if (!attrs.timestamp)
                 return "Notification must have timestamp.";
-        },
-
-        //parses out the object returned from CometD 
-        parse: function (resp) {
-            if(!_.isEmpty(resp.data)) {
-                return $.parseJSON(resp.data);
-            }
         }
     });
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/module/Notification.module.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/module/Notification.module.js
@@ -35,8 +35,8 @@ define(['application',
             this.subscription = Cometd.Comet.subscribe("/ddf/notifications/**", function(resp) {
                 // instead of doing a notifications.create(), make new Model and then add it to collection.
                 // this is done to avoid calling model.save() which notifications.create() will do.
-                var incomingNotification = new Notification.Notification(resp, {validate: true, parse: true});
-                
+                var incomingNotification = new Notification.Notification(resp.data, {validate: true});
+
                 //only add the Notification if it is properly formatted and contains application, message, and title
                 if(!incomingNotification.validationError){
                     notifications.add(incomingNotification);


### PR DESCRIPTION
The CometD listener attempts to parse the returned notification as a JSON string, but it’s actually a JSON object. Notifications have been returned as JSON objects since DDF-1415.

@EIrwin is the hero
@kcwire 
@beyelerb

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/275)
<!-- Reviewable:end -->
