### PR TITLE
DDF-1741 Updates save method to correctly dismiss modal

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -284,10 +284,7 @@ define([
                 spinner.stop();
                 view.jolokiaError.show(new AlertsView.View({'model': AlertsModel.Jolokia(jqXHROrerrorThrown)}));
             }).done(function () {
-                $('#config-modal').modal('hide');
-                // due to a bug in bootstrap, the backdrop does not get removed
-                // when calling 'hide' on the modal programmatically
-                $('.modal-backdrop').remove();
+                view.$el.parent().modal('hide');
                 view.close();
                 wreqr.vent.trigger('refreshConfigurations');
             });


### PR DESCRIPTION
 - Previously, the modal('hide') method was being called on the incorrect element.