### PR TITLE
DDF-1586:Create a HTTP session creation OSGi service

### DIFF
--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.http.impl;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import ddf.security.SecurityConstants;
+import ddf.security.common.util.SecurityTokenHolder;
+import ddf.security.http.SessionFactory;
+
+public class HttpSessionFactory implements SessionFactory {
+
+    /**
+     * Synchronized method because of jettys getSession method is not thread safe. Additionally,
+     * assures a SAML {@link SecurityTokenHolder} has been set on the {@link SecurityConstants#SAML_ASSERTION} attribute
+     *
+     * @param httpRequest
+     * @return
+     */
+    @Override
+    public synchronized HttpSession getOrCreateSession(HttpServletRequest httpRequest) {
+        HttpSession session = httpRequest.getSession(true);
+        if (session.getAttribute(SecurityConstants.SAML_ASSERTION) == null) {
+            session.setAttribute(SecurityConstants.SAML_ASSERTION, new SecurityTokenHolder(null));
+        }
+        return session;
+    }
+}

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,4 +36,11 @@
     <service id="serviceManager" ref="securityManagerImpl"
              interface="ddf.security.service.SecurityManager"/>
 
+    <service interface="ddf.security.http.SessionFactory">
+        <service-properties>
+            <entry key="id" value="http"/>
+        </service-properties>
+        <bean class="ddf.security.http.impl.HttpSessionFactory"/>
+    </service>
+
 </blueprint>

--- a/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,6 +30,10 @@
         <property name="securityManager" ref="securityManager"/>
         <property name="signaturePropertiesFile"
                   value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <property name="sessionFactory">
+            <reference interface="ddf.security.http.SessionFactory"
+                       filter="(id=http)"/>
+        </property>
     </bean>
 
     <service ref="filter"

--- a/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
+++ b/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -61,6 +61,7 @@ import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
 import ddf.security.common.util.SecurityTokenHolder;
+import ddf.security.http.impl.HttpSessionFactory;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
 
@@ -90,6 +91,7 @@ public class LoginFilterTest {
     public void testNoSubject() {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         try {
             loginFilter.init(filterConfig);
         } catch (ServletException e) {
@@ -124,6 +126,7 @@ public class LoginFilterTest {
     public void testBadSubject() throws IOException, ServletException {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         try {
             loginFilter.init(filterConfig);
         } catch (ServletException e) {
@@ -148,6 +151,7 @@ public class LoginFilterTest {
     public void testValidEmptySubject() throws IOException, ServletException {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         loginFilter.init(filterConfig);
 
         HttpServletRequest servletRequest = new TestHttpServletRequest();
@@ -166,6 +170,7 @@ public class LoginFilterTest {
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager = mock(
                 ddf.security.service.SecurityManager.class);
         loginFilter.setSecurityManager(securityManager);
@@ -181,7 +186,8 @@ public class LoginFilterTest {
 
         HttpSession session = mock(HttpSession.class);
         when(servletRequest.getSession(true)).thenReturn(session);
-        when(session.getAttribute(SecurityConstants.SAML_ASSERTION)).thenReturn(new SecurityTokenHolder(null));
+        when(session.getAttribute(SecurityConstants.SAML_ASSERTION))
+                .thenReturn(new SecurityTokenHolder(null));
 
         Subject subject = mock(Subject.class, RETURNS_DEEP_STUBS);
         when(securityManager.getSubject(token)).thenReturn(subject);
@@ -189,7 +195,8 @@ public class LoginFilterTest {
         SecurityToken securityToken = mock(SecurityToken.class);
         when(assertion.getSecurityToken()).thenReturn(securityToken);
         when(subject.getPrincipals().asList()).thenReturn(Arrays.asList(assertion));
-        when(securityToken.getToken()).thenReturn(readDocument("/good_saml.xml").getDocumentElement());
+        when(securityToken.getToken())
+                .thenReturn(readDocument("/good_saml.xml").getDocumentElement());
 
         loginFilter.doFilter(servletRequest, servletResponse, filterChain);
     }
@@ -200,6 +207,7 @@ public class LoginFilterTest {
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager = mock(
                 ddf.security.service.SecurityManager.class);
         loginFilter.setSecurityManager(securityManager);
@@ -230,6 +238,7 @@ public class LoginFilterTest {
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
         LoginFilter loginFilter = new LoginFilter(null);
+        loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager = mock(SecurityManager.class);
         loginFilter.setSecurityManager(securityManager);
         loginFilter.setSignaturePropertiesFile("signature.properties");

--- a/platform/security/handler/security-handler-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,7 +16,10 @@
   http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <bean id="handler" class="org.codice.ddf.security.handler.saml.SAMLAssertionHandler">
-
+        <property name="sessionFactory">
+            <reference interface="ddf.security.http.SessionFactory"
+                       filter="(id=http)"/>
+        </property>
     </bean>
 
     <service ref="handler" interface="org.codice.ddf.security.handler.api.AuthenticationHandler"

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -31,7 +31,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpSession;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -66,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
+import ddf.security.http.SessionFactory;
 import ddf.security.samlp.SamlProtocol;
 
 @Path("sso")
@@ -83,9 +83,6 @@ public class AssertionConsumerService {
 
     private static final String UNABLE_TO_LOGIN = "Unable to login with provided AuthN response assertion.";
 
-    // Interned string literal lock for creating new HTTP sessions
-    private final Object newSessionLock = "org.codice.ddf.security.NewHttpSession";
-
     private final SimpleSign simpleSign;
 
     private final IdpMetadata idpMetadata;
@@ -100,6 +97,8 @@ public class AssertionConsumerService {
     private Filter loginFilter;
 
     private SystemCrypto systemCrypto;
+
+    private SessionFactory sessionFactory;
 
     public AssertionConsumerService(SimpleSign simpleSign, IdpMetadata metadata,
             SystemCrypto crypto, SystemBaseUrl systemBaseUrl, RelayStates relayStates) {
@@ -174,8 +173,7 @@ public class AssertionConsumerService {
         }
 
         if (!validateResponse(samlResponse)) {
-            return Response.serverError()
-                    .entity("AuthN response failed validation.").build();
+            return Response.serverError().entity("AuthN response failed validation.").build();
         }
 
         String redirectLocation = relayStates.decode(relayState);
@@ -213,15 +211,14 @@ public class AssertionConsumerService {
         return true;
     }
 
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
     private boolean login(org.opensaml.saml2.core.Response samlResponse) {
         Map<String, Cookie> cookieMap = HttpUtils.getCookieMap(request);
         if (cookieMap.containsKey("JSESSIONID")) {
-            synchronized (newSessionLock) {
-                HttpSession session = request.getSession(true);
-                if (session != null) {
-                    session.invalidate();
-                }
-            }
+            sessionFactory.getOrCreateSession(request).invalidate();
         }
         String assertionValue = DOM2Writer
                 .nodeToString(samlResponse.getAssertions().get(0).getDOM());

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
 
     <ext:property-placeholder/>
 
-    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
+    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl"/>
 
     <bean id="idpMetadata" class="org.codice.ddf.security.idp.client.IdpMetadata">
         <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpMetadata"
@@ -34,37 +34,43 @@
     <bean id="crypto" class="org.codice.ddf.security.idp.client.SystemCrypto">
         <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
         <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
-        <argument ref="encryptionService" />
+        <argument ref="encryptionService"/>
     </bean>
 
     <bean id="simpleSign" class="org.codice.ddf.security.idp.client.SimpleSign">
-        <argument ref="crypto" />
+        <argument ref="crypto"/>
     </bean>
 
-    <bean id="relayStates" class="org.codice.ddf.security.idp.client.RelayStates" />
+    <bean id="relayStates" class="org.codice.ddf.security.idp.client.RelayStates"/>
 
     <bean id="idpHandler" class="org.codice.ddf.security.idp.client.IdpHandler">
         <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpHandler"
                                update-strategy="container-managed"/>
-        <argument ref="simpleSign" />
-        <argument ref="idpMetadata" />
-        <argument ref="baseUrl" />
-        <argument ref="relayStates" />
+        <argument ref="simpleSign"/>
+        <argument ref="idpMetadata"/>
+        <argument ref="baseUrl"/>
+        <argument ref="relayStates"/>
     </bean>
 
-    <service ref="idpHandler" interface="org.codice.ddf.security.handler.api.AuthenticationHandler" />
+    <service ref="idpHandler"
+             interface="org.codice.ddf.security.handler.api.AuthenticationHandler"/>
 
     <jaxrs:server id="restService" address="/saml">
         <jaxrs:serviceBeans>
-            <bean id="assertionConsumerService" class=" org.codice.ddf.security.idp.client.AssertionConsumerService">
-                <argument ref="simpleSign" />
-                <argument ref="idpMetadata" />
-                <argument ref="crypto" />
-                <argument ref="baseUrl" />
-                <argument ref="relayStates" />
+            <bean id="assertionConsumerService"
+                  class=" org.codice.ddf.security.idp.client.AssertionConsumerService">
+                <argument ref="simpleSign"/>
+                <argument ref="idpMetadata"/>
+                <argument ref="crypto"/>
+                <argument ref="baseUrl"/>
+                <argument ref="relayStates"/>
                 <property name="loginFilter">
                     <reference interface="javax.servlet.Filter"
                                filter="(filter-name=login-filter)"/>
+                </property>
+                <property name="sessionFactory">
+                    <reference interface="ddf.security.http.SessionFactory"
+                               filter="(id=http)"/>
                 </property>
             </bean>
         </jaxrs:serviceBeans>

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/http/SessionFactory.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/http/SessionFactory.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.security.http;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public interface SessionFactory {
+
+    /**
+     * Wrapper method over {@code HttpServletRequest#getOrCreateSession}
+     *
+     * @param httpRequest
+     * @return current session if exists or new session
+     */
+    HttpSession getOrCreateSession(HttpServletRequest httpRequest);
+}


### PR DESCRIPTION
Replace use of String literal global lock with a HTTP service creation OSGi service.

https://github.com/codice/ddf/search?utf8=%E2%9C%93&q=%22org.codice.ddf.security.NewHttpSession%22

1. Build new interface/impl/bundle _with tests_
2. Add to platform/security/core
3. Add to feature
4. Inject service to the bundles associated with the three linked classes
5. Remove interned String locks from three linked classes and use the new service

@rzwiefel @coyotesqrl @roelens8 @pklinef

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/283)
<!-- Reviewable:end -->
