### PR TITLE
DDF-1716 updated pki validator to also allow for only validating the

### DIFF
--- a/platform/security/sts/security-sts-pkivalidator/src/main/java/org/codice/ddf/security/validator/pki/PKITokenValidator.java
+++ b/platform/security/sts/security-sts-pkivalidator/src/main/java/org/codice/ddf/security/validator/pki/PKITokenValidator.java
@@ -79,6 +79,8 @@ public class PKITokenValidator implements TokenValidator {
 
     private List<String> realms = new ArrayList<>();
 
+    private boolean doPathValidation = true;
+
     /**
      * Initialize Merlin crypto object.
      */
@@ -193,7 +195,11 @@ public class PKITokenValidator implements TokenValidator {
                 if (token != null) {
                     X509Certificate[] certificates = merlin.getCertificatesFromBytes(token);
                     if (certificates != null) {
-                        credential.setCertificates(certificates);
+                        if (doPathValidation) {
+                            credential.setCertificates(certificates);
+                        } else {
+                            credential.setCertificates(new X509Certificate[] {certificates[0]});
+                        }
                     }
                 } else {
                     LOGGER.debug("Binary Security Token bytes were null.");
@@ -218,6 +224,10 @@ public class PKITokenValidator implements TokenValidator {
 
     public void setSignaturePropertiesPath(String signaturePropertiesPath) {
         this.signaturePropertiesPath = signaturePropertiesPath;
+    }
+
+    public void setPathValidation(boolean value) {
+        doPathValidation = value;
     }
 
     private PKIAuthenticationToken getPKITokenFromTarget(ReceivedToken validateTarget) {

--- a/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,6 +23,11 @@
             description="The realms to be validated by this validator.">
 	    </AD>
 
+		<AD name="Do Full Path Validation" id="pathValidation" required="true" type="Boolean"
+			default="true"
+			description="Validate the full certificate path. Uncheck to only validate the subject cert. (RFC5280 6.1)">
+		</AD>
+
 	</OCD>
 
 	<Designate pid="org.codice.ddf.security.validator.pki">


### PR DESCRIPTION
…subject cert instead of always validating the entire path

@pklinef @kcwire 