### PR TITLE
DDF-1785 Initialize SAML SOAP Builders in AttributeQueryClient

### DIFF
--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-soap-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
             <artifactId>opensaml-xmlsec-api</artifactId>
         </dependency>
         <dependency>
@@ -128,7 +132,8 @@
                             google-http-client,
                             guava,
                             validation-api,
-                            bcprov-jdk15on
+                            bcprov-jdk15on,
+                            opensaml-soap-impl
                         </Embed-Dependency>
                         <Export-Package>
                             ddf.security*;version=${project.version}

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -23,11 +23,15 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
 import org.joda.time.DateTime;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
 import org.opensaml.core.xml.XMLObjectBuilder;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.saml.common.SAMLObjectBuilder;
+import org.opensaml.saml.common.SAMLRuntimeException;
 import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.LogoutRequest;
@@ -46,6 +50,12 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
 import org.opensaml.security.credential.UsageType;
+import org.opensaml.soap.soap11.Body;
+import org.opensaml.soap.soap11.Envelope;
+import org.opensaml.soap.soap11.Header;
+import org.opensaml.soap.soap11.impl.BodyBuilder;
+import org.opensaml.soap.soap11.impl.EnvelopeBuilder;
+import org.opensaml.soap.soap11.impl.HeaderBuilder;
 import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.X509Certificate;
 import org.opensaml.xmlsec.signature.X509Data;
@@ -55,7 +65,8 @@ public class SamlProtocol {
 
     public static final String SUPPORTED_PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol";
 
-    public static final String REDIRECT_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+    public static final String REDIRECT_BINDING =
+            "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
 
     public static final String POST_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
 
@@ -64,90 +75,116 @@ public class SamlProtocol {
      */
     static {
         OpenSAMLUtil.initSamlEngine();
+
+        ClassLoader tccl = Thread.currentThread()
+                .getContextClassLoader();
+        Thread.currentThread()
+                .setContextClassLoader(SamlProtocol.class.getClassLoader());
+        try {
+            InitializationService.initialize();
+        } catch (InitializationException e) {
+            throw new SAMLRuntimeException("Unable to Initialize SAML SOAP builders.");
+        } finally {
+            Thread.currentThread()
+                    .setContextClassLoader(tccl);
+        }
     }
 
-    private static XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport
-            .getBuilderFactory();
+    private static XMLObjectBuilderFactory builderFactory =
+            XMLObjectProviderRegistrySupport.getBuilderFactory();
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<Response> responseSAMLObjectBuilder = (SAMLObjectBuilder<org.opensaml.saml.saml2.core.Response>) builderFactory
-            .getBuilder(org.opensaml.saml.saml2.core.Response.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<Response> responseSAMLObjectBuilder =
+            (SAMLObjectBuilder<org.opensaml.saml.saml2.core.Response>) builderFactory.getBuilder(org.opensaml.saml.saml2.core.Response.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<Issuer> issuerBuilder = (SAMLObjectBuilder<Issuer>) builderFactory
-            .getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<Issuer> issuerBuilder =
+            (SAMLObjectBuilder<Issuer>) builderFactory.getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<Status> statusBuilder = (SAMLObjectBuilder<Status>) builderFactory
-            .getBuilder(Status.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<Status> statusBuilder =
+            (SAMLObjectBuilder<Status>) builderFactory.getBuilder(Status.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<StatusCode> statusCodeBuilder = (SAMLObjectBuilder<StatusCode>) builderFactory
-            .getBuilder(StatusCode.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<StatusCode> statusCodeBuilder =
+            (SAMLObjectBuilder<StatusCode>) builderFactory.getBuilder(StatusCode.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<Subject> subjectBuilder = (SAMLObjectBuilder<Subject>) builderFactory
-            .getBuilder(Subject.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<Subject> subjectBuilder =
+            (SAMLObjectBuilder<Subject>) builderFactory.getBuilder(Subject.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<EntityDescriptor> entityDescriptorBuilder = (SAMLObjectBuilder<EntityDescriptor>) builderFactory
-            .getBuilder(EntityDescriptor.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<EntityDescriptor> entityDescriptorBuilder =
+            (SAMLObjectBuilder<EntityDescriptor>) builderFactory.getBuilder(EntityDescriptor.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<IDPSSODescriptor> idpssoDescriptorBuilder = (SAMLObjectBuilder<IDPSSODescriptor>) builderFactory
-            .getBuilder(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<IDPSSODescriptor> idpssoDescriptorBuilder =
+            (SAMLObjectBuilder<IDPSSODescriptor>) builderFactory.getBuilder(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<SPSSODescriptor> spSsoDescriptorBuilder = (SAMLObjectBuilder<SPSSODescriptor>) builderFactory
-            .getBuilder(SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<SPSSODescriptor> spSsoDescriptorBuilder =
+            (SAMLObjectBuilder<SPSSODescriptor>) builderFactory.getBuilder(SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<KeyDescriptor> keyDescriptorBuilder = (SAMLObjectBuilder<KeyDescriptor>) builderFactory
-            .getBuilder(KeyDescriptor.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<KeyDescriptor> keyDescriptorBuilder =
+            (SAMLObjectBuilder<KeyDescriptor>) builderFactory.getBuilder(KeyDescriptor.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<NameID> nameIdBuilder = (SAMLObjectBuilder<NameID>) builderFactory
-            .getBuilder(NameID.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<NameID> nameIdBuilder =
+            (SAMLObjectBuilder<NameID>) builderFactory.getBuilder(NameID.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<NameIDFormat> nameIdFormatBuilder = (SAMLObjectBuilder<NameIDFormat>) builderFactory
-            .getBuilder(NameIDFormat.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<NameIDFormat> nameIdFormatBuilder =
+            (SAMLObjectBuilder<NameIDFormat>) builderFactory.getBuilder(NameIDFormat.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<SingleSignOnService> singleSignOnServiceBuilder = (SAMLObjectBuilder<SingleSignOnService>) builderFactory
-            .getBuilder(SingleSignOnService.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<SingleSignOnService> singleSignOnServiceBuilder =
+            (SAMLObjectBuilder<SingleSignOnService>) builderFactory.getBuilder(SingleSignOnService.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<SingleLogoutService> singleLogOutServiceBuilder = (SAMLObjectBuilder<SingleLogoutService>) builderFactory
-            .getBuilder(SingleLogoutService.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<SingleLogoutService> singleLogOutServiceBuilder =
+            (SAMLObjectBuilder<SingleLogoutService>) builderFactory.getBuilder(SingleLogoutService.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<AssertionConsumerService> assertionConsumerServiceBuilder = (SAMLObjectBuilder<AssertionConsumerService>) builderFactory
-            .getBuilder(AssertionConsumerService.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<AssertionConsumerService> assertionConsumerServiceBuilder =
+            (SAMLObjectBuilder<AssertionConsumerService>) builderFactory.getBuilder(
+                    AssertionConsumerService.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static XMLObjectBuilder<KeyInfo> keyInfoBuilder = (XMLObjectBuilder<KeyInfo>) builderFactory
-            .getBuilder(KeyInfo.DEFAULT_ELEMENT_NAME);
+    private static XMLObjectBuilder<KeyInfo> keyInfoBuilder =
+            (XMLObjectBuilder<KeyInfo>) builderFactory.getBuilder(KeyInfo.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static XMLObjectBuilder<X509Data> x509DataBuilder = (XMLObjectBuilder<X509Data>) builderFactory
-            .getBuilder(X509Data.DEFAULT_ELEMENT_NAME);
+    private static XMLObjectBuilder<X509Data> x509DataBuilder =
+            (XMLObjectBuilder<X509Data>) builderFactory.getBuilder(X509Data.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static XMLObjectBuilder<X509Certificate> x509CertificateBuilder = (XMLObjectBuilder<X509Certificate>) builderFactory
-            .getBuilder(X509Certificate.DEFAULT_ELEMENT_NAME);
+    private static XMLObjectBuilder<X509Certificate> x509CertificateBuilder =
+            (XMLObjectBuilder<X509Certificate>) builderFactory.getBuilder(X509Certificate.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<AttributeQuery> attributeQueryBuilder = (SAMLObjectBuilder<AttributeQuery>) builderFactory
-            .getBuilder(AttributeQuery.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<AttributeQuery> attributeQueryBuilder =
+            (SAMLObjectBuilder<AttributeQuery>) builderFactory.getBuilder(AttributeQuery.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<LogoutRequest> logoutRequestBuilder = (SAMLObjectBuilder<LogoutRequest>) builderFactory
-            .getBuilder(LogoutRequest.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<LogoutRequest> logoutRequestBuilder =
+            (SAMLObjectBuilder<LogoutRequest>) builderFactory.getBuilder(LogoutRequest.DEFAULT_ELEMENT_NAME);
 
     @SuppressWarnings("unchecked")
-    private static SAMLObjectBuilder<LogoutResponse> logoutResponseBuilder = (SAMLObjectBuilder<LogoutResponse>) builderFactory
-            .getBuilder(LogoutResponse.DEFAULT_ELEMENT_NAME);
+    private static SAMLObjectBuilder<LogoutResponse> logoutResponseBuilder =
+            (SAMLObjectBuilder<LogoutResponse>) builderFactory.getBuilder(LogoutResponse.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static BodyBuilder soapBodyBuilder =
+            (BodyBuilder) builderFactory.getBuilder(Body.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static EnvelopeBuilder soapEnvelopeBuilder =
+            (EnvelopeBuilder) builderFactory.getBuilder(Envelope.DEFAULT_ELEMENT_NAME);
+
+    @SuppressWarnings("unchecked")
+    private static HeaderBuilder soapHeaderBuilder = (HeaderBuilder) builderFactory.getBuilder(
+            Header.DEFAULT_ELEMENT_NAME);
 
     public enum Binding {
         HTTP_POST("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"),
@@ -208,13 +245,15 @@ public class SamlProtocol {
         Response response = responseSAMLObjectBuilder.buildObject();
         response.setIssuer(issuer);
         response.setStatus(status);
-        response.setID("_" + UUID.randomUUID().toString());
+        response.setID("_" + UUID.randomUUID()
+                .toString());
         response.setIssueInstant(new DateTime());
         response.setInResponseTo(requestId);
         response.setVersion(SAMLVersion.VERSION_20);
         if (samlAssertion != null) {
             SamlAssertionWrapper samlAssertionWrapper = new SamlAssertionWrapper(samlAssertion);
-            response.getAssertions().add(samlAssertionWrapper.getSaml2());
+            response.getAssertions()
+                    .add(samlAssertionWrapper.getSaml2());
         }
         return response;
     }
@@ -260,64 +299,76 @@ public class SamlProtocol {
         signingKeyDescriptor.setUse(UsageType.SIGNING);
         KeyInfo signingKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
         X509Data signingX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
-        X509Certificate signingX509Certificate = x509CertificateBuilder
-                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        X509Certificate signingX509Certificate =
+                x509CertificateBuilder.buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
         signingX509Certificate.setValue(signingCert);
-        signingX509Data.getX509Certificates().add(signingX509Certificate);
-        signingKeyInfo.getX509Datas().add(signingX509Data);
+        signingX509Data.getX509Certificates()
+                .add(signingX509Certificate);
+        signingKeyInfo.getX509Datas()
+                .add(signingX509Data);
         signingKeyDescriptor.setKeyInfo(signingKeyInfo);
-        idpssoDescriptor.getKeyDescriptors().add(signingKeyDescriptor);
+        idpssoDescriptor.getKeyDescriptors()
+                .add(signingKeyDescriptor);
         //encryption
         KeyDescriptor encKeyDescriptor = keyDescriptorBuilder.buildObject();
         encKeyDescriptor.setUse(UsageType.ENCRYPTION);
         KeyInfo encKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
         X509Data encX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
-        X509Certificate encX509Certificate = x509CertificateBuilder
-                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        X509Certificate encX509Certificate =
+                x509CertificateBuilder.buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
         encX509Certificate.setValue(encryptionCert);
-        encX509Data.getX509Certificates().add(encX509Certificate);
-        encKeyInfo.getX509Datas().add(encX509Data);
+        encX509Data.getX509Certificates()
+                .add(encX509Certificate);
+        encKeyInfo.getX509Datas()
+                .add(encX509Data);
         encKeyDescriptor.setKeyInfo(encKeyInfo);
-        idpssoDescriptor.getKeyDescriptors().add(encKeyDescriptor);
+        idpssoDescriptor.getKeyDescriptors()
+                .add(encKeyDescriptor);
 
         for (String nameId : nameIds) {
             NameIDFormat nameIDFormat = nameIdFormatBuilder.buildObject();
             nameIDFormat.setFormat(nameId);
-            idpssoDescriptor.getNameIDFormats().add(nameIDFormat);
+            idpssoDescriptor.getNameIDFormats()
+                    .add(nameIDFormat);
         }
 
         if (StringUtils.isNotBlank(singleSignOnLocationRedirect)) {
-            SingleSignOnService singleSignOnServiceRedirect = singleSignOnServiceBuilder
-                    .buildObject();
+            SingleSignOnService singleSignOnServiceRedirect =
+                    singleSignOnServiceBuilder.buildObject();
             singleSignOnServiceRedirect.setBinding(REDIRECT_BINDING);
             singleSignOnServiceRedirect.setLocation(singleSignOnLocationRedirect);
-            idpssoDescriptor.getSingleSignOnServices().add(singleSignOnServiceRedirect);
+            idpssoDescriptor.getSingleSignOnServices()
+                    .add(singleSignOnServiceRedirect);
         }
 
         if (StringUtils.isNotBlank(singleSignOnLocationPost)) {
             SingleSignOnService singleSignOnServicePost = singleSignOnServiceBuilder.buildObject();
             singleSignOnServicePost.setBinding(POST_BINDING);
             singleSignOnServicePost.setLocation(singleSignOnLocationPost);
-            idpssoDescriptor.getSingleSignOnServices().add(singleSignOnServicePost);
+            idpssoDescriptor.getSingleSignOnServices()
+                    .add(singleSignOnServicePost);
         }
 
         if (StringUtils.isNotBlank(singleLogOutLocation)) {
             SingleLogoutService singleLogoutServiceRedir = singleLogOutServiceBuilder.buildObject();
             singleLogoutServiceRedir.setBinding(REDIRECT_BINDING);
             singleLogoutServiceRedir.setLocation(singleLogOutLocation);
-            idpssoDescriptor.getSingleLogoutServices().add(singleLogoutServiceRedir);
+            idpssoDescriptor.getSingleLogoutServices()
+                    .add(singleLogoutServiceRedir);
 
             SingleLogoutService singleLogoutServicePost = singleLogOutServiceBuilder.buildObject();
             singleLogoutServicePost.setBinding(POST_BINDING);
             singleLogoutServicePost.setLocation(singleLogOutLocation);
-            idpssoDescriptor.getSingleLogoutServices().add(singleLogoutServicePost);
+            idpssoDescriptor.getSingleLogoutServices()
+                    .add(singleLogoutServicePost);
         }
 
         idpssoDescriptor.setWantAuthnRequestsSigned(true);
 
         idpssoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);
 
-        entityDescriptor.getRoleDescriptors().add(idpssoDescriptor);
+        entityDescriptor.getRoleDescriptors()
+                .add(idpssoDescriptor);
 
         return entityDescriptor;
     }
@@ -334,62 +385,73 @@ public class SamlProtocol {
         signingKeyDescriptor.setUse(UsageType.SIGNING);
         KeyInfo signingKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
         X509Data signingX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
-        X509Certificate signingX509Certificate = x509CertificateBuilder
-                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        X509Certificate signingX509Certificate =
+                x509CertificateBuilder.buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
         signingX509Certificate.setValue(signingCert);
-        signingX509Data.getX509Certificates().add(signingX509Certificate);
-        signingKeyInfo.getX509Datas().add(signingX509Data);
+        signingX509Data.getX509Certificates()
+                .add(signingX509Certificate);
+        signingKeyInfo.getX509Datas()
+                .add(signingX509Data);
         signingKeyDescriptor.setKeyInfo(signingKeyInfo);
-        spSsoDescriptor.getKeyDescriptors().add(signingKeyDescriptor);
+        spSsoDescriptor.getKeyDescriptors()
+                .add(signingKeyDescriptor);
         //encryption
         KeyDescriptor encKeyDescriptor = keyDescriptorBuilder.buildObject();
         encKeyDescriptor.setUse(UsageType.ENCRYPTION);
         KeyInfo encKeyInfo = keyInfoBuilder.buildObject(KeyInfo.DEFAULT_ELEMENT_NAME);
         X509Data encX509Data = x509DataBuilder.buildObject(X509Data.DEFAULT_ELEMENT_NAME);
-        X509Certificate encX509Certificate = x509CertificateBuilder
-                .buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        X509Certificate encX509Certificate =
+                x509CertificateBuilder.buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
         encX509Certificate.setValue(encryptionCert);
-        encX509Data.getX509Certificates().add(encX509Certificate);
-        encKeyInfo.getX509Datas().add(encX509Data);
+        encX509Data.getX509Certificates()
+                .add(encX509Certificate);
+        encKeyInfo.getX509Datas()
+                .add(encX509Data);
         encKeyDescriptor.setKeyInfo(encKeyInfo);
-        spSsoDescriptor.getKeyDescriptors().add(encKeyDescriptor);
+        spSsoDescriptor.getKeyDescriptors()
+                .add(encKeyDescriptor);
 
         if (StringUtils.isNotBlank(singleLogOutLocation)) {
-            SingleLogoutService singleLogoutServiceRedirect = singleLogOutServiceBuilder
-                    .buildObject();
+            SingleLogoutService singleLogoutServiceRedirect =
+                    singleLogOutServiceBuilder.buildObject();
             singleLogoutServiceRedirect.setBinding(REDIRECT_BINDING);
             singleLogoutServiceRedirect.setLocation(singleLogOutLocation);
-            spSsoDescriptor.getSingleLogoutServices().add(singleLogoutServiceRedirect);
+            spSsoDescriptor.getSingleLogoutServices()
+                    .add(singleLogoutServiceRedirect);
 
             SingleLogoutService singleLogoutServicePost = singleLogOutServiceBuilder.buildObject();
             singleLogoutServicePost.setBinding(POST_BINDING);
             singleLogoutServicePost.setLocation(singleLogOutLocation);
-            spSsoDescriptor.getSingleLogoutServices().add(singleLogoutServicePost);
+            spSsoDescriptor.getSingleLogoutServices()
+                    .add(singleLogoutServicePost);
         }
 
         int acsIndex = 0;
 
         if (StringUtils.isNotBlank(assertionConsumerServiceLocationRedirect)) {
-            AssertionConsumerService assertionConsumerService = assertionConsumerServiceBuilder
-                    .buildObject();
+            AssertionConsumerService assertionConsumerService =
+                    assertionConsumerServiceBuilder.buildObject();
             assertionConsumerService.setBinding(REDIRECT_BINDING);
             assertionConsumerService.setIndex(acsIndex++);
             assertionConsumerService.setLocation(assertionConsumerServiceLocationRedirect);
-            spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
+            spSsoDescriptor.getAssertionConsumerServices()
+                    .add(assertionConsumerService);
         }
 
         if (StringUtils.isNotBlank(assertionConsumerServiceLocationPost)) {
-            AssertionConsumerService assertionConsumerService = assertionConsumerServiceBuilder
-                    .buildObject();
+            AssertionConsumerService assertionConsumerService =
+                    assertionConsumerServiceBuilder.buildObject();
             assertionConsumerService.setBinding(POST_BINDING);
             assertionConsumerService.setIndex(acsIndex++);
             assertionConsumerService.setLocation(assertionConsumerServiceLocationPost);
-            spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
+            spSsoDescriptor.getAssertionConsumerServices()
+                    .add(assertionConsumerService);
         }
 
         spSsoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);
 
-        entityDescriptor.getRoleDescriptors().add(spSsoDescriptor);
+        entityDescriptor.getRoleDescriptors()
+                .add(spSsoDescriptor);
 
         return entityDescriptor;
     }
@@ -397,7 +459,8 @@ public class SamlProtocol {
     public static AttributeQuery createAttributeQuery(Issuer issuer, Subject subject,
             String destination) {
         AttributeQuery attributeQuery = attributeQueryBuilder.buildObject();
-        attributeQuery.setID(UUID.randomUUID().toString());
+        attributeQuery.setID(UUID.randomUUID()
+                .toString());
         attributeQuery.setIssueInstant(new DateTime());
         attributeQuery.setIssuer(issuer);
         attributeQuery.setSubject(subject);
@@ -438,5 +501,17 @@ public class SamlProtocol {
 
     public static LogoutResponse createLogoutResponse(Issuer issuer, Status status, String id) {
         return createLogoutResponse(issuer, status, null, id);
+    }
+
+    public static Envelope createSoapMessage(SignableSAMLObject signableSAMLObject) {
+        Body body = soapBodyBuilder.buildObject();
+        body.getUnknownXMLObjects()
+                .add(signableSAMLObject);
+        Envelope envelope = soapEnvelopeBuilder.buildObject();
+        envelope.setBody(body);
+        Header header = soapHeaderBuilder.buildObject();
+        envelope.setHeader(header);
+
+        return envelope;
     }
 }

--- a/platform/security/sts/security-sts-attributequeryclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-attributequeryclaimshandler/pom.xml
@@ -53,14 +53,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-soap-impl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-common</artifactId>
         </dependency>
@@ -99,7 +91,6 @@
                         <Embed-Dependency>
                             guava,
                             commons-collections,
-                            security,
                             platform-util
                         </Embed-Dependency>
                         <Import-Package>

--- a/platform/security/sts/security-sts-attributequeryclaimshandler/src/main/java/org/codice/ddf/security/claims/attributequery/AttributeQueryClient.java
+++ b/platform/security/sts/security-sts-attributequeryclaimshandler/src/main/java/org/codice/ddf/security/claims/attributequery/AttributeQueryClient.java
@@ -34,13 +34,8 @@ import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
-import org.opensaml.soap.soap11.Body;
 import org.opensaml.soap.soap11.Envelope;
-import org.opensaml.soap.soap11.Header;
-import org.opensaml.soap.soap11.impl.BodyBuilder;
-import org.opensaml.soap.soap11.impl.EnvelopeBuilder;
 import org.opensaml.soap.soap11.impl.EnvelopeMarshaller;
-import org.opensaml.soap.soap11.impl.HeaderBuilder;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
 import org.slf4j.Logger;
@@ -129,7 +124,7 @@ public class AttributeQueryClient {
             simpleSign.signSamlObject(attributeQuery);
 
             // Create soap message for request.
-            soapElement = createSOAPMessage(attributeQuery);
+            soapElement = createSoapMessage(attributeQuery);
 
             // Sign soap message.
             Signer.signObject(attributeQuery.getSignature());
@@ -150,30 +145,13 @@ public class AttributeQueryClient {
      * @param attributeQuery is added to the SOAP message
      * @return soapElement is the Element of the SOAP message
      */
-    private Element createSOAPMessage(AttributeQuery attributeQuery)
+    private Element createSoapMessage(AttributeQuery attributeQuery)
             throws AttributeQueryException {
-        LOGGER.debug("Creating SAML SOAP object of the AttributeQuery.");
+        LOGGER.debug("Creating SOAP message from the SAML AttributeQuery.");
 
-        BodyBuilder soapBodyBuilder =
-                (BodyBuilder) builderFactory.getBuilder(Body.DEFAULT_ELEMENT_NAME);
+        Envelope envelope = SamlProtocol.createSoapMessage(attributeQuery);
 
-        EnvelopeBuilder soapEnvelopeBuilder =
-                (EnvelopeBuilder) builderFactory.getBuilder(Envelope.DEFAULT_ELEMENT_NAME);
-
-        HeaderBuilder soapHeaderBuilder =
-                (HeaderBuilder) builderFactory.getBuilder(Header.DEFAULT_ELEMENT_NAME);
-
-        Body body = soapBodyBuilder.buildObject();
-        body.getUnknownXMLObjects()
-                .add(attributeQuery);
-
-        Envelope envelope = soapEnvelopeBuilder.buildObject();
-        envelope.setBody(body);
-
-        Header header = soapHeaderBuilder.buildObject();
-        envelope.setHeader(header);
-
-        LOGGER.debug("SAML SOAP object of the AttributeQuery created.");
+        LOGGER.debug("SOAP message from the SAML AttributeQuery created.");
 
         try {
             return new EnvelopeMarshaller().marshall(envelope);


### PR DESCRIPTION
Moved the Soap builders from the AttributeQueryClient into SamlProtocol and initialized the builders via the InitializationService.

@rzwiefel @ryeats @coyotesqrl @tbatie 

ryeats is the hero.