### PR TITLE
ddf-1708 intermittent test failures during build

### DIFF
--- a/catalog/ui/search-ui/standard/src/test/js/wd/search.js
+++ b/catalog/ui/search-ui/standard/src/test/js/wd/search.js
@@ -48,6 +48,7 @@ for (var i = 0; i < shared.iterations; i++) {
             it("should return different results after editing search keyword", function () {
                 return this.browser
                     .waitForElementByClassName('backNavText').click()
+                    .waitForConditionInBrowser("document.querySelectorAll('#searchButton').length > 0")
                     .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
                     .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
                     .elementByCssSelector('input[name="q"]').clear().type('notfound')
@@ -57,6 +58,7 @@ for (var i = 0; i < shared.iterations; i++) {
                     .waitForElementByCssSelector('.result-count i', asserters.textInclude('results'), shared.timeout)
                     .waitForConditionInBrowser('document.querySelectorAll("a.metacard-link").length === 0', shared.timeout)
                     .waitForElementByClassName('backNavText').click()
+                    .waitForConditionInBrowser("document.querySelectorAll('#searchButton').length > 0")
                     .waitForConditionInBrowser('document.querySelector("#searchButton").getBoundingClientRect().left > 0')
                     .waitForElementByCssSelector('form#searchForm input[name="q"]', shared.timeout)
                     .elementByCssSelector('input[name="q"]').clear().type('*')


### PR DESCRIPTION
This change addresses test failures that were appearing on
VM environments with low CPU allocations.  The test was
proceeding before required DOM elements were rendered. This
change causes the test to wait for the required DOM element
before it tries to proceed.

@andrewkfiedler 
@bdeining 