### PR TITLE
DDF-1612 Add error reporting for config editing in Admin UI

### DIFF
--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -402,8 +402,9 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
     /**
      * @see ConfigurationAdminMBean#update(java.lang.String, java.util.Map)
      */
-    public void update(String pid, Map<String, Object> configurationTable) throws IOException {
+    public boolean update(String pid, Map<String, Object> configurationTable) throws IOException {
         updateForLocation(pid, null, configurationTable);
+        return true;
     }
 
     /**

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminMBean.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminMBean.java
@@ -203,6 +203,9 @@ public interface ConfigurationAdminMBean {
     /**
      * Update the configuration with the supplied properties For each property entry, the following
      * row is supplied
+     *
+     * It is necessary to have a return value so that the ajax call to Jolokia waits for it to finish
+     * and we get any errors returned
      * <p/>
      *
      * @see org.osgi.jmx.JmxConstants#PROPERTIES_TYPE for the details of the TabularType
@@ -214,7 +217,7 @@ public interface ConfigurationAdminMBean {
      * @throws IOException
      *             if the operation fails
      */
-    void update(String pid, Map<String, Object> configurationTable) throws IOException;
+    boolean update(String pid, Map<String, Object> configurationTable) throws IOException;
 
     /**
      * Update the configuration with the supplied properties For each property entry, the following

--- a/platform/admin/ui/src/main/webapp/css/style.css
+++ b/platform/admin/ui/src/main/webapp/css/style.css
@@ -123,12 +123,12 @@ main.container {
     margin-top: 30px;
 }
 
-#alerts .panel-title {
+.alerts .panel-title {
     color: #ffffff;
 }
 
-#alerts .alerts-table {
-    color: #2c3e50; 
+.alerts .alerts-table {
+    color: #2c3e50;
     background-color: #ebccd1;
     margin-right: 30px;
 }
@@ -137,19 +137,36 @@ table.alerts-table td {
     padding-top: 8px;
     padding-bottom: 8px;
     padding-left: 18px;
+    word-wrap: break-word;
 }
 
-#alerts {
+.main-content-wrapper > .container > .alerts {
     padding-left: 20px;
     padding-right: 0px;
 }
 
-#alerts > table {
+.alerts {
+    text-align: left;
+    max-width: 100%;
+}
+
+.alerts > table {
+    table-layout: fixed;
     width: 100%;
 }
 
-h4.panel-title > a {
+h4.panel-title > button,
+h4.panel-title > button:hover,
+h4.panel-title > button:visited {
     padding-left: 10px;
+    color: white;
+    padding-top: 0;
+    padding-bottom: 0;
+    font-size: inherit;
+    text-decoration: underline;
+    vertical-align: inherit;
+    float: right;
+    line-height: inherit;
 }
 
 h4.panel-title > i {
@@ -160,8 +177,10 @@ h4.panel-title > i {
     width: inherit;
 }
 
-#collapseAlerts {
-      background: #ebccd1;
+.collapseAlerts {
+    background: #ebccd1;
+    overflow: auto;
+    max-height: 200px;
 }
 
 .fa-chevron-circle-right {

--- a/platform/admin/ui/src/main/webapp/index.html
+++ b/platform/admin/ui/src/main/webapp/index.html
@@ -39,7 +39,7 @@
 
     </div>
     <div class="container">
-        <div id="alerts"></div>
+        <div class="alerts"></div>
         <!--<h2 id="pageHeader"></h2>-->
     </div>
     <main class="container" role="main">

--- a/platform/admin/ui/src/main/webapp/js/application.js
+++ b/platform/admin/ui/src/main/webapp/js/application.js
@@ -26,9 +26,8 @@ define([
     'text!templates/appHeader.handlebars',
     'text!templates/header.handlebars',
     'text!templates/footer.handlebars',
-    'text!templates/moduleTab.handlebars',
-    'text!templates/alerts.handlebars'
-    ],function (_, Backbone, Marionette, ich, $, poller, wreqr, Module, AppModel, tabs, appHeader, header, footer, moduleTab, alerts) {
+    'text!templates/moduleTab.handlebars'
+    ],function (_, Backbone, Marionette, ich, $, poller, wreqr, Module, AppModel, tabs, appHeader, header, footer, moduleTab) {
     'use strict';
 
     var Application = {};
@@ -46,7 +45,6 @@ define([
     ich.addTemplate('headerLayout', header);
     ich.addTemplate('footerLayout', footer);
     ich.addTemplate('moduleTab', moduleTab);
-    ich.addTemplate('alertsLayout', alerts);
 
     Application.App = new Marionette.Application();
 
@@ -57,7 +55,7 @@ define([
         footerRegion: 'footer',
         mainRegion: 'main',
         appHeader: '#appHeader',
-        alertsRegion: '#alerts'
+        alertsRegion: '.alerts'
     });
 
     //setup models

--- a/platform/admin/ui/src/main/webapp/js/application.js
+++ b/platform/admin/ui/src/main/webapp/js/application.js
@@ -105,8 +105,8 @@ define([
 
     Application.AppModel = new AppModel();
     Application.ModuleModel = new Module.Model();
-    Application.ModuleModel.fetch().success(addModuleRegions);
-    Application.AppModel.fetch().success(setHeader);
+    Application.ModuleModel.fetch().done(addModuleRegions);
+    Application.AppModel.fetch().done(setHeader);
 
     var modulePoller = poller.get(Application.ModuleModel, options);
     modulePoller.on('success', addModuleRegions);

--- a/platform/admin/ui/src/main/webapp/js/controllers/Feature.controller.js
+++ b/platform/admin/ui/src/main/webapp/js/controllers/Feature.controller.js
@@ -107,7 +107,7 @@ define([
                 if(status === "Uninstalled") {
                     var install = featureModel.install();
                     if(install){
-                        install.success(function() {
+                        install.done(function() {
                            self.showAppFeatures();
                         }).fail(function() {
                             if(console) {
@@ -118,7 +118,7 @@ define([
                 }else{
                     var uninstall = featureModel.uninstall();
                     if(uninstall){
-                        uninstall.success(function() {
+                        uninstall.done(function() {
                             self.showAppFeatures();
                         }).fail(function() {
                             if(console) {

--- a/platform/admin/ui/src/main/webapp/js/models/Alerts.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Alerts.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+define([
+    'underscore',
+    'backbone'
+], function (_, Backbone) {
+
+    var AlertsModel = {};
+
+    AlertsModel.AlertsDefaults = Backbone.Model.extend({
+        defaults: {
+            'banner': 'You should look at this.',
+            'button': 'Show',
+            'collapse': 'out'
+        }
+    });
+
+    //setup insecure defaults alerts
+    AlertsModel.InsecureAlerts = AlertsModel.AlertsDefaults.extend({
+        defaults: _.extend({}, AlertsModel.AlertsDefaults.prototype.defaults, {
+            'banner': 'The system is insecure because default configuration values are in use.'
+        }),
+        url: "/jolokia/exec/org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean:service=insecure-defaults-service/validate",
+        parse: function (resp) {
+            return {'items': resp.value};
+        }
+    });
+
+    AlertsModel.JolokiaAlerts = AlertsModel.AlertsDefaults.extend({
+        defaults: _.extend({}, AlertsModel.AlertsDefaults.prototype.defaults, {
+            'banner': 'Unable to save your changes.'
+        }),
+        parse: function (response) {
+            this.set('items', response.stacktrace.split(/\n/));
+        }
+    });
+
+    AlertsModel.Jolokia = function (jolokiaResponse) {
+        return new AlertsModel.JolokiaAlerts(jolokiaResponse, {'parse': true});
+    };
+
+    return AlertsModel;
+});

--- a/platform/admin/ui/src/main/webapp/js/models/Alerts.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Alerts.js
@@ -40,7 +40,15 @@ define([
             'banner': 'Unable to save your changes.'
         }),
         parse: function (response) {
-            this.set('items', response.stacktrace.split(/\n/));
+            if (response.stacktrace) {
+                var json = {'items': response.stacktrace.split(/\n/)};
+                if (response.stacktrace === 'Forbidden') {
+                    json.banner = 'Your session has expired. Please <a href="/login/index.html?prevurl=/admin/">log in</a> again.';
+                }
+                return json;
+            } else {
+                return response;
+            }
         }
     });
 

--- a/platform/admin/ui/src/main/webapp/js/models/Service.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Service.js
@@ -102,10 +102,11 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
                 try {
                     jsonResult = JSON.parse(jsonString.toString().trim());
                 } catch (e) {
-                    // this works around an issue in jolokia where the .toString() of an array
+                    // https://codice.atlassian.net/browse/DDF-1642
+                    // this works around an issue in json-simple where the .toString() of an array
                     // is returned in the arguments field of configs with array attributes,
-                    // causing the JSON string to be unparseable, so we remove it, since we
-                    // don't care about the arguments for our parsing needs
+                    // causing the JSON string from jolokia to be unparseable, so we remove it,
+                    // since we don't care about the arguments for our parsing needs
                     jsonString = jsonString.replace(/\[L[\w\.;@]*/g, '""');
                     jsonResult = JSON.parse(jsonString.toString().trim());
                 }

--- a/platform/admin/ui/src/main/webapp/js/models/Service.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Service.js
@@ -86,6 +86,40 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
         },
 
         /**
+         * Since jolokia always returns a 200, we need to parse the response
+         * to determine whether the request succeeded or failed, and trigger
+         * the corresponding callback
+         */
+        handleResult: function (result, deferred) {
+            // per ajax api, should be three args with the first
+            // either a string or a jqxhr object
+            if (!(result.length === 3 && (typeof result[0] === 'string' || result[0].setRequestHeader))) {
+                throw "Unexpected result contents";
+            }
+            var jsonResult;
+            var jsonString = result[0];
+            if (typeof jsonString === 'string') {
+                try {
+                    jsonResult = JSON.parse(jsonString.toString().trim());
+                } catch (e) {
+                    // this works around an issue in jolokia where the .toString() of an array
+                    // is returned in the arguments field of configs with array attributes,
+                    // causing the JSON string to be unparseable, so we remove it, since we
+                    // don't care about the arguments for our parsing needs
+                    jsonString = jsonString.replace(/\[L[\w\.;@]*/g, '""');
+                    jsonResult = JSON.parse(jsonString.toString().trim());
+                }
+            } else {
+                jsonResult = {'error': result[1], 'stacktrace': result[2]};
+            }
+            if (typeof jsonResult.error === 'undefined') {
+                deferred.resolve.apply(null, result);
+            } else {
+                deferred.reject.call(null, result[2], 'fail', jsonResult);
+            }
+        },
+
+        /**
          * When a model calls save the sync is called in Backbone.  I override it because this isn't a typical backbone
          * object
          * @return Return a deferred which is a handler with the success and failure callback.
@@ -102,35 +136,29 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
                 var collect = model.collectedData(model.get('properties').get("service.pid") || model.parents[0].get('id'));
                 var jData = JSON.stringify(collect);
 
-                return $.ajax({
+                $.ajax({
                     type: 'POST',
                     contentType: 'application/json',
                     data: jData,
                     url: addUrl
-                }).done(function (result) {
-                        deferred.resolve(result);
-                    }).fail(function (error) {
-                        deferred.fail(error);
-                    });
+                }).always(function () {
+                    model.handleResult(arguments, deferred);
+                });
             } else {
                 //no pid means this is a new record
                 model.makeConfigCall(model).done(function (data) {
                     var collect = model.collectedData(JSON.parse(data).value);
                     var jData = JSON.stringify(collect);
 
-                    return $.ajax({
+                    $.ajax({
                         type: 'POST',
                         contentType: 'application/json',
                         data: jData,
                         url: addUrl
-                    }).done(function (result) {
-                            deferred.resolve(result);
-                        }).fail(function (error) {
-                            deferred.fail(error);
-                        });
-                }).fail(function (error) {
-                        deferred.fail(error);
+                    }).always(function () {
+                        model.handleResult(arguments, deferred);
                     });
+                });
             }
             return deferred;
         },

--- a/platform/admin/ui/src/main/webapp/js/views/Alerts.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/Alerts.view.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'marionette',
+        'text!templates/alerts.handlebars',
+        'icanhaz'
+    ],
+    function (Marionette, alertsTemplate, ich) {
+
+        ich.addTemplate('alertsTemplate', alertsTemplate);
+
+        var AlertsView = {};
+
+        AlertsView.View = Marionette.ItemView.extend({
+            template: 'alertsTemplate',
+            tagName: 'table',
+            events: {
+                'shown.bs.collapse': 'toggleDetailsMsg',
+                'hidden.bs.collapse': 'toggleDetailsMsg'
+            },
+            modelEvents: {
+                'change': 'render'
+            },
+            /*jshint -W030 */
+            toggleDetailsMsg: function () {
+                var model = this.model;
+                model.get('button') === 'Show' ? model.set('button', 'Hide') : model.set('button', 'Show');
+                model.get('collapse') === 'out' ? model.set('collapse', 'in') : model.set('collapse', 'out');
+            },
+            serializeData: function () {
+                var json = this.model.toJSON();
+                json.collapseId = parseInt((Math.random() * Math.pow(2, 32)), 10);
+                return json;
+            }
+        });
+
+        return AlertsView;
+    });

--- a/platform/admin/ui/src/main/webapp/js/views/application/Application.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/application/Application.view.js
@@ -228,7 +228,7 @@ define([
         },
         saveChanges: function() {
             var view = this;
-            mvnUrlColl.save().success(function() {
+            mvnUrlColl.save().done(function() {
                 mvnUrlColl.reset();
                 view.response.fetch({
                     success: function(model){

--- a/platform/admin/ui/src/main/webapp/js/views/application/ApplicationGrid.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/application/ApplicationGrid.view.js
@@ -231,7 +231,7 @@ define([
         },
         saveChanges: function() {
             var view = this;
-            mvnUrlColl.save().success(function() {
+            mvnUrlColl.save().done(function() {
                 mvnUrlColl.reset();
                 view.response.fetch({
                     success: function(model){

--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -22,11 +22,13 @@ define([
     'js/wreqr.js',
     'spin',
     'jquery',
+    'js/models/Alerts.js',
+    'js/views/Alerts.view',
     'text!templates/configuration/configurationEdit.handlebars',
     'text!templates/configuration/configurationItem.handlebars',
     'text!templates/configuration/textTypeListHeader.handlebars',
     'text!templates/configuration/textTypeList.handlebars'
-], function (Marionette, ich, _, Backbone, wreqr, Spinner, $, configurationEdit, configurationItem, textTypeListHeader, textTypeList) {
+], function (Marionette, ich, _, Backbone, wreqr, Spinner, $, AlertsModel, AlertsView, configurationEdit, configurationItem, textTypeListHeader, textTypeList) {
 
     var ConfigurationEditView = {};
     var passwordType = 12;
@@ -181,7 +183,8 @@ define([
         tagName: 'div',
         className: 'modal-dialog',
         regions: {
-            configurationItems: '#config-div'
+            configurationItems: '#config-div',
+            jolokiaError: '.alerts'
         },
         /**
          * Button events, right now there's a submit button
@@ -297,18 +300,15 @@ define([
             }
 
             this.model.save().done(function () {
-                spinner.stop();
                 $('#config-modal').modal('hide');
                 // due to a bug in bootstrap, the backdrop does not get removed
                 // when calling 'hide' on the modal programmatically
                 $('.modal-backdrop').remove();
                 view.close();
                 wreqr.vent.trigger('refreshConfigurations');
-            }).fail(function (jqXHR, textStatus, errorThrown) {
+            }).always(function (dataOrjqXHR, textStatus, jqXHROrerrorThrown) {
                 spinner.stop();
-                $('#error-message').text(errorThrown.error);
-                $('#error-details').text(errorThrown.stacktrace);
-                $('#error-result').show();
+                view.jolokiaError.show(new AlertsView.View({'model': AlertsModel.Jolokia(jqXHROrerrorThrown)}));
             });
             wreqr.vent.trigger('sync');
             wreqr.vent.trigger('poller:start');

--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -299,16 +299,16 @@ define([
                 });
             }
 
-            this.model.save().done(function () {
+            this.model.save().always(function (dataOrjqXHR, textStatus, jqXHROrerrorThrown) {
+                spinner.stop();
+                view.jolokiaError.show(new AlertsView.View({'model': AlertsModel.Jolokia(jqXHROrerrorThrown)}));
+            }).done(function () {
                 $('#config-modal').modal('hide');
                 // due to a bug in bootstrap, the backdrop does not get removed
                 // when calling 'hide' on the modal programmatically
                 $('.modal-backdrop').remove();
                 view.close();
                 wreqr.vent.trigger('refreshConfigurations');
-            }).always(function (dataOrjqXHR, textStatus, jqXHROrerrorThrown) {
-                spinner.stop();
-                view.jolokiaError.show(new AlertsView.View({'model': AlertsModel.Jolokia(jqXHROrerrorThrown)}));
             });
             wreqr.vent.trigger('sync');
             wreqr.vent.trigger('poller:start');

--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -20,12 +20,14 @@ define([
     'underscore',
     'backbone',
     'js/wreqr.js',
+    'spin',
+    'jquery',
     'text!templates/configuration/configurationEdit.handlebars',
     'text!templates/configuration/configurationItem.handlebars',
     'text!templates/configuration/textTypeListHeader.handlebars',
     'text!templates/configuration/textTypeList.handlebars'
-    ], function (Marionette, ich, _, Backbone, wreqr, configurationEdit, configurationItem, textTypeListHeader, textTypeList ) {
-	
+], function (Marionette, ich, _, Backbone, wreqr, Spinner, $, configurationEdit, configurationItem, textTypeListHeader, textTypeList) {
+
     var ConfigurationEditView = {};
     var passwordType = 12;
 
@@ -85,7 +87,7 @@ define([
         },
         modelEvents: {
             "change": "updateValues"
-        },        
+        },
         initialize: function(options) {
             _.bindAll(this);
             this.configuration = options.configuration;
@@ -135,7 +137,7 @@ define([
          */
         plusButton: function() {
             this.addItem('');
-        }        
+        }
     });
 
     ConfigurationEditView.ConfigurationItem = Marionette.ItemView.extend({
@@ -180,7 +182,7 @@ define([
         className: 'modal-dialog',
         regions: {
             configurationItems: '#config-div'
-        },        
+        },
         /**
          * Button events, right now there's a submit button
          * I do not know where to go with the cancel button.
@@ -191,7 +193,7 @@ define([
             "click .enable-checkbox" : "toggleEnable",
             "change .sourceTypesSelect" : "render"
         },
-        
+
         /**
          * Initialize  the binder with the ManagedServiceFactory model.
          * @param options
@@ -255,9 +257,29 @@ define([
         /**
          * Submit to the backend.
          */
-        submitData: function() {
+        submitData: function () {
+            var spinner = new Spinner(define({
+                lines: 13, // The number of lines to draw
+                length: 12, // The length of each line
+                scale: 5, // The size of the spinner
+                width: 10, // The line thickness
+                radius: 30, // The radius of the inner circle
+                corners: 1, // Corner roundness (0..1)
+                rotate: 0, // The rotation offset
+                direction: 1, // 1: clockwise, -1: counterclockwise
+                color: '#000000', // #rgb or #rrggbb or array of colors
+                speed: 1, // Rounds per second
+                trail: 60, // Afterglow percentage
+                shadow: false, // Whether to render a shadow
+                hwaccel: false, // Whether to use hardware acceleration
+                className: 'spinner', // The CSS class to assign to the spinner
+                zIndex: 2e9, // The z-index (defaults to 2000000000)
+                top: 'auto', // Top position relative to parent in px
+                left: 'auto' // Left position relative to parent in px
+            }));
             wreqr.vent.trigger('beforesave');
             var view = this;
+            spinner.spin(view.el);
 
             if(this.service) {
                 if (!this.model.get('properties').has('service.pid')) {
@@ -274,14 +296,23 @@ define([
                 });
             }
 
-            this.model.save();
+            this.model.save().done(function () {
+                spinner.stop();
+                $('#config-modal').modal('hide');
+                // due to a bug in bootstrap, the backdrop does not get removed
+                // when calling 'hide' on the modal programmatically
+                $('.modal-backdrop').remove();
+                view.close();
+                wreqr.vent.trigger('refreshConfigurations');
+            }).fail(function (jqXHR, textStatus, errorThrown) {
+                spinner.stop();
+                $('#error-message').text(errorThrown.error);
+                $('#error-details').text(errorThrown.stacktrace);
+                $('#error-result').show();
+            });
             wreqr.vent.trigger('sync');
             wreqr.vent.trigger('poller:start');
 
-            _.defer(function() {
-                view.close();
-                wreqr.vent.trigger('refreshConfigurations');
-            });
         },
         /**
          * unbind the model and dom during close.
@@ -317,7 +348,7 @@ define([
         /**
          * This will set the defaults and set values for properties with cardinality of nonzero
          */
-        
+
         refresh: function() {
             wreqr.vent.trigger('refreshConfigurations');
         }

--- a/platform/admin/ui/src/main/webapp/js/views/installer/AnonClaims.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/installer/AnonClaims.view.js
@@ -143,7 +143,7 @@ define([
             var view = this;
             var saved = this.configObj.save();
             if (saved) {
-                saved.success(function () {
+                saved.done(function () {
                     view.navigationModel.nextStep('', 100);
                 }).fail(function () {
                     view.navigationModel.nextStep('Unable to Save Configuration: check logs', 0);

--- a/platform/admin/ui/src/main/webapp/less/configuration/style.less
+++ b/platform/admin/ui/src/main/webapp/less/configuration/style.less
@@ -64,20 +64,6 @@
   }
 }
 
-#error-message {
-  display: inline-block;
-}
-
-#error-result {
-  display: none;
-  text-align: left;
-}
-
-#error-details {
-  overflow: scroll;
-  max-height: 200px;
-}
-
 .no-results {
   height: 100px;
   display: table;

--- a/platform/admin/ui/src/main/webapp/less/configuration/style.less
+++ b/platform/admin/ui/src/main/webapp/less/configuration/style.less
@@ -64,6 +64,20 @@
   }
 }
 
+#error-message {
+  display: inline-block;
+}
+
+#error-result {
+  display: none;
+  text-align: left;
+}
+
+#error-details {
+  overflow: scroll;
+  max-height: 200px;
+}
+
 .no-results {
   height: 100px;
   display: table;

--- a/platform/admin/ui/src/main/webapp/main.js
+++ b/platform/admin/ui/src/main/webapp/main.js
@@ -124,12 +124,14 @@
         'icanhaz',
         'js/application',
         'js/views/Module.view',
+        'js/models/Alerts.js',
+        'js/views/Alerts.view',
         'properties',
         'js/HandlebarsHelpers',
         'modelbinder',
         'bootstrap',
         'templateConfig'
-    ], function ($, Backbone, Marionette, ich, Application, ModuleView, Properties) {
+    ], function ($, Backbone, Marionette, ich, Application, ModuleView, AlertsModel, AlertsView, Properties) {
 
         var app = Application.App;
 
@@ -153,35 +155,13 @@
             }));
         });
 
-        //setup insecure defaults alerts
-        var AlertsModel = Backbone.Model.extend({
-            url: "/jolokia/exec/org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean:service=insecure-defaults-service/validate",
-            parse: function (resp) {
-                return resp.value;
-            }
-        });
-        var alerts = new AlertsModel();
-
-        var AlertsView = Backbone.Marionette.ItemView.extend({
-            template: 'alertsLayout',
-            tagName: 'table',
-            events: {
-                'click #details': 'toggleDetailsMsg'
-            },
-            toggleDetailsMsg: function () {
-                if (!$('#collapseAlerts').hasClass('collapsing')) {
-                    $('#details').text(function (i, v) {
-                        return v === 'Show details' ? 'Hide details' : 'Show details';
-                    });
-                }
-            }
-        });
+        var alerts = new AlertsModel.InsecureAlerts();
 
         alerts.fetch({
             success: function () {
                 app.addInitializer(function () {
-                    Application.App.alertsRegion.show(new AlertsView({
-                        collection: alerts
+                    Application.App.alertsRegion.show(new AlertsView.View({
+                        model: alerts
                     }));
                 });
             }

--- a/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
@@ -16,7 +16,7 @@
         <div class="panel-heading">
             <h4 class="panel-title">
                 <i class="fa fa-exclamation-triangle"></i>
-                {{banner}}
+                {{{banner}}}
                 <button type="button" class="btn btn-link details" data-toggle="collapse"
                         data-parent=".accordion" data-target="#{{collapseId}}">{{button}} details
                 </button>

--- a/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
@@ -12,23 +12,30 @@
  **/
  --}}
 {{#notEmpty items}}
-<div class="panel panel-danger" id="accordion">
-  <div class="panel-heading">
-    <h4 class="panel-title">
-        <i class="fa fa-exclamation-triangle"></i>
-        The system is insecure because default configuration values are in use.
-        <a id="details" data-toggle="collapse" data-parent="#accordion" href="#collapseAlerts">Show details</a>
-    </h4>
-  </div>
-  <div id="collapseAlerts" class="panel-collapse collapse">
-    <table class="alerts-table">
-      {{#each items}}
-      <tr>
-       <td><i class="fa fa-chevron-circle-right"></i></td>
-       <td>{{this.message}}</td>
-      </tr>
-      {{/each}}
-    </table>
-  </div>
-</div>
+    <div class="panel panel-danger accordion">
+        <div class="panel-heading">
+            <h4 class="panel-title">
+                <i class="fa fa-exclamation-triangle"></i>
+                {{banner}}
+                <button type="button" class="btn btn-link details" data-toggle="collapse"
+                        data-parent=".accordion" data-target="#{{collapseId}}">{{button}} details
+                </button>
+
+            </h4>
+        </div>
+        <div class="panel-collapse collapse {{collapse}} collapseAlerts" id="{{collapseId}}">
+            <table class="alerts-table">
+                {{#each items}}
+                    <tr>
+                        <td><i class="fa fa-chevron-circle-right"></i></td>
+                        <td>{{#if this.message}}
+                            {{this.message}}
+                        {{else}}
+                            {{this}}
+                        {{/if}}</td>
+                    </tr>
+                {{/each}}
+            </table>
+        </div>
+    </div>
 {{/notEmpty}}

--- a/platform/admin/ui/src/main/webapp/templates/configuration/configurationEdit.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/configurationEdit.handlebars
@@ -26,21 +26,7 @@
         </form>
     </div>
     <div class="modal-footer">
-        <div id="error-result" class="well">
-            <div class="container">
-                <div class="row">
-                    <div class="col-md-10">
-                        <div id="error-message" class="alert alert-danger"></div>
-                    </div>
-                    <button type="button" class="btn btn-link col-md-2" data-toggle="collapse"
-                            data-target="#error-details-container">
-                        Show Details
-                    </button>
-                </div>
-            </div>
-            <div id="error-details-container" class="collapse out">
-                <div id="error-details"></div>
-            </div>
+        <div class="alerts">
         </div>
         <div class="btn-group">
             <button type="button" class="btn btn-primary submit-button">Save changes</button>

--- a/platform/admin/ui/src/main/webapp/templates/configuration/configurationEdit.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/configurationEdit.handlebars
@@ -11,7 +11,7 @@
  *
  **/
  --}}
-<div class="modal-content">
+<div class="modal-content" id="config-modal">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title">{{#if name}}{{name}}{{else}} {{service.name}} {{/if}}</h4>
@@ -26,8 +26,24 @@
         </form>
     </div>
     <div class="modal-footer">
+        <div id="error-result" class="well">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-10">
+                        <div id="error-message" class="alert alert-danger"></div>
+                    </div>
+                    <button type="button" class="btn btn-link col-md-2" data-toggle="collapse"
+                            data-target="#error-details-container">
+                        Show Details
+                    </button>
+                </div>
+            </div>
+            <div id="error-details-container" class="collapse out">
+                <div id="error-details"></div>
+            </div>
+        </div>
         <div class="btn-group">
-            <button type="button" class="btn btn-primary submit-button" data-dismiss="modal">Save changes</button>
+            <button type="button" class="btn btn-primary submit-button">Save changes</button>
             <button type="button" class="btn btn-default cancel-button" data-dismiss="modal">Cancel</button>
         </div>
     </div>


### PR DESCRIPTION
@djblue @AzGoalie @harrison-tarr @andrewkfiedler @stustison 

@clockard will hero

There are a couple of things you can do to manually try this out. In chrome, you can open a config to edit in the admin ui, then hit `/logout` in a separate  tab and try to save the configuration. You should get an error because you no longer have admin privileges to hit jolokia. You can also hook up a debugger and interfere on the backend to cause an exception to be thrown when the config is saved. This has the additional benefit of showing off the new spinner while the backend is suspended.

If any errors occur, they look something like this (`Forbidden` gets a special message):
![screen shot 2015-11-12 at 14 37 27](https://cloud.githubusercontent.com/assets/8660335/11132072/23ef9168-894b-11e5-8a7c-7a9a34e0c307.png)



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/314)
<!-- Reviewable:end -->
