### PR TITLE
DDF-1670: removed incorrect include statement in Managing documentation.

### DIFF
--- a/distribution/docs/src/main/resources/ManContents.adoc
+++ b/distribution/docs/src/main/resources/ManContents.adoc
@@ -222,7 +222,6 @@ Based on the browser's configuration, the .xls file will be downloaded or automa
 ====
 
 == Using {branding}
-include::config.adoc[]
 
 === Overview
 Distributed Data Framework ({branding}) is an agile and modular integration framework.  It is primarily focused on data integration, enabling clients to insert, query and transform information from disparate data sources via the {branding} Catalog. A Catalog API allows integrators to insert new capabilities at various stages throughout each operation.  {branding} is designed with the following architectural qualities to benefit integrators.


### PR DESCRIPTION
Including config.adoc[] files only work at head of file.


@pklinef @vinamartin @djblue @stustison @clockard 