### PR TITLE
DDF-1603 Quick fix to enable basic auth on redirects.

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -126,6 +126,35 @@ public class SecureCxfClientFactory<T> {
     }
 
     /**
+     * Constructs a factory that will return security-aware cxf clients. Once constructed,
+     * use the getClient* methods to retrieve a fresh client  with the same configuration.
+     * <p>
+     * This factory can and should be cached. The clients it constructs should not be.
+     * <p>
+     * This constructor represents a quick fix only.
+     *
+     * @param endpointUrl       the remote url to connect to
+     * @param interfaceClass    an interface representing the resource at the remote url
+     * @param providers         optional list of providers to further configure the client
+     * @param interceptor       optional message interceptor for the client
+     * @param disableCnCheck    disable ssl check for common name / host name match
+     * @param connectionTimeout timeout for the connection
+     * @param receiveTimeout    timeout for receiving responses
+     * @param username          a String representing the username
+     * @param password          a String representing a password
+     */
+    public SecureCxfClientFactory(String endpointUrl, Class<T> interfaceClass, List<?> providers,
+            Interceptor<? extends Message> interceptor, boolean disableCnCheck,
+            Integer connectionTimeout, Integer receiveTimeout, String username, String password) {
+
+        this(endpointUrl, interfaceClass, providers, interceptor, disableCnCheck, connectionTimeout,
+                receiveTimeout);
+
+        this.clientFactory.setPassword(password);
+        this.clientFactory.setUsername(username);
+    }
+
+    /**
      * Clients produced by this method will be secured with two-way ssl
      * and the provided security subject.
      * <p>


### PR DESCRIPTION
@kcwire 
@wmcnalli hero
@bdeining 

This is a quick fix only, implemented as another constructor that takes username,password strings and sets them on the factory.  

Successfully built with:
mvn -pl :security-rest-cxfwrapper clean install

No other code in ddf currently uses this new constructor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/292)
<!-- Reviewable:end -->
