### PR TITLE
DDF-1607 Fixes intermittant UI Test Failures

### DIFF
--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -107,7 +107,7 @@
                         <phase>test</phase>
                         <configuration>
                             <skip>${skipTests}</skip>
-                            <arguments>test --force</arguments>
+                            <arguments>test</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/catalog/ui/search-ui/standard/src/test/js/wd/search.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/search.js
@@ -1,4 +1,4 @@
-/*jslint node: true */
+/*jslint node: true, loopfunc:true */
 /* global describe, it, require */
 'use strict';
 
@@ -6,124 +6,124 @@ var shared = require('./shared');
 
 var asserters = shared.asserters;
 
-describe('Contextual', function () {
-    shared.setup(this);
+for (var i = 0; i < shared.iterations; i++) {
+    describe('Contextual:', function () {
+        shared.setup(this);
+        describe('wildcard query:', function () {
+            it("should show the map", function () {
+                return this.browser
+                    .waitForElementByCssSelector('canvas.ol-unselectable', shared.timeout);
+            });
 
-    describe('wildcard query', function () {
+            it("should allow saving searches", function () {
+                return this.browser
+                    .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
+                    // getLocationInView does not work in Firefox and IE
+                    .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
+                    .elementById('saveButton').click()
+                    .waitForElementByCssSelector('form#workspaceSelectForm input[name="searchName"]', shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('search-save.png'))
+                    .elementById('cancel').click();
+            });
 
-        it("should show the map", function () {
-            return this.browser
-                .waitForElementByCssSelector('canvas.ol-unselectable', shared.timeout);
-        });
+            it("should allow search", function () {
+                return this.browser
+                    .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('search-form.png'))
+                    .elementByCssSelector('input[name="q"]').type('*')
+                    // getLocationInView does not work in Firefox and IE
+                    .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
+                    .elementById('searchButton').click();
+            });
 
-        it("should allow saving searches", function () {
-            return this.browser
-                .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
-                // getLocationInView does not work in Firefox and IE
-                .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
-                .elementById('saveButton').click()
-                .waitForElementByCssSelector('form#workspaceSelectForm input[name="searchName"]', shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('search-save.png'))
-                .elementById('cancel').click();
-        });
+            it("should display results", function () {
+                return this.browser
+                    .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
+                    .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
+                    .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
+                    .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('results-list.png'));
+            });
 
-        it("should allow search", function () {
-            return this.browser
-                .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('search-form.png'))
-                .elementByCssSelector('input[name="q"]').type('*')
-                // getLocationInView does not work in Firefox and IE
-                .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
-                .elementById('searchButton').click();
-        });
+            it("should return different results after editing search keyword", function () {
+                return this.browser
+                    .waitForElementByClassName('backNavText').click()
+                    .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
+                    .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
+                    .elementByCssSelector('input[name="q"]').clear().type('notfound')
+                    .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
+                    .elementById('searchButton').click()
+                    .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
+                    .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
+                    .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length === 0', shared.timeout)
+                    .waitForElementByClassName('backNavText').click()
+                    .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
+                    .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
+                    .elementByCssSelector('input[name="q"]').clear().type('*')
+                    .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
+                    .elementById('searchButton').click()
+                    .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
+                    .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
+                    .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
+                    .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
+            });
 
-        it("should display results", function () {
-            return this.browser
-                .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
-                .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
-                .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
-                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('results-list.png'));
-        });
+            it("should display source status and filter options", function () {
+                return this.browser
+                    .waitForElementById('status-icon', shared.timeout).click()
+                    .waitForElementById('status-table', asserters.isDisplayed, shared.timeout)
+                    .waitForElementByCssSelector('.filter-view.active', asserters.isDisplayed, shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('results-filters.png'));
+            });
 
-        it("should return different results after editing search keyword", function () {
-            return this.browser
-                .waitForElementByClassName('backNavText').click()
-                .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
-                .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
-                .elementByCssSelector('input[name="q"]').clear().type('notfound')
-                .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
-                .elementById('searchButton').click()
-                .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
-                .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
-                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length === 0', shared.timeout)
-                .waitForElementByClassName('backNavText').click()
-                .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
-                .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
-                .elementByCssSelector('input[name="q"]').clear().type('*')
-                .safeExecute('document.querySelectorAll("#searchButton")[0].scrollIntoView(true)')
-                .elementById('searchButton').click()
-                .waitForElementsByCssSelector('div#progressRegion:empty', shared.timeout)
-                .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
-                .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
-                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
-        });
+            it("should allow for filtered search", function () {
+                return this.browser
+                    .waitForElementByCssSelector('div.value-input-group input[name="stringValue1"]', shared.timeout)
+                    .elementByCssSelector('input[name="stringValue1"]').clear().type('notfound')
+                    .elementByCssSelector('.apply').click()
+                    .waitForConditionInBrowser('document.querySelector(".result-count i").innerText.indexOf("0 ") === 0', shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('result-notfound.png'))
+                    .elementByCssSelector('input[name="stringValue1"]').clear().type('*')
+                    .elementByCssSelector('.apply').click()
+                    .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
+            });
 
-        it("should display source status and filter options", function () {
-             return this.browser
-                .waitForElementById('status-icon', shared.timeout).click()
-                .waitForElementById('status-table', asserters.isDisplayed, shared.timeout)
-                .waitForElementByCssSelector('.filter-view.active', asserters.isDisplayed, shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('results-filters.png'));
-        });
+            it("should be able to display uncached metacard summary", function () {
+                return this.browser
+                    .waitForElementByCssSelector('a.metacard-link').click()
+                    .waitForElementByClassName('metacard-details', asserters.nonEmptyText)
+                    .elementByCssSelector('#summary .pull-right .attribute-value', asserters.textInclude('Unknown'), shared.timeout)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-summary.png'));
+            });
 
-        it("should allow for filtered search", function() {
-            return this.browser
-                .waitForElementByCssSelector('div.value-input-group input[name="stringValue1"]', shared.timeout)
-                .elementByCssSelector('input[name="stringValue1"]').clear().type('notfound')
-                .elementByCssSelector('.apply').click()
-                .waitForElementByCssSelector('.result-count i', asserters.textInclude('0'), shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('result-notfound.png'))
-                .elementByCssSelector('input[name="stringValue1"]').clear().type('*')
-                .elementByCssSelector('.apply').click()
-                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
-        });
+            it("should be able to display cached metacard summary", function () {
+                return this.browser
+                    .waitForElementById('nextRecord', asserters.isDisplayed, shared.timeout).click()
+                    .waitForConditionInBrowser('document.querySelector("#summary .pull-right .attribute-value").innerHTML.indexOf("ago") >= 0', shared.timeout)
+                    .waitForElementById('prevRecord', asserters.isDisplayed, shared.timeout).click()
+                    .waitForConditionInBrowser('document.querySelector("#summary .pull-right .attribute-value").innerHTML.indexOf("Unknown") >= 0', shared.timeout);
+            });
 
-        it("should be able to display uncached metacard summary", function () {
-            return this.browser
-                .waitForElementByCssSelector('a.metacard-link').click()
-                .waitForElementByClassName('metacard-details', asserters.nonEmptyText)
-                .elementByCssSelector('#summary .pull-right .attribute-value', asserters.textInclude('Unknown'), shared.timeout)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-summary.png'));
-        });
+            it("should be able to display metacard details", function () {
+                return this.browser
+                    .waitForElementByLinkText('Details').click()
+                    .waitForElementByClassName('metacard-table', asserters.isDisplayed)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-details.png'));
+            });
 
-        it("should be able to display cached metacard summary", function () {
-            return this.browser
-                .waitForElementById('nextRecord', asserters.isDisplayed, shared.timeout).click()
-                .waitForConditionInBrowser('document.querySelector("#summary .pull-right .attribute-value").innerHTML.indexOf("ago") >= 0', shared.timeout)
-                .waitForElementById('prevRecord', asserters.isDisplayed, shared.timeout).click()
-                .waitForConditionInBrowser('document.querySelector("#summary .pull-right .attribute-value").innerHTML.indexOf("Unknown") >= 0', shared.timeout);
-        });
+            it("should be able to display metacard actions", function () {
+                return this.browser
+                    .waitForElementByLinkText('Actions').click()
+                    .waitForElementByCssSelector('#actions.active', asserters.isDisplayed)
+                    .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-actions.png'));
+            });
 
-        it("should be able to display metacard details", function () {
-            return this.browser
-                .waitForElementByLinkText('Details').click()
-                .waitForElementByClassName('metacard-table', asserters.isDisplayed)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-details.png'));
-        });
-
-        it("should be able to display metacard actions", function () {
-            return this.browser
-                .waitForElementByLinkText('Actions').click()
-                .waitForElementByCssSelector('#actions.active', asserters.isDisplayed)
-                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('record-actions.png'));
-        });
-
-        it("should allow previous and next navigation", function () {
-            return this.browser
-                .waitForElementByCssSelector('#prevRecord.disabled')
-                .waitForElementById('nextRecord', asserters.isDisplayed, shared.timeout).click()
-                .waitForElementByCssSelector('#prevRecord:not(.disabled)');
+            it("should allow previous and next navigation", function () {
+                return this.browser
+                    .waitForElementByCssSelector('#prevRecord.disabled')
+                    .waitForElementById('nextRecord', asserters.isDisplayed, shared.timeout).click()
+                    .waitForElementByCssSelector('#prevRecord:not(.disabled)');
+            });
         });
     });
-});
+}

--- a/catalog/ui/search-ui/standard/src/test/js/wd/shared.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/shared.js
@@ -1,5 +1,5 @@
 /*jslint node: true */
-/* global after, before, beforeEach, require */
+/* global after, before, beforeEach, afterEach, require */
 'use strict';
 
 require('colors');
@@ -9,6 +9,61 @@ var chaiAsPromised = require('chai-as-promised');
 var wd = require('wd');
 var fs = require('fs');
 var path = require('path');
+var url = argv.url || 'http://localhost:8888/';
+var newline = '\n';
+var indentation = '';
+var stackTrace = [];
+var browser;
+var failureScreenshotPath = path.join(__dirname, '../../../..', 'target/webapp/images/failures');
+var screenshotPath = path.join(__dirname, '../../../..', 'target/webapp/images');
+/*
+ Called when a test fails.  It constructs a screenshot name by removing problematic characters from
+ the full test name.  It then prints out the stack trace of commands and saves a screenshot to the
+ failure directory.
+ */
+function handleError(testName){
+    var screenshotName = testName.split(' ').join('-').split('/').join('-').split(':').join('-')+'.png';
+    console.error(indentation+screenshotName.red+' saved in target/webapp/images/failures.'.blue);
+    while(stackTrace.length>0){
+        console.error(indentation+stackTrace.pop().red);
+    }
+    return browser.saveScreenshot(path.join(failureScreenshotPath, screenshotName));
+}
+/*
+ Called whenever a command is issued to the browser.  Depending on the eventType (and command),
+ it constructs a message to put into the stack trace in case the test fails.  It is only
+ added if it is not equal to the previous command and the command before that.  This prevents
+ duplicate commands (in the case of our polling commands) and results in an easy to read
+ stack trace.
+ */
+function handleCommand(eventType, command, response) {
+    var message = eventType;
+    switch (eventType) {
+        case 'CALL':
+            message+= '     ' + command;
+            break;
+        case 'RESPONSE':
+            message+= ' ' + command;
+            if (command.indexOf('saveScreenshot') !== 0 && command.indexOf('takeScreenshot') !== 0)
+                message += ' ' + response;
+            break;
+    }
+    if (stackTrace[stackTrace.length - 1] !== message && stackTrace[stackTrace.length-2] !== message)
+        stackTrace.push(message);
+}
+
+fs.mkdir(screenshotPath, function () {
+    fs.mkdir(failureScreenshotPath);
+});
+
+wd.addPromiseChainMethod(
+    'logToConsole',
+    function(message) {
+        console.log(indentation + message.toString().blue);
+    }
+);
+
+exports.screenshotPath = screenshotPath;
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -32,23 +87,22 @@ function debugLogging(browser) {
     }
 }
 
-var screenshotPath = path.join(__dirname, '../../../..', 'target/webapp/images');
-fs.mkdir(screenshotPath);
-
-exports.screenshotPath = screenshotPath;
-
 exports.getPathForScreenshot = function (filename) {
     return path.join(screenshotPath, filename);
 };
 
-var url = argv.url || 'http://localhost:8888?map=2d';
-
 exports.asserters = wd.asserters;
+
+exports.iterations = argv.iterations || 1;
 
 exports.setup = function() {
 
     before(function () {
         exports.timeout = argv.timeout || this.mochaOptions.timeout || 30000;
+        // need reference in order to take screenshots
+        browser = this.browser;
+        // remove listener before adding since this is called before each test suites
+        this.browser.removeListener('command', handleCommand).on('command', handleCommand);
 
         if (argv.browser) {
             this.browser = wd.promiseChainRemote()
@@ -65,23 +119,46 @@ exports.setup = function() {
             .get(url);
     });
 
+    /*
+     We clear out the stackTrace of commands before each individual test.
+     Unfortunately, we have to use this hacky way (:'s in describes) of getting the proper indentation
+     for logging to the console.  Mocha hides the details of tests so that we don't know how deep
+     we are (we can get the fullTitle through a function, but we can't access the parent ourselves).
+     */
+    beforeEach(function () {
+        stackTrace = [];
+        var numOfIndents = this.currentTest.fullTitle().split(':').length;
+        var indent = '  ';
+        indentation = '';
+        for (var i = 0; i < numOfIndents; i++) {
+            indentation += indent;
+        }
+        console.log(newline + indentation + this.currentTest.title.blue + " . . .".blue);
+    });
+
+    /*
+     Pass 'Error' back into the done callback so further tests in the given suite are aborted
+     If we decoupled our tests from one another (cleaned up properly after each one),
+     this wouldn't be necessary.
+     */
+    afterEach(function (done) {
+        if (this.currentTest.err) {
+            console.error(indentation + this.currentTest.err.toString().red);
+            handleError(this.currentTest.fullTitle()).then(function () {
+                done('Error');
+            }, function () {
+                done('Error');
+            });
+        } else {
+            done();
+        }
+    });
+
     after(function () {
         if (argv.browser) {
             return this.browser.quit();
         } else {
             return this.browser;
         }
-    });
-};
-
-exports.reloadBeforeTests = function() {
-    before('refresh page', function () {
-        return this.browser.get(url);
-    });
-};
-
-exports.reloadBeforeEachTest = function() {
-    beforeEach('refresh page', function () {
-        return this.browser.get(url);
     });
 };

--- a/catalog/ui/search-ui/standard/src/test/js/wd/usng.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/usng.js
@@ -1,206 +1,203 @@
-/*jslint node: true */
+/*jslint node: true, loopfunc:true */
 /* global describe, it, require */
 'use strict';
 
 var shared = require('./shared');
 
-var convertLLtoUSNG = function(browser,lat1, lon1, lat2, lon2) {
+var convertLLtoUSNG = function (browser, lat1, lon1, lat2, lon2) {
     return browser
-        .waitForElementById('latlon', shared.timeout).click()
-        .waitForElementById('locationBbox', shared.timeout).click()
-        .waitForElementById('mapNorth', shared.timeout).clear().type(lat1)
-        .waitForElementById('mapSouth', shared.timeout).clear().type(lat2)
-        .waitForElementById('mapEast', shared.timeout).clear().type(lon1)
-        .waitForElementById('mapWest', shared.timeout).clear().type(lon2)
-        .waitForElementById('usng', shared.timeout).click()
+        .waitForElementById('latlon',shared.timeout)
+        .safeExecute('$("#latlon").click()')
+        .safeExecute('$("#locationBbox").click()')
+        .safeExecute('$("#mapNorth").val('+lat1+').trigger("change")')
+        .safeExecute('$("#mapSouth").val('+lat2+').trigger("change")')
+        .safeExecute('$("#mapEast").val('+lon1+').trigger("change")')
+        .safeExecute('$("#mapWest").val('+lon2+').trigger("change")')
+        .safeExecute('$("#usng").click()')
         .waitForElementById('usngbb', shared.timeout);
 };
 
-var convertUSNGtoLL = function(browser, usng) {
+var convertUSNGtoLL = function (browser, usng) {
     return browser
-        .waitForElementById('usng', shared.timeout).click()
-        .waitForElementById('locationBbox', shared.timeout).click()
-        .waitForElementById('usngbb', shared.timeout).type(usng)
-        .waitForElementById('latlon', shared.timeout).click();
+        .waitForElementById('usng', shared.timeout)
+        .safeExecute('$("#usng").click()')
+        .safeExecute('$("#locationBbox").click()')
+        .safeExecute('$("#usngbb").val("'+usng+'").trigger("change")')
+        .safeExecute('$("#latlon").click()')
+        .waitForElementById('latlon', shared.timeout);
 };
 
+for (var i = 0; i < shared.iterations; i++) {
+    describe('USNG Search:', function () {
+        shared.setup(this);
 
-describe('USNG Search', function () {
-    shared.setup(this);
+        // Create bigger and bigger boxes around the washington monument
+        // Tests the precision conversion from llbbox to usng
+        describe('lat/lon bbox to usng:', function () {
 
-    // Create bigger and bigger boxes around the washington monument
-    // Tests the precision conversion from llbbox to usng
-    describe('lat/lon bbox to usng', function() {
+            // 0-1m
+            it("should convert to 18S UJ 23495 06472", function () {
+                var lat = 38.8894;
+                var lon = -77.0351;
+                var usng = "18S UJ 23495 06472";
+                return convertLLtoUSNG(this.browser, lat, lon, lat, lon)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
-        // 0-1m
-        it("should convert to 18S UJ 23495 06472", function () {
-            var lat = 38.8894;
-            var lon = -77.0351;
-            var usng = "18S UJ 23495 06472";
-            return convertLLtoUSNG(this.browser, lat, lon, lat, lon)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
+            // 2-10m
+            it("should convert to 18S UJ 2349 0648", function () {
+                var north = 38.8895;
+                var south = 38.8895;
+                var east = -77.0352;
+                var west = -77.0351;
+                var usng = "18S UJ 2349 0648";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
-        // 2-10m
-        it("should convert to 18S UJ 2349 0648", function () {
-            var north = 38.8895;
-            var south = 38.8895;
-            var east = -77.0352;
-            var west = -77.0351;
-            var usng = "18S UJ 2349 0648";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
-
-        // 11-100m
-        it("should convert to 18S UJ 234 064", function () {
-            var north = 38.8896;
-            var south = 38.8895;
-            var east = -77.0357;
-            var west = -77.0361;
-            var usng = "18S UJ 234 064";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
+            // 11-100m
+            it("should convert to 18S UJ 234 064", function () {
+                var north = 38.8896;
+                var south = 38.8895;
+                var east = -77.0357;
+                var west = -77.0361;
+                var usng = "18S UJ 234 064";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
             // 100-1000m
-        it("should convert to 18S UJ 23 06", function () {
-            var north = 38.8905;
-            var south = 38.8891;
-            var east = -77.0355;
-            var west = -77.0376;
-            var usng = "18S UJ 23 06";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
+            it("should convert to 18S UJ 23 06", function () {
+                var north = 38.8905;
+                var south = 38.8891;
+                var east = -77.0355;
+                var west = -77.0376;
+                var usng = "18S UJ 23 06";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
             // 1000-10k
-        it("should convert to 18S UJ 2 0", function () {
-            var north = 38.8973;
-            var south = 38.8825;
-            var east = -77.0241;
-            var west = -77.0429;
-            var usng = "18S UJ 2 0";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
+            it("should convert to 18S UJ 2 0", function () {
+                var north = 38.8973;
+                var south = 38.8825;
+                var east = -77.0241;
+                var west = -77.0429;
+                var usng = "18S UJ 2 0";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
             // 10k-100k
-        it("should convert to 18S UJ", function () {
-            var north = 38.8973;
-            var south = 38.8825;
-            var east = -77.0241;
-            var west = -77.0429;
-            var usng = "18S UJ";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
-        });
+            it("should convert to 18S UJ", function () {
+                var north = 38.8973;
+                var south = 38.8825;
+                var east = -77.0241;
+                var west = -77.0429;
+                var usng = "18S UJ";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
 
             // 100k+
-        it("should convert to 18S", function () {
-            var north = 40;
-            var south = 32;
-            var east = -72;
-            var west = -78;
-            var usng = "18S";
-            return convertLLtoUSNG(this.browser, north, east, south, west)
-                .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout)
-                .refresh();
+            it("should convert to 18S", function () {
+                var north = 40;
+                var south = 32;
+                var east = -72;
+                var west = -78;
+                var usng = "18S";
+                return convertLLtoUSNG(this.browser, north, east, south, west)
+                    .waitForConditionInBrowser("document.getElementById('usngbb').value.includes('" + usng + "')", shared.timeout);
+            });
+        });
+
+        // Create bigger and bigger boxes around the washington monument
+        // Tests the precision conversion from usng to llbbox
+        describe('usng to lat/lon bbox:', function () {
+
+            it("should convert to 38.889 -77.0351", function () {
+                var north = 38.889;
+                var south = 38.889;
+                var east = -77.0351;
+                var west = -77.0351;
+                return convertUSNGtoLL(this.browser, "18S UJ 23487 06483")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 38.8895 -77.0351 38.8894 -77.0350", function () {
+                var north = 38.8895;
+                var south = 38.8894;
+                var east = -77.0350;
+                var west = -77.0351;
+                return convertUSNGtoLL(this.browser, "18S UJ 2349 0648")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 38.8896 -77.0361 38.8887 -77.0350", function () {
+                var north = 38.8896;
+                var south = 38.8887;
+                var east = -77.0350;
+                var west = -77.0361;
+                return convertUSNGtoLL(this.browser, "18S UJ 234 064")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 38.8942 -77.0406 38.8850 -77.0294", function () {
+                var north = 38.8942;
+                var south = 38.8850;
+                var east = -77.0294;
+                var west = -77.0406;
+                return convertUSNGtoLL(this.browser, "18S UJ 23 06")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 38.9224 -77.0736 38.8304 -76.9610", function () {
+                var north = 38.9224;
+                var south = 38.8304;
+                var east = -76.9610;
+                var west = -77.0736;
+                return convertUSNGtoLL(this.browser, "18S UJ 2 0")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 39.7440 -77.3039 38.8260 -76.1671", function () {
+                var north = 39.7440;
+                var south = 38.8260;
+                var east = -76.1671;
+                var west = -77.3039;
+                return convertUSNGtoLL(this.browser, "18S UJ")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
+
+            it("should convert to 40 -84 32 -84", function () {
+                var north = 40;
+                var south = 32;
+                var east = -78;
+                var west = -84;
+                return convertUSNGtoLL(this.browser, "17S")
+                    .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'" + west + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'" + east + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'" + north + "\') >= 0", shared.timeout)
+                    .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'" + south + "\') >= 0", shared.timeout);
+            });
         });
     });
-
-    // Create bigger and bigger boxes around the washington monument
-    // Tests the precision conversion from usng to llbbox
-    describe('usng to lat/lon bbox', function () {
-
-        it("should convert to 38.889 -77.0351", function () {
-            var north = 38.889;
-            var south = 38.889;
-            var east = -77.0351;
-            var west = -77.0351;
-            return convertUSNGtoLL(this.browser, "18S UJ 23487 06483")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 38.8895 -77.0351 38.8894 -77.0350", function () {
-            var north = 38.8895;
-            var south = 38.8894;
-            var east = -77.0350;
-            var west = -77.0351;
-            return convertUSNGtoLL(this.browser, "18S UJ 2349 0648")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 38.8896 -77.0361 38.8887 -77.0350", function () {
-            var north = 38.8896;
-            var south = 38.8887;
-            var east = -77.0350;
-            var west = -77.0361;
-            return convertUSNGtoLL(this.browser, "18S UJ 234 064")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 38.8942 -77.0406 38.8850 -77.0294", function () {
-            var north = 38.8942;
-            var south = 38.8850;
-            var east = -77.0294;
-            var west = -77.0406;
-            return convertUSNGtoLL(this.browser, "18S UJ 23 06")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 38.9224 -77.0736 38.8304 -76.9610", function () {
-            var north = 38.9224;
-            var south = 38.8304;
-            var east = -76.9610;
-            var west = -77.0736;
-            return convertUSNGtoLL(this.browser, "18S UJ 2 0")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 39.7440 -77.3039 38.8260 -76.1671", function () {
-            var north = 39.7440;
-            var south = 38.8260;
-            var east = -76.1671;
-            var west = -77.3039;
-            return convertUSNGtoLL(this.browser, "18S UJ")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-
-        it("should convert to 40 -84 32 -84", function () {
-            var north = 40;
-            var south = 32;
-            var east = -78;
-            var west = -84;
-            return convertUSNGtoLL(this.browser, "17S")
-                .waitForConditionInBrowser("document.getElementById('mapWest').value.indexOf(\'"+west+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapEast').value.indexOf(\'"+east+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapNorth').value.indexOf(\'"+north+"\') >= 0", shared.timeout)
-                .waitForConditionInBrowser("document.getElementById('mapSouth').value.indexOf(\'"+south+"\') >= 0", shared.timeout);
-        });
-    });
-});
+}

--- a/catalog/ui/search-ui/standard/src/test/js/wd/workspaces.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/workspaces.js
@@ -1,96 +1,98 @@
-/*jslint node: true */
+/*jslint node: true, loopfunc:true */
 /* global describe, it, require */
 'use strict';
 
 var shared = require('./shared');
 var asserters = shared.asserters;
 
-describe('Workspace', function () {
-    shared.setup(this);
+for (var i = 0; i < shared.iterations; i++) {
+    describe('Workspace:', function () {
+        shared.setup(this);
 
-    it("should show workspace list", function () {
-        return this.browser
-            .waitForElementByLinkText('Workspaces', asserters.isDisplayed, shared.timeout).click()
-            .waitForElementByClassName('workspace-table', shared.timeout);
-    });
+        it("should show workspace list", function () {
+            return this.browser
+                .waitForElementByLinkText('Workspaces', asserters.isDisplayed, shared.timeout).click()
+                .waitForElementByClassName('workspace-table', shared.timeout);
+        });
 
-    it("should allow adding a workspace", function () {
-        return this.browser
-            .elementById('Add', asserters.isDisplayed).click()
-            .waitForElementById('workspaceName', asserters.isDisplayed).type('foo')
-            .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-add.png'))
-            .elementByCssSelector('#workspaceAddForm a.submit').click()
-            .waitForElementByClassName('workspace-name', asserters.textInclude('foo'), shared.timeout)
-            .elementByClassName('workspace-row').click();
-    });
+        it("should allow adding a workspace", function () {
+            return this.browser
+                .elementById('Add', asserters.isDisplayed).click()
+                .waitForElementById('workspaceName', asserters.isDisplayed).type('foo')
+                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-add.png'))
+                .elementByCssSelector('#workspaceAddForm a.submit').click()
+                .waitForElementByClassName('workspace-name', asserters.textInclude('foo'), shared.timeout)
+                .elementByClassName('workspace-row').click();
+        });
 
-    it("should allow adding a search to a workspace", function () {
-        return this.browser
-            .waitForElementById('addSearch').click()
-            .waitForElementById('queryName', asserters.isDisplayed).type('bar')
-            .waitForElementByCssSelector('#workspaces input[name="q"]').type('*')
-            .waitForElementById('workspaceSearchButton')
-            .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-query.png'))
-            .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
-            .elementById('workspaceSearchButton').click()
-            .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
-            .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
-            .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-list.png'));
-    });
+        it("should allow adding a search to a workspace", function () {
+            return this.browser
+                .waitForElementById('addSearch').click()
+                .waitForElementById('queryName', asserters.isDisplayed).type('bar')
+                .waitForElementByCssSelector('#workspaces input[name="q"]').type('*')
+                .waitForElementById('workspaceSearchButton')
+                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-query.png'))
+                .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
+                .elementById('workspaceSearchButton').click()
+                .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
+                .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
+                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-list.png'));
+        });
 
-    it("should allow editing searches in workspace", function () {
-        return this.browser
-            .waitForElementByClassName('workspace-row')
-            .waitForElementById('Edit').click()
-            .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-edit.png'))
-            .waitForElementById('Done').click();
-    });
+        it("should allow editing searches in workspace", function () {
+            return this.browser
+                .waitForElementByClassName('workspace-row')
+                .waitForElementById('Edit').click()
+                .takeScreenshot().saveScreenshot(shared.getPathForScreenshot('workspace-edit.png'))
+                .waitForElementById('Done').click();
+        });
 
-    it("should return different results after editing search keyword", function () {
-        return this.browser
-            .waitForElementByClassName('workspace-row')
-            .waitForElementById('Edit').click()
-            .waitForElementById('edit').click()
-            .waitForElementByCssSelector('#workspaces input[name="q"]').clear().type('notfound')
-            .waitForElementById('workspaceSearchButton')
-            .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
-            .elementById('workspaceSearchButton').click()
-            .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
-            .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
-            .waitForElementByClassName('workspace-row').click()
-            .waitForElementById('low-count')
-            .waitForConditionInBrowser('document.querySelector("#low-count").innerHTML.indexOf("0") === 0', shared.timeout)
-            .waitForElementById('Workspace').click()
-            .waitForElementById('Edit').click()
-            .waitForElementById('edit').click()
-            .waitForElementByCssSelector('#workspaces input[name="q"]').clear().type('*')
-            .waitForElementById('workspaceSearchButton')
-            .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
-            .elementById('workspaceSearchButton').click()
-            .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
-            .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout);
-    });
+        it("should return different results after editing search keyword", function () {
+            return this.browser
+                .waitForElementByClassName('workspace-row')
+                .waitForElementById('Edit').click()
+                .waitForElementById('edit').click()
+                .waitForElementByCssSelector('#workspaces input[name="q"]').clear().type('notfound')
+                .waitForElementById('workspaceSearchButton')
+                .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
+                .elementById('workspaceSearchButton').click()
+                .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
+                .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
+                .waitForElementByClassName('workspace-row').click()
+                .waitForElementById('low-count')
+                .waitForConditionInBrowser('document.querySelector("#low-count").innerHTML.indexOf("0") === 0', shared.timeout)
+                .waitForElementById('Workspace').click()
+                .waitForElementById('Edit').click()
+                .waitForElementById('edit').click()
+                .waitForElementByCssSelector('#workspaces input[name="q"]').clear().type('*')
+                .waitForElementById('workspaceSearchButton')
+                .safeExecute('document.querySelectorAll("#workspaceSearchButton")[0].scrollIntoView(true)')
+                .elementById('workspaceSearchButton').click()
+                .waitForConditionInBrowser('document.querySelectorAll("a.workspace-name").length === 1', shared.timeout)
+                .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout);
+        });
 
-    it("should allow viewing search in workspace", function () {
-        return this.browser
-            .waitForElementByClassName('workspace-row').click()
-            .waitForElementById('low-count')
-            .waitForConditionInBrowser('document.querySelector("#low-count").innerHTML.indexOf("results") !== -1', shared.timeout)
-            .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
-    });
+        it("should allow viewing search in workspace", function () {
+            return this.browser
+                .waitForElementByClassName('workspace-row').click()
+                .waitForElementById('low-count')
+                .waitForConditionInBrowser('document.querySelector("#low-count").innerHTML.indexOf("results") !== -1', shared.timeout)
+                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 10', shared.timeout);
+        });
 
-    it("should allow saving results", function () {
-        return this.browser
-            .waitForElementById('status-icon').click()
-            .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
-            .waitForElementById('Save').click()
-            .waitForElementByCssSelector('#workspaces input.select-record-checkbox', shared.timeout).click()
-            .waitForElementById('Done').click()
-            .waitForElementByCssSelector('input[value="foo"]', asserters.isDisplayed, shared.timeout).click()
-            .waitForElementByCssSelector('a.submit').click()
-            .waitForElementById('Workspace', shared.timeout).click()
-            .waitForElementById('view-records', shared.timeout).click()
-            .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
-            .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 1', shared.timeout);
+        it("should allow saving results", function () {
+            return this.browser
+                .waitForElementById('status-icon').click()
+                .waitForConditionInBrowser('document.querySelectorAll(".fa-spin").length === 0', shared.timeout)
+                .waitForElementById('Save').click()
+                .waitForElementByCssSelector('#workspaces input.select-record-checkbox', shared.timeout).click()
+                .waitForElementById('Done').click()
+                .waitForElementByCssSelector('input[value="foo"]', asserters.isDisplayed, shared.timeout).click()
+                .waitForElementByCssSelector('a.submit').click()
+                .waitForElementById('Workspace', shared.timeout).click()
+                .waitForElementById('view-records', shared.timeout).click()
+                .waitForElementsByCssSelector('a.metacard-link', shared.timeout)
+                .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length >= 1', shared.timeout);
+        });
     });
-});
+}


### PR DESCRIPTION
 - Updates pom.xml to no longer use force when running grunt.  Now if a test failures, the build will fail.
 - Updates a search test to use waitForConditionInBrowser to avoid a caching of an element that was becoming stale.
 - Updates the usng tests to not use a refresh following each individual test case.  Now, a change event is triggered after changing values in order to make the tests work.
 - Adds a stack trace to test failures, saves a screenshot as well in the images/failures folder.
 - Aborts test suite following any failure.
 - Adds a flag (--iterations) that can be passed to grunt in order to run each test a certain number of times.  This is useful for stability testing.  As a result, all the test suites are wrapped in a for loop (this caused the formatting to change for each suite).  The default number of iterations (if not passed in) is 1.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/303)
<!-- Reviewable:end -->
