### PR TITLE
DDF-1706 Fixed Advanced search UI BBOX and Geos 

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterItem.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterItem.view.js
@@ -47,6 +47,7 @@ define([
             },
             initialize: function(){
                 this.modelbinder = new Backbone.ModelBinder();
+                this.listenTo(this.model, 'change:north change:south change:east change:west',this.setBBox);
             },
             templateHelpers: function(){
                 return {
@@ -63,7 +64,13 @@ define([
                     wreqr.vent.trigger('search:drawend');
                 }
             },
-
+            setBBox : function() {
+                var north = parseFloat(this.model.get('north'));
+                var south = parseFloat(this.model.get('south'));
+                var west = parseFloat(this.model.get('west'));
+                var east = parseFloat(this.model.get('east'));
+                this.model.set({mapNorth: north, mapSouth: south, mapEast: east, mapWest: west});
+            },
             onRender: function(){
                 var view = this;
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.bbox.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.bbox.js
@@ -60,7 +60,7 @@ define([
             setModelFromClicks: function (mn, mx) {
 
                 var e = new Cesium.Rectangle(),
-                    epsilon = Cesium.Math.EPSILON7,
+                    epsilon = Cesium.Math.EPSILON6,
                     modelProps;
 
 


### PR DESCRIPTION
(mapped to mapN/S/E/W instead of N/S/E/W)
Relaxed the Epsilon for North/South East/West equality.  This was causing errors in the Advanced Search with 2d maps.

@wmcnalli 
@kcwire 
@shane-voisard is hero
@jrnorth 