### PR TITLE
DDF-1600: Provide a generic wait framework for integration tests

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestCatalog.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.delete;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
+import static ddf.common.test.WaitCondition.expect;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -62,7 +63,6 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 
 import ddf.common.test.BeforeExam;
-import ddf.common.test.WaitCondition;
 
 /**
  * Tests the Catalog framework components. Includes helper methods at the Catalog level.
@@ -716,9 +716,8 @@ public class TestCatalog extends AbstractIntegrationTest {
             assertThat(pstore.get(PersistentStore.WORKSPACE_TYPE), is(empty()));
             pstore.add(PersistentStore.WORKSPACE_TYPE, item);
 
-            new WaitCondition("Wait for the solr core to be spun up and the item to be persisted")
-                    .timeoutAfter(5, TimeUnit.MINUTES)
-                    .waitFor(() -> pstore.get(PersistentStore.WORKSPACE_TYPE).size(), equalTo(1));
+            expect("Solr core to be spun up and item to be persisted").within(5, TimeUnit.MINUTES)
+                    .until(() -> pstore.get(PersistentStore.WORKSPACE_TYPE).size(), equalTo(1));
 
             List<Map<String, Object>> storedWs = pstore
                     .get(PersistentStore.WORKSPACE_TYPE, "id = 'itest'");
@@ -726,9 +725,8 @@ public class TestCatalog extends AbstractIntegrationTest {
             assertThat(storedWs.get(0).get("user_txt"), is("itest"));
         } finally {
             pstore.delete(PersistentStore.WORKSPACE_TYPE, "id = 'itest'");
-            new WaitCondition("Wait for workspace to be empty")
-                    .timeoutAfter(5, TimeUnit.MINUTES)
-                    .waitFor(() -> pstore.get(PersistentStore.WORKSPACE_TYPE).size(), equalTo(0));
+            expect("Workspace to be empty").within(5, TimeUnit.MINUTES)
+                    .until(() -> pstore.get(PersistentStore.WORKSPACE_TYPE).size(), equalTo(0));
         }
     }
 

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/WaitCondition.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/WaitCondition.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.common.test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class used to wait for a certain condition to be {@code true} or a timeout to expire. The
+ * condition is checked at regular interval. Both the timeout and polling interval can be
+ * configured.
+ */
+public class WaitCondition {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WaitCondition.class);
+
+    private static final long DEFAULT_TIMEOUT = SECONDS.toMillis(5);
+
+    private static final long DEFAULT_POLLING_INTERVAL = MILLISECONDS.toMillis(500);
+
+    private String description;
+
+    private long timeoutMs;
+
+    private long pollingIntervalMs;
+
+    /**
+     * Creates a instance of this class using the default timeout (5s) and polling interval (500ms).
+     */
+    public WaitCondition(String description) {
+        this.description = description;
+        this.timeoutMs = DEFAULT_TIMEOUT;
+        this.pollingIntervalMs = DEFAULT_POLLING_INTERVAL;
+    }
+
+    /**
+     * Sets the timeout on this {@link WaitCondition}.
+     *
+     * @param timeout timeout to use
+     * @param unit    timeout unit
+     * @return the current {@link WaitCondition} object
+     */
+    public WaitCondition timeoutAfter(long timeout, TimeUnit unit) {
+        this.timeoutMs = unit.toMillis(timeout);
+        return this;
+    }
+
+    /**
+     * Sets the polling interval this {@link WaitCondition} will use to re-evaluate the wait
+     * condition.
+     *
+     * @param pollingInterval polling interval to use
+     * @param unit            polling interval unit
+     * @return the current {@link WaitCondition} object
+     */
+    public WaitCondition pollEvery(long pollingInterval, TimeUnit unit) {
+        this.pollingIntervalMs = unit.toMillis(pollingInterval);
+        return this;
+    }
+
+    /**
+     * Waits until the value returned by the {@link Callable} satisfies the {@link Matcher}'s
+     * condition, or the timeout expires. The wait condition will be re-evaluated every polling
+     * interval. If the timeout expires or an exception occurs while waiting, the current test
+     * will be failed.
+     *
+     * @param <T>                   type of the value returned by the {@link Callable}
+     * @param currentValueRetriever object to call to retrieve the value to wait on
+     * @param matchCondition        matcher used to determine whether the condition has been
+     *                              met or not
+     */
+    public <T> void waitFor(Callable<T> currentValueRetriever, Matcher<T> matchCondition) {
+        long timeoutLimit = System.currentTimeMillis() + timeoutMs;
+
+        try {
+            while (!matchCondition.matches(currentValueRetriever.call())) {
+                Thread.sleep(pollingIntervalMs);
+
+                if (System.currentTimeMillis() > timeoutLimit) {
+                    fail(String.format("%s: timed out after %d seconds", description,
+                            TimeUnit.MILLISECONDS.toSeconds(timeoutMs)));
+                }
+            }
+        } catch (Exception e) {
+            String message = String
+                    .format("%s: Unexpected exception [%s] caught while waiting", description,
+                            e.getMessage());
+            LOGGER.error(message);
+            fail(message);
+        }
+    }
+
+    /**
+     * Waits until the value returned by the condition is {@code true}, or the timeout expires.
+     * The wait condition will be re-evaluated every polling interval. If the timeout expires or
+     * an exception occurs while waiting, the current test will be failed.
+     *
+     * @param condition object that indicates whether the wait condition has been met or not
+     */
+    public void waitFor(Callable<Boolean> condition) {
+        waitFor(condition, is(true));
+    }
+}


### PR DESCRIPTION
Added generic class that waits for a certain condition to be met or a timeout to occurs.
Updated TestCatalog class to use the new `WaitCondition` class.

Our goal here should be to come up with a generic way to do waits in our itests, use it moving forward and eventually replace the existing waits we have with this. Please review thoroughly. New ideas and suggestions are welcome :-)

Reviewers:
* @coyotesqrl 
* @pklinef 
* @brendan-hofmann 
* @kcwire 
* @andrewkfiedler 
* @oconnormi 
* @figliold 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/285)
<!-- Reviewable:end -->
