### PR TITLE
DDF-1595: Changes encrypt/decrypt to use Keyczar

### DIFF
--- a/distribution/docs/src/main/resources/ManContents.adoc
+++ b/distribution/docs/src/main/resources/ManContents.adoc
@@ -1763,6 +1763,15 @@ https.protocols=TLSv1,TLSv1.1,TLSv1.2
 *** Select the *Web Context Policy Manager*.
 *** Remove `/system/console` from the Whitelisted Contexts
 
+=== Configuring DDF to use an LDAP server
+[WARNING]
+====
+The configurations for Security STS LDAP and Roles Claims Handler and Security STS LDAP Login contain plain text default passwords for the embedded LDAP, which is insecure to use in production.
+====
+Use the encryption service, described in <<Encryption Service>>, on the command line to set passwords for your LDAP server.
+Then change the LDAP Bind User Password in the configurations to use the encrypted password.
+
+
 === Configuring Solr Catalog Provider
 
 ==== Configure the Solr Catalog Provider Data Directory

--- a/distribution/test/itests/test-itests-catalog/pom.xml
+++ b/distribution/test/itests/test-itests-catalog/pom.xml
@@ -11,7 +11,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/platform/security/encryption/platform-security-encryption-commands/src/main/java/ddf/security/command/EncryptCommand.java
+++ b/platform/security/encryption/platform-security-encryption-commands/src/main/java/ddf/security/command/EncryptCommand.java
@@ -36,7 +36,7 @@ public class EncryptCommand extends OsgiCommandSupport {
             return null;
         }
 
-        String encryptedValue = encryptionService.encrypt(plainTextValue);
+        String encryptedValue = "ENC(".concat(encryptionService.encrypt(plainTextValue)).concat(")");
         System.out.print(Ansi.ansi().fg(Ansi.Color.YELLOW).toString());
         System.out.println(encryptedValue);
         System.out.print(Ansi.ansi().reset().toString());

--- a/platform/security/encryption/platform-security-encryption-commands/src/test/java/ddf/security/command/EncryptCommandTest.java
+++ b/platform/security/encryption/platform-security-encryption-commands/src/test/java/ddf/security/command/EncryptCommandTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -16,8 +16,13 @@ package ddf.security.command;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,14 +32,27 @@ import ddf.security.encryption.impl.EncryptionServiceImpl;
 public class EncryptCommandTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptCommandTest.class);
 
+    private static File ddfHome;
+
+    @Before
+    public void setUp() throws Exception {
+        ddfHome = Files.createTempDirectory("encrypt").toFile();
+        System.setProperty("ddf.home", ddfHome.toString());
+        String path = new File(System.getProperty("ddf.home").concat("/etc/certs"))
+                .getCanonicalPath();
+        new File(path).mkdirs();
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        FileUtils.deleteDirectory(ddfHome);
+    }
+
     @Test
     public void testDoExecuteNonNullPlainTextValue() {
-        final String key = "secret";
         final String plainTextValue = "protect";
-        LOGGER.debug("key: {}", key);
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(key);
         final EncryptCommand encryptCommand = new EncryptCommand();
         encryptCommand.setEncryptionService(encryptionService);
         setPlainTextValueField(encryptCommand, plainTextValue);
@@ -55,12 +73,9 @@ public class EncryptCommandTest {
 
     @Test
     public void testDoExecuteNullPlainTextValue() {
-        final String key = "secret";
         final String plainTextValue = null;
-        LOGGER.debug("key: {}", key);
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(key);
         final EncryptCommand encryptCommand = new EncryptCommand();
         encryptCommand.setEncryptionService(encryptionService);
         setPlainTextValueField(encryptCommand, plainTextValue);

--- a/platform/security/encryption/platform-security-encryption-impl/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-impl/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -39,6 +41,20 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keyczar</groupId>
+            <artifactId>keyczar</artifactId>
+            <version>0.66</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -49,6 +65,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            keyczar,
+                            gson
+                        </Embed-Dependency>
                         <Import-Package>
                             *
                         </Import-Package>

--- a/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,10 +13,12 @@
  */
 package ddf.security.encryption.impl;
 
+import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jasypt.util.text.BasicTextEncryptor;
+import org.keyczar.Crypter;
+import org.keyczar.KeyczarTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,41 +27,59 @@ import ddf.security.encryption.EncryptionService;
 public class EncryptionServiceImpl implements EncryptionService {
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionServiceImpl.class);
 
-    private String key;
+    private static String passwordDirectory;
+
+    static Crypter crypter;
 
     public EncryptionServiceImpl() {
     }
 
-    /**
-     * Encrypts a plain text value using jasypt.
-     *
-     * @param plainTextValue
-     *            The value to encrypt.
-     */
-    public String encrypt(String plainTextValue) {
-        BasicTextEncryptor encryptor = new BasicTextEncryptor();
-        encryptor.setPassword(this.key);
-        return encryptor.encrypt(plainTextValue);
+    static {
+        passwordDirectory = System.getProperty("ddf.home").concat("/etc/certs");
+
+        if (!new File(passwordDirectory.concat("/meta")).exists()) {
+            KeyczarTool keyczarTool = new KeyczarTool();
+            keyczarTool.main(new String[] {"create", "--location=" + passwordDirectory,
+                    "--purpose=crypt", "--name=Password"});
+            keyczarTool.main(new String[] {"addkey", "--location=" + passwordDirectory,
+                    "--status=primary"});
+        }
+        try {
+            crypter = new Crypter(passwordDirectory);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+        }
     }
 
     /**
-     * Decrypts a plain text value using jasypt.
+     * Encrypts a plain text value using Keyczar.
      *
-     * @param encryptedValue
-     *            The value to decrypt.
+     * @param plainTextValue The value to encrypt.
      */
-    public String decrypt(String encryptedValue) {
-        BasicTextEncryptor dencryptor = new BasicTextEncryptor();
-        dencryptor.setPassword(this.key);
-        return dencryptor.decrypt(encryptedValue);
+    public synchronized String encrypt(String plainTextValue) {
+        try {
+            return crypter.encrypt(plainTextValue);
+
+        } catch (Exception e) {
+            LOGGER.error("Key and encryption service failed to set up. Failed to encrypt.");
+            LOGGER.error(e.getMessage());
+            return plainTextValue;
+        }
     }
 
     /**
-     * @param key
-     *            The master key used for encryption and decryption.
+     * Decrypts a plain text value using Keyczar
+     *
+     * @param encryptedValue The value to decrypt.
      */
-    public void setKey(String key) {
-        this.key = key;
+    public synchronized String decrypt(String encryptedValue) {
+        try {
+            return crypter.decrypt(encryptedValue);
+        } catch (Exception e) {
+            LOGGER.error("Key and encryption service failed to set up. Failed to decrypt.");
+            LOGGER.error(e.getMessage());
+            return encryptedValue;
+        }
     }
 
     // @formatter:off

--- a/platform/security/encryption/platform-security-encryption-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/encryption/platform-security-encryption-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,8 +14,6 @@
         >
 
 	<bean id="encryptionService" class="ddf.security.encryption.impl.EncryptionServiceImpl">
-	    <!-- The key used to encrypt and decrypt -->
-        <property name="key" value="secret"/>
 	</bean>
 
 	<service ref="encryptionService" interface="ddf.security.encryption.EncryptionService"/>

--- a/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -16,6 +16,12 @@ package ddf.security.encryption.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.io.File;
+import java.nio.file.Files;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,16 +29,49 @@ import org.slf4j.LoggerFactory;
 public class EncryptionServiceImplTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionServiceImplTest.class);
 
-    private static final String KEY = "secret";
+    private static File ddfHome;
+
+    @Before
+    public void setUp() throws Exception {
+        ddfHome = Files.createTempDirectory("encrypt").toFile();
+        System.setProperty("ddf.home", ddfHome.toString());
+        String path = new File(System.getProperty("ddf.home").concat("/etc/certs"))
+                .getCanonicalPath();
+        new File(path).mkdirs();
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        FileUtils.deleteDirectory(ddfHome);
+    }
 
     @Test
-    public void testEncryptDecrypt() {
+    public void testBadSetup() throws Exception {
+        cleanUp();
+        final String unencryptedPassword = "protect";
+
+        final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
+
+        final String encryptedPassword = encryptionService.encrypt(unencryptedPassword);
+        assertEquals(encryptedPassword, unencryptedPassword);
+
+        final String decryptedPassword = encryptionService.decrypt(encryptedPassword);
+        assertEquals(decryptedPassword, encryptedPassword);
+
+        final String wrappedPassword = "ENC(" + unencryptedPassword + ")";
+        final String unWrappedDecryptedPassword = encryptionService.decryptValue(wrappedPassword);
+
+        assertEquals(unWrappedDecryptedPassword, unencryptedPassword);
+    }
+
+    @Test
+    public void testEncryptDecrypt() throws Exception {
         final String unencryptedPassword = "protect";
 
         LOGGER.debug("Unencrypted Password: {}", unencryptedPassword);
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(KEY);
+
         final String encryptedPassword = encryptionService.encrypt(unencryptedPassword);
         LOGGER.debug("Encrypted Password: {}", encryptedPassword);
 
@@ -43,14 +82,14 @@ public class EncryptionServiceImplTest {
     }
 
     @Test
-    public void testUnwrapDecrypt() {
-        final String wrappedEncryptedValue = "ENC(OItcdA9Z79ZSyc8eczWfaw==)";
+    public void testUnwrapDecrypt() throws Exception {
         final String expectedDecryptedValue = "test";
+        final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
+
+        final String wrappedEncryptedValue = "ENC("
+                .concat(encryptionService.encrypt(expectedDecryptedValue)).concat(")");
 
         LOGGER.debug("Original wrapped encrypted value is: {}", wrappedEncryptedValue);
-
-        final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(KEY);
 
         final String decryptedValue = encryptionService.decryptValue(wrappedEncryptedValue);
         LOGGER.debug("Unwrapped decrypted value is: {}", decryptedValue);
@@ -59,13 +98,12 @@ public class EncryptionServiceImplTest {
     }
 
     @Test
-    public void testUnwrapDecryptNull() {
+    public void testUnwrapDecryptNull() throws Exception {
         final String wrappedEncryptedValue = null;
 
         LOGGER.debug("Original wrapped encrypted value is: null");
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(KEY);
 
         final String decryptedValue = encryptionService.decryptValue(wrappedEncryptedValue);
 
@@ -73,13 +111,12 @@ public class EncryptionServiceImplTest {
     }
 
     @Test
-    public void testUnwrapDecryptEmpty() {
+    public void testUnwrapDecryptEmpty() throws Exception {
         final String wrappedEncryptedValue = "";
 
         LOGGER.debug("Original wrapped encrypted value is: <blank>");
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(KEY);
 
         final String decryptedValue = encryptionService.decryptValue(wrappedEncryptedValue);
 
@@ -87,17 +124,17 @@ public class EncryptionServiceImplTest {
     }
 
     @Test
-    public void testUnwrapDecryptPlainText() {
+    public void testUnwrapDecryptPlainText() throws Exception {
         final String wrappedEncryptedValue = "plaintext";
 
         LOGGER.debug("Original value is: {}", wrappedEncryptedValue);
 
         final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();
-        encryptionService.setKey(KEY);
 
         final String decryptedValue = encryptionService.decryptValue(wrappedEncryptedValue);
         LOGGER.debug("Unwrapped decrypted value is: {}", decryptedValue);
 
         assertEquals(wrappedEncryptedValue, decryptedValue);
     }
+
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,7 +49,7 @@
         <property name="url" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
         <property name="startTls" value="false"/>
         <property name="ldapBindUserDn" value="cn=admin"/>
-        <property name="password" value="ENC(c+GitDfYAMTDRESXSDDsMw==)"/>
+        <property name="password" value="secret"/>
         <property name="userNameAttribute" value="uid"/>
         <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
         <property name="objectClass" value="groupOfNames"/>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,7 +34,7 @@
 	    </AD>
 
 	    <AD name="LDAP Bind User Password:" id="password" required="true" type="Password"
-            default="ENC(c+GitDfYAMTDRESXSDDsMw==)"
+            default="secret"
             description="Password used to bind user with LDAP.">
 	    </AD>
 

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
@@ -84,7 +84,7 @@ public class ClaimsHandlerManagerTest {
         manager.setLdapBindUserDn("cn=admin");
         manager.setObjectClass("ou=users,dc=example,dc=com");
         manager.setMemberNameAttribute("member");
-        manager.setPassword("ENC(c+GitDfYAMTDRESXSDDsMw==)");
+        manager.setPassword("secret");
         manager.setPropertyFileLocation("etc/ws-security/attributeMap.properties");
         manager.configure();
 

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -24,7 +24,7 @@
                                update-method="update"/>
         <!-- Default properties -->
         <property name="ldapBindUserDn" value="cn=admin"/>
-        <property name="ldapBindUserPass" value="ENC(c+GitDfYAMTDRESXSDDsMw==)"/>
+        <property name="ldapBindUserPass" value="secret"/>
         <property name="ldapUrl" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
         <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
         <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,7 +34,7 @@
 	    </AD>
 	    
 	    <AD name="LDAP Bind User Password:" id="ldapBindUserPass" required="true" type="Password"
-            default="ENC(c+GitDfYAMTDRESXSDDsMw==)"
+            default="secret"
             description="Password used to bind user with LDAP.">
 	    </AD>
 	    

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
@@ -71,7 +71,7 @@ public class LdapLoginConfigTest {
             }
         };
         ldapConfig.setLdapBindUserDn("cn=admin");
-        ldapConfig.setLdapBindUserPass("ENC(c+GitDfYAMTDRESXSDDsMw==)");
+        ldapConfig.setLdapBindUserPass("password");
         ldapConfig.setLdapUrl("ldaps://ldap:1636");
         ldapConfig.setUserBaseDn("ou=users,dc=example,dc=com");
         ldapConfig.setGroupBaseDn("ou=groups,dc=example,dc=com");
@@ -83,7 +83,7 @@ public class LdapLoginConfigTest {
                 Matchers.<Dictionary<String, Object>>any());
 
         ldapProps.put(LdapLoginConfig.LDAP_BIND_USER_DN, "cn=admin");
-        ldapProps.put(LdapLoginConfig.LDAP_BIND_USER_PASS, "ENC(c+GitDfYAMTDRESXSDDsMw==)");
+        ldapProps.put(LdapLoginConfig.LDAP_BIND_USER_PASS, "secret");
         ldapProps.put(LdapLoginConfig.USER_BASE_DN, "ou=users,dc=example,dc=com");
         ldapProps.put(LdapLoginConfig.GROUP_BASE_DN, "ou=groups,dc=example,dc=com");
         ldapProps.put(LdapLoginConfig.KEY_ALIAS, "server");

--- a/pom.xml
+++ b/pom.xml
@@ -1068,6 +1068,10 @@
             <name>Codice Repository</name>
             <url>http://artifacts.codice.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>KeyCzar</id>
+            <url>http://keyczar.googlecode.com/svn/trunk/java/maven/</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
-Encryption service now uses Keyczar's api for encryption and decryption
-Encryption console command now outputs the encrypted password with the ENC wrapping
-Fixes up unit tests to work with the Keyczar encryption/decryption

@djblue will hero. 
@clockard @oscaritoro @stustison

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/300)
<!-- Reviewable:end -->
