### PR TITLE
DDF-1731: Update Blueprints and iTests

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -440,7 +440,7 @@ public class TestPlatform extends AbstractIntegrationTest {
 
     @Test
     public void testExport() throws ConfigurationFileException, IOException {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
 
         console.runCommand(EXPORT_COMMAND);
 
@@ -466,7 +466,7 @@ public class TestPlatform extends AbstractIntegrationTest {
 
     @Test
     public void testExportOnTopOfFile() throws ConfigurationFileException, IOException {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
         File file = getExportDirectory().toFile();
         file.createNewFile();
         String response = console.runCommand(EXPORT_COMMAND);
@@ -485,7 +485,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void textExportAfterSavingAConfiguration() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
 
         managedServiceNewConfig1.addConfigurationFileAndWait(configAdmin);
         console.runCommand(EXPORT_COMMAND);
@@ -502,7 +502,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void testExportAfterDeletingAConfiguration() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
         managedServiceNewConfig2.addConfigurationFileAndWait(configAdmin);
         configAdmin.getConfiguration(managedServiceNewConfig2.pid, null)
                 .delete();
@@ -520,7 +520,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void testFailureForAbsolutePathOutsideDdfHome() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
         File systemProperties = new File(ddfHome + "/etc/system.properties");
         File testFile = new File("../cat.txt");
         FileUtils.copyFile(systemProperties, testFile);
@@ -543,7 +543,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void testFailureForAbsolutePathInsideDdfHome() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
 
         System.setProperty("javax.net.ssl.keyStore", ddfHome + "/etc/keystores/serverKeystore.jks");
         String response = console.runCommand(EXPORT_COMMAND);
@@ -553,7 +553,7 @@ public class TestPlatform extends AbstractIntegrationTest {
                 containsString(String.format("Failed to export all configurations to %s",
                         getExportDirectory())));
         System.setProperty("javax.net.ssl.keyStore", "etc/keystores/serverKeystore.jks");
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
     }
 
     /**
@@ -563,7 +563,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void testRelativePathOutsideDdfHome() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
         File systemProperties = new File(ddfHome + "/etc/system.properties");
         File testFile = new File("../cat.txt");
         FileUtils.copyFile(systemProperties, testFile);
@@ -586,7 +586,7 @@ public class TestPlatform extends AbstractIntegrationTest {
      */
     @Test
     public void testExportOverridesPreviousExport() throws Exception {
-        FileUtils.deleteDirectory(getExportDirectory().toFile());
+        FileUtils.deleteQuietly(getExportDirectory().toFile());
 
         String firstExportMessage = console.runCommand(EXPORT_COMMAND);
         File firstExport = getExportSubDirectory("system.properties").toFile();

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -51,9 +51,20 @@
     <reference id="configurationMigrationService"
                interface="org.codice.ddf.configuration.migration.ConfigurationMigrationService"/>
 
-    <bean id="defaultExportDirectoryPath" class="java.nio.file.Paths"
-          factory-method="get">
-        <argument value="file://${defaultExportDirectory}"/>
+    <!-- Base URI for DDF home -->
+    <bean id="baseFileUri" class="java.io.File">
+        <argument value="${ddf.home}"/>
+    </bean>
+
+    <bean id="baseUri" class="java.net.URI" factory-method="toURI" factory-ref="baseFileUri"/>
+
+    <!-- Default Directory Export Path -->
+    <bean id="defaultExportDirectoryPathUri" class="java.nio.file.Uri" factory-method="resolve" factory-ref="baseUri">
+        <argument value="etc/exported"/>
+    </bean>
+
+    <bean id="defaultExportDirectoryPath" class="java.nio.file.Paths" factory-method="get">
+        <argument ref="defaultExportDirectoryPathUri"/>
     </bean>
 
     <bean id="platformExportCommand" class="org.codice.ddf.commands.platform.ExportCommand">

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,15 +19,15 @@
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
 
         <command name="platform/describe">
-            <action class="org.codice.ddf.commands.platform.DescribeCommand" />
+            <action class="org.codice.ddf.commands.platform.DescribeCommand"/>
         </command>
         <command name="platform/envlist">
-            <action class="org.codice.ddf.commands.platform.EnvListCommand" />
+            <action class="org.codice.ddf.commands.platform.EnvListCommand"/>
         </command>
         <command name="platform/config-status">
             <action
-                class="org.codice.ddf.commands.platform.ConfigStatusCommand">
-                <argument ref="configStatusService" />
+                    class="org.codice.ddf.commands.platform.ConfigStatusCommand">
+                <argument ref="configStatusService"/>
             </action>
         </command>
         <command name="platform/config-export">
@@ -46,25 +46,26 @@
     </ext:property-placeholder>
 
     <reference id="configStatusService"
-        interface="org.codice.ddf.configuration.status.ConfigurationStatusService" />
+               interface="org.codice.ddf.configuration.status.ConfigurationStatusService"/>
 
     <reference id="configurationMigrationService"
                interface="org.codice.ddf.configuration.migration.ConfigurationMigrationService"/>
 
     <!-- Base URI for DDF home -->
-    <bean id="baseFileUri" class="java.io.File">
+    <bean id="ddfHomeFile" class="java.io.File">
         <argument value="${ddf.home}"/>
     </bean>
 
-    <bean id="baseUri" class="java.net.URI" factory-method="toURI" factory-ref="baseFileUri"/>
+    <bean id="ddfHomeUri" class="java.net.URI" factory-ref="ddfHomeFile" factory-method="toURI"/>
 
     <!-- Default Directory Export Path -->
-    <bean id="defaultExportDirectoryPathUri" class="java.nio.file.Uri" factory-method="resolve" factory-ref="baseUri">
+    <bean id="defaultExportDirectoryUri" class="java.nio.file.Uri" factory-ref="ddfHomeUri"
+          factory-method="resolve">
         <argument value="etc/exported"/>
     </bean>
 
     <bean id="defaultExportDirectoryPath" class="java.nio.file.Paths" factory-method="get">
-        <argument ref="defaultExportDirectoryPathUri"/>
+        <argument ref="defaultExportDirectoryUri"/>
     </bean>
 
     <bean id="platformExportCommand" class="org.codice.ddf.commands.platform.ExportCommand">
@@ -72,8 +73,8 @@
         <argument ref="defaultExportDirectoryPath"/>
     </bean>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl" />
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo" />
+    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
+    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
     <bean id="platformDescribeCommand" class="org.codice.ddf.commands.platform.DescribeCommand">
         <property name="bundleContext" ref="blueprintBundleContext"/>

--- a/platform/platform-configuration-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigration.java
+++ b/platform/platform-configuration-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigration.java
@@ -96,9 +96,9 @@ public class ConfigurationAdminMigration implements ChangeListener, Configuratio
 
         this.configDirectoryStream = configDirectoryStream;
         this.processedDirectory = processedDirectory;
-        LOGGER.debug("Processed Directory Path: [{}]", this.processedDirectory);
+        LOGGER.info("Processed Directory Path: [{}]", this.processedDirectory);
         this.failedDirectory = failedDirectory;
-        LOGGER.debug("Failed Directory Path: [{}]", this.failedDirectory);
+        LOGGER.info("Failed Directory Path: [{}]", this.failedDirectory);
         this.configurationFileFactory = configurationFileFactory;
         this.poller = poller;
         this.configurationAdmin = configurationAdmin;

--- a/platform/platform-configuration-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigration.java
+++ b/platform/platform-configuration-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigration.java
@@ -96,9 +96,9 @@ public class ConfigurationAdminMigration implements ChangeListener, Configuratio
 
         this.configDirectoryStream = configDirectoryStream;
         this.processedDirectory = processedDirectory;
-        LOGGER.info("Processed Directory Path: [{}]", this.processedDirectory);
+        LOGGER.debug("Processed Directory Path: [{}]", this.processedDirectory);
         this.failedDirectory = failedDirectory;
-        LOGGER.info("Failed Directory Path: [{}]", this.failedDirectory);
+        LOGGER.debug("Failed Directory Path: [{}]", this.failedDirectory);
         this.configurationFileFactory = configurationFileFactory;
         this.poller = poller;
         this.configurationAdmin = configurationAdmin;

--- a/platform/platform-configuration-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,7 +27,8 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <bean id="watchThread" class="java.util.concurrent.Executors" factory-method="newSingleThreadExecutor"/>
+    <bean id="watchThread" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadExecutor"/>
 
     <bean id="defaultFileSystem" class="java.nio.file.FileSystems" factory-method="getDefault"/>
 
@@ -37,33 +38,36 @@
           class="org.codice.ddf.configuration.persistence.felix.FelixPersistenceStrategy"/>
 
     <!-- Base URI for DDF home -->
-    <bean id="baseFileUri" class="java.io.File">
+    <bean id="ddfHomeFile" class="java.io.File">
         <argument value="${ddf.home}"/>
     </bean>
 
-    <bean id="baseUri" class="java.net.URI" factory-method="toURI" factory-ref="baseFileUri"/>
+    <bean id="ddfHomeUri" class="java.net.URI" factory-ref="ddfHomeFile" factory-method="toURI"/>
 
     <bean id="ddfHome" class="java.nio.file.Paths" factory-method="get">
-        <argument ref="baseUri"/>
+        <argument ref="ddfHomeUri"/>
     </bean>
 
     <!-- Config Directory Path ${ddf.home}/etc/ -->
-    <bean id="configDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+    <bean id="configDirectoryPath" class="java.nio.file.Path" factory-ref="ddfHome"
+          factory-method="resolve">
         <argument value="etc"/>
     </bean>
 
     <!-- Processed Directory Path ${ddf.home}/etc/processed -->
-    <bean id="processedDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+    <bean id="processedDirectoryPath" class="java.nio.file.Path" factory-ref="ddfHome"
+          factory-method="resolve">
         <argument value="etc/processed"/>
     </bean>
 
     <!-- Failed Directory Path ${ddf.home}/etc/failed -->
-    <bean id="failedDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+    <bean id="failedDirectoryPath" class="java.nio.file.Path" factory-ref="ddfHome"
+          factory-method="resolve">
         <argument value="etc/failed"/>
     </bean>
 
     <bean id="configurationFileFactory"
-        class="org.codice.ddf.configuration.admin.ConfigurationFileFactory">
+          class="org.codice.ddf.configuration.admin.ConfigurationFileFactory">
         <argument ref="persistenceStrategy"/>
         <argument ref="configurationAdmin"/>
     </bean>
@@ -78,14 +82,14 @@
     </bean>
 
     <bean id="configDirectoryStream" class="java.nio.file.Files"
-        factory-method="newDirectoryStream">
+          factory-method="newDirectoryStream">
         <argument ref="configDirectoryPath"/>
         <argument value="*${configFileExtension}"/>
     </bean>
 
     <bean id="configurationAdminMigration"
-        class="org.codice.ddf.configuration.admin.ConfigurationAdminMigration"
-        init-method="init">
+          class="org.codice.ddf.configuration.admin.ConfigurationAdminMigration"
+          init-method="init">
         <argument ref="configDirectoryStream"/>
         <argument ref="processedDirectoryPath"/>
         <argument ref="failedDirectoryPath"/>
@@ -96,20 +100,20 @@
     </bean>
 
     <bean id="systemConfigurationMigration"
-        class="org.codice.ddf.configuration.migration.SystemConfigurationMigration">
+          class="org.codice.ddf.configuration.migration.SystemConfigurationMigration">
         <argument ref="ddfHome"/>
     </bean>
 
     <bean id="configMigrationManager"
-        class="org.codice.ddf.configuration.migration.ConfigurationMigrationManager">
+          class="org.codice.ddf.configuration.migration.ConfigurationMigrationManager">
         <argument ref="configurationAdminMigration"/>
         <argument ref="systemConfigurationMigration"/>
     </bean>
 
     <service id="configurationFileDirectoryService" ref="configurationAdminMigration"
-        auto-export="interfaces"/>
+             auto-export="interfaces"/>
 
     <service id="configurationMigrationManager" ref="configMigrationManager"
-        auto-export="interfaces"/>
+             auto-export="interfaces"/>
 
 </blueprint>

--- a/platform/platform-configuration-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,50 +27,39 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <bean id="watchThread" class="java.util.concurrent.Executors"
-          factory-method="newSingleThreadExecutor">
-    </bean>
+    <bean id="watchThread" class="java.util.concurrent.Executors" factory-method="newSingleThreadExecutor"/>
 
-    <bean id="defaultFileSystem" class="java.nio.file.FileSystems"
-          factory-method="getDefault">
-    </bean>
+    <bean id="defaultFileSystem" class="java.nio.file.FileSystems" factory-method="getDefault"/>
 
-    <bean id="watchService" factory-ref="defaultFileSystem"
-          factory-method="newWatchService">
-    </bean>
+    <bean id="watchService" factory-ref="defaultFileSystem" factory-method="newWatchService"/>
 
     <bean id="persistenceStrategy"
           class="org.codice.ddf.configuration.persistence.felix.FelixPersistenceStrategy"/>
 
-    <bean id="configDirectoryPathUri" class="java.net.URI">
-        <argument value="file:///${configFileDirectory}"/>
+    <!-- Base URI for DDF home -->
+    <bean id="baseFileUri" class="java.io.File">
+        <argument value="${ddf.home}"/>
     </bean>
 
-    <bean id="configDirectoryPath" class="java.nio.file.Paths"
-          factory-method="get">
-        <argument ref="configDirectoryPathUri"/>
-    </bean>
-
-    <bean id="processedDirectoryPathUri" class="java.net.URI">
-        <argument value="file:///${processedDirectory}"/>
-    </bean>
-
-    <bean id="processedDirectoryPath" class="java.nio.file.Paths"
-          factory-method="get">
-        <argument ref="processedDirectoryPathUri"/>
-    </bean>
-
-    <bean id="failedDirectoryPathUri" class="java.net.URI">
-        <argument value="file:///${failedDirectory}"/>
-    </bean>
-
-    <bean id="failedDirectoryPath" class="java.nio.file.Paths"
-        factory-method="get">
-        <argument ref="failedDirectoryPathUri"/>
-    </bean>
+    <bean id="baseUri" class="java.net.URI" factory-method="toURI" factory-ref="baseFileUri"/>
 
     <bean id="ddfHome" class="java.nio.file.Paths" factory-method="get">
-        <argument value="file:///${ddf.home}"/>
+        <argument ref="baseUri"/>
+    </bean>
+
+    <!-- Config Directory Path ${ddf.home}/etc/ -->
+    <bean id="configDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+        <argument value="etc"/>
+    </bean>
+
+    <!-- Processed Directory Path ${ddf.home}/etc/processed -->
+    <bean id="processedDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+        <argument value="etc/processed"/>
+    </bean>
+
+    <!-- Failed Directory Path ${ddf.home}/etc/failed -->
+    <bean id="failedDirectoryPath" class="java.nio.file.Path" factory-method="resolve" factory-ref="ddfHome">
+        <argument value="etc/failed"/>
     </bean>
 
     <bean id="configurationFileFactory"
@@ -94,7 +83,7 @@
         <argument value="*${configFileExtension}"/>
     </bean>
 
-    <bean id="configurationFileDirectory"
+    <bean id="configurationAdminMigration"
         class="org.codice.ddf.configuration.admin.ConfigurationAdminMigration"
         init-method="init">
         <argument ref="configDirectoryStream"/>
@@ -113,11 +102,11 @@
 
     <bean id="configMigrationManager"
         class="org.codice.ddf.configuration.migration.ConfigurationMigrationManager">
-        <argument ref="configurationFileDirectory"/>
+        <argument ref="configurationAdminMigration"/>
         <argument ref="systemConfigurationMigration"/>
     </bean>
 
-    <service id="configurationFileDirectoryService" ref="configurationFileDirectory"
+    <service id="configurationFileDirectoryService" ref="configurationAdminMigration"
         auto-export="interfaces"/>
 
     <service id="configurationMigrationManager" ref="configMigrationManager"


### PR DESCRIPTION
- Blueprints were updated to turn ddf.home into a standard URI
before resolving directories using Path.
- Commands blueprint was also updated for this reason.
- TestPlatform itests were modified to use deleteQuietly to avoid
throwing an exception if the directory was already removed by a
previous itest.

@lessarderic @andrewkfiedler @figliold @oconnormi @bantillo 