### PR TITLE
DDF-1698 Mark invalid metacards as invalid

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -222,7 +222,7 @@
         <bundle>mvn:ddf.catalog.security/catalog-security-ingestplugin/${project.version}</bundle>
     </feature>
     
-    <feature name="catalog-admin-module-sources" install="manual" vrsion="${project.version}"
+    <feature name="catalog-admin-module-sources" install="manual" version="${project.version}"
              description="DDF Admin Module">
         <bundle>mvn:ddf.catalog.admin/catalog-admin-module-sources/${project.version}</bundle>
     </feature>
@@ -250,6 +250,11 @@
         <feature>catalog-admin-module-sources</feature>
         <feature>catalog-core-backupplugin</feature>
         <feature>catalog-plugin-jpeg2000</feature>
-    </feature>   
+    </feature>
+
+    <feature name="catalog-plugin-metacard-validation" install="manual" version="${project.version}"
+             description="DDF Metacard Validator Plugins">
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacard-validation/${project.version}</bundle>
+    </feature>
         
 </features>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
@@ -72,6 +72,41 @@ public class AttributeImpl implements Attribute {
         this.values = createPopulatedList(value);
     }
 
+    /**
+     * Multivalued Constructor
+     *
+     * @param name
+     *            - the name of this {@link Attribute}
+     * @param values
+     *            - the value of this {@link Attribute}
+     */
+
+    public AttributeImpl(String name, List<Serializable> values) {
+        /*
+         * If any defensive logic is added to this constructor, then that logic should be reflected
+         * in the deserialization (readObject()) of this object so that the integrity of a
+         * serialized object is maintained. For instance, if a null check is added in the
+         * constructor, the same check should be added in the readObject() method.
+         */
+        this.name = name;
+        this.values = new LinkedList<>(values);
+    }
+
+    /**
+     * Copy Constructor
+     */
+
+    public AttributeImpl(Attribute attribute) {
+        /*
+         * If any defensive logic is added to this constructor, then that logic should be reflected
+         * in the deserialization (readObject()) of this object so that the integrity of a
+         * serialized object is maintained. For instance, if a null check is added in the
+         * constructor, the same check should be added in the readObject() method.
+         */
+        this(attribute.getName(), attribute.getValues());
+    }
+
+
     @Override
     public String getName() {
         return name;

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -27,7 +27,6 @@ import ddf.catalog.data.MetacardType;
  * Constants for basic types, both {@link MetacardType} and {@link AttributeType}
  *
  * @author ddf.isgs@lmco.com
- *
  */
 public class BasicTypes {
 
@@ -95,6 +94,10 @@ public class BasicTypes {
      * A Constant for an {@link AttributeType} with {@link AttributeFormat#SHORT}.
      */
     public static final AttributeType<Short> SHORT_TYPE;
+
+    public static final String VALIDATION_WARNINGS = "validation-warnings";
+
+    public static final String VALIDATION_ERRORS = "validation-errors";
 
     static {
 
@@ -288,32 +291,42 @@ public class BasicTypes {
                 false /* tokenized */, false /* multivalued */, DATE_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.CREATED, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, DATE_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.ID, true /* indexed */, true /* stored */,
-                false /* tokenized */, false /* multivalued */, STRING_TYPE));
+        descriptors
+                .add(new AttributeDescriptorImpl(Metacard.ID, true /* indexed */, true /* stored */,
+                        false /* tokenized */, false /* multivalued */, STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.TITLE, true /* indexed */, true /* stored */,
                 true /* tokenized */, false /* multivalued */, STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.POINT_OF_CONTACT, true /* indexed */, true /* stored */,
-                false /* tokenized */, false /* multivalued */, STRING_TYPE));
+        descriptors
+                .add(new AttributeDescriptorImpl(Metacard.POINT_OF_CONTACT, true /* indexed */, true /* stored */,
+                        false /* tokenized */, false /* multivalued */, STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.CONTENT_TYPE, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.CONTENT_TYPE_VERSION, true /* indexed */,
-                true /* stored */, false /* tokenized */, false /* multivalued */, STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.TARGET_NAMESPACE, true /* indexed */, true /* stored */,
-                false /* tokenized */, false /* multivalued */, STRING_TYPE));
+        descriptors
+                .add(new AttributeDescriptorImpl(Metacard.CONTENT_TYPE_VERSION, true /* indexed */,
+                        true /* stored */, false /* tokenized */, false /* multivalued */,
+                        STRING_TYPE));
+        descriptors
+                .add(new AttributeDescriptorImpl(Metacard.TARGET_NAMESPACE, true /* indexed */, true /* stored */,
+                        false /* tokenized */, false /* multivalued */, STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.METADATA, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, XML_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_URI, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_DOWNLOAD_URL, false /* indexed */,
                 false /* stored */, false /* tokenized */, false /* multivalued */, STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_SIZE, false /* indexed */, true /* stored */,
-                false /* tokenized */, false /* multivalued */, STRING_TYPE));
+        descriptors
+                .add(new AttributeDescriptorImpl(Metacard.RESOURCE_SIZE, false /* indexed */, true /* stored */,
+                        false /* tokenized */, false /* multivalued */, STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.THUMBNAIL, false /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, BINARY_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.GEOGRAPHY, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, GEO_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.DESCRIPTION, true /* indexed */, true /* stored */,
                 false /* tokenized */, false /* multivalued */, STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(VALIDATION_WARNINGS, true /* indexed */, true /* stored */,
+                false /* tokenized */, true /* multivalued */, STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(VALIDATION_ERRORS, true /* indexed */, true /* stored */,
+                false /* tokenized */, true /* multivalued */, STRING_TYPE));
 
         basic = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME, descriptors);
 

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -227,7 +228,7 @@ public class MetacardImplTest {
         mc.setContentTypeName(null);
         mc.setContentTypeVersion(null);
         mc.setAttribute(null);
-        mc.setAttribute(new AttributeImpl("testNullValueAtt1", null));
+        mc.setAttribute(new AttributeImpl("testNullValueAtt1", (Serializable) null));
         mc.setAttribute("testNullValueAtt2", null);
         mc.setCreatedDate(null);
         mc.setEffectiveDate(null);

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -90,7 +90,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package>
-                            ddf.catalog*;version=2.0.12
+                            ddf.catalog*
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -304,6 +304,12 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     }
 
     @Override
+    public SolrQuery propertyIsEqualTo(String propertyName, boolean literal) {
+        String mappedPropertyName = getMappedPropertyName(propertyName, AttributeFormat.BOOLEAN, true);
+        return new SolrQuery(mappedPropertyName + ":" + literal);
+    }
+
+    @Override
     public SolrQuery propertyIsGreaterThan(String propertyName, Date startDate) {
         String formattedStartDate = formatDate(startDate);
         return buildDateQuery(propertyName, SOLR_EXCLUSIVE_START, formattedStartDate,

--- a/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ddf.catalog.plugin</groupId>
+    <artifactId>catalog-plugin-metacard-validation</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Catalog :: Metacard Validation Plugin</name>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>antlr</groupId>
+            <artifactId>antlr</artifactId>
+            <version>2.7.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package />
+                        <Embed-Dependency>catalog-core-api-impl, commons-lang3</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.8</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.8</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.6</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.8</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.validation;
+
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PreQueryPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MetacardValidityCheckerPlugin.class);
+
+    protected final FilterBuilder filterBuilder;
+
+    protected final FilterAdapter filterAdapter;
+
+    public MetacardValidityCheckerPlugin(FilterBuilder filterBuilder, FilterAdapter filterAdapter) {
+        this.filterBuilder = filterBuilder;
+        this.filterAdapter = filterAdapter;
+    }
+
+    @Override
+    public QueryRequest process(QueryRequest input)
+            throws PluginExecutionException, StopProcessingException {
+        QueryRequest queryRequest;
+        try {
+            if (!filterAdapter.adapt(input.getQuery(), new ValidationQueryDelegate())) {
+                QueryImpl query = new QueryImpl(filterBuilder.allOf(input.getQuery(),
+                        filterBuilder.attribute(VALIDATION_ERRORS).is().empty(),
+                        filterBuilder.attribute(VALIDATION_WARNINGS).is().empty()));
+                queryRequest = new QueryRequestImpl(query, input.isEnterprise(),
+                        input.getSourceIds(), input.getProperties());
+            } else {
+                queryRequest = input;
+            }
+        } catch (UnsupportedQueryException e) {
+            LOGGER.debug("This attribute filter is not supported by ValidationQueryDelegate.", e);
+            throw new StopProcessingException(e.getMessage());
+        }
+        return queryRequest;
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.validation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PreIngestPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+
+public class MetacardValidityMarkerPlugin implements PreIngestPlugin {
+
+    private List<String> enforcedMetacardValidators;
+
+    private List<MetacardValidator> metacardValidators;
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MetacardValidityMarkerPlugin.class);
+
+    public static final String VALIDATION_ERRORS = BasicTypes.VALIDATION_ERRORS;
+    public static final String VALIDATION_WARNINGS = BasicTypes.VALIDATION_WARNINGS;
+
+    public CreateRequest process(CreateRequest input)
+            throws PluginExecutionException, StopProcessingException {
+
+        // Initialize empty list of metacards to allow through
+        List<Metacard> returnMetacards = new ArrayList<Metacard>();
+        // Loop all metacards in request
+        for (Metacard metacard : input.getMetacards()) {
+            MetacardImpl newMetacard = new MetacardImpl(metacard);
+            List<Serializable> validationWarnings = new LinkedList<>();
+            List<Serializable> validationErrors = new LinkedList<>();
+            // Default to allowing metacard through
+            Boolean toReturn = true;
+            // Run metacard through each validator
+            for (MetacardValidator metacardValidator : metacardValidators) {
+                try {
+                    // Attempt validation
+                    metacardValidator.validate(metacard);
+                } catch (ValidationException e) {
+                    // If validator is not explicitly turned on by admin, set invalid and allow through
+                    if (checkEnforcedMetacardValidators(metacardValidator)) {
+                        Boolean validationErrorsExist = !e.getErrors().isEmpty();
+                        Boolean validationWarningsExist = !e.getWarnings().isEmpty();
+                        if (validationErrorsExist || validationWarningsExist) {
+                            // Check for warnings and errors
+                            if (validationErrorsExist) {
+                                validationErrors.add(getValidatorName(metacardValidator));
+                            }
+                            if (validationWarningsExist) {
+                                validationWarnings.add(getValidatorName(metacardValidator));
+                            }
+                        } else {
+                            LOGGER.error(
+                                    "Metacard validator {} did not have any warnings or errors but it threw a validation exception."
+                                            + " There is likely something wrong with your implementation. This will result in the metacard not"
+                                            + " being properly marked as invalid.",
+                                    getValidatorName(metacardValidator));
+                        }
+
+                    } else {
+                        // If validator is explicitly turned on, break out and do not include in the
+                        // list of metacards that will be allowed through.
+                        toReturn = false;
+                        break;
+                    }
+
+                }
+            }
+            if (toReturn) {
+                newMetacard
+                        .setAttribute(new AttributeImpl(VALIDATION_WARNINGS, validationWarnings));
+                newMetacard.setAttribute(new AttributeImpl(VALIDATION_ERRORS, validationErrors));
+                returnMetacards.add(newMetacard);
+            }
+        }
+        return new CreateRequestImpl(returnMetacards, input.getProperties());
+    }
+
+    @Override
+    public UpdateRequest process(UpdateRequest input)
+            throws PluginExecutionException, StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public DeleteRequest process(DeleteRequest input)
+            throws PluginExecutionException, StopProcessingException {
+        return input;
+    }
+
+    public void setEnforcedMetacardValidators(List<String> enforcedMetacardValidators) {
+        this.enforcedMetacardValidators = enforcedMetacardValidators;
+    }
+
+    public List<String> getEnforcedMetacardValidators() {
+        return this.enforcedMetacardValidators;
+    }
+
+    public void setMetacardValidators(List<MetacardValidator> metacardValidators) {
+        this.metacardValidators = metacardValidators;
+    }
+
+    public List<MetacardValidator> getMetacardValidators() {
+        return this.metacardValidators;
+    }
+
+    private Boolean checkEnforcedMetacardValidators(MetacardValidator metacardValidator) {
+        return (null == enforcedMetacardValidators || !enforcedMetacardValidators
+                .contains(getValidatorName(metacardValidator)));
+    }
+
+    private String getValidatorName(MetacardValidator metacardValidator) {
+        if (metacardValidator instanceof Describable) {
+            return ((Describable) metacardValidator).getId();
+        } else {
+            String canonicalName = metacardValidator.getClass().getCanonicalName();
+            LOGGER.warn("Metacard validators SHOULD implement Describable. Validator in error: {}",
+                    canonicalName);
+            return canonicalName;
+        }
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/ValidationQueryDelegate.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/ValidationQueryDelegate.java
@@ -1,0 +1,480 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.validation;
+
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import java.util.Date;
+import java.util.List;
+
+import ddf.catalog.filter.FilterDelegate;
+
+public class ValidationQueryDelegate extends FilterDelegate<Boolean> {
+
+    /**
+     * These three Boolean operations AND, OR, and NOT are not boolean operations in the traditional sense
+     * They should return true if any of the operands are true. This is because we want the delegate to return
+     * true whenever VALIDATION_WARNINGS or VALIDATION_ERRORS occur in the filter
+     * For example: if we get a filter that is like [ validation-warnings is test ] AND [ AnyText is * ] we want {@link ValidationQueryDelegate#and} to return true, so we need an or operation underneath
+     * if we get a filter that is like [ validation-warnings is test ] OR [ AnyText is * ] we want {@link ValidationQueryDelegate#or} to return true, so we need an or operation underneath
+     * if we get a filter this is like NOT [ validation-warnings is test ] we want {@link ValidationQueryDelegate#not} to return true, so we need to pass the operand as is
+     */
+
+    @Override
+    public Boolean and(List<Boolean> operands) {
+        return operands.stream().reduce(false, (a, b) -> a || b);
+    }
+
+    @Override
+    public Boolean or(List<Boolean> operands) {
+        return operands.stream().reduce(false, (a, b) -> a || b);
+    }
+
+    @Override
+    public Boolean not(Boolean operand) {
+        return operand;
+    }
+
+    @Override
+    public Boolean nearestNeighbor(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean include() {
+        return false;
+    }
+
+    @Override
+    public Boolean exclude() {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, String literal, boolean isCaseSensitive) {
+        return propertyName.equals(VALIDATION_ERRORS) || propertyName.equals(VALIDATION_WARNINGS);
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, Date startDate, Date endDate) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, boolean literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, byte[] literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsEqualTo(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, String literal,
+            boolean isCaseSensitive) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, Date startDate, Date endDate) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, boolean literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, byte[] literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNotEqualTo(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThan(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsGreaterThanOrEqualTo(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThan(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, Date literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, int literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, short literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, long literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, float literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, double literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsLessThanOrEqualTo(String propertyName, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, String lowerBoundary,
+            String upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, Date lowerBoundary, Date upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, int lowerBoundary, int upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, short lowerBoundary,
+            short upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, long lowerBoundary, long upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, float lowerBoundary,
+            float upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, double lowerBoundary,
+            double upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsBetween(String propertyName, Object lowerBoundary,
+            Object upperBoundary) {
+        return false;
+    }
+
+    @Override
+    public Boolean propertyIsNull(String propertyName) {
+        return propertyName.equals(VALIDATION_ERRORS) || propertyName.equals(VALIDATION_WARNINGS);
+    }
+
+    @Override
+    public Boolean propertyIsLike(String propertyName, String pattern, boolean isCaseSensitive) {
+        return propertyName.equals(VALIDATION_ERRORS) || propertyName.equals(VALIDATION_WARNINGS);
+    }
+
+    @Override
+    public Boolean propertyIsFuzzy(String propertyName, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean xpathExists(String xpath) {
+        return false;
+    }
+
+    @Override
+    public Boolean xpathIsLike(String xpath, String pattern, boolean isCaseSensitive) {
+        return false;
+    }
+
+    @Override
+    public Boolean xpathIsFuzzy(String xpath, String literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean beyond(String propertyName, String wkt, double distance) {
+        return false;
+    }
+
+    @Override
+    public Boolean contains(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean crosses(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean disjoint(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean dwithin(String propertyName, String wkt, double distance) {
+        return false;
+    }
+
+    @Override
+    public Boolean intersects(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean overlaps(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean touches(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean within(String propertyName, String wkt) {
+        return false;
+    }
+
+    @Override
+    public Boolean after(String propertyName, Date date) {
+        return false;
+    }
+
+    @Override
+    public Boolean before(String propertyName, Date date) {
+        return false;
+    }
+
+    @Override
+    public Boolean during(String propertyName, Date startDate, Date endDate) {
+        return false;
+    }
+
+    @Override
+    public Boolean relative(String propertyName, long duration) {
+        return false;
+    }
+
+    //    public Pair<Boolean, Boolean> getValidityParams() {
+    //        return new ImmutablePair<>(searchValid, searchInvalid);
+    //    }
+}

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,62 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <type-converters>
+        <bean id="listConverter" class="ddf.catalog.util.impl.ListConverter"/>
+    </type-converters>
+
+    <bean id="metacardValidatorList" class="ddf.catalog.util.impl.SortedServiceList" />
+    <reference-list id="metacardValidators"
+                    interface="ddf.catalog.validation.MetacardValidator"
+                    availability="optional">
+        <reference-listener ref="metacardValidatorList" bind-method="bindPlugin" unbind-method="unbindPlugin" />
+    </reference-list>
+
+    <reference id="filterBuilder"
+               interface="ddf.catalog.filter.FilterBuilder"/>
+    <reference id="filterAdapter"
+               interface="ddf.catalog.filter.FilterAdapter"/>
+
+
+    <!-- Pre-Ingest Metacard Validation Marker Plugin -->
+    <bean id="pre-ingest-plugin" class="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
+        <cm:managed-properties
+                persistent-id="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin"
+                update-strategy="container-managed"/>
+        <property name="metacardValidators" ref="metacardValidatorList"/>
+        <property name="enforcedMetacardValidators">
+            <list />
+        </property>
+
+    </bean>
+
+    <!-- Pre-Query Metacard Validity Checker Plugin -->
+    <bean id="pre-query-plugin" class="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
+        <!--<cm:managed-properties-->
+                <!--persistent-id="MetacardValidityCheckerPlugin"-->
+                <!--update-strategy="container-managed"/>-->
+        <argument ref="filterBuilder"/>
+        <argument ref="filterAdapter"/>
+
+    </bean>
+
+
+
+    <!-- Register in the OSGi Service Registry -->
+    <service ref="pre-ingest-plugin" interface="ddf.catalog.plugin.PreIngestPlugin"/>
+    <service ref="pre-query-plugin" interface="ddf.catalog.plugin.PreQueryPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Metacard Validation Plugin"
+         id="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
+        <AD
+                description="ID of Metacard Validator to enforce."
+                name="Enforced Validators" id="enforcedMetacardValidators" required="false" type="String"
+                default="" cardinality="100"/>
+    </OCD>
+
+    <Designate
+            pid="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
+        <Object
+                ocdref="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
@@ -1,0 +1,628 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.validation;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+public class MetacardValidityCheckerPluginTest {
+    private FilterBuilder filterBuilder;
+
+    private FilterAdapter filterAdapter;
+
+    private MetacardValidityCheckerPlugin metacardValidityCheckerPlugin;
+
+    private static ValidationQueryDelegate testValidationQueryDelegate;
+
+    @Before
+    public void setUp() {
+        FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+        FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
+        metacardValidityCheckerPlugin = new MetacardValidityCheckerPlugin(filterBuilder,
+                filterAdapter);
+        this.filterBuilder = filterBuilder;
+        this.filterAdapter = filterAdapter;
+        testValidationQueryDelegate = new ValidationQueryDelegate();
+    }
+
+    @Test
+    public void testSearchValid()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(filterBuilder.attribute(VALIDATION_WARNINGS).is().empty());
+        ValidationQueryDelegate delegate = new ValidationQueryDelegate();
+        assertThat(filterAdapter.adapt(query, delegate), is(true));
+        QueryRequest returnQuery = metacardValidityCheckerPlugin
+                .process(new QueryRequestImpl(query));
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), delegate), is(true));
+    }
+
+    @Test
+    public void testSearchInvalid()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(
+                filterBuilder.attribute(VALIDATION_WARNINGS).is().equalTo().text("sample"));
+        ValidationQueryDelegate delegate = new ValidationQueryDelegate();
+        assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(true));
+        QueryRequest returnQuery = metacardValidityCheckerPlugin
+                .process(new QueryRequestImpl(query));
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+    }
+
+    @Test
+    public void testSearchBoth()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(filterBuilder
+                .allOf(filterBuilder.attribute(VALIDATION_WARNINGS).is().empty(),
+                        filterBuilder.attribute(VALIDATION_WARNINGS).is().equalTo()
+                                .text("sample")));
+        QueryRequest returnQuery = metacardValidityCheckerPlugin
+                .process(new QueryRequestImpl(query));
+
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+    }
+
+    @Test
+    public void testSearchNone()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(
+                filterBuilder.attribute(Metacard.MODIFIED).is().equalTo().text("sample"));
+        assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(false));
+        QueryRequest returnQuery = metacardValidityCheckerPlugin
+                .process(new QueryRequestImpl(query));
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+    }
+
+    @Test
+    public void testSearchBothImplicit()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(filterBuilder
+                .allOf(filterBuilder.attribute(VALIDATION_WARNINGS).is().empty(),
+                        filterBuilder.attribute(VALIDATION_WARNINGS).is().equalTo().text("*")));
+        QueryRequest returnQuery = metacardValidityCheckerPlugin
+                .process(new QueryRequestImpl(query));
+
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+    }
+
+    @Test
+    public void testPropertyIsEqualToStringCaseSensitive() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToDate() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, mock(Date.class)),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToInt() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (short) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (long) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (float) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, new byte[0]),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsEqualToObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsEqualTo(Metacard.ANY_TEXT, (Object) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToString() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToDate() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsNotEqualTo(Metacard.ANY_TEXT, mock(Date.class)), is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToInt() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (short) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (long) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (float) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, new byte[0]),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsNotEqualToObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, (Object) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanString() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsNotEqualTo(Metacard.ANY_TEXT, "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanDate() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsNotEqualTo(Metacard.ANY_TEXT, mock(Date.class)), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanInt() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (short) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (long) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (float) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanByteArray() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, new byte[0]),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsGreaterThan(Metacard.ANY_TEXT, (Object) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToString() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, "helloworld"), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToDate() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, mock(Date.class)), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToInt() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (int) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (short) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (long) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (float) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (double) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, new byte[0]), is(false));
+    }
+
+    @Test
+    public void testPropertyIsGreaterThanOrEqualToObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsGreaterThanOrEqualTo(Metacard.ANY_TEXT, (Object) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanString() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanDate() {
+        assertThat(
+                testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, mock(Date.class)),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanInt() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (short) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (long) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (float) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, new byte[0]),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsLessThan(Metacard.ANY_TEXT, (Object) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToString() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, "helloworld"), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToDate() {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, mock(Date.class)), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToInt() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (short) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (long) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (float) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (double) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, new byte[0]), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLessThanOrEqualToObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLessThanOrEqualTo(Metacard.ANY_TEXT, (Object) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenString() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, "helloworld", "helloworld"), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenDate() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                        .propertyIsBetween(Metacard.ANY_TEXT, mock(Date.class), mock(Date.class)),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenInt() throws UnsupportedQueryException {
+        assertThat(
+                testValidationQueryDelegate.propertyIsBetween(Metacard.ANY_TEXT, (int) 0, (int) 0),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenShort() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, (short) 0, (short) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenLong() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, (long) 0, (long) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenFloat() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, (float) 0, (float) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenDouble() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, (double) 0, (double) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenByteArray() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, new byte[0], new byte[0]), is(false));
+    }
+
+    @Test
+    public void testPropertyIsBetweenObject() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate
+                .propertyIsBetween(Metacard.ANY_TEXT, (Object) 0, (Object) 0), is(false));
+    }
+
+    @Test
+    public void testPropertyIsNullTrueValidationErrors() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNull(VALIDATION_ERRORS), is(true));
+    }
+
+    @Test
+    public void testPropertyIsNullTrueValidationWarnings() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNull(VALIDATION_WARNINGS), is(true));
+    }
+
+    @Test
+    public void testPropertyIsNullFalse() throws UnsupportedQueryException {
+        assertThat(testValidationQueryDelegate.propertyIsNull("test"), is(false));
+    }
+
+    @Test
+    public void testPropertyIsLike() {
+        assertThat(
+                testValidationQueryDelegate.propertyIsLike(Metacard.ANY_TEXT, "helloworld", true),
+                is(false));
+    }
+
+    @Test
+    public void testPropertyIsFuzzy() {
+        assertThat(testValidationQueryDelegate.propertyIsFuzzy(Metacard.ANY_TEXT, "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testXpathExists() {
+        assertThat(testValidationQueryDelegate.xpathExists("some/xpath/"), is(false));
+    }
+
+    @Test
+    public void testXpathIsLike() {
+        assertThat(testValidationQueryDelegate.xpathIsLike("some/xpath/", "helloworld", true),
+                is(false));
+    }
+
+    @Test
+    public void testXpathIsFuzzy() {
+        assertThat(testValidationQueryDelegate.xpathIsFuzzy("some/xpath/", "helloworld"),
+                is(false));
+    }
+
+    @Test
+    public void testBeyond() {
+        assertThat(testValidationQueryDelegate.beyond(Metacard.ANY_TEXT, "thisisaWKT", (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testContains() {
+        assertThat(testValidationQueryDelegate.contains(Metacard.ANY_TEXT, "thisisaWKT"),
+                is(false));
+    }
+
+    @Test
+    public void testCrosses() {
+        assertThat(testValidationQueryDelegate.crosses(Metacard.ANY_TEXT, "thisisaWKT"), is(false));
+    }
+
+    @Test
+    public void testDisjoint() {
+        assertThat(testValidationQueryDelegate.disjoint(Metacard.ANY_TEXT, "thisisaWKT"),
+                is(false));
+    }
+
+    @Test
+    public void testDwithin() {
+        assertThat(testValidationQueryDelegate.dwithin(Metacard.ANY_TEXT, "thisisaWKT", (double) 0),
+                is(false));
+    }
+
+    @Test
+    public void testIntersects() {
+        assertThat(testValidationQueryDelegate.intersects(Metacard.ANY_TEXT, "thisisaWKT"),
+                is(false));
+    }
+
+    @Test
+    public void testOverlaps() {
+        assertThat(testValidationQueryDelegate.overlaps(Metacard.ANY_TEXT, "thisisaWKT"),
+                is(false));
+    }
+
+    @Test
+    public void testTouches() {
+        assertThat(testValidationQueryDelegate.touches(Metacard.ANY_TEXT, "thisisaWKT"), is(false));
+    }
+
+    @Test
+    public void testWithin() {
+        assertThat(testValidationQueryDelegate.within(Metacard.ANY_TEXT, "thisisaWKT"), is(false));
+    }
+
+    @Test
+    public void testAfter() {
+        assertThat(testValidationQueryDelegate.after(Metacard.ANY_TEXT, mock(Date.class)),
+                is(false));
+    }
+
+    @Test
+    public void testBefore() {
+        assertThat(testValidationQueryDelegate.before(Metacard.ANY_TEXT, mock(Date.class)),
+                is(false));
+    }
+
+    @Test
+    public void testDuring() {
+        assertThat(testValidationQueryDelegate
+                .during(Metacard.ANY_TEXT, mock(Date.class), mock(Date.class)), is(false));
+    }
+
+    @Test
+    public void testRelative() {
+        assertThat(testValidationQueryDelegate.relative(Metacard.ANY_TEXT, (long) 0), is(false));
+    }
+
+}

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.validation;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+
+public class MetacardValidityMarkerPluginTest {
+
+    private static final String ID = "ID";
+
+    private static final String SAMPLE = "sample";
+
+    @Test
+    public void testMarkMetacardValid()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockPassingValidator());
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS),
+                is(nullValue(null)));
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS),
+                is(nullValue(null)));
+    }
+
+    @Test
+    public void testMarkMetacardInvalidErrors()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockFailingValidatorWithErrors(ID));
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_ERRORS).getValues()
+                .contains(ID), is(true));
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_ERRORS).getValues()
+                .size(), is(1));
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS),
+                is(nullValue(null)));
+    }
+
+    @Test
+    public void testMarkMetacardInvalidWarnings()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockFailingValidatorWithWarnings(ID));
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_ERRORS),
+                is(nullValue(null)));
+        assertThat(
+                filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS).getValues()
+                        .contains(ID), is(true));
+        assertThat(
+                filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS).getValues()
+                        .size(), is(1));
+    }
+
+    @Test
+    public void testMarkMetacardInvalidErrorsAndWarnings()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings(ID));
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_ERRORS).getValues()
+                .contains(ID), is(true));
+        assertThat(filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_ERRORS).getValues()
+                .size(), is(1));
+        assertThat(
+                filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS).getValues()
+                        .contains(ID), is(true));
+        assertThat(
+                filteredRequest.getMetacards().get(0).getAttribute(VALIDATION_WARNINGS).getValues()
+                        .size(), is(1));
+    }
+
+    @Test
+    public void testUpdateProcess() throws StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        UpdateRequestImpl updateRequest = mock(UpdateRequestImpl.class);
+        UpdateRequest returnedUpdateRequest = plugin.process(updateRequest);
+        assertThat(returnedUpdateRequest, is(equalTo(updateRequest)));
+
+    }
+
+    @Test
+    public void testDeleteProcess() throws StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        DeleteRequestImpl deleteRequest = mock(DeleteRequestImpl.class);
+        DeleteRequest returnedDeleteRequest = plugin.process(deleteRequest);
+        assertThat(returnedDeleteRequest, is(equalTo(deleteRequest)));
+    }
+
+    @Test
+    public void testAllowMetacardEnforcedValidation()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        String id = ID + "1";
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockPassingValidatorWithId(id));
+        plugin.setMetacardValidators(metacardValidators);
+        List<String> enforcedMetacardValidators = new ArrayList<>();
+        enforcedMetacardValidators.add(id);
+        plugin.setEnforcedMetacardValidators(enforcedMetacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().isEmpty(), is(false));
+    }
+
+    @Test
+    public void testRemoveMetacardEnforcedValidation()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        String id = ID + "1";
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockFailingValidatorWithId(id));
+        plugin.setMetacardValidators(metacardValidators);
+        List<String> enforcedMetacardValidators = new ArrayList<>();
+        enforcedMetacardValidators.add(id);
+        plugin.setEnforcedMetacardValidators(enforcedMetacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testAllowMetacardNoDescribable()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockPassingValidatorNoDescribable());
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().isEmpty(), is(false));
+    }
+
+    @Test
+    public void testRemoveMetacardNoDescribable()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+        List<MetacardValidator> metacardValidators = new ArrayList<>();
+        metacardValidators.add(getMockFailingValidatorNoDescribable());
+        plugin.setMetacardValidators(metacardValidators);
+        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
+        assertThat(filteredRequest.getMetacards().isEmpty(), is(false));
+
+    }
+
+    @Test
+    public void testGetters() {
+        assertThat(new MetacardValidityMarkerPlugin().getMetacardValidators(), is(nullValue(null)));
+        assertThat(new MetacardValidityMarkerPlugin().getEnforcedMetacardValidators(),
+                is(nullValue(null)));
+    }
+
+    private CreateRequest getMockCreateRequest() {
+        List<Metacard> listMetacards = new ArrayList<>();
+        listMetacards.add(new MetacardImpl());
+        return new CreateRequestImpl(listMetacards);
+    }
+
+    private MetacardValidator getMockPassingValidator() throws ValidationException {
+        return mock(MetacardValidator.class, withSettings().extraInterfaces(Describable.class));
+    }
+
+    private MetacardValidator getMockFailingValidatorWithErrors(String id)
+            throws ValidationException {
+        ValidationException validationException = mock(ValidationException.class);
+        when(validationException.getErrors()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        MetacardValidator metacardValidator = mock(MetacardValidator.class,
+                withSettings().extraInterfaces(Describable.class));
+        when(((Describable) metacardValidator).getId()).thenReturn(id);
+        doThrow(validationException).when(metacardValidator).validate(any(Metacard.class));
+        return metacardValidator;
+    }
+
+    private MetacardValidator getMockFailingValidatorWithWarnings(String id)
+            throws ValidationException {
+        ValidationException validationException = mock(ValidationException.class);
+        when(validationException.getWarnings()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        MetacardValidator metacardValidator = mock(MetacardValidator.class,
+                withSettings().extraInterfaces(Describable.class));
+        when(((Describable) metacardValidator).getId()).thenReturn(id);
+        doThrow(validationException).when(metacardValidator).validate(any(Metacard.class));
+        return metacardValidator;
+    }
+
+    private MetacardValidator getMockFailingValidatorWithErrorsAndWarnings(String id)
+            throws ValidationException {
+        ValidationException validationException = mock(ValidationException.class);
+        when(validationException.getErrors()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        when(validationException.getWarnings()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        MetacardValidator metacardValidator = mock(MetacardValidator.class,
+                withSettings().extraInterfaces(Describable.class));
+        when(((Describable) metacardValidator).getId()).thenReturn(id);
+        doThrow(validationException).when(metacardValidator).validate(any(Metacard.class));
+        return metacardValidator;
+    }
+
+    private MetacardValidator getMockPassingValidatorWithId(String id) throws ValidationException {
+        MetacardValidator metacardValidator = mock(MetacardValidator.class,
+                withSettings().extraInterfaces(Describable.class));
+        when(((Describable) metacardValidator).getId()).thenReturn(id);
+        return metacardValidator;
+
+    }
+
+    private MetacardValidator getMockFailingValidatorWithId(String id) throws ValidationException {
+        MetacardValidator metacardValidator = mock(MetacardValidator.class,
+                withSettings().extraInterfaces(Describable.class));
+        doThrow(mock(ValidationException.class)).when(metacardValidator)
+                .validate(any(Metacard.class));
+        when(((Describable) metacardValidator).getId()).thenReturn(id);
+        return metacardValidator;
+    }
+
+    private MetacardValidator getMockPassingValidatorNoDescribable() throws ValidationException {
+        MetacardValidator metacardValidator = mock(MetacardValidator.class);
+        return metacardValidator;
+    }
+
+    private MetacardValidator getMockFailingValidatorNoDescribable() throws ValidationException {
+        MetacardValidator metacardValidator = mock(MetacardValidator.class);
+        doThrow(mock(ValidationException.class)).when(metacardValidator)
+                .validate(any(Metacard.class));
+        return metacardValidator;
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -28,6 +28,7 @@
   <modules>
     <module>catalog-plugin-federation-replication</module>
     <module>catalog-plugin-jpeg2000-thumbnail-converter</module>
+    <module>catalog-plugin-metacard-validation</module>
   </modules>
   
 </project>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -19,6 +19,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -167,7 +168,7 @@ public class TikaInputTransformer implements InputTransformer {
         if (StringUtils.isNotBlank(uri)) {
             metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_URI, URI.create(uri)));
         } else {
-            metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_URI, null));
+            metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_URI, (Serializable) null));
         }
 
         if (StringUtils.isNotBlank(metacardMetadata)) {

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -37,6 +37,7 @@
         <module>sample-rest-endpoint</module>
         <module>sample-metacard-filter</module>
         <module>sample-cometd</module>
+        <module>sample-metacard-validator</module>
         <module>sdk-app</module>
     </modules>
 

--- a/distribution/sdk/sample-metacard-validator/pom.xml
+++ b/distribution/sdk/sample-metacard-validator/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>sdk</artifactId>
+        <groupId>ddf.distribution</groupId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codice.ddf.sdk.validation.metacard</groupId>
+    <artifactId>sdk-sample-metacard-validator</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: SDK :: Sample Metacard Validator</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
+            <!-- Add in additional imports that this bundle requires using a comma-separated list. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                        <Embed-Dependency>
+                            catalog-core-api-impl
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
+++ b/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.sdk.validation.metacard;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.ValidationExceptionImpl;
+
+public class SampleMetacardValidator implements MetacardValidator, Describable {
+
+    private static String[] validWords = new String[] {"test", "default", "sample"};
+
+    @Override
+    public String getVersion() {
+        return "1.0";
+    }
+
+    @Override
+    public String getId() {
+        return "sample-validator";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Sample Metacard Validator";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A sample metacard validator used for development and testing.";
+    }
+
+    @Override
+    public String getOrganization() {
+        return "Codice";
+    }
+
+    @Override
+    public void validate(Metacard metacard) throws ValidationException {
+        if (!checkMetacard(metacard.getTitle(), new ArrayList<>(Arrays.asList(validWords)))) {
+            ValidationExceptionImpl validationException = new ValidationExceptionImpl(
+                    "Metacard title does not contain any of: " + Arrays.toString(validWords));
+            validationException.setErrors(new ArrayList<String>(Arrays.asList("sampleError")));
+            validationException.setWarnings(new ArrayList<String>(Arrays.asList("sampleWarnings")));
+            throw validationException;
+        }
+
+    }
+
+    private Boolean checkMetacard(String metacardAttribute, ArrayList<String> toCheck) {
+        List<String> result = toCheck.stream().filter(metacardAttribute::contains)
+                .collect(Collectors.toList());
+        return !result.isEmpty();
+    }
+
+    public void setValidWords(String... validWords) {
+        SampleMetacardValidator.validWords = validWords;
+    }
+
+    public String[] getValidWords() {
+        return SampleMetacardValidator.validWords;
+    }
+}

--- a/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+
+    <!-- Register in the OSGi Service Registry -->
+    <service interface="ddf.catalog.validation.MetacardValidator" >
+        <bean class="org.codice.ddf.sdk.validation.metacard.SampleMetacardValidator">
+            <!--<cm:managed-properties persistent-id="SampleMetacardValidator"-->
+                                   <!--update-strategy="container-managed"/>-->
+            <property name="validWords">
+                <array value-type="java.lang.String">
+                    <value>Metacard-1</value>
+                </array>
+            </property>
+        </bean>
+    </service>
+
+</blueprint>

--- a/distribution/sdk/sample-metacard-validator/src/test/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidatorTest.java
+++ b/distribution/sdk/sample-metacard-validator/src/test/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidatorTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.sdk.validation.metacard;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.validation.ValidationException;
+
+public class SampleMetacardValidatorTest {
+
+    @Test
+    public void testValidateValidMetacard() throws ValidationException {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("sample");
+        SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.validate(metacard);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateInvalidMetacard() throws ValidationException {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("invalid");
+        SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.validate(metacard);
+    }
+}

--- a/distribution/sdk/sdk-app/src/main/resources/features.xml
+++ b/distribution/sdk/sdk-app/src/main/resources/features.xml
@@ -32,10 +32,13 @@
              description="Catalog Filter Plugin for DDF">
         <bundle>mvn:ddf.catalog.security/catalog-security-filter/${project.version}</bundle>
     </feature>
-
     <feature name="sdk-rest" version="${project.version}" install="manual"
              description="SDK Sample rest service whoami">
         <bundle>mvn:ddf.distribution/sample-rest-endpoint/${project.version}</bundle>
+    </feature>
+    <feature name="sample-validator" version="${project.version}" install="manual"
+             description="SDK sample metacard validator">
+        <bundle>mvn:org.codice.ddf.sdk.validation.metacard/sdk-sample-metacard-validator/${project.version}</bundle>
     </feature>
 
     <feature name="sdk-app" version="${project.version}" description="SDK app.">
@@ -45,6 +48,7 @@
         <feature>security-pep-metacard-attributes</feature>
         <feature>sdk-soap</feature>
         <feature>sdk-rest</feature>
+        <feature>sample-validator</feature>
     </feature>
 
 </features>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -102,6 +102,12 @@
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-metacard-validation</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -49,6 +50,7 @@ import com.jayway.restassured.http.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.common.test.BeforeExam;
 import ddf.test.itests.AbstractIntegrationTest;
+import ddf.test.itests.common.CswQueryBuilder;
 import ddf.test.itests.common.Library;
 import ddf.test.itests.common.UrlResourceReaderConfigurator;
 
@@ -103,8 +105,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
         OpenSearchSourceProperties openSearchProperties = new OpenSearchSourceProperties(
                 OPENSEARCH_SOURCE_ID);
-        getServiceManager().createManagedService(OpenSearchSourceProperties.FACTORY_PID, openSearchProperties);
-
+        getServiceManager()
+                .createManagedService(OpenSearchSourceProperties.FACTORY_PID, openSearchProperties);
 
         getServiceManager().waitForHttpEndpoint(CSW_PATH + "?_wadl");
         get(CSW_PATH + "?_wadl").prettyPrint();
@@ -120,8 +122,8 @@ public class TestFederation extends AbstractIntegrationTest {
         getCatalogBundle().waitForFederatedSource(CSW_SOURCE_ID);
         getCatalogBundle().waitForFederatedSource(CSW_SOURCE_WITH_METACARD_XML_ID);
 
-        getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(), OPENSEARCH_SOURCE_ID, CSW_SOURCE_ID,
-                CSW_SOURCE_WITH_METACARD_XML_ID);
+        getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(), OPENSEARCH_SOURCE_ID,
+                CSW_SOURCE_ID, CSW_SOURCE_WITH_METACARD_XML_ID);
 
         metacardIds[GEOJSON_RECORD_INDEX] = TestCatalog
                 .ingest(Library.getSimpleGeoJson(), "application/json");
@@ -165,16 +167,13 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedQueryByWildCardSearchPhrase() throws Exception {
-        String queryUrl =
-                OPENSEARCH_PATH.getUrl() + "?q=*&format=xml&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&format=xml&src=" + OPENSEARCH_SOURCE_ID;
 
-        when().get(queryUrl).then().log().all().assertThat()
-                .body(hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE
-                                + "']/value[text()='" + RECORD_TITLE_1 + "']"),
-                        hasXPath("/metacards/metacard/geometry/value"), hasXPath(
-                                "/metacards/metacard/string[@name='" + Metacard.TITLE
-                                        + "']/value[text()='" + RECORD_TITLE_2 + "']"),
-                        hasXPath("/metacards/metacard/stringxml"));
+        when().get(queryUrl).then().log().all().assertThat().body(hasXPath(
+                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                        + RECORD_TITLE_1 + "']"), hasXPath("/metacards/metacard/geometry/value"),
+                hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                        + RECORD_TITLE_2 + "']"), hasXPath("/metacards/metacard/stringxml"));
     }
 
     /**
@@ -185,8 +184,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testAtomFederatedQueryByWildCardSearchPhrase() throws Exception {
-        String queryUrl =
-                OPENSEARCH_PATH.getUrl() + "?q=*&format=atom&src=" + OPENSEARCH_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&format=atom&src=" + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(hasXPath("/feed/entry/title[text()='" + RECORD_TITLE_1 + "']"),
@@ -202,9 +200,8 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedQueryBySearchPhrase() throws Exception {
-        String queryUrl =
-                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
-                        + OPENSEARCH_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                + OPENSEARCH_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat().body(hasXPath(
                 "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
@@ -237,9 +234,9 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFederatedNegativeSpatial() throws Exception {
-        String queryUrl = OPENSEARCH_PATH.getUrl()
-                + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS" + "&format=xml&src="
-                + OPENSEARCH_SOURCE_ID;
+        String queryUrl =
+                OPENSEARCH_PATH.getUrl() + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS"
+                        + "&format=xml&src=" + OPENSEARCH_SOURCE_ID;
         when().get(queryUrl).then().log().all().assertThat()
                 .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
     }
@@ -294,9 +291,8 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
-        String restUrl =
-                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                        + "?transform=resource";
+        String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
@@ -318,9 +314,8 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS});
 
-        String restUrl =
-                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                        + "?transform=resource";
+        String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/html")
@@ -330,18 +325,18 @@ public class TestFederation extends AbstractIntegrationTest {
     /**
      * Tests Source CANNOT retrieve existing product. The product is NOT located in one of the
      * URLResourceReader's root resource directories, so it CANNOT be downloaded.
-     * <p/>
+     * <p>
      * For example:
      * The resource uri in the metacard is:
      * file:/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/exam/e59b02bf-5774-489f-8aa9-53cf99c25d25/../../testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt
      * which really means:
      * file:/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt
-     * <p/>
+     * <p>
      * The URLResourceReader's root resource directories are:
      * <ddf.home>/data/products
      * and
      * /Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/exam/e59b02bf-5774-489f-8aa9-53cf99c25d25
-     * <p/>
+     * <p>
      * So the product (/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt) is
      * not located under either of the URLResourceReader's root resource directories.
      *
@@ -362,9 +357,8 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
-        String restUrl =
-                REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
-                        + "?transform=resource";
+        String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/" + metacardId
+                + "?transform=resource";
 
         // Perform Test and Verify
         when().get(restUrl).then().log().all().assertThat().contentType("text/html")
@@ -378,9 +372,8 @@ public class TestFederation extends AbstractIntegrationTest {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
-        String restUrl =
-                REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/" + metacardIds[XML_RECORD_INDEX]
-                        + "?transform=resource";
+        String restUrl = REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/"
+                + metacardIds[XML_RECORD_INDEX] + "?transform=resource";
         when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
                 .body(is(SAMPLE_DATA));
     }
@@ -429,13 +422,46 @@ public class TestFederation extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testCswQueryWithValidationCheckerPlugin() throws Exception {
+
+        // Construct a query to search for all metacards
+        String query = new CswQueryBuilder()
+                .addAttributeFilter(CswQueryBuilder.PROPERTY_IS_LIKE, "AnyText", "*").getQuery();
+
+        // Declare array of matchers so we can be sure we use the same matchers in each assertion
+        Matcher[] assertion = new Matcher[] {
+                hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
+                        metacardIds[GEOJSON_RECORD_INDEX] + "']"),
+                hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
+                        metacardIds[XML_RECORD_INDEX] + "']"),
+                hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned", is("2")),
+                hasXPath("/GetRecordsResponse/SearchResults/Record/relation",
+                        containsString("/services/catalog/sources/"))};
+
+        // Run a normal federated query to the CSW source and assert response
+        given().contentType(ContentType.XML).body(query).when().post(CSW_PATH.getUrl()).then().log()
+                .all().assertThat().body(assertion[0], assertion);
+
+        // Start metacard validation plugin; this will add on [validation-warnings = null] AND [validation-errors = null]
+        // filter to query
+        getServiceManager().startFeature(true, "catalog-plugin-metacard-validation");
+
+        // Assert that response is the same as without the plugin
+        given().contentType(ContentType.XML).body(query).when().post(CSW_PATH.getUrl()).then().log()
+                .all().assertThat().body(assertion[0], assertion);
+
+        // Turn off plugin to not interfere with other tests
+        getServiceManager().stopFeature(true, "catalog-plugin-metacard-validation");
+    }
+
+    @Test
     public void testCswQueryByTitle() throws Exception {
         String titleQuery = Library.getCswQuery("title", "myTitle");
 
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl())
-                .then().log().all().assertThat()
+        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl()).then()
+                .log().all().assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier",
-                                is(metacardIds[GEOJSON_RECORD_INDEX])),
+                        is(metacardIds[GEOJSON_RECORD_INDEX])),
                         hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned",
                                 is("1")));
     }
@@ -444,10 +470,10 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCswQueryForMetacardXml() throws Exception {
         String titleQuery = Library.getCswQueryMetacardXml("title", "myTitle");
 
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl())
-                .then().log().all().assertThat()
+        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl()).then()
+                .log().all().assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/metacard/@id",
-                                is(metacardIds[GEOJSON_RECORD_INDEX])),
+                        is(metacardIds[GEOJSON_RECORD_INDEX])),
                         hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned",
                                 is("1")),
                         hasXPath("/GetRecordsResponse/SearchResults/@recordSchema",
@@ -458,7 +484,8 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCswQueryForJson() throws Exception {
         String titleQuery = Library.getCswQueryJson("title", "myTitle");
 
-        given().headers("Accept", "application/json", "Content-Type", "application/xml").body(titleQuery).when().post(CSW_PATH.getUrl()).then().log().all().assertThat()
+        given().headers("Accept", "application/json", "Content-Type", "application/xml")
+                .body(titleQuery).when().post(CSW_PATH.getUrl()).then().log().all().assertThat()
                 .contentType(ContentType.JSON)
                 .body("results[0].metacard.properties.title", equalTo(RECORD_TITLE_1));
     }
@@ -466,9 +493,8 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testOpensearchToCswSourceToCswEndpointQuerywithCswRecordXml() throws Exception {
 
-        String queryUrl =
-                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
-                        + CSW_SOURCE_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                + CSW_SOURCE_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
@@ -480,9 +506,8 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testOpensearchToCswSourceToCswEndpointQuerywithMetacardXml() throws Exception {
 
-        String queryUrl =
-                OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
-                        + CSW_SOURCE_WITH_METACARD_XML_ID;
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
+                + CSW_SOURCE_WITH_METACARD_XML_ID;
 
         when().get(queryUrl).then().log().all().assertThat()
                 .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
@@ -503,10 +528,9 @@ public class TestFederation extends AbstractIntegrationTest {
         }
         */
 
-        given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH.getUrl())
-                .then().log().all().assertThat()
-                .body(containsString("\"fpid\":\"OpenSearchSource\""),
-                        containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
+        given().auth().basic("admin", "admin").when().get(ADMIN_ALL_SOURCES_PATH.getUrl()).then()
+                .log().all().assertThat().body(containsString("\"fpid\":\"OpenSearchSource\""),
+                containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
                 containsString("\"fpid\":\"Csw_Connected_Source\"")*/);
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/CswQueryBuilder.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/CswQueryBuilder.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package ddf.test.itests.common;
+
+public class CswQueryBuilder {
+
+    private String internalRepresentation;
+
+
+    public static final String PROPERTY_IS_EQUAL_TO = "PropertyIsEqualTo";
+    public static final String PROPERTY_IS_LIKE = "PropertyIsLike";
+    public static final String PROPERTY_IS_NULL = "PropertyIsNull";
+    public static final String OR = "Or";
+    public static final String AND = "And";
+    public static final String NOT = "Not";
+
+    public CswQueryBuilder() {
+        internalRepresentation = "";
+    }
+
+    public String getQuery() {
+        return "<csw:GetRecords resultType=\"results\" outputFormat=\"application/xml\" outputSchema=\"http://www.opengis.net/cat/csw/2.0.2\" startPosition=\"1\" maxRecords=\"10\" service=\"CSW\" version=\"2.0.2\" xmlns:ns2=\"http://www.opengis.net/ogc\" xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" xmlns:ns4=\"http://www.w3.org/1999/xlink\" xmlns:ns3=\"http://www.opengis.net/gml\" xmlns:ns9=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns5=\"http://www.opengis.net/ows\" xmlns:ns6=\"http://purl.org/dc/elements/1.1/\" xmlns:ns7=\"http://purl.org/dc/terms/\" xmlns:ns8=\"http://www.w3.org/2001/SMIL20/\">"
+                + "    <ns10:Query typeNames=\"csw:Record\" xmlns=\"\" xmlns:ns10=\"http://www.opengis.net/cat/csw/2.0.2\">"
+                + "        <ns10:ElementSetName>full</ns10:ElementSetName>"
+                + "        <ns10:Constraint version=\"1.1.0\">"
+                + "            <ns2:Filter>" + internalRepresentation + "</ns2:Filter>"
+                + "        </ns10:Constraint>"
+                + "    </ns10:Query>"
+                + "</csw:GetRecords>";
+    }
+
+    public CswQueryBuilder addAttributeFilter(String filter, String propertyName, String literalValue) {
+        internalRepresentation = internalRepresentation
+                + "                    <ns2:" + filter + " wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">"
+                + "                        <ns2:PropertyName>" + propertyName + "</ns2:PropertyName>"
+                + "                        <ns2:Literal>" + literalValue + "</ns2:Literal>"
+                + "                    </ns2:" + filter + ">";
+        return this;
+    }
+
+    public CswQueryBuilder addPropertyIsNullAttributeFilter(String propertyName) {
+        internalRepresentation = internalRepresentation
+                + "                    <ns2:PropertyIsNull wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">"
+                + "                        <ns2:PropertyName>" + propertyName + "</ns2:PropertyName>"
+                + "                    </ns2:PropertyIsNull>";
+        return this;
+    }
+
+    public CswQueryBuilder addLogicalOperator(String logicalOperator)
+            throws java.lang.Exception {
+        if (!OR.equals(logicalOperator) && !AND.equals(logicalOperator) && !NOT.equals(logicalOperator)) {
+            throw new java.lang.Exception("getCswLogicalWrapper requires \"Or,\" \"And,\" or \"Not\" as the first argument.");
+        }
+        internalRepresentation = "<ns2:" + logicalOperator + ">"
+                + internalRepresentation
+                + "</ns2:" + logicalOperator + ">";
+        return this;
+
+    }
+
+    @Override
+    public String toString() {
+        return this.getQuery();
+    }
+
+
+}


### PR DESCRIPTION
Added a pre-ingest plugin to validate and mark metacards as invalid
or valid.
Added a pre-query plugin to check the query and if it is missing a
'valid-state' parameter, add `valid-state=true`.
Added a sample metacard validator to use for testing.
Edited metacard to allow setting metacards as invalid

@michaelmenousek @pklinef @brendan-hofmann @beyelerb 