### PR TITLE
DDF-1633 Fix Admin UI source tab bugs

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
@@ -95,7 +95,7 @@ define(function (require) {
         makeEnableCall: function(){
             var model = this;
             var deferred = $.Deferred();
-            var pid = model.getServicePid();
+            var pid = model.get('id');
             var url = [model.configUrl, "enableConfiguration", pid].join("/");
             if(pid){
                 $.ajax({
@@ -122,7 +122,7 @@ define(function (require) {
         makeDisableCall: function(){
             var model = this;
             var deferred = $.Deferred();
-            var pid = model.getServicePid();
+            var pid = model.get('id');
             var url = [model.configUrl, "disableConfiguration", pid].join("/");
             if(pid){
                 $.ajax({
@@ -134,7 +134,7 @@ define(function (require) {
                         model.destroy();
                         deferred.resolve();
                     }).fail(function(){
-                        deferred.reject(new Error('Could not disable configuratoin ' + pid));
+                        deferred.reject(new Error('Could not disable configuration ' + pid));
                         deferred.resolve();
                     });
             } else {
@@ -144,17 +144,16 @@ define(function (require) {
             return deferred;
         },
 
-        getServicePid: function(){
-            var props = this.get('properties');
-            if (props) {
-                var config = props.parents[0];
-                if (config) {
-                    return config.id;
-                }
-            }
-            return null;
+        // Used to make a call to the backend to disable the service that corresponds to the pid.
+        // Note: this does NOT affect the service the function is called on.
+        // Treat this as a static function
+        makeDisableCallByPid: function(pid){
+           var url = [this.configUrl, "disableConfiguration", pid].join("/");
+           return $.ajax({
+               url: url,
+               dataType: 'json'
+           });
         },
-
 
         /**
          * When a model calls save the sync is called in Backbone.  I override it because this isn't a typical backbone
@@ -163,26 +162,24 @@ define(function (require) {
          */
         sync: function () {
             var deferred = $.Deferred(),
-                model = this,
-                addUrl = [model.configUrl, "add"].join("/");
+                model = this;
             //if it has a pid we are editing an existing record
-            if(model.parents.length > 0 && model.parents[0].get('id')) {
-                var collect = model.parents[0].get('id');
+            if(model.id) {
+                var collect = model.collectedData(model.id);
                 var jData = JSON.stringify(collect);
 
                 return $.ajax({
                     type: 'POST',
                     contentType: 'application/json',
                     data: jData,
-                    url: addUrl
+                    url: model.configUrl
                 }).done(function (result) {
                         deferred.resolve(result);
                     }).fail(function (error) {
                         deferred.fail(error);
                     });
-            }
-            else //no pid means this is a new record
-            {
+             //no pid means this is a new record
+            } else {
                 model.makeConfigCall(model).done(function (data) {
                     var collect = model.collectedData(JSON.parse(data).value);
                     var jData = JSON.stringify(collect);
@@ -191,7 +188,7 @@ define(function (require) {
                         type: 'POST',
                         contentType: 'application/json',
                         data: jData,
-                        url: addUrl
+                        url: model.configUrl
                     }).done(function (result) {
                         deferred.resolve(result);
                     }).fail(function (error) {

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -51,6 +51,14 @@ function (wreqr, Service, Backbone, _, poller, Status) {
             }
         },
         setCurrentConfiguration: function(configuration) {
+            // check to see if the source already has a 'currentConfiguration'
+            // if it does, make the currentConfiguration disabled and move it to the disabledConfiguration
+            // list
+            var currentConfig = this.get('currentConfiguration');
+            if (currentConfig) {
+                currentConfig.makeDisableCall();
+                this.addDisabledConfiguration(currentConfig);
+            }
             this.set({currentConfiguration: configuration});
 
             var pid = configuration.id;

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
@@ -73,7 +73,7 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
          */
         initialize: function(options) {
             _.bindAll(this);
-            this.parentModel = options.parentModel;
+            this.source = options.source;
             this.modelBinder = new Backbone.ModelBinder();
             this.mode = options.mode;
         },
@@ -152,34 +152,47 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
         submitData: function() {
             wreqr.vent.trigger('beforesave');
             var view = this;
-            var model = view.model.get('editConfig');
-            if (model) {
-                var fpid = model.get("fpid");
-                var idx = fpid.indexOf("_disabled");
-                if (idx > 0) {
-                    model.set("fpid", fpid.substring(0, idx));
-                }
-                model.save().then(function() {
-                    var needsRefresh = true;
-                    var existingSource = view.parentModel.get('collection').find(function(item) {
-                        var config = item.get('currentConfiguration');
-                        return (config && config.id === model.id);
-                    });
-                    if (existingSource) {
-                        var toDisable = existingSource.get('currentConfiguration');
-                        if (toDisable) {
-                            $.when(toDisable.makeDisableCall()).then(function() {
-                                wreqr.vent.trigger('refreshSources');
-                                view.closeAndUnbind();
-                            });
-                            needsRefresh = false;
-                        }
-                    }
-                    if (needsRefresh) {
+            var service = view.model.get('editConfig');
+            if (service) {
+            var fpid = service.get("fpid");
+            var idx = fpid.indexOf("_disabled");
+            if (idx > 0) {
+               service.set("fpid", fpid.substring(0, idx));
+            }
+            service.save().then(function(response) {
+                // check to see if the service corresponds to an existing source
+                // if it does, return the source
+                var existingSource = view.source.get('collection').find(function(item) {
+                    var config = item.get('currentConfiguration');
+                   return (config && config.get('properties').id === service.get('properties').id);
+                });
+
+                // Logic to check if the service we are adding is going to be a member of an already existing source;
+                // if it is, we need to disable the new service as soon at is created.
+                if (existingSource && view.mode === 'add' && existingSource.get('currentConfiguration') !== service) {
+
+                    // https://codice.atlassian.net/browse/DDF-1642
+                    // this works around an issue in json-simple where the .toString() of an array
+                    // is returned in the arguments field of configs with array attributes,
+                    // causing the JSON string from jolokia to be unparseable, so we remove it,
+                    // since we don't care about the arguments for our parsing needs
+
+                    response = response.replace(/\[L[\w\.;@]*/g, '""');
+                    var jsonResult = JSON.parse(response.toString().trim());
+
+                    // Since the source we are editing has a currentConfig already, we don't want to disable it.
+                    // Using the response from the creation of the new service, disable the newly created service
+                    // with a call to makeDisableCallByPid.
+
+                    Service.Configuration.prototype.makeDisableCallByPid(jsonResult.request['arguments'][0]).done(function() {
                         wreqr.vent.trigger('refreshSources');
                         view.closeAndUnbind();
-                    }
-                },
+                    });
+                } else {
+                    wreqr.vent.trigger('refreshSources');
+                    view.closeAndUnbind();
+                }
+            },
                 function() {
                     wreqr.vent.trigger('refreshSources');
                 }).always(function() {
@@ -255,7 +268,7 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
         },
         nameIsValid: function(name, fpid) {
             var valid = false;
-            var configs = this.parentModel.get('collection');
+            var configs = this.source.get('collection');
             var match = configs.find(function(sourceConfig) {
                 return sourceConfig.get('name') === name;
             });
@@ -274,13 +287,13 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
             if (!_.isUndefined(modelConfig) && (modelConfig.get('fpid') === fpid || modelConfig.get('fpid') + "_disabled" === fpid)) {
                 matchFound = true;
             } else if (!_.isUndefined(disabledConfigs)) {
-                matchFound = !_.isUndefined(disabledConfigs.find(function(modelConfig) {
+                matchFound = !_.isUndefined(disabledConfigs.find(function(modelDisableConfig) {
                     //check the ID property to ensure that the config we're checking exists server side
                     //otherwise assume it's a template/placeholder for filling in the default modal form data
-                    if (_.isUndefined(modelConfig.id)) {
+                    if (_.isUndefined(modelDisableConfig.id)) {
                         return false;
                     } else {
-                        return modelConfig.get('fpid') === fpid;
+                        return (modelDisableConfig.get('fpid') === fpid || modelDisableConfig.get('fpid') + "_disabled" === fpid);
                     }
                 }));
             }

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -81,8 +81,8 @@ function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,
         },
         editSource: function(evt) {
             evt.stopPropagation();
-            var model = this.model;
-            wreqr.vent.trigger('editSource', model);
+            var service = this.model;
+            wreqr.vent.trigger('editSource', service);
         },
         changeConfiguration: function(evt) {
             var model = this.model;
@@ -171,11 +171,11 @@ function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,
                 }
             });
         },
-        editSource: function(model) {
+        editSource: function(service) {
             wreqr.vent.trigger("showModal",
                 new ModalSource.View({
-                    model: model,
-                    parentModel: this.model,
+                    model: service,
+                    source: this.model,
                     mode: 'edit'
                 })
             );
@@ -195,7 +195,7 @@ function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,
                 wreqr.vent.trigger("showModal",
                     new ModalSource.View({
                         model: this.model.getSourceModelWithServices(),
-                        parentModel: this.model,
+                        source: this.model,
                         mode: 'add'
                     })
                 );
@@ -238,7 +238,41 @@ function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,
         itemView: SourceView.DeleteItem,
         itemViewContainer: '.modal-body',
         events: {
-            'click .submit-button' : 'deleteSources'
+            'click .submit-button' : 'deleteSources',
+            'click .deleteSource' : 'toggleChecks',
+            'click .selectSourceDelete' : 'toggleChecks'
+        },
+        toggleChecks: function(e) {
+            var view = this;
+            var checked = e.target.checked;
+            // Loop through all the source views available to get the one relevant to the click.
+            // We don't want to go deleting/checking the wrong source/service.
+            var sourceView = view.children.find(function (childView) {
+                return (childView.model.get("name") === e.target.value);
+            });
+
+            // Check to see if user clicked the source (top-level) checkbox or a service checkbox.
+            if (e.target.className === "deleteSource") {
+                // If user clicked source checkbox, toggle all services underneath to match it.
+                sourceView.$(".selectSourceDelete").each(function() {
+                    this.checked = checked;
+                });
+            } else if (e.target.className === "selectSourceDelete") {
+                // If user deselected a service checkbox, make sure to also deselect the source checkbox.
+                if (!checked) {
+                    sourceView.$(".deleteSource")[0].checked = false;
+
+                // Check to see if a user has manually selected all the services in a source, if they have,
+                // also select the source checkbox.
+                } else if (checked) {
+                    var allChecked = true;
+                    sourceView.$(".selectSourceDelete").each(function() {
+                        allChecked = allChecked && this.checked;
+                    });
+                    sourceView.$(".deleteSource")[0].checked = allChecked;
+                }
+            }
+
         },
         deleteSources: function() {
             var view = this;
@@ -250,11 +284,11 @@ function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,
                     if (content.checked) {
 
                         var id = currentConfig ? currentConfig.get('id') : null;
-                        if (id === content.value) {
+                        if (id === content.id) {
                             toDelete.push(view.createDeletePromise(item, currentConfig));
                         } else if (disableConfigs) {
                             disableConfigs.each(function (disabledConfig) {
-                                if (disabledConfig.get('id') === content.value) {
+                                if (disabledConfig.get('id') === content.id) {
                                     toDelete.push(view.createDeletePromise(item, disabledConfig));
                                 }
                             });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/deleteSource.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/deleteSource.handlebars
@@ -11,14 +11,17 @@
  *
  **/
  --}}
-<div class="delete-source-name">{{name}}</div>
+<div class="delete-source-name">
+    <input class="deleteSource" type="checkbox" value="{{name}}"> {{name}}
+
+</div>
 {{#if currentConfiguration}}
     <div class="delete-source-config">
-        <input class="selectSourceDelete" type="checkbox" value="{{currentConfiguration.attributes.id}}"> {{currentConfiguration.attributes.name}}
+        <input class="selectSourceDelete" type="checkbox" id="{{currentConfiguration.attributes.id}}" value="{{name}}"> {{currentConfiguration.attributes.name}}
     </div>
 {{/if}}
 {{#each disabledConfigurations.models}}
     <div class="delete-source-config">
-        <input class="selectSourceDelete" type="checkbox" value="{{attributes.id}}"> {{attributes.service.attributes.name}} <span class="label label-danger">Disabled</label>
+        <input class="selectSourceDelete" type="checkbox" id="{{attributes.id}}" value="{{attributes.properties.attributes.id}}"> {{attributes.service.attributes.name}} <span class="label label-danger">Disabled</label>
     </div>
 {{/each}}

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdmin.java
@@ -443,7 +443,7 @@ public class ConfigurationAdmin implements ConfigurationAdminMBean {
         List<Map<String, Object>> tempMetatype = null;
         for (Map<String, Object> service : services) {
             String id = String.valueOf(service.get(ConfigurationAdminExt.MAP_ENTRY_ID));
-            if (id.equals(config.getPid()) || (id.equals(config.getFactoryPid()) && Boolean
+            if (id.equals(config.getPid()) || ((id.equals(config.getFactoryPid()) || (id + "_disabled").equals(config.getFactoryPid())) && Boolean
                     .valueOf(String.valueOf(service.get(ConfigurationAdminExt.MAP_FACTORY))))) {
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> mapList = (List<Map<String, Object>>) service


### PR DESCRIPTION
Could create duplicate service configurations of the same type under
the same Source name
Could not create multiple service configurations of different types
under the same Source name

DDF-1633 Add "delete source" check

Deleting each service config was getting annoying during debugging
so I added the ability to delete all configs. This should be useful
to admins irl too.

DDF-1633 Allow editing a disabled source

ConfigurationAdmin would only match a metatype if it was enabled
now it will match in both case and allow updating

DDF-1633 Fix delete source

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/328)
<!-- Reviewable:end -->
