### PR TITLE
DDF-1601 Implement dynamic port allocation

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/AbstractIntegrationTest.java
@@ -29,10 +29,13 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRunti
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.useOwnExamBundlesStartLevel;
+import static ddf.catalog.test.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
+import static ddf.catalog.test.AbstractIntegrationTest.DynamicUrl.SECURE_ROOT;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -55,6 +58,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.metatype.MetaTypeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.sun.istack.NotNull;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.source.CatalogProvider;
@@ -81,38 +86,140 @@ public abstract class AbstractIntegrationTest {
 
     protected static final String KARAF_VERSION = "2.4.3";
 
-    // TODO: Use the Camel AvailablePortFinder.getNextAvailable() test method
-    protected static final String HTTP_PORT = "9081";
-
-    protected static final String HTTPS_PORT = "9993";
-
-    protected static final String SSH_PORT = "9101";
-
-    protected static final String RMI_SERVER_PORT = "44445";
-
-    protected static final String RMI_REG_PORT = "1100";
-
-    protected static final String SECURE_ROOT = "https://localhost:";
-
-    protected static final String SERVICE_ROOT = SECURE_ROOT + HTTPS_PORT + "/services";
-
-    protected static final String INSECURE_ROOT = "http://localhost:";
-
-    protected static final String INSECURE_SERVICE_ROOT = INSECURE_ROOT + HTTP_PORT + "/services";
-
-    protected static final String REST_PATH = SERVICE_ROOT + "/catalog/";
-
-    protected static final String OPENSEARCH_PATH = REST_PATH + "query";
-
-    protected static final String CSW_PATH = SERVICE_ROOT + "/csw";
-
     protected static final String OPENSEARCH_SOURCE_ID = "openSearchSource";
 
     protected static final String CSW_SOURCE_ID = "cswSource";
 
+    protected static ServerSocket placeHolderSocket;
+
+    protected static Integer basePort;
+
     protected static final String DDF_HOME_PROPERTY = "ddf.home";
 
     protected static String ddfHome;
+
+    /**
+     * An enum that returns a port number based on the class variable {@link #basePort}. Used to allow parallel itests
+     * and dynamic allocation of ports to prevent conflicts on hard coded port numbers.
+     * {@link #basePort} needs to be set in the {@link @BeforeExam} method of every test class that uses DynamicPort or
+     * {@link DynamicUrl}. E.g. 'basePort = {@link #getBasePort()}`
+     */
+    public static class DynamicPort {
+
+        private final String systemProperty;
+        private final Integer ordinal;
+
+        public DynamicPort(Integer ordinal) {
+            this.systemProperty = null;
+            this.ordinal = ordinal;
+        }
+
+        public DynamicPort(String systemProperty, Integer ordinal) {
+            this.systemProperty = systemProperty;
+            this.ordinal = ordinal;
+        }
+
+        String getSystemProperty() {
+            return this.systemProperty;
+        }
+
+        public String getPort(Integer basePort) {
+            return String.valueOf(basePort + this.ordinal());
+        }
+
+        public String getPort() {
+            return String.valueOf(basePort + this.ordinal());
+        }
+
+        Integer ordinal() {
+            return this.ordinal;
+        }
+    }
+
+    /**
+     * A class used to give a dynamic {@link String} that evaluates when called rather than at compile time.
+     * Used to allow parallel itests and dynamic URLs to prevent conflicts on hard coded port numbers and endpoint, source, etc URLs.
+     * Constructed with a {@link ddf.catalog.test.AbstractIntegrationTest.DynamicPort}
+     */
+    public static class DynamicUrl {
+        public static final String SECURE_ROOT = "https://localhost:";
+
+        public static final String INSECURE_ROOT = "http://localhost:";
+
+        private final String root;
+
+        private final String tail;
+
+        private final DynamicPort port;
+
+        private final DynamicUrl url;
+
+        public DynamicUrl(String root, @NotNull DynamicPort port) {
+            this(root, port, "");
+        }
+
+        public DynamicUrl(String root, @NotNull DynamicPort port, String tail) {
+            if (null == port) {
+                throw new IllegalArgumentException("Port cannot be null");
+            }
+            this.root = root;
+            this.port = port;
+            this.url = null;
+            this.tail = tail;
+        }
+
+        public DynamicUrl(@NotNull DynamicUrl url, String tail) {
+            if (null == url) {
+                throw new IllegalArgumentException("Url cannot be null");
+            }
+            this.root = null;
+            this.port = null;
+            this.url = url;
+            this.tail = tail;
+        }
+
+        public String getUrl() {
+            if (null != port) {
+                return root + port.getPort() + tail;
+            } else {
+                return url.getUrl() + tail;
+            }
+        }
+
+        /**
+         * @return the same String as {@link #getUrl()}
+         */
+        @Override
+        public String toString() {
+            return this.getUrl();
+        }
+
+    }
+    public static final DynamicPort BASE_PORT = new DynamicPort("org.codice.ddf.system.basePort", 0);
+    public static final DynamicPort HTTP_PORT = new DynamicPort("org.codice.ddf.system.httpPort", 1);
+    public static final DynamicPort HTTPS_PORT = new DynamicPort(
+            "org.codice.ddf.system.httpsPort", 2);
+    public static final DynamicPort SSH_PORT = new DynamicPort(3);
+    public static final DynamicPort RMI_SERVER_PORT = new DynamicPort(4);
+    public static final DynamicPort RMI_REG_PORT = new DynamicPort(5);
+
+    public static final DynamicUrl SERVICE_ROOT = new DynamicUrl(SECURE_ROOT, HTTPS_PORT,
+            "/services");
+
+    public static final DynamicUrl INSECURE_SERVICE_ROOT = new DynamicUrl(INSECURE_ROOT, HTTP_PORT,
+            "/services");
+
+    public static final DynamicUrl REST_PATH = new DynamicUrl(SERVICE_ROOT, "/catalog/");
+
+    public static final DynamicUrl OPENSEARCH_PATH = new DynamicUrl(REST_PATH, "query");
+
+    public static final DynamicUrl CSW_PATH = new DynamicUrl(SERVICE_ROOT, "/csw");
+
+    public static final DynamicUrl ADMIN_ALL_SOURCES_PATH = new DynamicUrl(SECURE_ROOT, HTTPS_PORT,
+            "/jolokia/exec/org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean:service=admin-source-poller-service/allSourceInfo");
+
+    public static final DynamicUrl ADMIN_STATUS_PATH = new DynamicUrl(SECURE_ROOT, HTTPS_PORT,
+            "/jolokia/exec/org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean:service=admin-source-poller-service/sourceStatus/");
 
     static {
         // Make Pax URL use the maven.repo.local setting if present
@@ -166,9 +273,22 @@ public abstract class AbstractIntegrationTest {
      */
     @org.ops4j.pax.exam.Configuration
     public Option[] config() throws URISyntaxException {
+        basePort = findPortNumber(20000);
         return combineOptions(configureCustom(), configureDistribution(), configurePaxExam(),
                 configureAdditionalBundles(), configureConfigurationPorts(), configureMavenRepos(),
                 configureSystemSettings(), configureVmOptions(), configureStartScript());
+    }
+
+    private static Integer findPortNumber(Integer portToTry) {
+        try {
+            placeHolderSocket = new ServerSocket(portToTry);
+            placeHolderSocket.setReuseAddress(true);
+            return portToTry;
+        } catch (Exception e) {
+            portToTry += 10;
+            LOGGER.debug("Bad port, trying {}", portToTry);
+            return findPortNumber(portToTry);
+        }
     }
 
     protected AdminConfig getAdminConfig() {
@@ -260,14 +380,17 @@ public abstract class AbstractIntegrationTest {
     protected Option[] configureConfigurationPorts() throws URISyntaxException {
         return options(editConfigurationFilePut("etc/system.properties", "urlScheme", "https"),
                 editConfigurationFilePut("etc/system.properties", "host", "localhost"),
-                editConfigurationFilePut("etc/system.properties", "jetty.port", HTTPS_PORT),
+                editConfigurationFilePut("etc/system.properties", "jetty.port",
+                        HTTPS_PORT.getPort()),
                 editConfigurationFilePut("etc/system.properties", "hostContext", "/solr"),
                 editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
 
-                editConfigurationFilePut("etc/system.properties", "org.codice.ddf.system.httpPort",
-                        HTTP_PORT),
-                editConfigurationFilePut("etc/system.properties", "org.codice.ddf.system.httpsPort",
-                        HTTPS_PORT),
+                editConfigurationFilePut("etc/system.properties", HTTP_PORT.getSystemProperty(),
+                        HTTP_PORT.getPort()),
+                editConfigurationFilePut("etc/system.properties", HTTPS_PORT.getSystemProperty(),
+                        HTTPS_PORT.getPort()),
+                editConfigurationFilePut("etc/system.properties", BASE_PORT.getSystemProperty(),
+                        BASE_PORT.getPort()),
 
                 // DDF-1572: Disables the periodic backups of .bundlefile. In itests, having those
                 // backups serves no purpose and it appears that intermittent failures have occurred
@@ -276,20 +399,25 @@ public abstract class AbstractIntegrationTest {
                 editConfigurationFilePut("etc/system.properties", "eclipse.enableStateSaver",
                         Boolean.FALSE.toString()),
 
-                editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", SSH_PORT),
-                editConfigurationFilePut("etc/ddf.platform.config.cfg", "port", HTTPS_PORT),
+                editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort",
+                        SSH_PORT.getPort()),
+                editConfigurationFilePut("etc/ddf.platform.config.cfg", "port",
+                        HTTPS_PORT.getPort()),
                 editConfigurationFilePut("etc/ddf.platform.config.cfg", "host", "localhost"),
                 editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port",
-                        HTTP_PORT), editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
-                        "org.osgi.service.http.port.secure", HTTPS_PORT),
+                        HTTP_PORT.getPort()), editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
+                        "org.osgi.service.http.port.secure", HTTPS_PORT.getPort()),
                 editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort",
-                        RMI_REG_PORT),
+                        RMI_REG_PORT.getPort()),
                 editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort",
-                        RMI_SERVER_PORT), replaceConfigurationFile("etc/hazelcast.xml",
+                        RMI_SERVER_PORT.getPort()), replaceConfigurationFile("etc/hazelcast.xml",
                         new File(this.getClass().getResource("/hazelcast.xml").toURI())),
                 replaceConfigurationFile("etc/ddf.security.sts.client.configuration.cfg", new File(
                         this.getClass().getResource("/ddf.security.sts.client.configuration.cfg")
-                                .toURI())), replaceConfigurationFile(
+                                .toURI())),
+                editConfigurationFilePut("etc/ddf.security.sts.client.configuration.cfg", "address",
+                        SECURE_ROOT + HTTPS_PORT.getPort() + "/services/SecurityTokenService?wsdl"),
+                replaceConfigurationFile(
                         "etc/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg", new File(
                                 this.getClass().getResource(
                                         "/ddf.catalog.solr.external.SolrHttpCatalogProvider.cfg")
@@ -338,6 +466,10 @@ public abstract class AbstractIntegrationTest {
                         "security-services-app,catalog-app,solr-app,spatial-app,sdk-app"),
                 editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                         "featuresRepositories", featuresUrl));
+    }
+
+    protected Integer getBasePort() {
+        return Integer.parseInt(System.getProperty(BASE_PORT.getSystemProperty()));
     }
 
     /**
@@ -434,7 +566,7 @@ public abstract class AbstractIntegrationTest {
      */
     @Deprecated
     protected void waitForSourcesToBeAvailable(String... sources) throws InterruptedException {
-        serviceManager.waitForSourcesToBeAvailable(REST_PATH, sources);
+        serviceManager.waitForSourcesToBeAvailable(REST_PATH.getUrl(), sources);
     }
 
     /**
@@ -503,7 +635,7 @@ public abstract class AbstractIntegrationTest {
             this.putAll(getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
 
             this.put("shortname", sourceId);
-            this.put("endpointUrl", OPENSEARCH_PATH);
+            this.put("endpointUrl", OPENSEARCH_PATH.getUrl());
         }
 
     }
@@ -518,7 +650,7 @@ public abstract class AbstractIntegrationTest {
             this.putAll(getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
 
             this.put("id", sourceId);
-            this.put("cswUrl", CSW_PATH);
+            this.put("cswUrl", CSW_PATH.getUrl());
             this.put("pollInterval", 1);
         }
 
@@ -534,7 +666,7 @@ public abstract class AbstractIntegrationTest {
             this.putAll(getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
 
             this.put("id", sourceId);
-            this.put("cswUrl", CSW_PATH);
+            this.put("cswUrl", CSW_PATH.getUrl());
             this.put("pollInterval", 1);
         }
 

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFanout.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFanout.java
@@ -33,27 +33,29 @@ public class TestFanout extends AbstractIntegrationTest {
 
     @BeforeExam
     public void beforeExam() throws Exception {
+        basePort = getBasePort();
         getAdminConfig().setLogLevels();
         getServiceManager().waitForAllBundles();
         getCatalogBundle().setFanout(true);
         getCatalogBundle().waitForCatalogProvider();
-        getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query?_wadl");
+        getServiceManager().waitForHttpEndpoint(SERVICE_ROOT.getUrl() + "/catalog/query?_wadl");
 
-        getServiceManager().waitForSourcesToBeAvailable(REST_PATH, LOCAL_SOURCE_ID);
+        getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(), LOCAL_SOURCE_ID);
 
-        LOGGER.info("Source status: \n{}", get(REST_PATH + "sources").body().prettyPrint());
+        LOGGER.info("Source status: \n{}",
+                get(REST_PATH.getUrl() + "sources").body().prettyPrint());
     }
 
     @Test
     public void testFanoutQueryWithUnknownSource() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?q=*&src=does.not.exist";
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&src=does.not.exist";
 
         when().get(queryUrl).then().log().all().assertThat().body(containsString("Unknown source"));
     }
 
     @Test
     public void testFanoutQueryWithoutFederatedSources() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?q=*&src=local";
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&src=local";
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(containsString("SiteNames could not be resolved"));

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestFederation.java
@@ -75,14 +75,6 @@ public class TestFederation extends AbstractIntegrationTest {
 
     private static final String CSW_SOURCE_WITH_METACARD_XML_ID = "cswSource2";
 
-    private static final String ADMIN_SOURCE_PATH = "https://localhost:" + HTTPS_PORT;
-
-    private static final String ADMIN_ALL_SOURCES_PATH = ADMIN_SOURCE_PATH
-            + "/jolokia/exec/org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean:service=admin-source-poller-service/allSourceInfo";
-
-    private static final String ADMIN_STATUS_PATH = ADMIN_SOURCE_PATH
-            + "/jolokia/exec/org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean:service=admin-source-poller-service/sourceStatus/";
-
     private static final String DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS = "data/products";
 
     private static final String DEFAULT_SAMPLE_PRODUCT_FILE_NAME = "sample.txt";
@@ -100,6 +92,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @BeforeExam
     public void beforeExam() throws Exception {
+        basePort = getBasePort();
         getAdminConfig().setLogLevels();
         getServiceManager().waitForAllBundles();
         getCatalogBundle().waitForCatalogProvider();
@@ -108,6 +101,7 @@ public class TestFederation extends AbstractIntegrationTest {
         OpenSearchSourceProperties openSearchProperties = new OpenSearchSourceProperties(
                 OPENSEARCH_SOURCE_ID);
         getServiceManager().createManagedService(OpenSearchSourceProperties.FACTORY_PID, openSearchProperties);
+
 
         getServiceManager().waitForHttpEndpoint(CSW_PATH + "?_wadl");
         get(CSW_PATH + "?_wadl").prettyPrint();
@@ -123,7 +117,7 @@ public class TestFederation extends AbstractIntegrationTest {
         getCatalogBundle().waitForFederatedSource(CSW_SOURCE_ID);
         getCatalogBundle().waitForFederatedSource(CSW_SOURCE_WITH_METACARD_XML_ID);
 
-        getServiceManager().waitForSourcesToBeAvailable(REST_PATH, OPENSEARCH_SOURCE_ID, CSW_SOURCE_ID,
+        getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(), OPENSEARCH_SOURCE_ID, CSW_SOURCE_ID,
                 CSW_SOURCE_WITH_METACARD_XML_ID);
 
         metacardIds[GEOJSON_RECORD_INDEX] = TestCatalog
@@ -131,7 +125,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
         metacardIds[XML_RECORD_INDEX] = ingestXmlWithProduct(DEFAULT_SAMPLE_PRODUCT_FILE_NAME);
 
-        LOGGER.info("Source status: \n{}", get(REST_PATH + "sources").body().prettyPrint());
+        LOGGER.info("Source status: \n{}",
+                get(REST_PATH.getUrl() + "sources").body().prettyPrint());
     }
 
     @Before
@@ -167,7 +162,8 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedQueryByWildCardSearchPhrase() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?q=*&format=xml&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?q=*&format=xml&src=" + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE
@@ -186,7 +182,8 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testAtomFederatedQueryByWildCardSearchPhrase() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?q=*&format=atom&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?q=*&format=atom&src=" + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(hasXPath("/feed/entry/title[text()='" + RECORD_TITLE_1 + "']"),
@@ -202,8 +199,9 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedQueryBySearchPhrase() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
-                + OPENSEARCH_SOURCE_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                        + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat().body(hasXPath(
                 "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
@@ -219,9 +217,9 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedSpatial() throws Exception {
-        String queryUrl =
-                OPENSEARCH_PATH + "?lat=10.0&lon=30.0&radius=250000&spatialType=POINT_RADIUS"
-                        + "&format=xml&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl()
+                + "?lat=10.0&lon=30.0&radius=250000&spatialType=POINT_RADIUS" + "&format=xml&src="
+                + OPENSEARCH_SOURCE_ID;
         when().get(queryUrl).then().log().all().assertThat().body(hasXPath(
                 "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
                         + RECORD_TITLE_1 + "']"), hasXPath(
@@ -236,8 +234,9 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedNegativeSpatial() throws Exception {
-        String queryUrl = OPENSEARCH_PATH + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS"
-                + "&format=xml&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl()
+                + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS" + "&format=xml&src="
+                + OPENSEARCH_SOURCE_ID;
         when().get(queryUrl).then().log().all().assertThat()
                 .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
     }
@@ -250,8 +249,9 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testFederatedQueryByNegativeSearchPhrase() throws Exception {
         String negativeSearchPhrase = "negative";
-        String queryUrl = OPENSEARCH_PATH + "?q=" + negativeSearchPhrase + "&format=xml&src="
-                + OPENSEARCH_SOURCE_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?q=" + negativeSearchPhrase + "&format=xml&src="
+                        + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
@@ -264,7 +264,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedQueryById() throws Exception {
-        String restUrl = REST_PATH + "sources/" + OPENSEARCH_SOURCE_ID + "/"
+        String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/"
                 + metacardIds[GEOJSON_RECORD_INDEX];
 
         when().get(restUrl).then().log().all().assertThat().body(hasXPath(
@@ -291,8 +291,9 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
-        String restUrl = REST_PATH + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                + "?transform=resource";
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                        + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
@@ -314,8 +315,9 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS});
 
-        String restUrl = REST_PATH + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                + "?transform=resource";
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                        + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/html")
@@ -346,7 +348,7 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testFederatedRetrieveProductInvalidResourceUrlWithBackReferences()
             throws Exception {
         // Setup
-        String fileName = testName.getMethodName() + ".txt";
+        String fileName = testName.getMethodName() + HTTPS_PORT.getPort() + ".txt";
         String fileNameWithBackReferences =
                 ".." + File.separator + ".." + File.separator + fileName;
         resourcesToDelete.add(fileNameWithBackReferences);
@@ -357,8 +359,9 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
-        String restUrl = REST_PATH + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                + "?transform=resource";
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                        + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/html")
@@ -373,9 +376,8 @@ public class TestFederation extends AbstractIntegrationTest {
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
         String restUrl =
-                REST_PATH + "sources/" + CSW_SOURCE_ID + "/" + metacardIds[XML_RECORD_INDEX]
+                REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/" + metacardIds[XML_RECORD_INDEX]
                         + "?transform=resource";
-
         when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
                 .body(is(SAMPLE_DATA));
     }
@@ -390,7 +392,7 @@ public class TestFederation extends AbstractIntegrationTest {
         // Setup 
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS});
-        String restUrl = REST_PATH + "sources/" + OPENSEARCH_SOURCE_ID + "/"
+        String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/"
                 + metacardIds[GEOJSON_RECORD_INDEX] + "?transform=resource";
 
         // Perform Test and Verify
@@ -402,9 +404,8 @@ public class TestFederation extends AbstractIntegrationTest {
         File[] rootDirectories = File.listRoots();
         String rootDir = rootDirectories[0].getCanonicalPath();
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {rootDir});
-        String restUrl =
-                REST_PATH + "sources/" + CSW_SOURCE_ID + "/" + metacardIds[GEOJSON_RECORD_INDEX]
-                        + "?transform=resource";
+        String restUrl = REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/"
+                + metacardIds[GEOJSON_RECORD_INDEX] + "?transform=resource";
         when().get(restUrl).then().log().all().assertThat().statusCode(equalTo(500));
     }
 
@@ -412,8 +413,8 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCswQueryByWildCardSearchPhrase() throws Exception {
         String wildcardQuery = Library.getCswQuery("AnyText", "*");
 
-        given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_PATH).then().log()
-                .all().assertThat()
+        given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_PATH.getUrl())
+                .then().log().all().assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
                                 metacardIds[GEOJSON_RECORD_INDEX] + "']"),
                         hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
@@ -428,8 +429,8 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCswQueryByTitle() throws Exception {
         String titleQuery = Library.getCswQuery("title", "myTitle");
 
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH).then().log()
-                .all().assertThat()
+        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl())
+                .then().log().all().assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier",
                                 is(metacardIds[GEOJSON_RECORD_INDEX])),
                         hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned",
@@ -440,20 +441,21 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCswQueryForMetacardXml() throws Exception {
         String titleQuery = Library.getCswQueryMetacardXml("title", "myTitle");
 
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH).then().log()
-                .all().assertThat().body(hasXPath("/GetRecordsResponse/SearchResults/metacard/@id",
-                        is(metacardIds[GEOJSON_RECORD_INDEX])),
-                hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned", is("1")),
-                hasXPath("/GetRecordsResponse/SearchResults/@recordSchema",
-                        is("urn:catalog:metacard")));
+        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl())
+                .then().log().all().assertThat()
+                .body(hasXPath("/GetRecordsResponse/SearchResults/metacard/@id",
+                                is(metacardIds[GEOJSON_RECORD_INDEX])),
+                        hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned",
+                                is("1")),
+                        hasXPath("/GetRecordsResponse/SearchResults/@recordSchema",
+                                is("urn:catalog:metacard")));
     }
 
     @Test
     public void testCswQueryForJson() throws Exception {
         String titleQuery = Library.getCswQueryJson("title", "myTitle");
 
-        given().headers("Accept", "application/json", "Content-Type", "application/xml")
-                .body(titleQuery).when().post(CSW_PATH).then().log().all().assertThat()
+        given().headers("Accept", "application/json", "Content-Type", "application/xml").body(titleQuery).when().post(CSW_PATH.getUrl()).then().log().all().assertThat()
                 .contentType(ContentType.JSON)
                 .body("results[0].metacard.properties.title", equalTo(RECORD_TITLE_1));
     }
@@ -462,7 +464,8 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testOpensearchToCswSourceToCswEndpointQuerywithCswRecordXml() throws Exception {
 
         String queryUrl =
-                OPENSEARCH_PATH + "?q=" + DEFAULT_KEYWORD + "&format=xml&src=" + CSW_SOURCE_ID;
+                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                        + CSW_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
@@ -474,8 +477,9 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testOpensearchToCswSourceToCswEndpointQuerywithMetacardXml() throws Exception {
 
-        String queryUrl = OPENSEARCH_PATH + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
-                + CSW_SOURCE_WITH_METACARD_XML_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                        + CSW_SOURCE_WITH_METACARD_XML_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
@@ -496,25 +500,27 @@ public class TestFederation extends AbstractIntegrationTest {
         }
         */
 
-        given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH).then().log().all()
-                .assertThat().body(containsString("\"fpid\":\"OpenSearchSource\""),
-                containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
+        given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH.getUrl())
+                .then().log().all().assertThat()
+                .body(containsString("\"fpid\":\"OpenSearchSource\""),
+                        containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
                 containsString("\"fpid\":\"Csw_Connected_Source\"")*/);
     }
 
     @Test
     public void testFederatedSourceStatus() {
         // Find and test OpenSearch Federated Source
-        String json = given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH)
-                .asString();
+        String json = given().auth().basic("admin", "admin").when()
+                .get(ADMIN_ALL_SOURCES_PATH.getUrl()).asString();
 
         List<Map<String, Object>> sources = with(json).param("name", "OpenSearchSource")
                 .get("value.findAll { source -> source.id == name}");
         String openSearchPid = (String) ((ArrayList<Map<String, Object>>) (sources.get(0)
                 .get("configurations"))).get(0).get("id");
 
-        given().auth().basic("admin", "admin").when().get(ADMIN_STATUS_PATH + openSearchPid).then()
-                .log().all().assertThat().body(containsString("\"value\":true"));
+        given().auth().basic("admin", "admin").when()
+                .get(ADMIN_STATUS_PATH.getUrl() + openSearchPid).then().log().all().assertThat()
+                .body(containsString("\"value\":true"));
     }
 
     // TODO: Connected csw/wfs sources are broken. Ticket: DDF-1366
@@ -527,8 +533,8 @@ public class TestFederation extends AbstractIntegrationTest {
             LOGGER.error("Couldn't create connected sources: {}", e);
         }
 
-        String json = given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH)
-                .asString();
+        String json = given().auth().basic("admin", "admin").when()
+                .get(ADMIN_ALL_SOURCES_PATH.getUrl()).asString();
 
         List<Map<String, Object>> sources = with(json).param("name", "Csw_Connected_Source")
                 .get("value.findAll { source -> source.id == name}");
@@ -536,8 +542,9 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("configurations"))).get(0).get("id");
 
         // Test CSW Connected Source status
-        given().auth().basic("admin", "admin").when().get(ADMIN_STATUS_PATH + connectedSourcePid)
-                .then().log().all().assertThat().body(containsString("\"value\":true"));
+        given().auth().basic("admin", "admin").when()
+                .get(ADMIN_STATUS_PATH.getUrl() + connectedSourcePid).then().log().all()
+                .assertThat().body(containsString("\"value\":true"));
     }
 
     public void setupConnectedSources() throws IOException {

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -172,8 +172,15 @@ public class TestSecurity extends AbstractIntegrationTest {
 
     private static final String OPENSEARCH_SAML_SOURCE_ID = "openSearchSamlSource";
 
+    private static final DynamicUrl SECURE_ROOT_AND_PORT = new DynamicUrl(
+            DynamicUrl.SECURE_ROOT, HTTPS_PORT);
+
+    private static final DynamicUrl ADMIN_PATH = new DynamicUrl(SECURE_ROOT_AND_PORT,
+            "/admin/index.html");
+
     @BeforeExam
     public void beforeTest() throws Exception {
+        basePort = getBasePort();
         getAdminConfig().setLogLevels();
         getServiceManager().waitForAllBundles();
         configurePDP();
@@ -198,7 +205,7 @@ public class TestSecurity extends AbstractIntegrationTest {
 
     @Test
     public void testAnonymousRestAccess() throws Exception {
-        String url = SERVICE_ROOT + "/catalog/query?q=*";
+        String url = SERVICE_ROOT.getUrl() + "/catalog/query?q=*";
 
         //test that anonymous works and check that we get an sso token
         String cookie = when().get(url).then().log().all().assertThat().statusCode(equalTo(200))
@@ -210,13 +217,13 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .statusCode(equalTo(200));
 
         //try to hit an admin restricted page and see that we are unauthorized
-        given().cookie("JSESSIONID", cookie).when().get("https://localhost:9993/admin/index.html")
-                .then().log().all().assertThat().statusCode(equalTo(403));
+        given().cookie("JSESSIONID", cookie).when().get(ADMIN_PATH.getUrl()).then().log().all()
+                .assertThat().statusCode(equalTo(403));
     }
 
     @Test
     public void testBasicRestAccess() throws Exception {
-        String url = SERVICE_ROOT + "/catalog/query?q=*";
+        String url = SERVICE_ROOT.getUrl() + "/catalog/query?q=*";
 
         configureRestForBasic();
 
@@ -237,8 +244,8 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .statusCode(equalTo(200));
 
         //try that admin level sso token on a restricted resource and get in... sso works!
-        given().cookie("JSESSIONID", cookie).when().get("https://localhost:9993/admin/index.html")
-                .then().log().all().assertThat().statusCode(equalTo(200));
+        given().cookie("JSESSIONID", cookie).when().get(ADMIN_PATH.getUrl()).then().log().all()
+                .assertThat().statusCode(equalTo(200));
     }
 
     @Test
@@ -256,7 +263,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         getCatalogBundle().waitForFederatedSource(OPENSEARCH_SAML_SOURCE_ID);
 
         String openSearchQuery =
-                SERVICE_ROOT + "/catalog/query?q=*&src=" + OPENSEARCH_SAML_SOURCE_ID;
+                SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + OPENSEARCH_SAML_SOURCE_ID;
         given().auth().basic("admin", "admin").when().get(openSearchQuery).then().log().all()
                 .assertThat().statusCode(equalTo(200)).assertThat().body(hasXPath(
                 "//metacard/string[@name='" + Metacard.TITLE + "']/value[text()='myTitle']"));
@@ -285,12 +292,13 @@ public class TestSecurity extends AbstractIntegrationTest {
         getCatalogBundle().waitForFederatedSource(OPENSEARCH_SOURCE_ID);
         getCatalogBundle().waitForFederatedSource(CSW_SOURCE_ID);
 
-        String openSearchQuery = SERVICE_ROOT + "/catalog/query?q=*&src=" + OPENSEARCH_SOURCE_ID;
+        String openSearchQuery =
+                SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + OPENSEARCH_SOURCE_ID;
         given().auth().basic("admin", "admin").when().get(openSearchQuery).then().log().all()
                 .assertThat().statusCode(equalTo(200)).assertThat().body(hasXPath(
                 "//metacard/string[@name='" + Metacard.TITLE + "']/value[text()='myTitle']"));
 
-        String cswQuery = SERVICE_ROOT + "/catalog/query?q=*&src=" + CSW_SOURCE_ID;
+        String cswQuery = SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + CSW_SOURCE_ID;
         given().auth().basic("admin", "admin").when().get(cswQuery).then().log().all().assertThat()
                 .statusCode(equalTo(200)).assertThat().body(hasXPath(
                 "//metacard/string[@name='" + Metacard.TITLE + "']/value[text()='myTitle']"));
@@ -302,7 +310,8 @@ public class TestSecurity extends AbstractIntegrationTest {
         cswProperties.put("password", "auth");
         getServiceManager().createManagedService(CswSourceProperties.FACTORY_PID, cswProperties);
 
-        String cswQueryUnavail = SERVICE_ROOT + "/catalog/query?q=*&src=" + unavailableCswSourceId;
+        String cswQueryUnavail =
+                SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + unavailableCswSourceId;
         given().auth().basic("admin", "admin").when().get(cswQueryUnavail).then().log().all()
                 .assertThat().statusCode(equalTo(500));
 
@@ -316,7 +325,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         getCatalogBundle().waitForFederatedSource(unavailableOpenSourceId);
 
         String unavailableOpenSearchQuery =
-                SERVICE_ROOT + "/catalog/query?q=*&src=" + unavailableOpenSourceId;
+                SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + unavailableOpenSourceId;
 
         given().auth().basic("admin", "admin").when().get(unavailableOpenSearchQuery).then().log()
                 .all().assertThat().statusCode(equalTo(200)).assertThat().body(not(hasXPath(
@@ -336,9 +345,9 @@ public class TestSecurity extends AbstractIntegrationTest {
         //we are only testing anonymous because that hits the most code, testing with an assertion would be mostly testing the same stuff that this is hitting
         given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "helloWorld").expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/sdk/SoapService").then().log().all().assertThat()
+                .post(SERVICE_ROOT.getUrl() + "/sdk/SoapService").then().log().all().assertThat()
                 .body(HasXPath.hasXPath("//*[local-name()='helloWorldResponse']/result/text()",
-                        containsString("Anonymous")));
+                                containsString("Anonymous")));
     }
 
     @Test
@@ -353,9 +362,10 @@ public class TestSecurity extends AbstractIntegrationTest {
         //we are only testing anonymous because that hits the most code, testing with an assertion would be mostly testing the same stuff that this is hitting
         given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "helloWorld").expect().statusCode(equalTo(200)).when()
-                .post(INSECURE_SERVICE_ROOT + "/sdk/SoapService").then().log().all().assertThat()
+                .post(INSECURE_SERVICE_ROOT.getUrl() + "/sdk/SoapService").then().log().all()
+                .assertThat()
                 .body(HasXPath.hasXPath("//*[local-name()='helloWorldResponse']/result/text()",
-                        containsString("Anonymous")));
+                                containsString("Anonymous")));
 
         getServiceManager().stopFeature(false, "platform-http-proxy");
     }
@@ -378,8 +388,8 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
-                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all()
+                .assertThat().body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
     }
 
     @Test
@@ -397,7 +407,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all();
     }
 
     @Test
@@ -413,7 +423,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all();
 
     }
 
@@ -431,8 +441,8 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
-                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all()
+                .assertThat().body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
 
     }
 
@@ -450,8 +460,8 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all().assertThat()
-                .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all()
+                .assertThat().body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
 
     }
 
@@ -467,7 +477,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all();
 
     }
 
@@ -483,7 +493,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         given().log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(500)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().log().all();
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().log().all();
 
     }
 
@@ -502,7 +512,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 .log().all().body(body).header("Content-Type", "text/xml; charset=utf-8")
                 .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
                 .expect().statusCode(equalTo(200)).when()
-                .post(SERVICE_ROOT + "/SecurityTokenService").then().extract().response()
+                .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService").then().extract().response()
                 .asString();
         assertionHeader = assertionHeader.substring(assertionHeader.indexOf("<saml2:Assertion"),
                 assertionHeader.indexOf("</saml2:Assertion>") + "</saml2:Assertion>".length());
@@ -512,8 +522,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         //try that admin level assertion token on a restricted resource
         given().header(SecurityConstants.SAML_HEADER_NAME,
                 "SAML " + RestSecurity.deflateAndBase64Encode(assertionHeader)).when()
-                .get("https://localhost:9993/admin/index.html").then().log().all().assertThat()
-                .statusCode(equalTo(200));
+                .get(ADMIN_PATH.getUrl()).then().log().all().assertThat().statusCode(equalTo(200));
     }
 
     private String getSoapEnvelope(String onBehalfOf) {
@@ -556,7 +565,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         String commonName = "pangalactic";
         String expectedValue = "CN=" + commonName;
         String featureName = "security-certificate-generator";
-        String certGenPath = SECURE_ROOT + HTTPS_PORT
+        String certGenPath = SECURE_ROOT_AND_PORT
                 + "/jolokia/exec/org.codice.ddf.security.certificate.generator.CertificateGenerator:service=certgenerator";
         getBackupKeystoreFile();
         try {

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSolrCommands.java
@@ -52,6 +52,7 @@ public class TestSolrCommands extends AbstractIntegrationTest {
 
     @BeforeExam
     public void beforeExam() throws Exception {
+        basePort = getBasePort();
         getAdminConfig().setLogLevels();
         getServiceManager().waitForAllBundles();
         getCatalogBundle().waitForCatalogProvider();

--- a/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.security.sts.client.configuration.cfg
+++ b/distribution/test/itests/test-itests-catalog/src/test/resources/ddf.security.sts.client.configuration.cfg
@@ -1,1 +1,0 @@
-address=https://localhost:9993/services/SecurityTokenService?wsdl


### PR DESCRIPTION
Port numbers and URLs based thereon were declared as finals in
AbstractIntegrationTest. These are now dynamically allocated
based on what ports are in use. Test files had to be changed to
load in the new port numbers instead of using the class defaults.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/287)
<!-- Reviewable:end -->
