### PR TITLE
DDF-1739 SAML Logout verbiage cleanup

### DIFF
--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
@@ -48,14 +48,14 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import ddf.security.samlp.LogoutService;
+import ddf.security.samlp.LogoutMessage;
 import ddf.security.samlp.SamlProtocol;
 import ddf.security.samlp.SimpleSign;
 import ddf.security.samlp.SystemCrypto;
 
-public class LogoutServiceImpl implements LogoutService {
+public class LogoutMessageImpl implements LogoutMessage {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogoutServiceImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogoutMessageImpl.class);
 
     public static final String SOAP_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP";
 
@@ -67,7 +67,7 @@ public class LogoutServiceImpl implements LogoutService {
         OpenSAMLUtil.initSamlEngine();
     }
 
-    public String getIdpSingleLogoutLocation(IDPSSODescriptor descriptor) {
+    public String getIdpSingleLogoutLocation(@NotNull IDPSSODescriptor descriptor) {
         return descriptor.getSingleLogoutServices()
                 .stream()
                 .filter(service -> SOAP_BINDING.equals(service.getBinding()))
@@ -76,7 +76,7 @@ public class LogoutServiceImpl implements LogoutService {
                 .orElse("");
     }
 
-    public SignableSAMLObject extractXmlObject(String samlLogoutResponse)
+    public SignableSAMLObject extractXmlObject(@NotNull String samlLogoutResponse)
             throws WSSecurityException, XMLStreamException {
         Document responseDoc =
                 StaxUtils.read(new ByteArrayInputStream(samlLogoutResponse.getBytes()));
@@ -87,7 +87,7 @@ public class LogoutServiceImpl implements LogoutService {
         return null;
     }
 
-    private <T extends SAMLObject> T extract(String samlObject, Class<T> clazz)
+    private <T extends SAMLObject> T extract(@NotNull String samlObject, @NotNull Class<T> clazz)
             throws WSSecurityException, XMLStreamException {
         Document responseDoc = StaxUtils.read(new ByteArrayInputStream(samlObject.getBytes()));
         XMLObject responseXmlObject = OpenSAMLUtil.fromDom(responseDoc.getDocumentElement());
@@ -98,13 +98,13 @@ public class LogoutServiceImpl implements LogoutService {
     }
 
     @Override
-    public LogoutResponse extractSamlLogoutResponse(String samlLogoutResponse)
+    public LogoutResponse extractSamlLogoutResponse(@NotNull String samlLogoutResponse)
             throws XMLStreamException, WSSecurityException {
         return extract(samlLogoutResponse, LogoutResponse.class);
     }
 
     @Override
-    public LogoutRequest extractSamlLogoutRequest(String samlLogoutResponse)
+    public LogoutRequest extractSamlLogoutRequest(@NotNull String samlLogoutResponse)
             throws XMLStreamException, WSSecurityException {
         return extract(samlLogoutResponse, LogoutRequest.class);
     }
@@ -144,7 +144,8 @@ public class LogoutServiceImpl implements LogoutService {
     }
 
     @Override
-    public LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue) {
+    public LogoutResponse buildLogoutResponse(@NotNull String issuerOrEntityId,
+            @NotNull String statusCodeValue) {
         return buildLogoutResponse(issuerOrEntityId, statusCodeValue, null);
     }
 
@@ -158,8 +159,8 @@ public class LogoutServiceImpl implements LogoutService {
                         .toString());
     }
 
-    public LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue,
-            String inResponseTo, String id) {
+    public LogoutResponse buildLogoutResponse(@NotNull String issuerOrEntityId,
+            @NotNull String statusCodeValue, String inResponseTo, @NotNull String id) {
         if (issuerOrEntityId == null) {
             throw new IllegalArgumentException("Issuer cannot be null");
         }
@@ -177,14 +178,14 @@ public class LogoutServiceImpl implements LogoutService {
     }
 
     @Override
-    public Element getElementFromSaml(XMLObject xmlObject) throws WSSecurityException {
+    public Element getElementFromSaml(@NotNull XMLObject xmlObject) throws WSSecurityException {
         Document doc = DOMUtils.createDocument();
         doc.appendChild(doc.createElement("root"));
         return OpenSAMLUtil.toDom(xmlObject, doc);
     }
 
     @Override
-    public String sendSamlLogoutRequest(@NotNull LogoutRequest request, String targetUri)
+    public String sendSamlLogoutRequest(@NotNull LogoutRequest request, @NotNull String targetUri)
             throws IOException, WSSecurityException {
         Element requestElement = getElementFromSaml(request);
         String requestMessage = DOM2Writer.nodeToString(requestElement);
@@ -200,21 +201,23 @@ public class LogoutServiceImpl implements LogoutService {
     }
 
     @Override
-    public URI signSamlGetResponse(SAMLObject samlObject, URI target, String relayState)
+    public URI signSamlGetResponse(@NotNull SAMLObject samlObject, @NotNull URI target,
+            String relayState)
             throws WSSecurityException, SimpleSign.SignatureException, IOException {
 
         return signSamlGet(samlObject, target, relayState, SSOConstants.SAML_RESPONSE);
     }
 
     @Override
-    public URI signSamlGetRequest(SAMLObject samlObject, URI target, String relayState)
+    public URI signSamlGetRequest(@NotNull SAMLObject samlObject, @NotNull URI target,
+            String relayState)
             throws WSSecurityException, SimpleSign.SignatureException, IOException {
 
         return signSamlGet(samlObject, target, relayState, SSOConstants.SAML_REQUEST);
     }
 
-    private URI signSamlGet(SAMLObject samlObject, URI target, String relayState,
-            String requestType)
+    private URI signSamlGet(@NotNull SAMLObject samlObject, @NotNull URI target, String relayState,
+            @NotNull String requestType)
             throws WSSecurityException, SimpleSign.SignatureException, IOException {
         Document doc = DOMUtils.createDocument();
         doc.appendChild(doc.createElement("root"));

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlValidator.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlValidator.java
@@ -78,7 +78,7 @@ public abstract class SamlValidator implements Validator<ValidatingXMLObject> {
         }
 
         if (instant.plus(builder.clockSkew)
-                .isBefore(now.minus(builder.issueTimeout))) {
+                .isBefore(now.minus(builder.timeout))) {
             throw new ValidationException("Issue Instant was outside valid time range");
         }
 
@@ -147,11 +147,11 @@ public abstract class SamlValidator implements Validator<ValidatingXMLObject> {
 
         protected XMLObject xmlObject;
 
-        protected Duration issueTimeout = Duration.ofMinutes(10);
+        protected Duration timeout = Duration.ofMinutes(10);
 
         protected Duration clockSkew = Duration.ofSeconds(30);
 
-        protected String inResponse;
+        protected String requestId;
 
         protected String endpoint;
 
@@ -232,19 +232,19 @@ public abstract class SamlValidator implements Validator<ValidatingXMLObject> {
             return this;
         }
 
-        public Builder setInResponse(@NotNull String inResponse) {
-            if (isBlank(inResponse)) {
-                throw new IllegalArgumentException("InResponseTo Id cannot be blank!");
+        public Builder setRequestId(@NotNull String requestId) {
+            if (isBlank(requestId)) {
+                throw new IllegalArgumentException("Logout Request Id cannot be blank!");
             }
-            this.inResponse = inResponse;
+            this.requestId = requestId;
             return this;
         }
 
-        public Builder setIssueTimeout(@NotNull Duration issueTimeout) {
-            if (issueTimeout == null) {
-                throw new IllegalArgumentException("Issue Timeout cannot be null!");
+        public Builder setTimeout(@NotNull Duration timeout) {
+            if (timeout == null) {
+                throw new IllegalArgumentException("Timeout cannot be null!");
             }
-            this.issueTimeout = issueTimeout;
+            this.timeout = timeout;
             return this;
         }
 
@@ -344,9 +344,10 @@ public abstract class SamlValidator implements Validator<ValidatingXMLObject> {
 
         @Override
         protected void checkId() throws ValidationException {
-            if (isNotBlank(builder.inResponse)) {
-                if (!builder.inResponse.equals(logoutResponse.getInResponseTo())) {
-                    throw new ValidationException("The InResponseTo value was incorrect");
+            if (isNotBlank(builder.requestId)) {
+                if (!builder.requestId.equals(logoutResponse.getInResponseTo())) {
+                    throw new ValidationException(
+                            "The InResponseTo value did not match the Logout Request Id");
                 }
             }
         }

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,13 +42,13 @@
         <argument ref="encryptionService"/>
     </bean>
 
-    <bean id="logoutServiceImpl" class="ddf.security.samlp.impl.LogoutServiceImpl">
-        <cm:managed-properties persistent-id="ddf.security.samlp.LogoutService"
+    <bean id="logoutMessageImpl" class="ddf.security.samlp.impl.LogoutMessageImpl">
+        <cm:managed-properties persistent-id="ddf.security.samlp.LogoutMessage"
                                update-strategy="container-managed"/>
         <property name="systemCrypto" ref="crypto"/>
     </bean>
 
-    <service ref="logoutServiceImpl" interface="ddf.security.samlp.LogoutService"/>
+    <service ref="logoutMessageImpl" interface="ddf.security.samlp.LogoutMessage" />
 
     <service id="serviceManager" ref="securityManagerImpl"
              interface="ddf.security.service.SecurityManager"/>

--- a/platform/security/core/security-core-impl/src/test/groovy/ddf/security/samlp/impl/SamlValidatorBuilderTest.groovy
+++ b/platform/security/core/security-core-impl/src/test/groovy/ddf/security/samlp/impl/SamlValidatorBuilderTest.groovy
@@ -56,35 +56,35 @@ class SamlValidatorBuilderTest extends Specification {
         'abc'      | null      | null    | 'lkj'      | null
     }
 
-    def 'check inResponse'() {
+    def 'check requestId'() {
         setup:
         def builder = new SamlValidator.Builder(null)
 
         when:
-        builder.setInResponse('xyz')
+        builder.setRequestId('xyz')
 
         then:
-        builder.inResponse == 'xyz'
+        builder.requestId == 'xyz'
 
         when:
-        builder.setInResponse(null)
+        builder.setRequestId(null)
 
         then:
         thrown(IllegalArgumentException)
     }
 
-    def 'check issueTimeout'() {
+    def 'check timeout'() {
         setup:
         def builder = new SamlValidator.Builder(null)
 
         when:
-        builder.setIssueTimeout(Duration.ofSeconds(1))
+        builder.setTimeout(Duration.ofSeconds(1))
 
         then:
-        builder.issueTimeout.equals(Duration.ofSeconds(1))
+        builder.timeout.equals(Duration.ofSeconds(1))
 
         when:
-        builder.setIssueTimeout(null)
+        builder.setTimeout(null)
 
         then:
         thrown(IllegalArgumentException)

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
@@ -53,7 +53,7 @@ import ddf.security.SecurityConstants;
 import ddf.security.common.util.SecurityTokenHolder;
 import ddf.security.encryption.EncryptionService;
 import ddf.security.http.SessionFactory;
-import ddf.security.samlp.LogoutService;
+import ddf.security.samlp.LogoutMessage;
 import ddf.security.samlp.SamlProtocol;
 import ddf.security.samlp.SimpleSign;
 import ddf.security.samlp.SystemCrypto;
@@ -84,7 +84,7 @@ public class LogoutRequestService {
 
     private SystemCrypto systemCrypto;
 
-    private LogoutService logoutService;
+    private LogoutMessage logoutMessage;
 
     private String submitForm;
 
@@ -145,7 +145,7 @@ public class LogoutRequestService {
                     return buildLogoutResponse(msg);
                 }
                 logout();
-                LogoutRequest logoutRequest = logoutService.buildLogoutRequest(name, getEntityId());
+                LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(name, getEntityId());
 
                 String relayState = relayStates.encode(name);
 
@@ -210,7 +210,7 @@ public class LogoutRequestService {
         LOGGER.debug("Configuring SAML Response for Redirect.");
         Document doc = DOMUtils.createDocument();
         doc.appendChild(doc.createElement("root"));
-        URI location = logoutService.signSamlGetRequest(logoutRequest,
+        URI location = logoutMessage.signSamlGetRequest(logoutRequest,
                 new URI(idpMetadata.getSingleLogoutLocation()),
                 relayState);
         String redirectUpdated = String.format(redirectPage, location.toString());
@@ -232,7 +232,7 @@ public class LogoutRequestService {
                 new SamlValidator.Builder(simpleSign).buildAndValidate(request.getRequestURL()
                         .toString(), SamlProtocol.Binding.HTTP_POST, logoutRequest);
                 LogoutResponse logoutResponse =
-                        logoutService.buildLogoutResponse(logoutRequest.getIssuer()
+                        logoutMessage.buildLogoutResponse(logoutRequest.getIssuer()
                                 .getValue(), StatusCode.SUCCESS_URI);
 
                 return getSamlpPostLogoutResponse(relayState, logoutResponse);
@@ -282,7 +282,7 @@ public class LogoutRequestService {
                                 .toString(), SamlProtocol.Binding.HTTP_REDIRECT, logoutRequest);
                 logout();
                 String entityId = getEntityId();
-                LogoutResponse logoutResponse = logoutService.buildLogoutResponse(entityId,
+                LogoutResponse logoutResponse = logoutMessage.buildLogoutResponse(entityId,
                         StatusCode.SUCCESS_URI);
                 return getLogoutResponse(relayState, logoutResponse);
             } catch (IOException e) {
@@ -325,7 +325,7 @@ public class LogoutRequestService {
             throws IdpClientException {
         LogoutResponse logoutResponse;
         try {
-            logoutResponse = logoutService.extractSamlLogoutResponse(logoutResponseStr);
+            logoutResponse = logoutMessage.extractSamlLogoutResponse(logoutResponseStr);
         } catch (XMLStreamException | WSSecurityException e) {
             throw new IdpClientException("Unable to parse logout response.", e);
         }
@@ -349,7 +349,7 @@ public class LogoutRequestService {
 
         LogoutRequest logoutRequest;
         try {
-            logoutRequest = logoutService.extractSamlLogoutRequest(logoutRequestStr);
+            logoutRequest = logoutMessage.extractSamlLogoutRequest(logoutRequestStr);
         } catch (XMLStreamException | WSSecurityException e) {
             throw new IdpClientException("Unable to parse logout request.", e);
         }
@@ -415,7 +415,7 @@ public class LogoutRequestService {
         LOGGER.debug("Configuring SAML Response for Redirect.");
         Document doc = DOMUtils.createDocument();
         doc.appendChild(doc.createElement("root"));
-        URI location = logoutService.signSamlGetResponse(samlResponse,
+        URI location = logoutMessage.signSamlGetResponse(samlResponse,
                 new URI(idpMetadata.getSingleLogoutLocation()),
                 relayState);
         String redirectUpdated = String.format(redirectPage, location.toString());
@@ -443,8 +443,8 @@ public class LogoutRequestService {
         this.systemCrypto = systemCrypto;
     }
 
-    public void setLogoutService(LogoutService logoutService) {
-        this.logoutService = logoutService;
+    public void setLogoutMessage(LogoutMessage logoutMessage) {
+        this.logoutMessage = logoutMessage;
     }
 
     public void setEncryptionService(EncryptionService encryptionService) {

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -89,8 +89,8 @@
         <argument ref="crypto"/>
         <argument ref="baseUrl"/>
         <argument ref="relayStates"/>
-        <property name="logoutService">
-            <reference interface="ddf.security.samlp.LogoutService" />
+        <property name="logoutMessage">
+            <reference interface="ddf.security.samlp.LogoutMessage" />
         </property>
         <property name="encryptionService" ref="encryptionService"/>
         <property name="sessionFactory" ref="sessionFactory"/>

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
@@ -43,7 +43,7 @@ import ddf.security.SecurityConstants;
 import ddf.security.common.util.SecurityTokenHolder;
 import ddf.security.encryption.EncryptionService;
 import ddf.security.http.SessionFactory;
-import ddf.security.samlp.LogoutService;
+import ddf.security.samlp.LogoutMessage;
 import ddf.security.samlp.SamlProtocol;
 import ddf.security.samlp.SimpleSign;
 import ddf.security.samlp.SystemCrypto;
@@ -69,7 +69,7 @@ public class LogoutRequestServiceTest {
 
     private HttpServletRequest request;
 
-    private LogoutService logoutService;
+    private LogoutMessage logoutMessage;
 
     private EncryptionService encryptionService;
 
@@ -94,7 +94,7 @@ public class LogoutRequestServiceTest {
         relayStates = mock(RelayStates.class);
         sessionFactory = mock(SessionFactory.class);
         request = mock(HttpServletRequest.class);
-        logoutService = mock(LogoutService.class);
+        logoutMessage = mock(LogoutMessage.class);
         encryptionService = mock(EncryptionService.class);
         session = mock(HttpSession.class);
         securityTokenHolder = mock(SecurityTokenHolder.class);
@@ -106,7 +106,7 @@ public class LogoutRequestServiceTest {
                 relayStates);
         logoutRequestService.setEncryptionService(encryptionService);
         logoutRequestService.setLogOutPageTimeOut(3600000);
-        logoutRequestService.setLogoutService(logoutService);
+        logoutRequestService.setLogoutMessage(logoutMessage);
         logoutRequestService.setRequest(request);
         logoutRequestService.setSessionFactory(sessionFactory);
         logoutRequestService.setSystemCrypto(systemCrypto);
@@ -127,7 +127,7 @@ public class LogoutRequestServiceTest {
     public void testSendLogoutRequest() throws Exception {
         String encryptedNameIdWithTime = nameId + "\n" + time;
         when(encryptionService.decrypt(any(String.class))).thenReturn(nameId + "\n" + time);
-        when(logoutService.signSamlGetRequest(any(LogoutRequest.class),
+        when(logoutMessage.signSamlGetRequest(any(LogoutRequest.class),
                 any(URI.class),
                 anyString())).thenReturn(new URI(logoutUrl));
         Response response = logoutRequestService.sendLogoutRequest(encryptedNameIdWithTime);
@@ -149,10 +149,10 @@ public class LogoutRequestServiceTest {
         Issuer issuer = mock(Issuer.class);
         OpenSAMLUtil.initSamlEngine();
         LogoutResponse logoutResponse = new LogoutResponseBuilder().buildObject();
-        when(logoutService.extractSamlLogoutRequest(any(String.class))).thenReturn(logoutRequest);
+        when(logoutMessage.extractSamlLogoutRequest(any(String.class))).thenReturn(logoutRequest);
         when(logoutRequest.getIssuer()).thenReturn(issuer);
         when(issuer.getValue()).thenReturn(issuerStr);
-        when(logoutService.buildLogoutResponse(eq(issuerStr),
+        when(logoutMessage.buildLogoutResponse(eq(issuerStr),
                 eq(StatusCode.SUCCESS_URI))).thenReturn(logoutResponse);
         when(idpMetadata.getSingleLogoutBinding()).thenReturn(SamlProtocol.POST_BINDING);
         when(idpMetadata.getSingleLogoutLocation()).thenReturn(postLogoutUrl);
@@ -175,7 +175,7 @@ public class LogoutRequestServiceTest {
         Issuer issuer = mock(Issuer.class);
         LogoutResponse logoutResponse = mock(LogoutResponse.class);
         logoutResponse.setIssuer(issuer);
-        when(logoutService.extractSamlLogoutResponse(any(String.class))).thenReturn(logoutResponse);
+        when(logoutMessage.extractSamlLogoutResponse(any(String.class))).thenReturn(logoutResponse);
         when(request.getRequestURL()).thenReturn(new StringBuffer("www.url.com/url"));
         when(logoutResponse.getIssuer()).thenReturn(issuer);
         when(issuer.getValue()).thenReturn(issuerStr);
@@ -200,9 +200,9 @@ public class LogoutRequestServiceTest {
                 .toString();
         String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode("deflatedSamlRequest");
         LogoutRequest logoutRequest = mock(LogoutRequest.class);
-        when(logoutService.extractSamlLogoutRequest(eq("deflatedSamlRequest"))).thenReturn(
+        when(logoutMessage.extractSamlLogoutRequest(eq("deflatedSamlRequest"))).thenReturn(
                 logoutRequest);
-        when(logoutService.signSamlGetResponse(any(LogoutRequest.class),
+        when(logoutMessage.signSamlGetResponse(any(LogoutRequest.class),
                 any(URI.class),
                 anyString())).thenReturn(new URI(redirectLogoutUrl));
         Response response = logoutRequestService.getLogoutRequest(deflatedSamlRequest,
@@ -225,7 +225,7 @@ public class LogoutRequestServiceTest {
                 .toString();
         String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode("deflatedSamlResponse");
         LogoutResponse logoutResponse = mock(LogoutResponse.class);
-        when(logoutService.extractSamlLogoutResponse(eq("deflatedSamlResponse"))).thenReturn(
+        when(logoutMessage.extractSamlLogoutResponse(eq("deflatedSamlResponse"))).thenReturn(
                 logoutResponse);
         Response response = logoutRequestService.getLogoutRequest(null,
                 deflatedSamlResponse,

--- a/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,7 +29,7 @@
 
     <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService" />
 
-    <reference id="logoutService" interface="ddf.security.samlp.LogoutService" />
+    <reference id="logoutMessage" interface="ddf.security.samlp.LogoutMessage" />
 
 
     <bean id="IdpExceptionMapperProvider"
@@ -53,7 +53,7 @@
         <property name="securityManager" ref="securityManager"/>
         <property name="tokenFactory" ref="tokenFactory" />
         <property name="strictSignature" value="true" />
-        <property name="logoutService" ref="logoutService" />
+        <property name="logoutMessage" ref="logoutMessage" />
         <property name="logoutStates" ref="logoutStates" />
     </bean>
 

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
@@ -28,33 +28,37 @@ import org.opensaml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.xml.XMLObject;
 import org.w3c.dom.Element;
 
-public interface LogoutService {
-    String getIdpSingleLogoutLocation(IDPSSODescriptor descriptor);
+public interface LogoutMessage {
+    String getIdpSingleLogoutLocation(@NotNull IDPSSODescriptor descriptor);
 
-    SignableSAMLObject extractXmlObject(String samlLogoutResponse)
+    SignableSAMLObject extractXmlObject(@NotNull String samlLogoutResponse)
             throws WSSecurityException, XMLStreamException;
 
-    LogoutResponse extractSamlLogoutResponse(String samlLogoutResponse)
+    LogoutResponse extractSamlLogoutResponse(@NotNull String samlLogoutResponse)
             throws XMLStreamException, WSSecurityException;
 
-    LogoutRequest extractSamlLogoutRequest(String samlLogoutRequest)
+    LogoutRequest extractSamlLogoutRequest(@NotNull String samlLogoutRequest)
             throws XMLStreamException, WSSecurityException;
 
-    LogoutRequest buildLogoutRequest(@NotNull String nameIdString, @NotNull String issuerOrEntityId);
+    LogoutRequest buildLogoutRequest(@NotNull String nameIdString,
+            @NotNull String issuerOrEntityId);
 
-    LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue);
+    LogoutResponse buildLogoutResponse(@NotNull String issuerOrEntityId,
+            @NotNull String statusCodeValue);
 
-    LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue,
-            String inResponseTo);
+    LogoutResponse buildLogoutResponse(@NotNull String issuerOrEntityId,
+            @NotNull String statusCodeValue, String inResponseTo);
 
-    Element getElementFromSaml(XMLObject xmlObject) throws WSSecurityException;
+    Element getElementFromSaml(@NotNull XMLObject xmlObject) throws WSSecurityException;
 
-    String sendSamlLogoutRequest(@NotNull LogoutRequest request, String targetUri)
+    String sendSamlLogoutRequest(@NotNull LogoutRequest request, @NotNull String targetUri)
             throws IOException, WSSecurityException;
 
-    URI signSamlGetResponse(SAMLObject samlObject, URI uriNameMeLater, String relayState)
+    URI signSamlGetResponse(@NotNull SAMLObject samlObject, @NotNull URI uriNameMeLater,
+            String relayState)
             throws WSSecurityException, SimpleSign.SignatureException, IOException;
 
-    URI signSamlGetRequest(SAMLObject samlObject, URI uriNameMeLater, String relayState)
+    URI signSamlGetRequest(@NotNull SAMLObject samlObject, @NotNull URI uriNameMeLater,
+            String relayState)
             throws WSSecurityException, SimpleSign.SignatureException, IOException;
 }


### PR DESCRIPTION
-Cleaned up verbiage contained in the SAML Logout code:
     1. Renamed inResponse to requestId in the Builder class of SamlValidator.
     2. Renamed issueTimeout to timeout in the Builder class of SamlValidator.
     3. Renamed LogoutService to LogoutMessage.
     4. Cleaned verbiage in various places throughout the SAML Logout code.
     5. Renamed reqres to samlType in IdpEndpoint.
-Added additional NotNull annotations in LogoutMessageImpl.

If there is any verbiage that I had missed or any other suggestions, please say so in the comments.

@codice/green 
@rzwiefel (could you hero this)