### PR TITLE
DDF-1693 Removes grunt "Newer" plugin

### DIFF
--- a/catalog/ui/search-ui/standard/Gruntfile.js
+++ b/catalog/ui/search-ui/standard/Gruntfile.js
@@ -159,7 +159,7 @@ module.exports = function (grunt) {
         watch: {
             jsFiles: {
                 files: ['<%= jshint.all.src %>'],
-                tasks: ['newer:jshint']
+                tasks: ['jshint']
             },
             livereload : {
                 options : {livereload :true},
@@ -188,8 +188,8 @@ module.exports = function (grunt) {
     grunt.registerTask('test:selenium', ['port:allocator', 'express:test', 'mochaWebdriver:selenium']);
     grunt.registerTask('test:sauce', ['port:allocator', 'express:test', 'mochaWebdriver:sauce']);
 
-    grunt.registerTask('build', ['bower-offline-install', 'sed', 'newer:less',
-        'newer:cssmin', 'newer:jshint']);
+    grunt.registerTask('build', ['bower-offline-install', 'sed', 'less',
+        'cssmin', 'jshint']);
 
     grunt.registerTask('default', ['build','express:server','watch']);
 

--- a/catalog/ui/search-ui/standard/package.json
+++ b/catalog/ui/search-ui/standard/package.json
@@ -31,7 +31,6 @@
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
     "grunt-mocha-webdriver": "1.2.2",
-    "grunt-newer": "0.8.0",
     "grunt-port-allocator": "file:target/npm/grunt-port-allocator",
     "grunt-sed": "0.1.1",
     "http-proxy": "0.10.0",

--- a/platform/admin/ui/Gruntfile.js
+++ b/platform/admin/ui/Gruntfile.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
         watch: {
             jsFiles: {
                 files: ['<%= jshint.files %>'],
-                tasks: ['newer:jshint']
+                tasks: ['jshint']
             },
             livereload : {
                 options : {livereload :true},
@@ -179,8 +179,8 @@ module.exports = function (grunt) {
     grunt.registerTask('test:selenium', ['port:allocator', 'express:test', 'mochaWebdriver:selenium']);
     grunt.registerTask('test:sauce', ['port:allocator', 'express:test', 'mochaWebdriver:sauce']);
 
-    grunt.registerTask('build', ['bower-offline-install', 'sed', 'newer:less',
-        'newer:cssmin', 'newer:jshint']);
+    grunt.registerTask('build', ['bower-offline-install', 'sed', 'less',
+        'cssmin', 'jshint']);
 
     grunt.registerTask('default', ['build','express:server','watch']);
 

--- a/platform/admin/ui/package.json
+++ b/platform/admin/ui/package.json
@@ -31,7 +31,6 @@
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
     "grunt-mocha-webdriver": "1.2.2",
-    "grunt-newer": "1.1.1",
     "grunt-port-allocator": "file:target/npm/grunt-port-allocator",
     "grunt-sed": "0.1.1",
     "load-grunt-tasks": "3.2.0",

--- a/platform/security/certificate/security-certificate-adminmodule/Gruntfile.js
+++ b/platform/security/certificate/security-certificate-adminmodule/Gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function (grunt) {
         watch: {
             jsFiles: {
                 files: ['<%= jshint.all.src %>'],
-                tasks: ['newer:jshint']
+                tasks: ['jshint']
             },
             livereload : {
                 options : {livereload :true},
@@ -178,8 +178,8 @@ module.exports = function (grunt) {
     grunt.registerTask('test:selenium', ['express:test', 'mochaWebdriver:selenium']);
     grunt.registerTask('test:sauce', ['express:test', 'mochaWebdriver:sauce']);
 
-    grunt.registerTask('build', ['bower-offline-install', 'sed', 'newer:less',
-        'newer:cssmin', 'newer:jshint']);
+    grunt.registerTask('build', ['bower-offline-install', 'sed', 'less',
+        'cssmin', 'jshint']);
 
     grunt.registerTask('default', ['build','express:server','watch']);
 

--- a/platform/security/certificate/security-certificate-adminmodule/package.json
+++ b/platform/security/certificate/security-certificate-adminmodule/package.json
@@ -31,7 +31,6 @@
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
     "grunt-mocha-webdriver": "1.1.2",
-    "grunt-newer": "0.8.0",
     "grunt-sed": "0.1.1",
     "jshint-stylish": "1.0.2",
     "load-grunt-tasks": "1.0.0",

--- a/platform/security/security-admin-module/Gruntfile.js
+++ b/platform/security/security-admin-module/Gruntfile.js
@@ -157,7 +157,7 @@ module.exports = function (grunt) {
         watch: {
             jsFiles: {
                 files: ['<%= jshint.all.src %>'],
-                tasks: ['newer:jshint']
+                tasks: ['jshint']
             },
             livereload : {
                 options : {livereload :true},
@@ -186,8 +186,8 @@ module.exports = function (grunt) {
     grunt.registerTask('test:selenium', ['express:test', 'mochaWebdriver:selenium']);
     grunt.registerTask('test:sauce', ['express:test', 'mochaWebdriver:sauce']);
 
-    grunt.registerTask('build', ['bower-offline-install', 'sed', 'newer:less',
-        'newer:cssmin', 'newer:jshint']);
+    grunt.registerTask('build', ['bower-offline-install', 'sed', 'less',
+        'cssmin', 'jshint']);
 
     grunt.registerTask('default', ['build','express:server','watch']);
 

--- a/platform/security/security-admin-module/package.json
+++ b/platform/security/security-admin-module/package.json
@@ -31,7 +31,6 @@
     "grunt-contrib-watch": "0.4.4",
     "grunt-express": "1.2.1",
     "grunt-mocha-webdriver": "1.2.2",
-    "grunt-newer": "0.8.0",
     "grunt-port-allocator": "file:target/npm/grunt-port-allocator",
     "grunt-sed": "0.1.1",
     "jshint-stylish": "1.0.2",


### PR DESCRIPTION
 - The "Newer" plugin is designed to try and save time by only running a grunt task if there are changes or if the task has never been run before.  It relies on the task having src and destination files, comparing their modified times to determine if the task needs to run.  Because we compose our "less" files out of other "less" files by using the "import" command, our "less" compilation task only specifies a single source file.  This source file never really changes.  As a result, the recompilation will only occur if the destination file doesn't exist.  As such, changes to the imported "less" files are not being picked up.