### PR TITLE
DDF-1616 SAMLAssertionHandler checks session when using basic authentication

### DIFF
--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/handler/saml/SAMLAssertionHandler.java
@@ -80,8 +80,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
     }
 
     @Override
-    public HandlerResult getNormalizedToken(ServletRequest request,
-                                            ServletResponse response, FilterChain chain, boolean resolve) {
+    public HandlerResult getNormalizedToken(ServletRequest request, ServletResponse response,
+            FilterChain chain, boolean resolve) {
         HandlerResult handlerResult = new HandlerResult();
         String realm = (String) request.getAttribute(ContextPolicy.ACTIVE_REALM);
 
@@ -93,45 +93,39 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
         // check for full SAML assertions coming in (federated requests, etc.)
         if (authHeader != null) {
             String[] tokenizedAuthHeader = authHeader.split(" ");
-            if (tokenizedAuthHeader.length != 2) {
-                LOGGER.warn("Unexpected error - Authorization header tokenized incorrectly.");
-                return handlerResult;
-            }
-            if (!tokenizedAuthHeader[0].equals("SAML")) {
-                LOGGER.trace("Header is not a SAML assertion.");
-                return handlerResult;
-            }
-            String encodedSamlAssertion = tokenizedAuthHeader[1];
-            LOGGER.trace("Header retrieved");
-            try {
-                String tokenString = RestSecurity.inflateBase64(encodedSamlAssertion);
-                LOGGER.trace("Header value: {}", tokenString);
-                securityToken = new SecurityToken();
+            if (tokenizedAuthHeader.length == 2 && tokenizedAuthHeader[0].equals("SAML")) {
+                String encodedSamlAssertion = tokenizedAuthHeader[1];
+                LOGGER.trace("Header retrieved");
+                try {
+                    String tokenString = RestSecurity.inflateBase64(encodedSamlAssertion);
+                    LOGGER.trace("Header value: {}", tokenString);
+                    securityToken = new SecurityToken();
 
-                Element thisToken = null;
+                    Element thisToken = null;
 
-                if (tokenString.contains(SAML_NAMESPACE)) {
-                    try {
-                        thisToken = StaxUtils.read(new StringReader(tokenString))
-                                .getDocumentElement();
-                    } catch (XMLStreamException e) {
-                        LOGGER.warn(
-                                "Unexpected error converting XML string to element - proceeding without SAML token.",
-                                e);
+                    if (tokenString.contains(SAML_NAMESPACE)) {
+                        try {
+                            thisToken = StaxUtils.read(new StringReader(tokenString))
+                                    .getDocumentElement();
+                        } catch (XMLStreamException e) {
+                            LOGGER.warn(
+                                    "Unexpected error converting XML string to element - proceeding without SAML token.",
+                                    e);
+                        }
+                    } else {
+                        thisToken = parseAssertionWithoutNamespace(tokenString);
                     }
-                } else {
-                    thisToken = parseAssertionWithoutNamespace(tokenString);
-                }
 
-                securityToken.setToken(thisToken);
-                SAMLAuthenticationToken samlToken = new SAMLAuthenticationToken(null, securityToken,
-                        realm);
-                handlerResult.setToken(samlToken);
-                handlerResult.setStatus(HandlerResult.Status.COMPLETED);
-            } catch (IOException e) {
-                LOGGER.warn("Unexpected error converting header value to string", e);
+                    securityToken.setToken(thisToken);
+                    SAMLAuthenticationToken samlToken = new SAMLAuthenticationToken(null,
+                            securityToken, realm);
+                    handlerResult.setToken(samlToken);
+                    handlerResult.setStatus(HandlerResult.Status.COMPLETED);
+                } catch (IOException e) {
+                    LOGGER.warn("Unexpected error converting header value to string", e);
+                }
+                return handlerResult;
             }
-            return handlerResult;
         }
 
         // Check for legacy SAML cookie
@@ -173,11 +167,13 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
             SecurityTokenHolder savedToken = (SecurityTokenHolder) session
                     .getAttribute(SecurityConstants.SAML_ASSERTION);
             if (savedToken != null && savedToken.getSecurityToken() != null) {
-                SecurityAssertionImpl assertion = new SecurityAssertionImpl(savedToken.getSecurityToken());
+                SecurityAssertionImpl assertion = new SecurityAssertionImpl(
+                        savedToken.getSecurityToken());
                 if (assertion.getNotOnOrAfter() == null
                         || assertion.getNotOnOrAfter().getTime() - System.currentTimeMillis() > 0) {
                     LOGGER.trace("Creating SAML authentication token with session.");
-                    SAMLAuthenticationToken samlToken = new SAMLAuthenticationToken(null, session.getId(), realm);
+                    SAMLAuthenticationToken samlToken = new SAMLAuthenticationToken(null,
+                            session.getId(), realm);
                     handlerResult.setToken(samlToken);
                     handlerResult.setStatus(HandlerResult.Status.COMPLETED);
                     return handlerResult;
@@ -244,8 +240,8 @@ public class SAMLAssertionHandler implements AuthenticationHandler {
      * @throws ServletException
      */
     @Override
-    public HandlerResult handleError(ServletRequest servletRequest,
-                                     ServletResponse servletResponse, FilterChain chain) throws ServletException {
+    public HandlerResult handleError(ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain chain) throws ServletException {
         HandlerResult result = new HandlerResult();
 
         HttpServletRequest httpRequest = servletRequest instanceof HttpServletRequest ?


### PR DESCRIPTION
This ticket needs to be back-ported to DDF SNAPSHOT-2.8.0.

There is currently a bug in SAMLAssertionHandler that adds SAML assertions to every request coming in when it's not needed. This noticeably slows down the performance of the system. 

@coyotesqrl @tbatie @rzwiefel @ryeats @pklinef
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/301)
<!-- Reviewable:end -->