### PR TITLE
DDF-1592: Return Error Message For Revoked Certs

### DIFF
--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -94,7 +94,7 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
         }
 
         // CRL was specified, check against CRL and return the result
-        handlerResult = crlChecker.check(httpResponse, token, certs, handlerResult);
+        handlerResult = crlChecker.check(token, certs, handlerResult);
         return handlerResult;
     }
 

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/CrlChecker.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/CrlChecker.java
@@ -81,8 +81,7 @@ public class CrlChecker {
             handlerResult.setToken(token);
             handlerResult.setStatus(HandlerResult.Status.COMPLETED);
         } else {
-            // cert is present and listed as revoked in the CRL - set handlerResult to REDIRECTED and return 401
-            handlerResult.setStatus(HandlerResult.Status.REDIRECTED);
+            // cert is present and listed as revoked in the CRL - throw a ServletException so the error message is displayed to the user
             String errorMsg = "The certificate used to complete the request has been revoked.";
             LOGGER.error(errorMsg);
             throw new ServletException(errorMsg);

--- a/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
+++ b/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
@@ -160,12 +160,11 @@ public class PKIHandlerTest {
         X509Certificate[] certs = new X509Certificate[1];
         certs[0] = cert;
 
-        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
         BaseAuthenticationToken token = new BaseAuthenticationToken(new Object(), "test",
                 new Object());
         HandlerResult result = new HandlerResult();
 
-        result = handler.crlChecker.check(httpResponse, token, certs, result);
+        result = handler.crlChecker.check(token, certs, result);
         assertThat(result.getStatus(), equalTo(HandlerResult.Status.COMPLETED));
     }
 
@@ -206,7 +205,7 @@ public class PKIHandlerTest {
      * @throws java.security.cert.CertificateException
      * @throws ServletException
      */
-    @Test
+    @Test(expected = ServletException.class)
     public void testCertFailsCRLCheckWhenListedInCRL()
             throws java.security.cert.CertificateException, ServletException {
 
@@ -222,13 +221,11 @@ public class PKIHandlerTest {
         X509Certificate[] certs = new X509Certificate[1];
         certs[0] = cert;
 
-        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
         BaseAuthenticationToken token = new BaseAuthenticationToken(new Object(), "UnitTest",
                 new Object());
         HandlerResult result = new HandlerResult();
 
-        result = handler.crlChecker.check(httpResponse, token, certs, result);
-        assertThat(result.getStatus(), equalTo(HandlerResult.Status.REDIRECTED));
+        handler.crlChecker.check(token, certs, result);
     }
 
     /**
@@ -244,19 +241,13 @@ public class PKIHandlerTest {
         PKIHandler handler = configurePKIHandlerWithCRL("signature.properties",
                 "encryption-crl-revoked.properties");
 
-        String certificateString = getLocalhostCert();
-
-        InputStream stream = new ByteArrayInputStream(
-                Base64.decodeBase64(certificateString.getBytes()));
-        CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate[] certs = null;
 
-        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
         BaseAuthenticationToken token = new BaseAuthenticationToken(new Object(), "UnitTest",
                 new Object());
         HandlerResult result = new HandlerResult();
 
-        result = handler.crlChecker.check(httpResponse, token, certs, result);
+        result = handler.crlChecker.check(token, certs, result);
 
         assertThat(result.getStatus(), equalTo(HandlerResult.Status.COMPLETED));
 
@@ -287,12 +278,11 @@ public class PKIHandlerTest {
         X509Certificate[] certs = new X509Certificate[1];
         certs[0] = cert;
 
-        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
         BaseAuthenticationToken token = new BaseAuthenticationToken(new Object(), "UnitTest",
                 new Object());
         HandlerResult result = new HandlerResult();
 
-        result = handler.crlChecker.check(httpResponse, token, certs, result);
+        result = handler.crlChecker.check(token, certs, result);
 
         assertThat(result.getStatus(), equalTo(HandlerResult.Status.COMPLETED));
     }
@@ -367,12 +357,11 @@ public class PKIHandlerTest {
         X509Certificate[] certs = new X509Certificate[1];
         certs[0] = cert;
 
-        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
         BaseAuthenticationToken token = new BaseAuthenticationToken(new Object(), "UnitTest",
                 new Object());
         HandlerResult result = new HandlerResult();
 
-        result = handler.crlChecker.check(httpResponse, token, certs, result);
+        result = handler.crlChecker.check(token, certs, result);
 
         assertThat(result.getStatus(), equalTo(HandlerResult.Status.COMPLETED));
     }


### PR DESCRIPTION
 - Modified the CrlChecker to return an error message when the user
   attempts to access a web context with a revoked certificate.
   Previously, the user was presented with a blank page.
- Removed httpResponse from some CrlChecker methods that were
  no longer needed after this change.
- Modified the unit tests to reflect these method changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/280)
<!-- Reviewable:end -->
