### PR TITLE
DDF-1594: AdminConfig could bind Configuration objects to the itest bundle

### DIFF
--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
@@ -85,14 +85,14 @@ public class AdminConfig {
         LOGGER.debug("Waiting for condition {} in Configuration object [{}] to be true",
                 predicate.toString(), pid);
 
-        Configuration configuration = configAdmin.getConfiguration(pid);
+        Configuration configuration = configAdmin.getConfiguration(pid, null);
 
         int waitPeriod = 0;
 
         while ((waitPeriod < timeoutMs) && !predicate.test(configuration)) {
             TimeUnit.MILLISECONDS.sleep(CONFIG_WAIT_POLLING_INTERVAL);
             waitPeriod += CONFIG_WAIT_POLLING_INTERVAL;
-            configuration = configAdmin.getConfiguration(pid);
+            configuration = configAdmin.getConfiguration(pid, null);
         }
 
         LOGGER.debug("Waited for {}ms", waitPeriod);


### PR DESCRIPTION
Added null parameter to getConfiguration() calls to make sure Configuration objects
are never bound to the itest bundle.

Hero: @figliold  
Reviewers: @andrewkfiedler, @garrettfreibott  

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/282)
<!-- Reviewable:end -->
