### PR TITLE
DDF-1577 Editing saved searches in a workspace

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Workspace.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Workspace.view.js
@@ -160,8 +160,9 @@ define([
             removeSearch: function() {
                 this.model.collection.remove(this.model);
             },
-            showSearch: function() {
-                if(!this.model.get('editing')) {
+            showSearch: function(event) {
+                if(['edit','remove'].indexOf(event.target.id) === -1) {
+                    wreqr.vent.trigger('workspace:editcancel');
                     var progressFunction = function (value, model) {
                         model.mergeLatest();
                         wreqr.vent.trigger('map:clear');


### PR DESCRIPTION
Fixed a bug where saved searches in a workspace in the search ui could not be edited. I saw all of the unit tests in catalog/ui/search-ui/standard successfully pass.

@tbatie
@harrison-tarr
@rzwiefel
@coyotesqrl
@roelens8
@andrewkfiedler

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/289)
<!-- Reviewable:end -->
