### PR TITLE
DDF-1581: Fix Activity/Task handling in the Search UI

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/pom.xml
+++ b/catalog/ui/search-ui/search-endpoint/pom.xml
@@ -451,22 +451,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.37</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Task.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Task.js
@@ -12,16 +12,21 @@
 /*global define*/
 define([
     'backbone',
-    'jquery',
-    'underscore'
-], function(Backbone, $, _) {
+    'underscore',
+    'moment'
+], function(Backbone, _, moment) {
     var Task = {};
 
     Task.Model = Backbone.Model.extend({
         url: '/service/action',
         useAjaxSync: false,
-        initialize : function(){
-            this.set("timestamp", parseInt(this.get("timestamp"), 10));
+        initialize : function() {
+            this.set("timestamp", moment(this.get("timestamp")));
+
+            var operations = this.get("operations");
+            // Extract any operations we don't have predefined actions for in the template.
+            var operationsExt = _.omit(operations, 'download', 'retry', 'cancel', 'pause', 'remove', 'resume');
+            this.set("operationsExt", operationsExt);
         },
         validate : function(attrs) {
             if(!attrs.id)
@@ -30,23 +35,6 @@ define([
                 return "Task must have message.";
             if(!attrs.timestamp)
                 return "Task must have timestamp.";
-        },
-        parse : function(resp){
-            if(!_.isEmpty(resp.data)) {
-                var json = $.parseJSON(resp.data);
-                if(json.operations) {
-                    //remove the stuff that we have pre-defined actions for in the template
-                    json.operationsExt = this.pluck(json.operations, ['download', 'retry', 'cancel', 'pause', 'remove', 'resume']);
-                }
-                return json;
-            }
-        },
-        pluck: function(object, items) {
-            var newObject = _.clone(object), i;
-            for(i = 0; i < items.length; i++) {
-                delete newObject[items[i]];
-            }
-            return newObject;
         }
     });
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/module/Tasks.module.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/module/Tasks.module.js
@@ -29,7 +29,7 @@ define(['application',
             TaskModule.addInitializer(function() {
 
                 this.subscription = Cometd.Comet.subscribe("/ddf/activities/**", function(resp) {
-                    var task = new Task.Model(resp, {validate: true, parse: true});
+                    var task = new Task.Model(resp.data, {validate: true});
 
                     if(!task.validationError){
                         var model = tasks.updateTask(task);
@@ -37,7 +37,7 @@ define(['application',
                     }
                 });
 
-                Cometd.Comet.publish("/ddf/activities", null);
+                Cometd.Comet.publish("/ddf/activities", {});
             });
         });
 


### PR DESCRIPTION
-New activities were published on a CometD channel that was not being subscribed to in the Search UI. Fixed by publishing the Activities on an appropriate CometD channel.
-Add unit tests for ActivityController.
-Activities returned via CometD were being parsed as JSON strings, but the Activities are actually JSON objects. The returned Activities are no longer treated as JSON strings.
-Simplified the logic in the JavaScript Task model for extracting operations that don't have predefined actions.
-Activities' timestamps were being parsed as integers, but they are actually ISO 8601 strings. The timestamps are no longer parsed as integers.

@EIrwin is the hero
@kcwire 
@jlcsmith

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/290)
<!-- Reviewable:end -->
