### PR TITLE
DDF-1613 Basic auth header invalidation requires non-blank username/password.

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Menu.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Menu.view.js
@@ -360,8 +360,8 @@ define([
                     type: "GET",
                     url: document.URL,
                     async: false,
-                    username: "",
-                    password: "",
+                    username: "1",
+                    password: "1",
                     error: function() {
                         document.location.reload();
                     },


### PR DESCRIPTION
Search UI was using blank username and password and not correctly removing the basic auth header on logout from the LDAP realm. The Admin UI was not invalidating at all.

@pklinef 
@tbatie 
@jckilmer
@rzwiefel
@roelens8
@ryeats

@tbatie will hero.

To hero, change to LDAP realm and logout.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/297)
<!-- Reviewable:end -->
