### PR TITLE
DDF-1758 Improved error message

### DIFF
--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/PkiTools.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/PkiTools.java
@@ -153,7 +153,7 @@ public abstract class PkiTools {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            throw new CertificateGeneratorException("Cannot get this machine's host name", e);
+            throw new CertificateGeneratorException("Cannot get this machine's host name. On *NIX machines, check hosts file for entry with machines's IP addresses. Localhost entries do not work.", e);
         }
     }
 


### PR DESCRIPTION
Instruct developer or tester to check the hosts file
if Java cannot determine the machine's hostname while
generating demo certificates

@stustison Pls review and merge at your convenience.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/422)
<!-- Reviewable:end -->
