### PR TITLE
DDF-1597 Authenticating against one realm now allows access to only that realm.

### DIFF
--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestSecurity.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License

--- a/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestXACML.java
+++ b/distribution/test/itests/test-itests-catalog/src/test/java/ddf/catalog/test/TestXACML.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- **/
+ */
 package ddf.catalog.test;
 
 import java.io.IOException;

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/SecurityTokenHolder.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/SecurityTokenHolder.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,20 +13,29 @@
  */
 package ddf.security.common.util;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 
 public class SecurityTokenHolder {
-    SecurityToken securityToken;
 
-    public SecurityTokenHolder(SecurityToken securityToken) {
-        this.securityToken = securityToken;
+    final Map<String, SecurityToken> realmTokenMap = new ConcurrentHashMap<>();
+
+    public SecurityToken getSecurityToken(String realm) {
+        return realmTokenMap.get(realm);
     }
 
-    public SecurityToken getSecurityToken() {
-        return securityToken;
+    public void addSecurityToken(String realm, SecurityToken securityToken) {
+        realmTokenMap.put(realm, securityToken);
     }
 
-    public void setSecurityToken(SecurityToken securityToken) {
-        this.securityToken = securityToken;
+    public void remove(String realm) {
+        realmTokenMap.remove(realm);
     }
+
+    public void removeAll() {
+        realmTokenMap.clear();
+    }
+
 }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
@@ -33,7 +33,7 @@ public class HttpSessionFactory implements SessionFactory {
     public synchronized HttpSession getOrCreateSession(HttpServletRequest httpRequest) {
         HttpSession session = httpRequest.getSession(true);
         if (session.getAttribute(SecurityConstants.SAML_ASSERTION) == null) {
-            session.setAttribute(SecurityConstants.SAML_ASSERTION, new SecurityTokenHolder(null));
+            session.setAttribute(SecurityConstants.SAML_ASSERTION, new SecurityTokenHolder());
         }
         return session;
     }

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/common/util/SecurityTokenHolderTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/common/util/SecurityTokenHolderTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.common.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.junit.Test;
+
+public class SecurityTokenHolderTest {
+
+    @Test
+    public void testRetrieveSecurityTokenByRealm() {
+        // given
+        SecurityTokenHolder securityTokenHolder = new SecurityTokenHolder();
+        SecurityToken securityTokenOne = new SecurityToken();
+        SecurityToken securityTokenTwo = new SecurityToken();
+        String realmOne = "realmOne";
+        String realmTwo = "realmTwo";
+
+        // when
+        securityTokenHolder.addSecurityToken(realmOne, securityTokenOne);
+        securityTokenHolder.addSecurityToken(realmTwo, securityTokenTwo);
+
+        // then
+        assertThat(securityTokenOne, is(equalTo(securityTokenHolder.getSecurityToken(realmOne))));
+        assertThat(securityTokenTwo, is(equalTo(securityTokenHolder.getSecurityToken(realmTwo))));
+    }
+
+    @Test
+    public void testRemoveSecurityTokenByRealm() {
+        // given
+        SecurityTokenHolder securityTokenHolder = new SecurityTokenHolder();
+        SecurityToken securityToken = new SecurityToken();
+        String realm = "realm";
+        securityTokenHolder.addSecurityToken(realm, securityToken);
+
+        // when
+        securityTokenHolder.remove(realm);
+
+        // then
+        assertThat(securityTokenHolder.getSecurityToken(realm), is(nullValue()));
+    }
+
+    @Test
+    public void testRemoveAllSecurityTokens() {
+        // given
+        SecurityTokenHolder securityTokenHolder = new SecurityTokenHolder();
+        SecurityToken securityTokenOne = new SecurityToken();
+        SecurityToken securityTokenTwo = new SecurityToken();
+        String realmOne = "realmOne";
+        String realmTwo = "realmTwo";
+        securityTokenHolder.addSecurityToken(realmOne, securityTokenOne);
+        securityTokenHolder.addSecurityToken(realmTwo, securityTokenTwo);
+
+        // when
+        securityTokenHolder.removeAll();
+
+        // then
+        assertThat(securityTokenHolder.getSecurityToken(realmOne), is(nullValue()));
+        assertThat(securityTokenHolder.getSecurityToken(realmTwo), is(nullValue()));
+    }
+}

--- a/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
+++ b/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
@@ -341,7 +341,8 @@ public class LoginFilter implements Filter {
                 }
                 SecurityToken savedToken = null;
                 try {
-                    savedToken = ((SecurityTokenHolder) sessionToken).getSecurityToken();
+                    savedToken = ((SecurityTokenHolder) sessionToken)
+                            .getSecurityToken(token.getRealm());
                 } catch (ClassCastException e) {
                     httpRequest.getSession(false).invalidate();
                 }
@@ -416,7 +417,7 @@ public class LoginFilter implements Filter {
                 // if it is all good, then we'll create our subject
                 subject = securityManager.getSubject(securityToken);
 
-                addSamlToSession(httpRequest, securityToken);
+                addSamlToSession(httpRequest, token.getRealm(), securityToken);
             }
         } catch (SecurityServiceException e) {
             LOGGER.error("Unable to get subject from SAML request.", e);
@@ -478,7 +479,7 @@ public class LoginFilter implements Filter {
                                 }
                                 ((SecurityTokenHolder) session
                                         .getAttribute(SecurityConstants.SAML_ASSERTION))
-                                        .setSecurityToken(token);
+                                        .addSecurityToken(savedToken.getRealm(), token);
 
                                 SecurityAssertion assertion = new SecurityAssertionImpl(
                                         ((SecurityToken) savedToken.getCredentials()));
@@ -512,11 +513,10 @@ public class LoginFilter implements Filter {
     private Subject handleAuthenticationToken(HttpServletRequest httpRequest,
             BaseAuthenticationToken token) throws ServletException {
         Subject subject;
-
         synchronized (lock) {
             HttpSession session = sessionFactory.getOrCreateSession(httpRequest);
             //if we already have an assertion inside the session and it has not expired, then use that instead
-            SecurityToken sessionToken = getSecurityToken(session);
+            SecurityToken sessionToken = getSecurityToken(session, token.getRealm());
 
             if (sessionToken == null) {
 
@@ -538,7 +538,7 @@ public class LoginFilter implements Filter {
                             }
                             SecurityToken securityToken = ((SecurityAssertion) principal)
                                     .getSecurityToken();
-                            addSamlToSession(httpRequest, securityToken);
+                            addSamlToSession(httpRequest, token.getRealm(), securityToken);
                         }
                     }
                 } catch (SecurityServiceException e) {
@@ -556,7 +556,7 @@ public class LoginFilter implements Filter {
         return subject;
     }
 
-    private SecurityToken getSecurityToken(HttpSession session) {
+    private SecurityToken getSecurityToken(HttpSession session, String realm) {
         if (session.getAttribute(SecurityConstants.SAML_ASSERTION) == null) {
             LOGGER.error(
                     "Security token holder missing from session. New session created improperly.");
@@ -566,14 +566,14 @@ public class LoginFilter implements Filter {
         SecurityTokenHolder tokenHolder = ((SecurityTokenHolder) session
                 .getAttribute(SecurityConstants.SAML_ASSERTION));
 
-        SecurityToken token = tokenHolder.getSecurityToken();
+        SecurityToken token = tokenHolder.getSecurityToken(realm);
 
         if (token != null) {
             SecurityAssertionImpl assertion = new SecurityAssertionImpl(token);
             if (assertion.getNotOnOrAfter() != null
                     && assertion.getNotOnOrAfter().getTime() - System.currentTimeMillis() < 0) {
                 LOGGER.debug("Session SAML token has expired.  Removing from session.");
-                tokenHolder.setSecurityToken(null);
+                tokenHolder.remove(realm);
                 return null;
             }
         }
@@ -581,11 +581,11 @@ public class LoginFilter implements Filter {
         return token;
     }
 
-    private void addSecurityToken(HttpSession session, SecurityToken token) {
+    private void addSecurityToken(HttpSession session, String realm, SecurityToken token) {
         SecurityTokenHolder holder = (SecurityTokenHolder) session
                 .getAttribute(SecurityConstants.SAML_ASSERTION);
 
-        holder.setSecurityToken(token);
+        holder.addSecurityToken(realm, token);
     }
 
     /**
@@ -594,7 +594,8 @@ public class LoginFilter implements Filter {
      * @param httpRequest   the http request object for this request
      * @param securityToken the SecurityToken object representing the SAML assertion
      */
-    private void addSamlToSession(HttpServletRequest httpRequest, SecurityToken securityToken) {
+    private void addSamlToSession(HttpServletRequest httpRequest, String realm,
+            SecurityToken securityToken) {
         if (securityToken == null) {
             LOGGER.debug("Cannot add null security token to session.");
             return;
@@ -602,9 +603,9 @@ public class LoginFilter implements Filter {
 
         synchronized (lock) {
             HttpSession session = sessionFactory.getOrCreateSession(httpRequest);
-            SecurityToken sessionToken = getSecurityToken(session);
+            SecurityToken sessionToken = getSecurityToken(session, realm);
             if (sessionToken == null) {
-                addSecurityToken(session, securityToken);
+                addSecurityToken(session, realm, securityToken);
 
                 SecurityAssertion assertion = new SecurityAssertionImpl(securityToken);
 

--- a/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
+++ b/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
@@ -187,7 +187,7 @@ public class LoginFilterTest {
         HttpSession session = mock(HttpSession.class);
         when(servletRequest.getSession(true)).thenReturn(session);
         when(session.getAttribute(SecurityConstants.SAML_ASSERTION))
-                .thenReturn(new SecurityTokenHolder(null));
+                .thenReturn(new SecurityTokenHolder());
 
         Subject subject = mock(Subject.class, RETURNS_DEEP_STUBS);
         when(securityManager.getSubject(token)).thenReturn(subject);

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -166,9 +166,9 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
             //If so, create a SAMLAuthenticationToken using the sessionId
             SecurityTokenHolder savedToken = (SecurityTokenHolder) session
                     .getAttribute(SecurityConstants.SAML_ASSERTION);
-            if (savedToken != null && savedToken.getSecurityToken() != null) {
+            if (savedToken != null && savedToken.getSecurityToken(realm) != null) {
                 SecurityAssertionImpl assertion = new SecurityAssertionImpl(
-                        savedToken.getSecurityToken());
+                        savedToken.getSecurityToken(realm));
                 if (assertion.getNotOnOrAfter() == null
                         || assertion.getNotOnOrAfter().getTime() - System.currentTimeMillis() > 0) {
                     LOGGER.trace("Creating SAML authentication token with session.");
@@ -180,7 +180,7 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
                 } else {
                     LOGGER.trace(
                             "SAML token in session has expired - removing from session and returning with no results");
-                    savedToken.setSecurityToken(null);
+                    savedToken.remove(realm);
                 }
             } else {
                 LOGGER.trace("No SAML token located in session - returning with no results");

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandlerTest.java
@@ -36,6 +36,7 @@ import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.codice.ddf.security.handler.api.HandlerResult;
+import org.codice.ddf.security.policy.context.ContextPolicy;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -167,16 +168,18 @@ public class SAMLAssertionHandlerTest {
         SAMLAssertionHandler handler = new SAMLAssertionHandler();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
+
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain chain = mock(FilterChain.class);
 
         when(request.getCookies()).thenReturn(null);
         HttpSession session = mock(HttpSession.class);
         when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(ContextPolicy.ACTIVE_REALM)).thenReturn("foo");
         SecurityTokenHolder tokenHolder = mock(SecurityTokenHolder.class);
         when(session.getAttribute(SecurityConstants.SAML_ASSERTION)).thenReturn(tokenHolder);
         SecurityToken securityToken = mock(SecurityToken.class);
-        when(tokenHolder.getSecurityToken()).thenReturn(securityToken);
+        when(tokenHolder.getSecurityToken("foo")).thenReturn(securityToken);
         when(securityToken.getToken()).thenReturn(readDocument("/saml.xml").getDocumentElement());
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);

--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -33,6 +33,14 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -74,7 +82,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.61</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServlet.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServlet.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -22,6 +22,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import ddf.security.SecurityConstants;
+import ddf.security.common.util.SecurityTokenHolder;
+
 public class LogoutServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -32,6 +35,11 @@ public class LogoutServlet extends HttpServlet {
 
         HttpSession session = request.getSession(false);
         if (session != null) {
+            SecurityTokenHolder savedToken = (SecurityTokenHolder) session
+                    .getAttribute(SecurityConstants.SAML_ASSERTION);
+            if (savedToken != null) {
+                savedToken.removeAll();
+            }
             session.invalidate();
             deleteJSessionId(response);
         }

--- a/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutServlet.java
+++ b/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutServlet.java
@@ -30,6 +30,9 @@ import javax.servlet.http.HttpSession;
 
 import org.junit.Test;
 
+import ddf.security.SecurityConstants;
+import ddf.security.common.util.SecurityTokenHolder;
+
 public class TestLogoutServlet {
     @Test
     public void testLogout() {
@@ -45,6 +48,8 @@ public class TestLogoutServlet {
         when(request.getSession(anyBoolean())).thenReturn(httpSession);
         when(request.getSession(anyBoolean()).getId()).thenReturn("id");
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://foo.bar"));
+        SecurityTokenHolder securityTokenHolder = mock(SecurityTokenHolder.class);
+        when(httpSession.getAttribute(SecurityConstants.SAML_ASSERTION)).thenReturn(securityTokenHolder);
         try {
             logoutServlet.doGet(request, response);
         } catch (ServletException | IOException e) {

--- a/platform/security/sts/security-sts-upbstvalidator/src/test/java/org/codice/ddf/security/validator/uname/UPBSTValidatorTest.java
+++ b/platform/security/sts/security-sts-upbstvalidator/src/test/java/org/codice/ddf/security/validator/uname/UPBSTValidatorTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -135,7 +135,7 @@ public class UPBSTValidatorTest {
             @Override
             public SecurityToken getToken(String identifier) {
                 SecurityToken securityToken = new SecurityToken();
-                securityToken.setTokenHash(-1432225335);
+                securityToken.setTokenHash(584149325);
                 return securityToken;
             }
         });

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
@@ -1,17 +1,17 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- * <p/>
- * <p/>
+ * <p>
+ * <p>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -19,44 +19,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
- * <p/>
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -69,7 +34,6 @@ package org.codice.ddf.security.validator.username;
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -82,16 +46,13 @@ import javax.xml.bind.Marshaller;
 import org.apache.cxf.common.jaxb.JAXBContextCache;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.sts.QNameConstants;
-import org.apache.cxf.sts.STSConstants;
 import org.apache.cxf.sts.STSPropertiesMBean;
 import org.apache.cxf.sts.request.ReceivedToken;
-import org.apache.cxf.sts.token.realm.UsernameTokenRealmCodec;
 import org.apache.cxf.sts.token.validator.TokenValidator;
 import org.apache.cxf.sts.token.validator.TokenValidatorParameters;
 import org.apache.cxf.sts.token.validator.TokenValidatorResponse;
 import org.apache.cxf.ws.security.sts.provider.model.ObjectFactory;
 import org.apache.cxf.ws.security.sts.provider.model.secext.UsernameTokenType;
-import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.karaf.jaas.config.JaasRealm;
 import org.apache.wss4j.common.crypto.Crypto;
 import org.apache.wss4j.common.ext.WSSecurityException;
@@ -122,8 +83,6 @@ public class UsernameTokenValidator implements TokenValidator {
 
     protected Map<String, Validator> validators = new ConcurrentHashMap<>();
 
-    private UsernameTokenRealmCodec usernameTokenRealmCodec;
-
     public void addRealm(ServiceReference<JaasRealm> serviceReference) {
         Bundle bundle = FrameworkUtil.getBundle(UsernameTokenValidator.class);
         if (null != bundle) {
@@ -142,15 +101,6 @@ public class UsernameTokenValidator implements TokenValidator {
             LOGGER.trace("Removing validator for JaasRealm {}", realm.getName());
             validators.remove(realm.getName());
         }
-    }
-
-    /**
-     * Set the UsernameTokenRealmCodec instance to use to return a realm from a validated token
-     * @param usernameTokenRealmCodec the UsernameTokenRealmCodec instance to use to return a
-     *                                realm from a validated token
-     */
-    public void setUsernameTokenRealmCodec(UsernameTokenRealmCodec usernameTokenRealmCodec) {
-        this.usernameTokenRealmCodec = usernameTokenRealmCodec;
     }
 
     /**
@@ -239,69 +189,29 @@ public class UsernameTokenValidator implements TokenValidator {
                 return response;
             }
 
-            // See if the UsernameToken is stored in the cache
-            int hash = ut.hashCode();
-            SecurityToken secToken = null;
-            if (tokenParameters.getTokenStore() != null) {
-                secToken = tokenParameters.getTokenStore().getToken(Integer.toString(hash));
-                if (secToken != null && secToken.getTokenHash() != hash) {
-                    secToken = null;
+            Credential credential = new Credential();
+            credential.setUsernametoken(ut);
+            //Only this section is new, the rest is copied from the apache class
+            Set<Map.Entry<String, Validator>> entries = validators.entrySet();
+            for (Map.Entry<String, Validator> entry : entries) {
+                try {
+                    entry.getValue().validate(credential, requestData);
+                    validateTarget.setState(ReceivedToken.STATE.VALID);
+                    break;
+                } catch (WSSecurityException ex) {
+                    LOGGER.debug("Unable to validate user against {}" + entry.getKey(), ex);
                 }
             }
-
-            if (secToken == null) {
-                Credential credential = new Credential();
-                credential.setUsernametoken(ut);
-                //Only this section is new, the rest is copied from the apache class
-                Set<Map.Entry<String, Validator>> entries = validators.entrySet();
-                for (Map.Entry<String, Validator> entry : entries) {
-                    try {
-                        entry.getValue().validate(credential, requestData);
-                        validateTarget.setState(ReceivedToken.STATE.VALID);
-                        break;
-                    } catch (WSSecurityException ex) {
-                        LOGGER.debug("Unable to validate user against {}" + entry.getKey(), ex);
-                    }
-                }
-                if (ReceivedToken.STATE.INVALID.equals(validateTarget.getState())) {
-                    return response;
-                }
-                //end new section
+            if (ReceivedToken.STATE.INVALID.equals(validateTarget.getState())) {
+                return response;
             }
+            //end new section
 
             Principal principal = createPrincipal(ut.getName(), ut.getPassword(),
                     ut.getPasswordType(), ut.getNonce(), ut.getCreated());
 
-            // Get the realm of the UsernameToken
-            String tokenRealm = null;
-            if (usernameTokenRealmCodec != null) {
-                tokenRealm = usernameTokenRealmCodec.getRealmFromToken(ut);
-                // verify the realm against the cached token
-                if (secToken != null) {
-                    Properties props = secToken.getProperties();
-                    if (props != null) {
-                        String cachedRealm = props.getProperty(STSConstants.TOKEN_REALM);
-                        if (!tokenRealm.equals(cachedRealm)) {
-                            validateTarget.setState(ReceivedToken.STATE.INVALID);
-                            return response;
-                        }
-                    }
-                }
-            }
-
-            // Store the successfully validated token in the cache
-            if (tokenParameters.getTokenStore() != null && secToken == null
-                    && ReceivedToken.STATE.VALID.equals(validateTarget.getState())) {
-                secToken = new SecurityToken(ut.getID());
-                secToken.setToken(ut.getElement());
-                int hashCode = ut.hashCode();
-                String identifier = Integer.toString(hashCode);
-                secToken.setTokenHash(hashCode);
-                tokenParameters.getTokenStore().add(identifier, secToken);
-            }
-
             response.setPrincipal(principal);
-            response.setTokenRealm(tokenRealm);
+            response.setTokenRealm(null);
             validateTarget.setState(ReceivedToken.STATE.VALID);
             validateTarget.setPrincipal(principal);
         } catch (WSSecurityException ex) {

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/test/java/org/codice/ddf/security/validator/username/TestUsernameTokenValidator.java
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/test/java/org/codice/ddf/security/validator/username/TestUsernameTokenValidator.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License


### PR DESCRIPTION
Users used to have the ability to login to one realm and gain access to all other realms, but this wasn't correct. Once a user logs in to a particular realm, he now only has access to that realm. (Example: If User Admin logs into search UI over the ldap realm, he does't have access to the Admin UI over the karaf realm) Also note that when a users logs out, all other users are also logged out of their realms.
For more info: https://codice.atlassian.net/browse/DDF-1597

Instructions to hero PR:
1. Install OpenDJEmbedded app
2. Set the following web contexts in the Web Context Policy Manager which are required for ldap to work:
     /search=ldap
     /cometd=ldap
     /services=ldap
     /logout=ldap
2. Set the Authentication type to: SAML | basic
3. Install the ldap features: security-sts-ldapclaimshandler and security-sts-ldaplogin

@coyotesqrl @rzwiefel @tbatie @ryeats @jckilmer @pklinef 

@ryeats is the hero

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/299)
<!-- Reviewable:end -->
