### PR TITLE
DDF-1660 Fix bug with config

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -243,6 +243,7 @@ define([
             _.each(bindObjs, function(value) {
                 if(view.$(value.selector).attr('type') === 'checkbox') {
                     value.converter = function(direction, bindValue) {
+                        bindValue = bindValue || false;
                         switch(direction) {
                             case 'ViewToModel':
                                 return bindValue.toString();


### PR DESCRIPTION
If someone imports a config that doesn't have a setting,
it can give an undefined boolean which causes issues. This
is now fixed

This is an additional bug fix that came up after the fact for https://github.com/codice/ddf/pull/345/

@jckilmer @andrewkfiedler @stustison 