### PR TITLE
DDF-1745 Add post query plugin for filtering

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
@@ -59,7 +61,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package />
+                        <Export-Package/>
                         <Embed-Dependency>catalog-core-api-impl, commons-lang3</Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -82,22 +84,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
+                                            <minimum>0.9</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.6</minimum>
+                                            <minimum>0.8</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
+                                            <minimum>0.9</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.metacard.validation;
+
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PostQueryPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+
+public class MetacardValidityFilterPlugin implements PostQueryPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetacardValidityFilterPlugin.class);
+
+    private static Map<String, List<String>> attributeMap = new HashMap<>();
+
+    @Override
+    public QueryResponse process(QueryResponse input)
+            throws PluginExecutionException, StopProcessingException {
+        List<Result> results = input.getResults();
+        if (results == null) {
+            return input;
+        }
+
+        // process security
+        for (Result result : results) {
+            Metacard metacard = result.getMetacard();
+            if (metacard == null) {
+                continue;
+            }
+            Attribute securityAttribute = metacard.getAttribute(Metacard.SECURITY);
+            HashMap<String, List<String>> securityMap = new HashMap<>();
+            if (securityAttribute != null && securityAttribute.getValue() != null
+                    && securityAttribute.getValue() instanceof Map) {
+                try {
+                    securityMap = (HashMap<String, List<String>>) securityAttribute.getValue();
+                } catch (ClassCastException e) {
+                    LOGGER.debug("Metacard Security attribute not an instance of HashMap, changing it to an empty HashMap", e);
+                }
+            }
+            if ((metacard.getAttribute(VALIDATION_ERRORS) != null
+                    && metacard.getAttribute(VALIDATION_ERRORS).getValues() != null) || (
+                    metacard.getAttribute(VALIDATION_WARNINGS) != null
+                            && metacard.getAttribute(VALIDATION_WARNINGS).getValues() != null)) {
+                for (Map.Entry<String, List<String>> attributeMapping : attributeMap.entrySet()) {
+                    securityMap.put(attributeMapping.getKey(), attributeMapping.getValue());
+                }
+
+            }
+            if (!securityMap.isEmpty()) {
+                metacard.setAttribute(new AttributeImpl(Metacard.SECURITY, securityMap));
+            }
+
+        }
+        return input;
+    }
+
+    public Map<String, List<String>> getAttributeMap() {
+        return attributeMap;
+    }
+
+    public void setAttributeMap(List<String> attributeMappings) {
+        for (String attributeMapping : attributeMappings) {
+            String[] keyValue = attributeMapping.split("=");
+            attributeMap.put(keyValue[0].trim(),
+                    Arrays.asList(keyValue[1].split(",")).stream().map(String::trim)
+                            .collect(Collectors.toList()));
+        }
+    }
+
+    public void setAttributeMap(Map<String, List<String>> attributeMap) {
+        MetacardValidityFilterPlugin.attributeMap = attributeMap;
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
@@ -47,6 +47,7 @@ public class MetacardValidityMarkerPlugin implements PreIngestPlugin {
             .getLogger(MetacardValidityMarkerPlugin.class);
 
     public static final String VALIDATION_ERRORS = BasicTypes.VALIDATION_ERRORS;
+
     public static final String VALIDATION_WARNINGS = BasicTypes.VALIDATION_WARNINGS;
 
     public CreateRequest process(CreateRequest input)

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,11 +18,12 @@
         <bean id="listConverter" class="ddf.catalog.util.impl.ListConverter"/>
     </type-converters>
 
-    <bean id="metacardValidatorList" class="ddf.catalog.util.impl.SortedServiceList" />
+    <bean id="metacardValidatorList" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardValidators"
                     interface="ddf.catalog.validation.MetacardValidator"
                     availability="optional">
-        <reference-listener ref="metacardValidatorList" bind-method="bindPlugin" unbind-method="unbindPlugin" />
+        <reference-listener ref="metacardValidatorList" bind-method="bindPlugin"
+                            unbind-method="unbindPlugin"/>
     </reference-list>
 
     <reference id="filterBuilder"
@@ -32,31 +33,45 @@
 
 
     <!-- Pre-Ingest Metacard Validation Marker Plugin -->
-    <bean id="pre-ingest-plugin" class="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
+    <bean id="pre-ingest-plugin"
+          class="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
         <cm:managed-properties
                 persistent-id="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin"
                 update-strategy="container-managed"/>
         <property name="metacardValidators" ref="metacardValidatorList"/>
         <property name="enforcedMetacardValidators">
-            <list />
+            <list/>
         </property>
 
     </bean>
 
     <!-- Pre-Query Metacard Validity Checker Plugin -->
-    <bean id="pre-query-plugin" class="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
+    <bean id="pre-query-plugin"
+          class="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
         <!--<cm:managed-properties-->
-                <!--persistent-id="MetacardValidityCheckerPlugin"-->
-                <!--update-strategy="container-managed"/>-->
+        <!--persistent-id="MetacardValidityCheckerPlugin"-->
+        <!--update-strategy="container-managed"/>-->
         <argument ref="filterBuilder"/>
         <argument ref="filterAdapter"/>
 
     </bean>
 
 
+    <!-- Post-Query Metacard Validity Filter Plugin -->
+    <bean id="post-query-plugin"
+          class="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin">
+        <cm:managed-properties
+                persistent-id="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin"
+                update-strategy="container-managed"/>
+        <property name="attributeMap">
+            <list/>
+        </property>
+    </bean>
+
 
     <!-- Register in the OSGi Service Registry -->
     <service ref="pre-ingest-plugin" interface="ddf.catalog.plugin.PreIngestPlugin"/>
     <service ref="pre-query-plugin" interface="ddf.catalog.plugin.PreQueryPlugin"/>
+    <service ref="post-query-plugin" interface="ddf.catalog.plugin.PostQueryPlugin" ranking="100"/>
 
 </blueprint>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -15,11 +15,21 @@
  -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-    <OCD name="Metacard Validation Plugin"
+
+    <OCD name="Metacard Validation Filter Plugin"
+         id="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin">
+        <AD
+                description="Mapping of Metacard SECURITY attribute to user attribute."
+                name="Attribute map" id="attributeMap" required="false" type="String"
+                default="invalid-state=system-admin" cardinality="100"/>
+    </OCD>
+
+    <OCD name="Metacard Validation Marker Plugin"
          id="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
         <AD
                 description="ID of Metacard Validator to enforce."
-                name="Enforced Validators" id="enforcedMetacardValidators" required="false" type="String"
+                name="Enforced Validators" id="enforcedMetacardValidators" required="false"
+                type="String"
                 default="" cardinality="100"/>
     </OCD>
 
@@ -27,6 +37,12 @@
             pid="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
         <Object
                 ocdref="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin"/>
+    </Designate>
+
+    <Designate
+            pid="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin">
+        <Object
+                ocdref="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin"/>
     </Designate>
 
 </metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
 import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import org.junit.Before;
@@ -118,6 +119,21 @@ public class MetacardValidityCheckerPluginTest {
 
         assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
                 is(true));
+    }
+
+    @Test
+    public void testOrTrueTrue() {
+        assertThat(testValidationQueryDelegate.or(Arrays.asList(true, true)), is(true));
+    }
+
+    @Test
+    public void testOrTrueFalse() {
+        assertThat(testValidationQueryDelegate.or(Arrays.asList(true, false)), is(true));
+    }
+
+    @Test
+    public void testOrFalseFalse() {
+        assertThat(testValidationQueryDelegate.or(Arrays.asList(false, false)), is(false));
     }
 
     @Test
@@ -522,10 +538,22 @@ public class MetacardValidityCheckerPluginTest {
     }
 
     @Test
-    public void testPropertyIsLike() {
+    public void testPropertyIsLikeFalse() {
         assertThat(
                 testValidationQueryDelegate.propertyIsLike(Metacard.ANY_TEXT, "helloworld", true),
                 is(false));
+    }
+
+    @Test
+    public void testPropertyIsLikeTrueErrors() {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLike(VALIDATION_ERRORS, "sample-validator", true), is(true));
+    }
+
+    @Test
+    public void testPropertyIsLikeTrueWarnings() {
+        assertThat(testValidationQueryDelegate
+                .propertyIsLike(VALIDATION_WARNINGS, "sample-validator", true), is(true));
     }
 
     @Test

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityFilterPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityFilterPluginTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.metacard.validation;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
+import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.StopProcessingException;
+
+public class MetacardValidityFilterPluginTest {
+
+    private MetacardValidityFilterPlugin metacardValidityFilterPlugin;
+
+    @Before
+    public void setUp() {
+        metacardValidityFilterPlugin = new MetacardValidityFilterPlugin();
+    }
+
+    @Test
+    public void testSetAttributeMapping() {
+        List<String> attributeMapping = Arrays.asList("sample=test1,test2");
+        metacardValidityFilterPlugin.setAttributeMap(attributeMapping);
+        Map<String, List<String>> assertMap = metacardValidityFilterPlugin.getAttributeMap();
+        assertThat(assertMap.size(), is(1));
+        assertThat(assertMap.containsKey("sample"), is(true));
+        assertThat(assertMap.get("sample").contains("test1"), is(true));
+        assertThat(assertMap.get("sample").contains("test2"), is(true));
+
+    }
+
+    @Test
+    public void testValidMetacards() {
+        Result result = mock(Result.class);
+        Metacard metacard = getValidMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.SECURITY, getPopulatedSecurity()));
+
+        when(result.getMetacard()).thenReturn(metacard);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(Arrays.asList(result));
+        try {
+            metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(
+                    queryResponse.getResults().get(0).getMetacard().getAttribute(Metacard.SECURITY)
+                            .getValues().size(), is(1));
+            assertThat(((HashMap) queryResponse.getResults().get(0).getMetacard()
+                            .getAttribute(Metacard.SECURITY).getValues().get(0)).get("marking"),
+                    is(not(nullValue())));
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testValidMetacardsEmptySecurity() {
+        Result result = mock(Result.class);
+        Metacard metacard = getValidMetacard();
+
+        when(result.getMetacard()).thenReturn(metacard);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(Arrays.asList(result));
+        try {
+            metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(
+                    queryResponse.getResults().get(0).getMetacard().getAttribute(Metacard.SECURITY),
+                    is(nullValue()));
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testInvalidMetacards() {
+        List<String> attributeMapping = Arrays.asList("sample=test1,test2");
+        metacardValidityFilterPlugin.setAttributeMap(attributeMapping);
+        Result result = mock(Result.class);
+        Metacard metacard = getInvalidMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.SECURITY, getPopulatedSecurity()));
+
+        when(result.getMetacard()).thenReturn(metacard);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(Arrays.asList(result));
+        try {
+            metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(((List) ((HashMap) queryResponse.getResults().get(0).getMetacard()
+                    .getAttribute(Metacard.SECURITY).getValues().get(0)).get("sample"))
+                    .contains("test1"), is(true));
+            assertThat(((List) ((HashMap) queryResponse.getResults().get(0).getMetacard()
+                            .getAttribute(Metacard.SECURITY).getValues().get(0)).get("marking")).isEmpty(),
+                    is(false));
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testInvalidMetacardsEmptySecurity() {
+        List<String> attributeMapping = Arrays.asList("sample=test1,test2");
+        metacardValidityFilterPlugin.setAttributeMap(attributeMapping);
+        Result result = mock(Result.class);
+        Metacard metacard = getInvalidMetacard();
+
+        when(result.getMetacard()).thenReturn(metacard);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(Arrays.asList(result));
+        try {
+            metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(((List) ((HashMap) queryResponse.getResults().get(0).getMetacard()
+                    .getAttribute(Metacard.SECURITY).getValues().get(0)).get("sample"))
+                    .contains("test1"), is(true));
+            assertThat(((HashMap) queryResponse.getResults().get(0).getMetacard()
+                            .getAttribute(Metacard.SECURITY).getValues().get(0)).get("marking"),
+                    is(nullValue()));
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testNullMetacard() {
+        List<String> attributeMapping = Arrays.asList("sample=test1,test2");
+        metacardValidityFilterPlugin.setAttributeMap(attributeMapping);
+        Result result = mock(Result.class);
+
+        when(result.getMetacard()).thenReturn(null);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(Arrays.asList(result));
+        try {
+            QueryResponse returnedQueryResponse = metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(returnedQueryResponse.equals(queryResponse), is(true));
+
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testNullResults() {
+        List<String> attributeMapping = Arrays.asList("sample=test1,test2");
+        metacardValidityFilterPlugin.setAttributeMap(attributeMapping);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        when(queryResponse.getResults()).thenReturn(null);
+        try {
+            QueryResponse returnedQueryResponse = metacardValidityFilterPlugin.process(queryResponse);
+            assertThat(returnedQueryResponse.equals(queryResponse), is(true));
+
+        } catch (PluginExecutionException | StopProcessingException e) {
+            fail();
+        }
+    }
+
+
+    private MetacardImpl getValidMetacard() {
+        MetacardImpl returnMetacard = new MetacardImpl();
+        return returnMetacard;
+    }
+
+    private MetacardImpl getInvalidMetacard() {
+        MetacardImpl returnMetacard = new MetacardImpl();
+        returnMetacard.setAttribute(
+                new AttributeImpl(VALIDATION_ERRORS, Arrays.asList("sample-validator")));
+        returnMetacard.setAttribute(
+                new AttributeImpl(VALIDATION_WARNINGS, Arrays.asList("sample-validator")));
+        return returnMetacard;
+    }
+
+    private HashMap getPopulatedSecurity() {
+        HashMap<String, List<String>> returnMap = new HashMap();
+        returnMap.put("marking", Arrays.asList("TS, U"));
+        return returnMap;
+    }
+}
+
+

--- a/distribution/ddf-common/src/main/resources/etc/pdp/policies/access-policy.xml
+++ b/distribution/ddf-common/src/main/resources/etc/pdp/policies/access-policy.xml
@@ -95,12 +95,6 @@
                 </AllOf>
                 <AllOf>
                     <Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-                        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</AttributeValue>
-                        <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
-                    </Match>
-                </AllOf>
-                <AllOf>
-                    <Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
                         <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">update</AttributeValue>
                         <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
                     </Match>
@@ -169,6 +163,30 @@
                 <AttributeDesignator AttributeId="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
                 <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
                     <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">guest</AttributeValue>
+                </Apply>
+            </Apply>
+        </Condition>
+    </Rule>
+    <Rule Effect="Permit" RuleId="permit-read-action">
+        <Target>
+            <AnyOf>
+                <AllOf>
+                    <Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</AttributeValue>
+                        <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
+                    </Match>
+                </AllOf>
+            </AnyOf>
+        </Target>
+        <Condition>
+            <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:and">
+                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-subset">
+                    <AttributeDesignator AttributeId="invalid-state" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+                    <AttributeDesignator AttributeId="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+                </Apply>
+                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-subset">
+                    <AttributeDesignator AttributeId="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+                    <AttributeDesignator AttributeId="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
                 </Apply>
             </Apply>
         </Condition>

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
 
         <AD description="Comma-delimited list of 'Match-One' subject attribute to Metacard attribute mapping. One value of this metacard key must be present in the corresponding subject key values. Format is subjectAttrName=metacardAttrName."
             name="Match-One Mappings" id="matchOneMappings" required="false"
-            type="String" default=""/>
+            type="String" default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=invalid-state"/>
     </OCD>
 
     <Designate pid="ddf.security.pdp.realm.SimpleAuthzRealm">


### PR DESCRIPTION
Post query plugin sets Metacard SECURITY attribute according
to metatype configuration. Uses existing filter plugin to do actual
filtering.
Add default configuration in XACML and Java PDP to allow users with
system-admin attribute to view invalid metacards.
@codice/security @brendan-hofmann @vinamartin 
@AzGoalie is hero