### PR TITLE
DDF-1589

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/README.md
+++ b/catalog/admin/module/catalog-admin-module-sources/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# sources-module: The Catalog Admin Sources Module.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/catalog/admin/module/catalog-admin-module-sources/package.json
+++ b/catalog/admin/module/catalog-admin-module-sources/package.json
@@ -3,20 +3,14 @@
   "author": "Codice",
   "description": "The Catalog Admin Sources Module",
   "version": "2.5.0",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Scott Tustison",
-      "email": "scott.tustison@gmail.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-catalog.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
@@ -24,21 +18,21 @@
   "devDependencies": {
     "grunt": "0.4.1",
     "grunt-cli": "0.1.13",
-    "bower": "~1.4.1",
+    "bower": "1.4.1",
     "grunt-bower-task": "0.4.0",
     "grunt-contrib-jshint": "0.3.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-watch": "0.4.4",
     "grunt-contrib-cssmin": "0.5.0",
     "grunt-contrib-less": "0.11.0",
-    "connect-livereload": "~0.3.0",
+    "connect-livereload": "0.3.2",
     "grunt-express": "1.2.1",
-    "load-grunt-tasks": "^1.0.0"
+    "load-grunt-tasks": "1.0.0"
   },
   "dependencies": {
     "lodash": "2.4.1",
     "http-proxy": "0.10.0",
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9"

--- a/catalog/ui/search-ui/standard/package.json
+++ b/catalog/ui/search-ui/standard/package.json
@@ -3,38 +3,24 @@
   "author": "Codice",
   "description": "A frontend UI for DDF",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Scott Tustison",
-      "email": "scott.tustison@gmail.com"
-    },
-    {
-      "name": "Phillip Klinefelter",
-      "email": "phillip.klinefelter@gmail.com"
-    },
-    {
-      "name": "Mike Macaulay",
-      "email": "michael.macaulayy@aviture.us.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-ui.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
   },
   "devDependencies": {
-    "bower": "~1.3.8",
-    "chai": "^1.10.0",
-    "chai-as-promised": "^4.1.1",
-    "colors": "^1.0.3",
-    "connect-livereload": "~0.3.0",
+    "bower": "1.3.12",
+    "chai": "1.10.0",
+    "chai-as-promised": "4.3.0",
+    "colors": "1.1.2",
+    "connect-livereload": "0.3.2",
     "grunt": "0.4.5",
     "grunt-bower-task": "0.4.0",
     "grunt-cli": "0.1.13",
@@ -44,20 +30,20 @@
     "grunt-contrib-less": "0.11.0",
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
-    "grunt-mocha-webdriver": "^1.1.2",
-    "grunt-newer": "^0.8.0",
+    "grunt-mocha-webdriver": "1.2.2",
+    "grunt-newer": "0.8.0",
     "grunt-sed": "0.1.1",
     "http-proxy": "0.10.0",
-    "jshint-stylish": "^1.0.0",
-    "load-grunt-tasks": "^1.0.0",
-    "mocha": "^2.0.1",
-    "phantomjs": "^1.9.12",
-    "wd": "^0.3.11",
+    "jshint-stylish": "1.0.2",
+    "load-grunt-tasks": "1.0.0",
+    "mocha": "2.3.3",
+    "phantomjs": "1.9.18",
+    "wd": "0.3.12",
     "which": "1.0.5",
-    "yargs": "^1.3.3"
+    "yargs": "1.3.3"
   },
   "dependencies": {
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "faye": "1.1.0",
     "lodash": "2.4.1",
     "node-fs": "0.1.7",

--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -149,6 +149,7 @@
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
+                <version>1.0.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -157,6 +158,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.2</version>
                 <executions>
                     <execution>
                         <id>output-html</id>
@@ -225,7 +227,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>0.0.23</version>
+                        <version>0.0.26</version>
                         <executions>
                             <execution>
                                 <id>grunt build</id>

--- a/platform/admin/ui/README.md
+++ b/platform/admin/ui/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# admin-ui: An administration UI for DDF.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/admin/ui/package.json
+++ b/platform/admin/ui/package.json
@@ -3,20 +3,14 @@
   "author": "Codice",
   "description": "An administration UI for DDF",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Scott Tustison",
-      "email": "scott.tustison@gmail.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-ui.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"

--- a/platform/admin/ui/pom.xml
+++ b/platform/admin/ui/pom.xml
@@ -164,7 +164,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>0.0.23</version>
+                        <version>0.0.26</version>
                         <executions>
                             <execution>
                                 <id>grunt build</id>

--- a/platform/error/platform-error-impl/README.md
+++ b/platform/error/platform-error-impl/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# platform-error-impl: Platform Error Handler API for DDF.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/error/platform-error-impl/package.json
+++ b/platform/error/platform-error-impl/package.json
@@ -1,22 +1,16 @@
 {
-  "name": "annonymous-security-handler",
+  "name": "platform-error-impl",
   "author": "Codice",
-  "description": "Simple login for DDF",
+  "description": "Platform Error Handler API for DDF",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Dave Willison",
-      "email": "dave.willison@aviture.us.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-platform.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
@@ -24,7 +18,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "bower": "~1.4.1",
+    "bower": "1.4.1",
     "grunt-bower-task": "0.4.0",
     "grunt-casperjs": "git+https://github.com/codice/grunt-casperjs.git",
     "grunt-contrib-jshint": "0.3.0",
@@ -34,17 +28,17 @@
     "grunt-express": "1.2.1",
     "grunt-sed": "0.1.1",
     "which": "1.0.5",
-    "connect-livereload": "~0.3.0",
-    "load-grunt-tasks": "^1.0.0"
+    "connect-livereload": "0.3.2",
+    "load-grunt-tasks": "1.0.0"
   },
   "dependencies": {
     "http-proxy": "0.10.0",
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "lodash": "2.4.1",
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9",
-    "casperjs": "~1.1.0",
+    "casperjs": "1.1.0-beta3",
     "request": "2.49.0"
   }
 }

--- a/platform/metrics/platform-metrics-ui/README.md
+++ b/platform/metrics/platform-metrics-ui/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# metrics-module: The Metrics Module.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/metrics/platform-metrics-ui/package.json
+++ b/platform/metrics/platform-metrics-ui/package.json
@@ -3,20 +3,14 @@
   "author": "Codice",
   "description": "The Metrics Module",
   "version": "2.5.0",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Brendan Hofmann",
-      "email": "brendan.hofmann@connexta.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-platform.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
@@ -24,21 +18,21 @@
   "devDependencies": {
     "grunt": "0.4.1",
     "grunt-cli": "0.1.13",
-    "bower": "~1.4.1",
+    "bower": "1.4.1",
     "grunt-bower-task": "0.4.0",
     "grunt-contrib-jshint": "0.3.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-watch": "0.4.4",
     "grunt-contrib-cssmin": "0.5.0",
     "grunt-contrib-less":"0.11.0",
-    "connect-livereload": "~0.3.0",
+    "connect-livereload": "0.3.2",
     "grunt-express": "1.2.1",
-    "load-grunt-tasks": "^1.0.0"
+    "load-grunt-tasks": "1.0.0"
   },
   "dependencies": {
     "lodash": "2.4.1",
     "http-proxy": "0.10.0",
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9"

--- a/platform/security/certificate/security-certificate-adminmodule/README.md
+++ b/platform/security/certificate/security-certificate-adminmodule/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# security-certificate-adminmodule: Certificate modification.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/security/certificate/security-certificate-adminmodule/package.json
+++ b/platform/security/certificate/security-certificate-adminmodule/package.json
@@ -3,19 +3,23 @@
   "author": "Codice",
   "description": "Certificate modification",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codice/ddf.git"
+  },
   "engines": {
     "node": ">=0.10.5"
   },
   "devDependencies": {
     "bower": "1.3.12",
     "chai": "1.10.0",
-    "chai-as-promised": "^4.1.1",
-    "colors": "^1.0.3",
+    "chai-as-promised": "4.3.0",
+    "colors": "1.1.2",
     "connect-livereload": "0.3.2",
     "grunt": "0.4.5",
     "grunt-bower-task": "0.4.0",
@@ -33,7 +37,7 @@
     "load-grunt-tasks": "1.0.0",
     "mocha": "2.3.0",
     "phantomjs": "1.9.12",
-    "wd": "^0.3.12",
+    "wd": "0.3.12",
     "which": "1.0.5",
     "yargs": "3.23.0"
   },

--- a/platform/security/handler/security-handler-anonymous/README.md
+++ b/platform/security/handler/security-handler-anonymous/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# annonymous-security-handler: Simple login for DDF.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/security/handler/security-handler-anonymous/package.json
+++ b/platform/security/handler/security-handler-anonymous/package.json
@@ -3,20 +3,14 @@
   "author": "Codice",
   "description": "Simple login for DDF",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Dave Willison",
-      "email": "dave.willison@aviture.us.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-platform.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
@@ -24,7 +18,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "bower": "~1.4.1",
+    "bower": "1.4.1",
     "grunt-bower-task": "0.4.0",
     "grunt-casperjs": "git+https://github.com/codice/grunt-casperjs.git",
     "grunt-contrib-jshint": "0.3.0",
@@ -34,16 +28,16 @@
     "grunt-express": "1.2.1",
     "grunt-sed": "0.1.1",
     "which": "1.0.5",
-    "connect-livereload": "~0.3.0",
-    "load-grunt-tasks": "^1.0.0"
+    "connect-livereload": "0.3.2",
+    "load-grunt-tasks": "1.0.0"
   },
   "dependencies": {
     "http-proxy": "0.10.0",
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "lodash": "2.4.1",
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9",
-    "casperjs": "~1.1.0"
+    "casperjs": "1.1.0-beta3"
   }
 }

--- a/platform/security/idp/security-idp-server/README.md
+++ b/platform/security/idp/security-idp-server/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# security-idp-server: IdP DDF.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/security/idp/security-idp-server/package.json
+++ b/platform/security/idp/security-idp-server/package.json
@@ -3,7 +3,7 @@
   "author": "Codice",
   "description": "IdP DDF",
   "version": "0.0.1",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
@@ -18,7 +18,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "bower": "~1.4.1",
+    "bower": "1.4.1",
     "grunt-bower-task": "0.4.0",
     "grunt-casperjs": "git+https://github.com/codice/grunt-casperjs.git",
     "grunt-contrib-jshint": "0.3.0",
@@ -28,16 +28,16 @@
     "grunt-express": "1.2.1",
     "grunt-sed": "0.1.1",
     "which": "1.0.5",
-    "connect-livereload": "~0.3.0",
-    "load-grunt-tasks": "^1.0.0"
+    "connect-livereload": "0.3.2",
+    "load-grunt-tasks": "1.0.0"
   },
   "dependencies": {
     "http-proxy": "0.10.0",
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "lodash": "2.4.1",
     "node-fs": "0.1.7",
     "node-options": "0.0.3",
     "path": "0.4.9",
-    "casperjs": "~1.1.0"
+    "casperjs": "1.1.0-beta3"
   }
 }

--- a/platform/security/security-admin-module/README.md
+++ b/platform/security/security-admin-module/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# security-admin-module: A frontend UI for security configuration on DDF.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/platform/security/security-admin-module/package.json
+++ b/platform/security/security-admin-module/package.json
@@ -3,30 +3,24 @@
   "author": "Codice",
   "description": "A frontend UI for security configuration on DDF.",
   "version": "0.1.0",
-  "license": "LGPL",
+  "license": "LGPL-3.0",
   "keywords": [
     "backbone",
     "express"
   ],
-  "contributors": [
-    {
-      "name": "Scott Tustison",
-      "email": "scott.tustison@gmail.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/codice/ddf-platform.git"
+    "url": "https://github.com/codice/ddf.git"
   },
   "engines": {
     "node": ">=0.10.5"
   },
   "devDependencies": {
-    "bower": "~1.3.8",
-    "chai": "^1.10.0",
-    "chai-as-promised": "^4.1.1",
-    "colors": "^1.0.3",
-    "connect-livereload": "~0.3.0",
+    "bower": "1.3.12",
+    "chai": "1.10.0",
+    "chai-as-promised": "4.3.0",
+    "colors": "1.1.2",
+    "connect-livereload": "0.3.2",
     "grunt": "0.4.5",
     "grunt-bower-task": "0.4.0",
     "grunt-cli": "0.1.13",
@@ -36,19 +30,19 @@
     "grunt-contrib-less": "0.11.0",
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
-    "grunt-mocha-webdriver": "^1.1.2",
-    "grunt-newer": "^0.8.0",
+    "grunt-mocha-webdriver": "1.2.2",
+    "grunt-newer": "0.8.0",
     "grunt-sed": "0.1.1",
-    "jshint-stylish": "^1.0.0",
-    "load-grunt-tasks": "^1.0.0",
-    "mocha": "^2.0.1",
-    "phantomjs": "^1.9.12",
-    "wd": "^0.3.11",
+    "jshint-stylish": "1.0.2",
+    "load-grunt-tasks": "1.0.0",
+    "mocha": "2.3.3",
+    "phantomjs": "1.9.18",
+    "wd": "0.3.12",
     "which": "1.0.5",
-    "yargs": "^1.3.3"
+    "yargs": "1.3.3"
   },
   "dependencies": {
-    "express": "~3.3.4",
+    "express": "3.3.8",
     "faye": "1.1.0",
     "lodash": "2.4.1",
     "node-fs": "0.1.7",

--- a/platform/security/security-admin-module/pom.xml
+++ b/platform/security/security-admin-module/pom.xml
@@ -43,28 +43,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>0.0.23</version>
                 <executions>
-                     <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v0.10.40</nodeVersion>
-                            <npmVersion>2.0.2</npmVersion>
-                            <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm install</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>grunt build</id>
                         <goals>
@@ -142,6 +121,7 @@
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
+                <version>1.0.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -176,7 +156,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>0.0.16</version>
+                        <version>0.0.26</version>
                         <executions>
                             <execution>
                                 <id>grunt build</id>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
         <project.report.output.directory>project-info</project.report.output.directory>
 
         <!-- Properties for the frontend-maven-plugin -->
-        <node.version>v0.10.30</node.version>
-        <npm.version>1.4.12</npm.version>
+        <node.version>v0.10.40</node.version>
+        <npm.version>2.14.8</npm.version>
 
         <camel.version>2.14.2</camel.version>
         <commons-io.version>2.1</commons-io.version>
@@ -454,7 +454,10 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>0.0.23</version>
+                    <version>0.0.26</version>
+                    <configuration>
+                        <installDirectory>${session.executionRootDirectory}</installDirectory>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>install node and npm</id>
@@ -464,8 +467,7 @@
                             <configuration>
                                 <nodeVersion>${node.version}</nodeVersion>
                                 <npmVersion>${npm.version}</npmVersion>
-                                <downloadRoot>http://artifacts.codice.org/nodejs/dist/
-                                </downloadRoot>
+                                <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
                             </configuration>
                         </execution>
                         <execution>


### PR DESCRIPTION
In an effort to make our builds more stable when it comes to node/npm, this PR includes: 

1. Updating the following components:
 * frontend-maven-plugin: upgraded to 0.0.26
 * node: standardized around v0.10.40
 * npm: upgraded to 2.14.8
2. Added the <installDirectory> flag for frontend-maven-plugin so that node/npm only get installed once on the root directory; node_modules still get installed on each module.
3. General cleanup of several warnings associated with the modules that were touched.

Adding a few suggested reviewers:
@djblue 
@lessarderic 
@shaundmorris 
@brendan-hofmann 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/286)
<!-- Reviewable:end -->
