### PR TITLE
DDF-1620: Updated pom for automated release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <snapshots.repository.url />
         <reports.repository.url />
 
+        <project.scm.id>github</project.scm.id>
+
         <!-- Must MANUALLY update this if the ddf/support project's version changes -->
         <ddf.support.version>2.3.4</ddf.support.version>
 
@@ -94,9 +96,9 @@
     in your .m2/settings.xml file.
     -->
     <scm>
-        <url>https://github.com/codice/ddf.git</url>
-        <connection>scm:git:git://github.com/codice/ddf.git</connection>
-        <developerConnection>scm:git:git://github.com/codice/ddf.git</developerConnection>
+        <url>https://github.com/codice/ddf</url>
+        <connection>scm:git:https://github.com/codice/ddf.git</connection>
+        <developerConnection>scm:git:https://github.com/codice/ddf.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -277,8 +279,7 @@
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>clean verify install</preparationGoals>
-                        <arguments>-Pjavadoc-unpack</arguments>
-                        <pushChanges>false</pushChanges>
+                        <arguments>-Pjavadoc-unpack ${arguments}</arguments>
                     </configuration>
                 </plugin>
 
@@ -522,7 +523,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.15</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Summary of changes
* added scm server for github, this needs to be set in maven settings!
* updated scm tag settings (url/connection/developerconnection/tag)
* fixed passing arguments to the release plugin
* allowed release plugin to push tag changes
* updated checkstyle plugin for reports profile to 2.15

The scm tag settings may need to be changed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/308)
<!-- Reviewable:end -->
