### PR TITLE
DDF-1695 script-generate-certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ atlassian-ide-plugin.xml
 *.sonar-ide.properties
 **/webapp/css/styles.css
 platform/solr/**/overlays
+dependency-reduced-pom.xml

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
@@ -1,72 +1,52 @@
-#! /bin/bash
+#! /bin/bash 
+#
+# Usage:
+#   CertNew.sh
+#    CertNew.sh <common-name>
+#
+# Create new certificate and certificate chain signed by Demo Certificate Authority.  
+# The new certificate chain and private key are installed in the keystore.
+# The alias will be the same as the common name.
+# The localhost key will be deleted from the keystore.
+# If no arguments specified on the command line, `hostname -f` is used as the
+# the  the common-name for the certificate.
 
-if [ -z "$OPENSSL" ]; then OPENSSL=openssl; fi
-if [ -z "$DAYS" ] ; then DAYS="-days 365" ; fi	# 1 year
-if [ -z "$CATOP" ] ; then CATOP=./demoCA ; fi
+#Assume script is in <DDF>/etc/certs/ directory
+cd `dirname $0`
 
-CACERT=./cacert.pem
+#Set password, keystore location and other variables
+PASSWORD="changeit"
+KEYFILE="../keystores/serverKeystore.jks"
+KEYTYPE="JKS"
+CLASSNAME="org.codice.ddf.security.certificate.generator.CertificateCommand"
+JARPATTERN=security-certificate-generator*.jar
 
-REQ="$OPENSSL req"
-CA="$OPENSSL ca"
-PKCS12="openssl pkcs12"
-
-export OPENSSL_CONF=openssl-demo.cnf
-if [[ ! -w ${CATOP}/index.txt ]]; then
-  touch ${CATOP}/index.txt
+if [[ ! -e $KEYFILE ]]; then
+    echo "Could not find $KEYFILE. Exiting."
+    exit 1
 fi
-if [[ ! -w ${CATOP}/serial ]]; then
-  echo 01 > ${CATOP}/serial
-fi
+echo "Found keystore file at $KEYFILE"
 
-read -p "Enter server or user name (common name): " CN
-if [[ -d ${CN} ]]; then
-  echo "${CN} already has been generated. Use a different name or clean up ${CN}/
-    and openssl's index and serial lists in ${CATOP}/ first."
-  exit 1
-fi
-mkdir -p "$CN"
+JARFILE=$(find ../.. -name $JARPATTERN)
 
-# Create new CSR
-$REQ -new -keyout "${CN}/${CN}-key.pem" -out "${CN}/${CN}-req.pem" $DAYS <<EOF
-$CN
-
-
-
-
-
-${CN}@example.org
-EOF
-
-if [[ ! -r "${CN}/${CN}-key.pem" && ! -r "${CN}/${CN}-req.pem" ]]; then
-  echo "Cert request failed." >&2
-  exit 1
+if [[ -z $JARFILE ]]; then
+  echo "Could not find JAR file matching $JARPATTERN"
+  exit 2
 fi
 
-# Sign CSR
-$CA -policy policy_anything -passin "pass:secret" -out "${CN}/${CN}-cert.pem" -infiles "${CN}/${CN}-req.pem" <<EOF
-y
-y
-EOF
-
-if [[ ! -r "${CN}/${CN}-cert.pem" ]]; then
-  echo "Cert signing failed." >&2
-  exit 1
+if [[ $1 ]]; then
+    COMMONNAME="$1"
+else
+    COMMONNAME=$(hostname -f)
 fi
 
-cat "${CN}/${CN}-cert.pem"
+echo "--IGNORE SLF4J ERRORS"--
 
-# Convert key/cert to PKCS12 form
-$PKCS12 -in "${CN}/${CN}-cert.pem" -inkey "${CN}/${CN}-key.pem" -certfile ${CATOP}/$CACERT \
-        -out "${CN}/${CN}-cert.p12" -export -name "$CN" -passin "pass:changeit" -passout "pass:changeit"
+RETURNCODE=$(java -cp "$JARFILE" -Djavax.net.ssl.keyStore="$KEYFILE" -Djavax.net.ssl.keyStorePassword="$PASSWORD" -Djavax.net.ssl.keyStoreType="$KEYTYPE" "$CLASSNAME" "$COMMONNAME")
 
-if [[ ! -r "${CN}/${CN}-cert.p12" ]]; then
-  echo "Failed to create PKCS12 cert." >&2
-  exit 1
+if [[ $RETURNCODE == 0 ]]; then
+    echo "---SUCCESS==="
+    KEYSTORECONTENTS=$(keytool -list -keystore "$KEYFILE" -storepass "$PASSWORD" -storetype "$KEYTYPE")
+    printf "%s" "$KEYSTORECONTENTS"
 fi
 
-# Import into a Java Keystore
-keytool -importkeystore -srckeystore ${CN}/${CN}-cert.p12 -srcalias $CN -srcstoretype pkcs12 \
-  -destkeystore ${CN}/${CN}.jks -deststoretype jks -destalias ${CN} -deststorepass changeit -srcstorepass changeit
-
-echo
-echo "Certificates are created in ${CN}/"

--- a/platform/security/certificate/security-certificate-generator/pom.xml
+++ b/platform/security/certificate/security-certificate-generator/pom.xml
@@ -12,7 +12,10 @@
  *
  **/
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>certificate</artifactId>
         <groupId>ddf.security.certificate</groupId>
@@ -61,10 +64,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.security.core</groupId>
-            <artifactId>security-core-api</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
     <build>
@@ -80,6 +85,31 @@
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -104,17 +134,17 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>.69</minimum>
+                                            <minimum>.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.security.certificate.generator;
+
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+public class CertificateCommand {
+
+    /**
+     * Pass in a string to use as the common name of the certificate to be generated.
+     * Exception thrown if 0 arguments or more than 1 argument.
+     *
+     * @param args
+     */
+    public static void main(String args[]) {
+
+        if (args.length != 1) {
+            throw new RuntimeException(
+                    "Expecting exactly one command-line argument. Detected " + args.length
+                            + " arguments.");
+        }
+        String commonname = args[0];
+        configureDemoCert(commonname);
+        removeKey("localhost");
+    }
+
+    /**
+     * Generates new signed certificate. The input parameter is used as the certificate's common name.
+     * Postcondition is the server keystore is updated to include a private entry. The private
+     * entry has the new certificate chain  that connects the server to the Demo CA. The matching
+     * private key is also stored in the entry.
+     *
+     * @param commonName string to use as the common name in the new certificate.
+     * @return the string used as the common name in the new certificate
+     */
+
+    public static String configureDemoCert(String commonName) {
+        CertificateAuthority demoCa = new DemoCertificateAuthority();
+        CertificateSigningRequest csr = new CertificateSigningRequest();
+        csr.setCommonName(commonName);
+        KeyStore.PrivateKeyEntry pkEntry = demoCa.sign(csr);
+        KeyStoreFile ksFile = getKeyStoreFile();
+        ksFile.setEntry(commonName, pkEntry);
+        ksFile.save();
+        String distinguishedName = ((X509Certificate) pkEntry.getCertificate()).getSubjectDN()
+                .getName();
+        return distinguishedName;
+    }
+
+    /**
+     * Remove key from server keystore. The input is the key's alias in the keystore.
+     * The method returns true if the key is no longer in the keystore, or false if the
+     * key is in the keystore.
+     *
+     * @param alias
+     * @return true if the key is not in the keystore, otherwise false
+     */
+    public static Boolean removeKey(String alias) {
+        KeyStoreFile ksFile = getKeyStoreFile();
+        Boolean success = ksFile.deleteEntry(alias);
+        ksFile.save();
+        return success;
+    }
+
+    protected static KeyStoreFile getKeyStoreFile() {
+        return KeyStoreFile.openFile(System.getProperty("javax.net.ssl.keyStore"),
+                System.getProperty("javax.net.ssl.keyStorePassword")
+                        .toCharArray());
+    }
+
+}

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -15,8 +15,6 @@
 package org.codice.ddf.security.certificate.generator;
 
 import java.lang.management.ManagementFactory;
-import java.security.KeyStore;
-import java.security.cert.X509Certificate;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
@@ -30,9 +28,6 @@ public class CertificateGenerator implements CertificateGeneratorMBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CertificateGenerator.class);
 
-    /**
-     * Constructor. Registers the object as a service provider.
-     */
     public CertificateGenerator() {
         registerMbean();
     }
@@ -59,26 +54,24 @@ public class CertificateGenerator implements CertificateGeneratorMBean {
      * @return the string used as the common name in the new certificate
      */
     public String configureDemoCert(String commonName) {
-        CertificateAuthority demoCa = new DemoCertificateAuthority();
-        CertificateSigningRequest csr = new CertificateSigningRequest();
-        csr.setCommonName(commonName);
-        KeyStore.PrivateKeyEntry pkEntry = demoCa.sign(csr);
-        KeyStoreFile ksFile = getKeyStoreFile();
-        for (String alias : ksFile.aliases()) {
-            if (ksFile.isKey(alias)) {
-                ksFile.deleteEntry(alias);
-            }
-        }
-        ksFile.setEntry(commonName, pkEntry);
-        ksFile.save();
-        String distinguishedName = ((X509Certificate) pkEntry.getCertificate()).getSubjectDN()
-                .getName();
-        return distinguishedName;
+        return CertificateCommand.configureDemoCert(commonName);
     }
 
-    protected KeyStoreFile getKeyStoreFile() {
-        return KeyStoreFile.openFile(System.getProperty("javax.net.ssl.keyStore"),
-                System.getProperty("javax.net.ssl.keyStorePassword").toCharArray());
+    /**
+     * Remove key from server keystore. The input is the key's alias in the keystore.
+     * The method returns true if the key is no longer in the keystore, or false if the
+     * key is in the keystore.
+     *
+     * @param alias
+     * @return true if the key is not in the keystore, otherwise false
+     */
+    public Boolean removeKey(String alias) {
+
+        return CertificateCommand.removeKey(alias);
+    }
+
+    public KeyStoreFile getKeyStoreFile() {
+        return CertificateCommand.getKeyStoreFile();
     }
 
     protected void registerMbean() {

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGeneratorMBean.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGeneratorMBean.java
@@ -18,4 +18,6 @@ public interface CertificateGeneratorMBean {
     public String configureDemoCert(String commonName);
 
     public String configureDemoCertWithDefaultHostname();
+
+    public Boolean removeKey(String alias);
 }

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/KeyStoreFile.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/KeyStoreFile.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -27,8 +27,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import ddf.security.SecurityConstants;
 
 /**
  * Facade class for a Java Keystore (JKS) file. Exposes a few high-level behaviors to abstract away the
@@ -57,8 +55,8 @@ public class KeyStoreFile {
                 keyStore.load(resource, pw);
             }
         } catch (GeneralSecurityException | IOException e) {
-            throw new CertificateGeneratorException("Could not create new instance of KeyStoreFile",
-                    e);
+            String msg = "Could not create new instance of KeyStoreFile";
+            throw new CertificateGeneratorException(msg, e);
         }
 
         facade.file = file;
@@ -69,7 +67,7 @@ public class KeyStoreFile {
 
     static KeyStore newKeyStore() throws KeyStoreException {
 
-        return KeyStore.getInstance(System.getProperty(SecurityConstants.KEYSTORE_TYPE));
+        return KeyStore.getInstance(System.getProperty("javax.net.ssl.keyStoreType"));
     }
 
     /**
@@ -136,14 +134,14 @@ public class KeyStoreFile {
     /**
      * Add a new entry to the keystore. Use the given alias.
      *
-     * @param alias
-     * @param entry
+     * @param alias of keystore entry
+     * @param entry instance
      */
     public void setEntry(String alias, KeyStore.Entry entry) {
         try {
             keyStore.setEntry(alias, entry, getPasswordObject());
         } catch (KeyStoreException e) {
-            throw new RuntimeException(String.format("Could add %s to keystore", alias), e);
+            throw new RuntimeException(String.format("Could not add %s to keystore", alias), e);
         }
     }
 
@@ -151,16 +149,15 @@ public class KeyStoreFile {
      * Remove the key store entry at the given alias. If the alias does not exist, log that it does not exist.
      *
      * @param alias the name of the entry in the keystore
-     * @return true if entry exists and was removed, false otherwise
+     * @return true if entry is not in the keystore false otherwise
      */
     public boolean deleteEntry(String alias) {
         try {
             keyStore.deleteEntry(alias);
         } catch (KeyStoreException e) {
             LOGGER.info("Attempted to remove key named {} from keyStore. No such such key", alias);
-            return false;
         }
-        return true;
+        return isKey(alias);
     }
 
     /**
@@ -172,8 +169,8 @@ public class KeyStoreFile {
         try (FileOutputStream fd = new FileOutputStream(file)) {
             keyStore.store(fd, password);
         } catch (Exception e) {
-            throw new RuntimeException(
-                    String.format("Could not save the keystore %s", file.getAbsolutePath()), e);
+            throw new RuntimeException(String.format("Could not save the keystore %s",
+                    file.getAbsolutePath()), e);
         }
     }
 

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateGeneratorTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateGeneratorTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -38,15 +38,14 @@ public class CertificateGeneratorTest {
 
         systemKeystoreFile = temporaryFolder.newFile("serverKeystore.jks");
         FileOutputStream systemKeyOutStream = new FileOutputStream(systemKeystoreFile);
-        InputStream systemKeyStream = CertificateGenerator.class
-                .getResourceAsStream("/serverKeystore.jks");
+        InputStream systemKeyStream = CertificateGenerator.class.getResourceAsStream(
+                "/serverKeystore.jks");
         IOUtils.copy(systemKeyStream, systemKeyOutStream);
 
         IOUtils.closeQuietly(systemKeyOutStream);
         IOUtils.closeQuietly(systemKeyStream);
 
         System.setProperty("javax.net.ssl.keyStoreType", "jks");
-        System.setProperty("ddf.home", "");
         System.setProperty("javax.net.ssl.keyStore", systemKeystoreFile.getAbsolutePath());
         System.setProperty("javax.net.ssl.keyStorePassword", "changeit");
     }
@@ -60,13 +59,13 @@ public class CertificateGeneratorTest {
             }
         };
         KeyStoreFile ksf = generator.getKeyStoreFile();
-        assertThat(ksf.aliases().size(), is(2));
-        assertThat(ksf.isKey("localhost"), is(true));
-
+        assertThat(ksf.aliases()
+                .size(), is(2));
         assertThat(generator.configureDemoCert("my-fqdn"), is("CN=my-fqdn"));
+        generator.configureDemoCert("test2");
         ksf = generator.getKeyStoreFile();
-        assertThat(ksf.aliases().size(), is(2));
+        assertThat(ksf.aliases()
+                .size(), is(4));
         assertThat(ksf.isKey("my-fqdn"), is(true));
-        assertThat(ksf.isKey("localhost"), is(false));
     }
 }

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/KeyStoreFileTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/KeyStoreFileTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -36,8 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import ddf.security.SecurityConstants;
-
 @RunWith(value = MockitoJUnitRunner.class)
 public class KeyStoreFileTest {
 
@@ -60,7 +58,7 @@ public class KeyStoreFileTest {
     @BeforeClass
     public static void init() {
         properties = System.getProperties();
-        System.setProperty(SecurityConstants.KEYSTORE_TYPE, "JKS");
+        System.setProperty("javax.net.ssl.keyStoreType", "JKS");
     }
 
     @AfterClass
@@ -69,7 +67,9 @@ public class KeyStoreFileTest {
     }
 
     String getPathTo(String path) {
-        return getClass().getClassLoader().getResource(path).getPath();
+        return getClass().getClassLoader()
+                .getResource(path)
+                .getPath();
     }
 
     @Before
@@ -125,9 +125,9 @@ public class KeyStoreFileTest {
     }
 
     Path refreshKeyStoreFile() throws IOException {
-        return Files
-                .copy(Paths.get(getPathTo(KEYSTORE_TEMPLATE)), Paths.get(getPathTo(KEYSTORE_COPY)),
-                        REPLACE_EXISTING);
+        return Files.copy(Paths.get(getPathTo(KEYSTORE_TEMPLATE)),
+                Paths.get(getPathTo(KEYSTORE_COPY)),
+                REPLACE_EXISTING);
     }
 
     @Test
@@ -136,8 +136,8 @@ public class KeyStoreFileTest {
         KeyStoreFile ksFile = KeyStoreFile.openFile(getPathTo(KEYSTORE_COPY), PASSWORD);
 
         //Get a cert from the keystore
-        KeyStore.TrustedCertificateEntry demoCa = (KeyStore.TrustedCertificateEntry) ksFile
-                .getEntry(ALIAS_DEMO_CA);
+        KeyStore.TrustedCertificateEntry demoCa =
+                (KeyStore.TrustedCertificateEntry) ksFile.getEntry(ALIAS_DEMO_CA);
         assertThat("Could not retrieve Demo CA from keystore", demoCa,
                 instanceOf(KeyStore.TrustedCertificateEntry.class));
         assertThat(ksFile.isKey(ALIAS_DEMO_CA), is(false));


### PR DESCRIPTION
CertNew.sh generates certificate signed by Demo CA and installs it in the server keystore
Shader plugin creates self-contained JAR used by script.

 * The script usage is in the comments. To try it out, change to <DDF_HOME>/etc/keystores and 
   * execute **sh CertNew.sh** create certs using your hostname
   * execute **sh CertNew.sh <i>name</i> to create certs using what name you want.
 * I didn't parameterize the script much for two reasons. First, I didn't want the user to be to have to figure out a bunch of stuff just to get going. Second, I didn't want to spend time building in flexibility that wasn't going to be use. Have a look and add comments if you think it would work differently.
   * The automatically removes the keystore entry for *localhost* because it's presence can cause problems.
    * The script expects to be execute in the <DDF_HOME>/etc/keystores  and expects the keystore to be in <DDF_HOME>/etc/certs. It also has some (looser) expectations about where to find its JAR file.

@stustison @pklinef @spearskw @brendan-hofmann @harrison-tarr @AzGoalie

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/385)
<!-- Reviewable:end -->
