### PR TITLE
DDF-1640 Incorrectly configured Woodstox dependency configuration.

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <version>${lux.woodstox.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.xml.stream</groupId>
             <artifactId>stax-api</artifactId>
             <version>1.0-2</version>

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -173,6 +173,7 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
+            <version>${lux.woodstox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/catalog/solr/catalog-solr-embedded-provider/pom.xml
+++ b/catalog/solr/catalog-solr-embedded-provider/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
+            <version>${lux.woodstox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/catalog/solr/catalog-solr-external-provider/pom.xml
+++ b/catalog/solr/catalog-solr-external-provider/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
+            <version>${lux.woodstox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/catalog/solr/catalog-solr-external-provider/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
+++ b/catalog/solr/catalog-solr-external-provider/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
@@ -1,0 +1,1 @@
+com.ctc.wstx.stax.WstxInputFactory

--- a/catalog/ui/search-ui/search-endpoint/pom.xml
+++ b/catalog/ui/search-ui/search-endpoint/pom.xml
@@ -191,6 +191,7 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
+            <version>${lux.woodstox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
@@ -1,0 +1,1 @@
+com.ctc.wstx.stax.WstxInputFactory

--- a/platform/solr/platform-solr-server-standalone/pom.xml
+++ b/platform/solr/platform-solr-server-standalone/pom.xml
@@ -135,6 +135,16 @@
                                     </outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
+                                    <groupId>org.codehaus.woodstox</groupId>
+                                    <artifactId>woodstox-core-asl</artifactId>
+                                    <version>${lux.woodstox.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>
+                                        ${project.build.directory}/${project.artifactId}-${project.version}/WEB-INF/lib
+                                    </outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>com.google.guava</groupId>
                                     <artifactId>guava</artifactId>
                                     <version>14.0.1</version>
@@ -245,11 +255,7 @@
                             WEB-INF/lib/Saxon-HE-${saxon.version}.jar,
                             WEB-INF/lib/solr-xpath-${project.version}.jar,
                             WEB-INF/lib/stax2-api-3.1.1.jar,
-                            WEB-INF/lib/woodstox-core-asl-${woodstox.version}.jar,
-                            WEB-INF/lib/metrics-core-3.0.1.jar,
-                            WEB-INF/lib/lz4-1.2.0.jar,
-                            WEB-INF/lib/netty-3.6.6.Final.jar,
-                            WEB-INF/lib/snappy-java-1.1.0.1.jar,
+                            WEB-INF/lib/woodstox-core-asl-${lux.woodstox.version}.jar,
 
                             <!-- Solr WAR libs -->
                             WEB-INF/lib/antlr-runtime-3.5.jar,
@@ -295,7 +301,6 @@
                             WEB-INF/lib/solr-core-4.10.4.jar,
                             WEB-INF/lib/solr-solrj-4.10.4.jar,
                             WEB-INF/lib/spatial4j-0.4.1.jar,
-                            WEB-INF/lib/wstx-asl-3.2.7.jar,
                             WEB-INF/lib/zookeeper-3.4.6.jar,
                         </Bundle-ClassPath>
                         <Private-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <handlebars.version>2.0.0</handlebars.version>
         <antlr.version>4.3</antlr.version>
+        <lux.woodstox.version>4.1.1</lux.woodstox.version>
     </properties>
 
     <!--


### PR DESCRIPTION
This causes an indeterminate version to be selected at runtime, sometimes resulting in errors interacting with Lux.

@pklinef 
@tbatie Please hero this
@ryeats
@stustison

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/323)
<!-- Reviewable:end -->
