### PR TITLE
DDF-1653 Removes erroneous instructions blocks from pom files.

### DIFF
--- a/libs/activities/pom.xml
+++ b/libs/activities/pom.xml
@@ -42,12 +42,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>clean verify install</preparationGoals>
                         <pushChanges>false</pushChanges>
-                        <instructions>
-                            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                            <Embed-Dependency>
-                                joda-time
-                            </Embed-Dependency>
-                        </instructions>
                     </configuration>
                 </plugin>
             </plugins>

--- a/libs/notifications/pom.xml
+++ b/libs/notifications/pom.xml
@@ -43,12 +43,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>clean verify install</preparationGoals>
                         <pushChanges>false</pushChanges>
-                        <instructions>
-                            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                            <Embed-Dependency>
-                                joda-time
-                            </Embed-Dependency>
-                        </instructions>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
During a routine scan of poms for cruft, these two blocks were found.

@pklinef 
@tbatie 
@jckilmer
@ryeats

Jason, please hero.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/335)
<!-- Reviewable:end -->
