### PR TITLE
DDF-1604 added Gitter badge and removed Travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 -->
 <img src="https://tools.codice.org/wiki/download/attachments/1179800/ddf.jpg"/>
 # [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
-[![Build Status](https://travis-ci.org/codice/ddf.png)](https://travis-ci.org/codice/ddf?branch=master)
+[![Join the chat at https://gitter.im/codice/ddf](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/codice/ddf?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/3703/badge.svg)](https://scan.coverity.com/projects/3703)
 
 


### PR DESCRIPTION
The Travis-CI badge has reflected a state of failing for quite some time so figured it was time to at least remove that and advertise Gitter at the same time. I would love to find a way to get our bamboo badge on there as mentioned on the ticket.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/295)
<!-- Reviewable:end -->
