### PR TITLE
Ddf 1790 - Changes SystemBaseUrl and SystemInfo to be static utilties

### DIFF
--- a/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
+++ b/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
@@ -99,12 +99,9 @@ public final class CatalogMetrics
 
     private FilterAdapter filterAdapter;
 
-    private SystemInfo systemInfo;
-
-    public CatalogMetrics(FilterAdapter filterAdapter, SystemInfo info) {
+    public CatalogMetrics(FilterAdapter filterAdapter) {
 
         this.filterAdapter = filterAdapter;
-        this.systemInfo = info;
 
         resultCount = metrics.register(MetricRegistry.name(QUERIES_SCOPE, "TotalResults"),
                 new Histogram(new SlidingTimeWindowReservoir(1, TimeUnit.MINUTES)));
@@ -241,7 +238,7 @@ public final class CatalogMetrics
             return false;
         } else {
             return (sourceIds.size() > 1) || (sourceIds.size() == 1 && !sourceIds.contains("")
-                    && !sourceIds.contains(null) && !sourceIds.contains(systemInfo.getSiteName()));
+                    && !sourceIds.contains(null) && !sourceIds.contains(SystemInfo.getSiteName()));
         }
     }
 }

--- a/catalog/core/catalog-core-metricsplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-metricsplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,11 +15,9 @@
     
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
 	<bean id="catalogMetrics" class="ddf.catalog.metrics.CatalogMetrics">
         <argument ref="filterAdapter"/>
-        <argument ref="systemInfo"/>
     </bean>
 
     <service ref="catalogMetrics" interface="ddf.catalog.plugin.PreQueryPlugin"/>

--- a/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
+++ b/catalog/core/catalog-core-metricsplugin/src/test/java/ddf/catalog/metrics/CatalogMetricsTest.java
@@ -73,7 +73,7 @@ public class CatalogMetricsTest {
 
     @Before
     public void setup() {
-        underTest = new CatalogMetrics(filterAdapter, new SystemInfo());
+        underTest = new CatalogMetrics(filterAdapter);
         System.setProperty(SystemInfo.SITE_NAME, "testSite");
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -26,7 +26,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -68,6 +67,7 @@ import ddf.catalog.source.solr.SolrFilterDelegate;
 import ddf.catalog.source.solr.SolrFilterDelegateFactory;
 import ddf.catalog.source.solr.SolrMetacardClient;
 
+
 /**
  * Catalog cache implementation using Apache Solr 4
  */
@@ -108,19 +108,15 @@ public class SolrCache implements SolrCacheMBean {
 
     private MBeanServer mbeanServer;
 
-    private SystemBaseUrl systemBaseUrl;
-
     /**
      * Convenience constructor that creates a the Solr server
      *
      * @param adapter injected implementation of FilterAdapter
      */
-    public SolrCache(FilterAdapter adapter, SolrFilterDelegateFactory solrFilterDelegateFactory,
-            SystemBaseUrl sbu) {
+    public SolrCache(FilterAdapter adapter, SolrFilterDelegateFactory solrFilterDelegateFactory) {
         this.filterAdapter = adapter;
         this.solrFilterDelegateFactory = solrFilterDelegateFactory;
-        this.systemBaseUrl = sbu;
-        this.url = systemBaseUrl.constructUrl("/solr");
+        this.url = SystemBaseUrl.constructUrl("/solr");
         this.updateServer(this.url);
         configureCacheExpirationScheduler();
 
@@ -145,8 +141,8 @@ public class SolrCache implements SolrCacheMBean {
         List<Metacard> updatedMetacards = new ArrayList<>();
         for (Metacard metacard : metacards) {
             if (metacard != null) {
-                if (StringUtils.isNotBlank(metacard.getSourceId()) && StringUtils.isNotBlank(
-                        metacard.getId())) {
+                if (StringUtils.isNotBlank(metacard.getSourceId()) && StringUtils
+                        .isNotBlank(metacard.getId())) {
                     updatedMetacards.add(metacard);
                 }
             } else {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -412,6 +412,9 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         this.reliableResourceDownloadManager = frameworkProperties.getReliableResourceDownloadManager();
         this.pool = frameworkProperties.getPool();
 
+        setId(SystemInfo.getSiteName());
+        setVersion(SystemInfo.getVersion());
+        setOrganization(SystemInfo.getOrganization());
     }
 
     public void setFanoutEnabled(boolean fanoutEnabled) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -260,8 +260,6 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
 
     private QueryResponsePostProcessor queryResponsePostProcessor;
 
-    private SystemInfo systemInfo;
-
     /**
      * Instantiates a new CatalogFrameworkImpl
      *
@@ -374,6 +372,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         this.retrieveStatusEventPublisher = eventPublisher;
         this.reliableResourceDownloadManager = rrdm;
         this.pool = pool;
+
+        setId(SystemInfo.getSiteName());
+        setVersion(SystemInfo.getVersion());
+        setOrganization(SystemInfo.getOrganization());
     }
 
     /**
@@ -409,6 +411,7 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         this.retrieveStatusEventPublisher = frameworkProperties.getDownloadsStatusEventPublisher();
         this.reliableResourceDownloadManager = frameworkProperties.getReliableResourceDownloadManager();
         this.pool = frameworkProperties.getPool();
+
     }
 
     public void setFanoutEnabled(boolean fanoutEnabled) {
@@ -2725,16 +2728,5 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         public URI getResourceUri() {
             return resourceUri;
         }
-    }
-
-    public SystemInfo getSystemInfo() {
-        return systemInfo;
-    }
-
-    public void setSystemInfo(SystemInfo systemInfo) {
-        this.systemInfo = systemInfo;
-        setId(systemInfo.getSiteName());
-        setVersion(systemInfo.getVersion());
-        setOrganization(systemInfo.getOrganization());
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -251,8 +251,6 @@
         <argument ref="downloadThreadPool"/>
     </bean>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
     <!-- create the ddf bean -->
     <bean id="ddf" class="ddf.catalog.impl.CatalogFrameworkImpl">
         <cm:managed-properties persistent-id="ddf.catalog.CatalogFrameworkImpl"
@@ -282,7 +280,6 @@
                 <property name="accessPlugins" ref="accessSortedList"/>
             </bean>
         </argument>
-        <property name="systemInfo" ref="systemInfo"/>
         <property name="masker" ref="sourceListener"/>
         <property name="cacheEnabled" value="true"/>
         <property name="delayBetweenRetryAttempts" value="10"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -172,8 +172,6 @@
 
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-
     <!-- Create the SolrCache -->
     <bean id="solrCatalogCache" class="ddf.catalog.cache.solr.impl.SolrCache"
           destroy-method="shutdown">
@@ -181,7 +179,6 @@
         <argument>
             <bean class="ddf.catalog.source.solr.SolrFilterDelegateFactoryImpl"/>
         </argument>
-        <argument ref="urlHelper"/>
     </bean>
 
     <bean id="federationStrategy" class="ddf.catalog.cache.solr.impl.CachingFederationStrategy"

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/endpoints/OpenSearchEndpoint.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/endpoints/OpenSearchEndpoint.java
@@ -79,14 +79,11 @@ public class OpenSearchEndpoint implements OpenSearch {
 
     private final FilterBuilder filterBuilder;
 
-    private SystemInfo systemInfo;
-
-    public OpenSearchEndpoint(CatalogFramework framework, FilterBuilder filterBuilder, SystemInfo info) {
+    public OpenSearchEndpoint(CatalogFramework framework, FilterBuilder filterBuilder) {
         LOGGER.trace("Entering OpenSearch Endpoint Constructor.");
         this.framework = framework;
         this.filterBuilder = filterBuilder;
-        this.systemInfo = info;
-        LOGGER.trace("Exiting OpenSearch Endpoint Constructor.");        
+        LOGGER.trace("Exiting OpenSearch Endpoint Constructor.");
     }
 
     /**
@@ -164,9 +161,9 @@ public class OpenSearchEndpoint implements OpenSearch {
                 // Since local is a magic work, not in any specification, weneed to
                 // eventually remove support for it.
                 if (siteSet.remove(LOCAL)) {
-                    LOGGER.debug("Found 'local' alias, replacing with " + systemInfo.getSiteName()
+                    LOGGER.debug("Found 'local' alias, replacing with " + SystemInfo.getSiteName()
                             + ".");
-                    siteSet.add(systemInfo.getSiteName());
+                    siteSet.add(SystemInfo.getSiteName());
                 }
 
                 if (siteSet.contains(framework.getId()) && siteSet.size() == 1) {

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,12 +36,9 @@
         </jaxrs:outInterceptors>
     </jaxrs:server>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
     <bean id="OsSvc" class="org.codice.ddf.endpoints.OpenSearchEndpoint">
         <argument ref="ddf"/>
         <argument ref="filterBuilder"/>
-        <argument ref="systemInfo"/>
     </bean>
 
 </blueprint>

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/endpoints/OpenSearchEndpointTest.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/endpoints/OpenSearchEndpointTest.java
@@ -136,8 +136,7 @@ public class OpenSearchEndpointTest {
         when(mockFramework.transform(any(QueryResponse.class), anyString(), anyMap()))
                 .thenReturn(mockBinaryContent);
 
-        OpenSearchEndpoint osEndPoint = new OpenSearchEndpoint(mockFramework, mockFilterBuilder,
-                new SystemInfo());
+        OpenSearchEndpoint osEndPoint = new OpenSearchEndpoint(mockFramework, mockFilterBuilder);
 
         System.setProperty(SystemInfo.SITE_NAME, testSiteName);
 

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
@@ -33,17 +33,14 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     static final String PATH = "/catalog/sources";
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(AbstractMetacardActionProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            AbstractMetacardActionProvider.class);
 
     protected String actionProviderId;
 
-    protected SystemBaseUrl systemBaseUrl;
-
     protected SystemInfo systemInfo;
 
-    protected AbstractMetacardActionProvider(SystemBaseUrl sbu, SystemInfo info) {
-        this.systemBaseUrl = sbu;
+    protected AbstractMetacardActionProvider(SystemInfo info) {
         this.systemInfo = info;
     }
 
@@ -67,7 +64,7 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
                 return null;
             }
 
-            if (systemBaseUrl == null || isHostUnset(systemBaseUrl.getHost())) {
+            if (isHostUnset(SystemBaseUrl.getHost())) {
                 LOGGER.info("Host name/ip not set. Cannot create link for metacard.");
                 return null;
             }
@@ -92,7 +89,8 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     protected boolean isHostUnset(String host) {
 
-        return (host == null || host.trim().equals(UNKNOWN_TARGET));
+        return (host == null || host.trim()
+                .equals(UNKNOWN_TARGET));
     }
 
     protected String getSource(Metacard metacard) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
@@ -38,10 +38,7 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     protected String actionProviderId;
 
-    protected SystemInfo systemInfo;
-
-    protected AbstractMetacardActionProvider(SystemInfo info) {
-        this.systemInfo = info;
+    protected AbstractMetacardActionProvider() {
     }
 
     protected abstract Action getAction(String metacardId, String metacardSource);
@@ -99,7 +96,7 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
             return metacard.getSourceId();
         }
 
-        return systemInfo.getSiteName();
+        return SystemInfo.getSiteName();
     }
 
     @Override

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
@@ -29,14 +29,15 @@ import ddf.action.impl.ActionImpl;
 
 public class MetacardTransformerActionProvider extends AbstractMetacardActionProvider {
 
-    static final String DESCRIPTION_PREFIX = "Provides a URL to the metacard that transforms the return value via the ";
+    static final String DESCRIPTION_PREFIX =
+            "Provides a URL to the metacard that transforms the return value via the ";
 
     static final String DESCRIPTION_SUFFIX = " transformer";
 
     static final String TITLE_PREFIX = "Export as ";
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(MetacardTransformerActionProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            MetacardTransformerActionProvider.class);
 
     private String metacardTransformerId;
 
@@ -47,8 +48,8 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
      * @param metacardTransformerId
      */
     public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId,
-            SystemBaseUrl sbu, SystemInfo info) {
-        super(sbu, info);
+            SystemInfo info) {
+        super(info);
         this.actionProviderId = actionProviderId;
         this.metacardTransformerId = metacardTransformerId;
     }
@@ -59,7 +60,7 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
         URL url = null;
         try {
 
-            URI uri = new URI(systemBaseUrl.constructUrl(
+            URI uri = new URI(SystemBaseUrl.constructUrl(
                     PATH + "/" + metacardSource + "/" + metacardId + "?transform="
                             + metacardTransformerId, true));
             url = uri.toURL();

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
@@ -19,7 +19,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
-import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,13 +42,11 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
 
     /**
      * Constructor to instantiate this Metacard {@link ActionProvider}
-     *
-     * @param actionProviderId
+     *  @param actionProviderId
      * @param metacardTransformerId
      */
-    public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId,
-            SystemInfo info) {
-        super(info);
+    public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId) {
+        super();
         this.actionProviderId = actionProviderId;
         this.metacardTransformerId = metacardTransformerId;
     }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
@@ -13,29 +13,21 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 
 public class MetacardTransformerActionProviderFactory {
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SystemInfo systemInfo;
 
-    public MetacardTransformerActionProviderFactory(SystemBaseUrl sbu, SystemInfo info) {
-        this.systemBaseUrl = sbu;
+    public MetacardTransformerActionProviderFactory(SystemInfo info) {
         this.systemInfo = info;
     }
 
     public MetacardTransformerActionProvider createActionProvider(String id, String transformer) {
-        return new MetacardTransformerActionProvider(id, transformer, systemBaseUrl, systemInfo);
+        return new MetacardTransformerActionProvider(id, transformer, systemInfo);
     }
 
     public SystemInfo getSystemInfo() {
         return systemInfo;
-    }
-
-    public SystemBaseUrl getSystemBaseUrl() {
-        return systemBaseUrl;
     }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProviderFactory.java
@@ -13,21 +13,9 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
-import org.codice.ddf.configuration.SystemInfo;
-
 public class MetacardTransformerActionProviderFactory {
 
-    private SystemInfo systemInfo;
-
-    public MetacardTransformerActionProviderFactory(SystemInfo info) {
-        this.systemInfo = info;
-    }
-
     public MetacardTransformerActionProvider createActionProvider(String id, String transformer) {
-        return new MetacardTransformerActionProvider(id, transformer, systemInfo);
-    }
-
-    public SystemInfo getSystemInfo() {
-        return systemInfo;
+        return new MetacardTransformerActionProvider(id, transformer);
     }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
@@ -19,7 +19,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
-import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +33,8 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewMetacardActionProvider.class);
 
-    public ViewMetacardActionProvider(String id, SystemInfo info) {
-        super(info);
+    public ViewMetacardActionProvider(String id) {
+        super();
         this.actionProviderId = id;
     }
 

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/ViewMetacardActionProvider.java
@@ -34,8 +34,8 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewMetacardActionProvider.class);
 
-    public ViewMetacardActionProvider(String id, SystemBaseUrl sbu, SystemInfo info) {
-        super(sbu, info);
+    public ViewMetacardActionProvider(String id, SystemInfo info) {
+        super(info);
         this.actionProviderId = id;
     }
 
@@ -45,8 +45,9 @@ public class ViewMetacardActionProvider extends AbstractMetacardActionProvider {
         URL url = null;
         try {
 
-            URI uri = new URI(systemBaseUrl
-                    .constructUrl(PATH + "/" + metacardSource + "/" + metacardId, true));
+            URI uri = new URI(
+                    SystemBaseUrl.constructUrl(PATH + "/" + metacardSource + "/" + metacardId,
+                            true));
             url = uri.toURL();
 
         } catch (MalformedURLException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,11 +21,9 @@
 	<reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver"/>
 
-	<bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"></bean>
 	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"></bean>
 
 	<bean id="actionFactory" class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory">
-		<argument ref="urlHelper"/>
 		<argument ref="systemInfo"/>
 	</bean>
 
@@ -65,7 +63,6 @@
 	<bean id="viewActionProvider"
           class="org.codice.ddf.endpoints.rest.action.ViewMetacardActionProvider">
 		<argument value="catalog.data.metacard.view"/>
-		<argument ref="urlHelper"/>
 		<argument ref="systemInfo"/>
 	</bean>
 

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,11 +21,7 @@
 	<reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver"/>
 
-	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"></bean>
-
-	<bean id="actionFactory" class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory">
-		<argument ref="systemInfo"/>
-	</bean>
+	<bean id="actionFactory" class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory"/>
 
 	<reference-list id="metacardTransformerRefList"
                     interface="ddf.catalog.transform.MetacardTransformer" availability="optional">
@@ -63,7 +59,6 @@
 	<bean id="viewActionProvider"
           class="org.codice.ddf.endpoints.rest.action.ViewMetacardActionProvider">
 		<argument value="catalog.data.metacard.view"/>
-		<argument ref="systemInfo"/>
 	</bean>
 
 	<service ref="viewActionProvider" interface="ddf.action.ActionProvider">

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Dictionary;
 
-import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -65,7 +64,7 @@ public class TestActionProviderRegistryProxy {
         BundleContext bundleContext = givenBundleContext(answer);
 
         MetacardTransformerActionProviderFactory mtapf =
-                new MetacardTransformerActionProviderFactory(new SystemInfo());
+                new MetacardTransformerActionProviderFactory();
 
         ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext, mtapf);
 

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Dictionary;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
@@ -34,8 +33,8 @@ public class TestActionProviderRegistryProxy {
 
     private static final String SAMPLE_TRANSFORMER_ID = "sampleTransformerId";
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(TestActionProviderRegistryProxy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            TestActionProviderRegistryProxy.class);
 
     @Test
     public void testNoTransformerId() {
@@ -52,8 +51,8 @@ public class TestActionProviderRegistryProxy {
         proxy.bind(reference);
 
         // then
-        verify(bundleContext, times(0))
-                .registerService(isA(String.class), isA(Object.class), isA(Dictionary.class));
+        verify(bundleContext, times(0)).registerService(isA(String.class), isA(Object.class),
+                isA(Dictionary.class));
 
     }
 
@@ -65,8 +64,8 @@ public class TestActionProviderRegistryProxy {
 
         BundleContext bundleContext = givenBundleContext(answer);
 
-        MetacardTransformerActionProviderFactory mtapf = new MetacardTransformerActionProviderFactory(
-                new SystemBaseUrl(), new SystemInfo());
+        MetacardTransformerActionProviderFactory mtapf =
+                new MetacardTransformerActionProviderFactory(new SystemInfo());
 
         ActionProviderRegistryProxy proxy = new ActionProviderRegistryProxy(bundleContext, mtapf);
 
@@ -79,10 +78,11 @@ public class TestActionProviderRegistryProxy {
         proxy.unbind(reference);
 
         // then
-        verify(bundleContext, times(1))
-                .registerService(isA(String.class), isA(Object.class), isA(Dictionary.class));
+        verify(bundleContext, times(1)).registerService(isA(String.class), isA(Object.class),
+                isA(Dictionary.class));
 
-        ServiceRegistration mockRegistration1 = answer.getIssuedServiceRegistrations().get(0);
+        ServiceRegistration mockRegistration1 = answer.getIssuedServiceRegistrations()
+                .get(0);
 
         verify(mockRegistration1, times(1)).unregister();
 
@@ -91,9 +91,8 @@ public class TestActionProviderRegistryProxy {
     private BundleContext givenBundleContext(ServiceRegistrationAnswer answer) {
         BundleContext bundleContext = mock(BundleContext.class);
 
-        when(bundleContext
-                .registerService(isA(String.class), isA(Object.class), isA(Dictionary.class)))
-                .then(answer);
+        when(bundleContext.registerService(isA(String.class), isA(Object.class),
+                isA(Dictionary.class))).then(answer);
 
         return bundleContext;
     }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -36,8 +35,8 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
 
     private static final String SAMPLE_TRANSFORMER_ID = "XML";
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(TestMetacardTransformerActionProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            TestMetacardTransformerActionProvider.class);
 
     @Test
     public void testMalformedUrlException() {
@@ -46,7 +45,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
 
         this.configureActionProvider("badProtocol", SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -63,7 +62,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
 
         this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -82,7 +81,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
@@ -93,12 +92,11 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
                 action.getTitle());
 
         assertEquals(MetacardTransformerActionProvider.DESCRIPTION_PREFIX + SAMPLE_TRANSFORMER_ID +
-                        MetacardTransformerActionProvider.DESCRIPTION_SUFFIX,
-                action.getDescription());
+                MetacardTransformerActionProvider.DESCRIPTION_SUFFIX, action.getDescription());
 
-        assertThat(action.getUrl().toString(),
-                is(expectedDefaultAddressWith(metacard.getId(), SAMPLE_SOURCE_NAME,
-                        SAMPLE_TRANSFORMER_ID)));
+        assertThat(action.getUrl()
+                .toString(), is(expectedDefaultAddressWith(metacard.getId(), SAMPLE_SOURCE_NAME,
+                SAMPLE_TRANSFORMER_ID)));
         assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
 
     }
@@ -106,7 +104,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
     @Test
     public void testToString() {
         String toString = new MetacardTransformerActionProvider(ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo()).toString();
+                SAMPLE_TRANSFORMER_ID, new SystemInfo()).toString();
 
         LOGGER.info(toString);
 
@@ -138,16 +136,16 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         metacard.setSourceId(newSourceName);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
         Action action = actionProvider.getAction(metacard);
 
         // then
-        assertThat(action.getUrl().toString(),
-                is(expectedDefaultAddressWith(metacard.getId(), newSourceName,
-                        SAMPLE_TRANSFORMER_ID)));
+        assertThat(action.getUrl()
+                .toString(), is(expectedDefaultAddressWith(metacard.getId(), newSourceName,
+                SAMPLE_TRANSFORMER_ID)));
         assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
 
     }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
 
         this.configureActionProvider("badProtocol", SAMPLE_IP, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -62,7 +61,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
 
         this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -81,7 +80,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
         this.configureActionProvider();
 
         // when
@@ -104,7 +103,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
     @Test
     public void testToString() {
         String toString = new MetacardTransformerActionProvider(ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID, new SystemInfo()).toString();
+                SAMPLE_TRANSFORMER_ID).toString();
 
         LOGGER.info(toString);
 
@@ -136,7 +135,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
         metacard.setSourceId(newSourceName);
 
         AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID, SAMPLE_TRANSFORMER_ID);
         this.configureActionProvider();
 
         // when

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Date;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
     @Test
     public void testMetacardNull() {
         assertEquals(null,
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID, null, null).getAction(null));
+                new ViewMetacardActionProvider(ACTION_PROVIDER_ID, null).getAction(null));
     }
 
     @Test
@@ -45,7 +44,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
 
@@ -63,11 +62,13 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId("abd ef");
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
-        String url = actionProvider.getAction(metacard).getUrl().toString();
+        String url = actionProvider.getAction(metacard)
+                .getUrl()
+                .toString();
 
         // then
         assertThat(url, is(expectedDefaultAddressWith("abd+ef")));
@@ -83,11 +84,13 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId("abd&ef");
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
-        String url = actionProvider.getAction(metacard).getUrl().toString();
+        String url = actionProvider.getAction(metacard)
+                .getUrl()
+                .toString();
 
         // then
         assertThat(url, is(expectedDefaultAddressWith("abd%26ef")));
@@ -102,25 +105,11 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(null);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         assertNull("An action should not have been created when no id is provided.",
                 actionProvider.getAction(metacard));
-
-    }
-
-    @Test
-    public void testNoConfigSettings() {
-
-        MetacardImpl metacard = new MetacardImpl();
-
-        metacard.setId(SAMPLE_ID);
-
-        AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, null, null);
-
-        assertNull(actionProvider.getAction(metacard));
 
     }
 
@@ -132,13 +121,14 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
 
         this.configureActionProvider(SAMPLE_PROTOCOL, null, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
 
-        assertThat(actionProvider.getAction(metacard).getUrl().toString(),
-                containsString("localhost"));
+        assertThat(actionProvider.getAction(metacard)
+                .getUrl()
+                .toString(), containsString("localhost"));
 
     }
 
@@ -150,7 +140,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
 
         this.configureActionProvider(SAMPLE_PROTOCOL, "0.0.0.0", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -167,12 +157,14 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
 
         this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, null, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
 
-        assertThat(actionProvider.getAction(metacard).getUrl().toString(), containsString("8181"));
+        assertThat(actionProvider.getAction(metacard)
+                .getUrl()
+                .toString(), containsString("8181"));
     }
 
     @Test
@@ -183,20 +175,21 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
 
         this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, null,
                 SAMPLE_SOURCE_NAME);
 
-        assertThat(actionProvider.getAction(metacard).getUrl().toString(),
-                not(containsString("/services")));
+        assertThat(actionProvider.getAction(metacard)
+                .getUrl()
+                .toString(), not(containsString("/services")));
     }
 
     @Test
     public void testNonMetacard() {
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         assertNull("An action when metacard was not provided.",
@@ -213,7 +206,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
@@ -222,7 +215,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         // then
         assertEquals(ViewMetacardActionProvider.TITLE, action.getTitle());
         assertEquals(ViewMetacardActionProvider.DESCRIPTION, action.getDescription());
-        assertThat(action.getUrl().toString(), is(expectedDefaultAddressWith(metacard.getId())));
+        assertThat(action.getUrl()
+                .toString(), is(expectedDefaultAddressWith(metacard.getId())));
         assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
 
     }
@@ -239,7 +233,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setSourceId(newSourceName);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureActionProvider();
 
         // when
@@ -248,8 +242,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         // then
         assertEquals(ViewMetacardActionProvider.TITLE, action.getTitle());
         assertEquals(ViewMetacardActionProvider.DESCRIPTION, action.getDescription());
-        assertThat(action.getUrl().toString(),
-                is(expectedDefaultAddressWith(metacard.getId(), newSourceName)));
+        assertThat(action.getUrl()
+                .toString(), is(expectedDefaultAddressWith(metacard.getId(), newSourceName)));
         assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
 
     }
@@ -261,7 +255,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId(SAMPLE_ID);
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
         this.configureSecureActionProvider();
 
         Action action = actionProvider.getAction(metacard);
@@ -270,8 +264,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         assertEquals(ViewMetacardActionProvider.DESCRIPTION, action.getDescription());
         assertEquals(
                 SAMPLE_SECURE_PROTOCOL + SAMPLE_IP + ":" + SAMPLE_SECURE_PORT + SAMPLE_SERVICES_ROOT
-                        + SAMPLE_PATH + SAMPLE_SOURCE_NAME + "/" + metacard.getId(),
-                action.getUrl().toString());
+                        + SAMPLE_PATH + SAMPLE_SOURCE_NAME + "/" + metacard.getId(), action.getUrl()
+                        .toString());
         assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
 
     }
@@ -284,7 +278,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemBaseUrl(), new SystemInfo());
+                ACTION_PROVIDER_ID, new SystemInfo());
 
         this.configureActionProvider(null, SAMPLE_IP, SAMPLE_SECURE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -292,7 +286,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         Action action = actionProvider.getAction(metacard);
 
         //when null protocal should default to https
-        assertThat(action.getUrl().toString(), containsString("https"));
+        assertThat(action.getUrl()
+                .toString(), containsString("https"));
 
     }
 

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Date;
 
-import org.codice.ddf.configuration.SystemInfo;
 import org.junit.Test;
 
 import ddf.action.Action;
@@ -33,7 +32,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
     @Test
     public void testMetacardNull() {
         assertEquals(null,
-                new ViewMetacardActionProvider(ACTION_PROVIDER_ID, null).getAction(null));
+                new ViewMetacardActionProvider(ACTION_PROVIDER_ID).getAction(null));
     }
 
     @Test
@@ -44,7 +43,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
 
@@ -62,7 +61,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId("abd ef");
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         // when
@@ -84,7 +83,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId("abd&ef");
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         // when
@@ -105,7 +104,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(null);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         assertNull("An action should not have been created when no id is provided.",
@@ -121,7 +120,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
 
         this.configureActionProvider(SAMPLE_PROTOCOL, null, SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -140,7 +139,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
 
         this.configureActionProvider(SAMPLE_PROTOCOL, "0.0.0.0", SAMPLE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -157,7 +156,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
 
         this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, null, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);
@@ -175,7 +174,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
 
         this.configureActionProvider(SAMPLE_PROTOCOL, SAMPLE_IP, SAMPLE_PORT, null,
                 SAMPLE_SOURCE_NAME);
@@ -189,7 +188,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
     public void testNonMetacard() {
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         assertNull("An action when metacard was not provided.",
@@ -206,7 +205,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         // when
@@ -233,7 +232,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setSourceId(newSourceName);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureActionProvider();
 
         // when
@@ -255,7 +254,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         metacard.setId(SAMPLE_ID);
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
         this.configureSecureActionProvider();
 
         Action action = actionProvider.getAction(metacard);
@@ -278,7 +277,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
         metacard.setId(SAMPLE_ID);
 
         AbstractMetacardActionProvider actionProvider = new ViewMetacardActionProvider(
-                ACTION_PROVIDER_ID, new SystemInfo());
+                ACTION_PROVIDER_ID);
 
         this.configureActionProvider(null, SAMPLE_IP, SAMPLE_SECURE_PORT, SAMPLE_SERVICES_ROOT,
                 SAMPLE_SOURCE_NAME);

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
@@ -129,12 +129,10 @@ public class KmlEndpoint {
 
     private ClassPathTemplateLoader templateLoader;
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SystemInfo systemInfo;
 
     public KmlEndpoint(BrandingPlugin brandingPlugin, CatalogFramework catalogFramework,
-            SystemBaseUrl sbu, SystemInfo info) {
+            SystemInfo info) {
         LOGGER.trace("ENTERING: KML Endpoint Constructor");
         this.branding = brandingPlugin;
         this.framework = catalogFramework;
@@ -142,7 +140,6 @@ public class KmlEndpoint {
         templateLoader.setPrefix("/templates");
         templateLoader.setSuffix(".hbt");
         this.productName = branding.getProductName().split(" ")[0];
-        this.systemBaseUrl = sbu;
         this.systemInfo = info;
         LOGGER.trace("EXITING: KML Endpoint Constructor");
     }
@@ -299,7 +296,7 @@ public class KmlEndpoint {
         Link link = rootNetworkLink.createAndSetLink();
         UriBuilder builder = UriBuilder.fromUri(uriInfo.getBaseUri());
         builder = generateEndpointUrl(
-                systemBaseUrl.getRootContext() + FORWARD_SLASH + CATALOG_URL_PATH + FORWARD_SLASH
+                SystemBaseUrl.getRootContext() + FORWARD_SLASH + CATALOG_URL_PATH + FORWARD_SLASH
                         + KML_TRANSFORM_PARAM + FORWARD_SLASH + "sources", builder);
         link.setHref(builder.build().toString());
         link.setViewRefreshMode(ViewRefreshMode.NEVER);
@@ -331,7 +328,7 @@ public class KmlEndpoint {
             for (SourceDescriptor descriptor : response.getSourceInfo()) {
                 UriBuilder builder = UriBuilder.fromUri(uriInfo.getBaseUri());
                 builder = generateEndpointUrl(
-                        systemBaseUrl.getRootContext() + FORWARD_SLASH + CATALOG_URL_PATH
+                        SystemBaseUrl.getRootContext() + FORWARD_SLASH + CATALOG_URL_PATH
                                 + FORWARD_SLASH + OPENSEARCH_URL_PATH, builder);
                 builder = builder.queryParam(SOURCE_PARAM, descriptor.getSourceId());
                 builder = builder.queryParam(OPENSEARCH_SORT_KEY, OPENSEARCH_DEFAULT_SORT);
@@ -388,13 +385,13 @@ public class KmlEndpoint {
     private UriBuilder generateEndpointUrl(String path, UriBuilder uriBuilder)
             throws UnknownHostException {
         UriBuilder builder = uriBuilder;
-        builder.host(systemBaseUrl.getHost());
+        builder.host(SystemBaseUrl.getHost());
 
         try {
-            builder.port(Integer.parseInt(systemBaseUrl.getPort()));
+            builder.port(Integer.parseInt(SystemBaseUrl.getPort()));
         } catch (NumberFormatException nfe) {
             LOGGER.debug("Cannot convert the current DDF port: {} to an integer."
-                    + " Defaulting to port in invocation.", systemBaseUrl.getPort());
+                    + " Defaulting to port in invocation.", SystemBaseUrl.getPort());
             throw new UnknownHostException("Unable to determine port DDF is using.");
         }
 

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
@@ -129,10 +129,7 @@ public class KmlEndpoint {
 
     private ClassPathTemplateLoader templateLoader;
 
-    private SystemInfo systemInfo;
-
-    public KmlEndpoint(BrandingPlugin brandingPlugin, CatalogFramework catalogFramework,
-            SystemInfo info) {
+    public KmlEndpoint(BrandingPlugin brandingPlugin, CatalogFramework catalogFramework) {
         LOGGER.trace("ENTERING: KML Endpoint Constructor");
         this.branding = brandingPlugin;
         this.framework = catalogFramework;
@@ -140,7 +137,6 @@ public class KmlEndpoint {
         templateLoader.setPrefix("/templates");
         templateLoader.setSuffix(".hbt");
         this.productName = branding.getProductName().split(" ")[0];
-        this.systemInfo = info;
         LOGGER.trace("EXITING: KML Endpoint Constructor");
     }
 
@@ -246,7 +242,7 @@ public class KmlEndpoint {
     }
 
     public String getContact() {
-        return systemInfo.getSiteContatct();
+        return SystemInfo.getSiteContatct();
     }
 
     public String getBaseUrl() {

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,12 +36,9 @@
         </jaxrs:providers>
     </jaxrs:server>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
 	<bean id="kmlEndpoint" class="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint">
 		<argument ref="branding"/>
 		<argument ref="framework"/>
-        <argument ref="systemInfo"/>
 		<cm:managed-properties persistent-id="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint"
                                update-strategy="container-managed"/>
 	</bean>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,13 +36,11 @@
         </jaxrs:providers>
     </jaxrs:server>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
     <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
 	<bean id="kmlEndpoint" class="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint">
 		<argument ref="branding"/>
 		<argument ref="framework"/>
-        <argument ref="urlHelper"/>
         <argument ref="systemInfo"/>
 		<cm:managed-properties persistent-id="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint"
                                update-strategy="container-managed"/>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
@@ -125,7 +125,7 @@ public class TestKmlEndpoint {
     @Test
     public void testGetKmlNetworkLink() {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         kmlEndpoint.setDescription("This is some description.");
         kmlEndpoint.setLogo(
                 "https://tools.codice.org/wiki/download/attachments/3047457/DDF?version=1&modificationDate=1369422662164&api=v2");
@@ -150,7 +150,7 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
@@ -175,7 +175,7 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
@@ -202,7 +202,7 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         kmlEndpoint.setMaxResults(250);
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
@@ -232,7 +232,7 @@ public class TestKmlEndpoint {
      */
     @Test
     public void testGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         byte[] response = kmlEndpoint.getIcon(null, BOMBER_ICON);
         assertThat(response, is(bomberBytes));
     }
@@ -242,13 +242,13 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         kmlEndpoint.getIcon(null, JET_ICON);
     }
 
     @Test
     public void testGetIconCustomLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         kmlEndpoint.setIconLoc(jetPath);
         byte[] response = kmlEndpoint.getIcon(null, JET_ICON);
         assertThat(response, is(jetBtyes));
@@ -259,7 +259,7 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetCustomIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework);
         kmlEndpoint.setIconLoc(bomberPath);
         kmlEndpoint.getIcon(null, JET_ICON);
     }

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
@@ -97,11 +97,13 @@ public class TestKmlEndpoint {
         when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://example.com"));
 
         URL bomberLocation = TestKmlEndpoint.class.getResource(ICONS_DIR + BOMBER_ICON);
-        bomberPath = bomberLocation.getPath().replaceAll(BOMBER_ICON, "");
+        bomberPath = bomberLocation.getPath()
+                .replaceAll(BOMBER_ICON, "");
         bomberBytes = IOUtils.toByteArray(bomberLocation.openStream());
 
         URL jetLocation = TestKmlEndpoint.class.getResource(TEST_ICONS_DIR + JET_ICON);
-        jetPath = jetLocation.getPath().replaceAll(JET_ICON, "");
+        jetPath = jetLocation.getPath()
+                .replaceAll(JET_ICON, "");
         jetBtyes = IOUtils.toByteArray(jetLocation.openStream());
 
         System.setProperty(SystemBaseUrl.HOST, TEST_HOST);
@@ -110,8 +112,8 @@ public class TestKmlEndpoint {
         System.setProperty(SystemBaseUrl.ROOT_CONTEXT, "/services");
         System.setProperty(SystemInfo.SITE_CONTACT, "example@example.com");
 
-        when(mockFramework.getSourceInfo(any(SourceInfoRequest.class)))
-                .thenReturn(mockSourceInfoResponse);
+        when(mockFramework.getSourceInfo(any(SourceInfoRequest.class))).thenReturn(
+                mockSourceInfoResponse);
         SourceDescriptorImpl localDescriptor = new SourceDescriptorImpl(LOCAL_SITE_NAME, null);
         SourceDescriptorImpl remoteDescriptor = new SourceDescriptorImpl(REMOTE_SITE_NAME, null);
         descriptors.add(localDescriptor);
@@ -123,8 +125,7 @@ public class TestKmlEndpoint {
     @Test
     public void testGetKmlNetworkLink() {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         kmlEndpoint.setDescription("This is some description.");
         kmlEndpoint.setLogo(
                 "https://tools.codice.org/wiki/download/attachments/3047457/DDF?version=1&modificationDate=1369422662164&api=v2");
@@ -149,19 +150,23 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
         Folder folder = (Folder) response.getFeature();
         assertThat(folder.getFeature(), notNullValue());
-        assertThat(folder.getFeature().size(), is(2));
-        assertThat(folder.getFeature().get(0), is(NetworkLink.class));
-        assertThat(folder.getFeature().get(1), is(NetworkLink.class));
-        NetworkLink nl1 = (NetworkLink) folder.getFeature().get(0);
+        assertThat(folder.getFeature()
+                .size(), is(2));
+        assertThat(folder.getFeature()
+                .get(0), is(NetworkLink.class));
+        assertThat(folder.getFeature()
+                .get(1), is(NetworkLink.class));
+        NetworkLink nl1 = (NetworkLink) folder.getFeature()
+                .get(0);
         assertThat(nl1.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
-        NetworkLink nl2 = (NetworkLink) folder.getFeature().get(1);
+        NetworkLink nl2 = (NetworkLink) folder.getFeature()
+                .get(1);
         assertThat(nl2.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
     }
 
@@ -170,20 +175,24 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
         Folder folder = (Folder) response.getFeature();
         assertThat(folder.getFeature(), notNullValue());
-        assertThat(folder.getFeature().size(), is(2));
-        assertThat(folder.getFeature().get(0), is(NetworkLink.class));
-        assertThat(folder.getFeature().get(1), is(NetworkLink.class));
-        NetworkLink nl1 = (NetworkLink) folder.getFeature().get(0);
+        assertThat(folder.getFeature()
+                .size(), is(2));
+        assertThat(folder.getFeature()
+                .get(0), is(NetworkLink.class));
+        assertThat(folder.getFeature()
+                .get(1), is(NetworkLink.class));
+        NetworkLink nl1 = (NetworkLink) folder.getFeature()
+                .get(0);
         assertThat(nl1.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
         assertThat(nl1.isVisibility(), is(false));
-        NetworkLink nl2 = (NetworkLink) folder.getFeature().get(1);
+        NetworkLink nl2 = (NetworkLink) folder.getFeature()
+                .get(1);
         assertThat(nl2.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
         assertThat(nl2.isVisibility(), is(false));
     }
@@ -193,23 +202,29 @@ public class TestKmlEndpoint {
             throws UnknownHostException, MalformedURLException, IllegalArgumentException,
             UriBuilderException, SourceUnavailableException {
         when(mockUriInfo.getQueryParameters(false)).thenReturn(mockMap);
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         kmlEndpoint.setMaxResults(250);
         Kml response = kmlEndpoint.getAvailableSources(mockUriInfo);
         assertThat(response, notNullValue());
         assertThat(response.getFeature(), is(Folder.class));
         Folder folder = (Folder) response.getFeature();
         assertThat(folder.getFeature(), notNullValue());
-        assertThat(folder.getFeature().size(), is(2));
-        assertThat(folder.getFeature().get(0), is(NetworkLink.class));
-        assertThat(folder.getFeature().get(1), is(NetworkLink.class));
-        NetworkLink nl1 = (NetworkLink) folder.getFeature().get(0);
+        assertThat(folder.getFeature()
+                .size(), is(2));
+        assertThat(folder.getFeature()
+                .get(0), is(NetworkLink.class));
+        assertThat(folder.getFeature()
+                .get(1), is(NetworkLink.class));
+        NetworkLink nl1 = (NetworkLink) folder.getFeature()
+                .get(0);
         assertThat(nl1.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
-        assertThat(nl1.getLink().getHttpQuery(), is("count=250"));
-        NetworkLink nl2 = (NetworkLink) folder.getFeature().get(1);
+        assertThat(nl1.getLink()
+                .getHttpQuery(), is("count=250"));
+        NetworkLink nl2 = (NetworkLink) folder.getFeature()
+                .get(1);
         assertThat(nl2.getName(), anyOf(is(REMOTE_SITE_NAME), is(LOCAL_SITE_NAME)));
-        assertThat(nl2.getLink().getHttpQuery(), is("count=250"));
+        assertThat(nl2.getLink()
+                .getHttpQuery(), is("count=250"));
     }
 
     /**
@@ -217,8 +232,7 @@ public class TestKmlEndpoint {
      */
     @Test
     public void testGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         byte[] response = kmlEndpoint.getIcon(null, BOMBER_ICON);
         assertThat(response, is(bomberBytes));
     }
@@ -228,15 +242,13 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         kmlEndpoint.getIcon(null, JET_ICON);
     }
 
     @Test
     public void testGetIconCustomLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         kmlEndpoint.setIconLoc(jetPath);
         byte[] response = kmlEndpoint.getIcon(null, JET_ICON);
         assertThat(response, is(jetBtyes));
@@ -247,8 +259,7 @@ public class TestKmlEndpoint {
      */
     @Test(expected = WebApplicationException.class)
     public void testExceptionGetCustomIconLocation() {
-        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemBaseUrl(),
-                new SystemInfo());
+        KmlEndpoint kmlEndpoint = new KmlEndpoint(mockBranding, mockFramework, new SystemInfo());
         kmlEndpoint.setIconLoc(bomberPath);
         kmlEndpoint.getIcon(null, JET_ICON);
     }

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/FeatureCollectionMessageBodyWriter.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/FeatureCollectionMessageBodyWriter.java
@@ -45,12 +45,12 @@ public class FeatureCollectionMessageBodyWriter implements MessageBodyWriter<Wfs
 
     private FeatureCollectionConverterWfs10 featureCollectionConverter;
 
-    public FeatureCollectionMessageBodyWriter(SystemBaseUrl sbu) {
+    public FeatureCollectionMessageBodyWriter() {
         xstream = new XStream(new EnhancedStaxDriver(new NoNameCoder()));
         xstream.setClassLoader(xstream.getClass().getClassLoader());
 
         featureCollectionConverter = new FeatureCollectionConverterWfs10();
-        featureCollectionConverter.setContextRoot(sbu.getRootContext());
+        featureCollectionConverter.setContextRoot(SystemBaseUrl.getRootContext());
         xstream.registerConverter(featureCollectionConverter);
         xstream.registerConverter(new GenericFeatureConverter());
 

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,15 +33,12 @@
         <argument ref="ddf"/>
     </bean>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-
     <bean id="WfsResourceComparator"
           class="org.codice.ddf.spatial.ogc.catalog.common.EndpointOperationInfoResourceComparator"/>
     <bean id="XmlSchemaWriter"
           class="org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer.XmlSchemaMessageBodyWriter"/>
     <bean id="FeatureCollectionWriter"
           class="org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer.FeatureCollectionMessageBodyWriter">
-        <argument ref="urlHelper"/>
     </bean>
 
 

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/TestFeatureCollectionMessageBodyWriter.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/endpoint/writer/TestFeatureCollectionMessageBodyWriter.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.ogc.wfs.catalog.endpoint.writer;
 
@@ -38,7 +37,6 @@ import javax.xml.validation.SchemaFactory;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.xerces.dom.DOMInputImpl;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsFeatureCollection;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
@@ -94,10 +92,10 @@ public class TestFeatureCollectionMessageBodyWriter {
     private static final String BASIC_LOCATION = "POINT(1 1)";
 
     @Test
-    public void testWriteToGeneratesGMLConformantXml() throws IOException, WebApplicationException,
-            SAXException {
+    public void testWriteToGeneratesGMLConformantXml()
+            throws IOException, WebApplicationException, SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getWfsFeatureCollection(), null, null, null, null, null, stream);
         String actual = stream.toString();
@@ -121,8 +119,8 @@ public class TestFeatureCollectionMessageBodyWriter {
                 schemaLocations.put("gml.xsd", "/gml/2.1.2/gml.xsd");
                 schemaLocations.put("expr.xsd", "/filter/1.0.0/expr.xsd");
                 schemaLocations.put("filter.xsd", "/filter/1.0.0/filter.xsd");
-                schemaLocations
-                        .put("filterCapabilities.xsd", "/filter/1.0.0/filterCapabilties.xsd");
+                schemaLocations.put("filterCapabilities.xsd",
+                        "/filter/1.0.0/filterCapabilties.xsd");
                 schemaLocations.put("WFS-capabilities.xsd", "/wfs/1.0.0/WFS-capabilities.xsd");
                 schemaLocations.put("OGC-exception.xsd", "/wfs/1.0.0/OGC-exception.xsd");
                 schemaLocations.put("WFS-basic.xsd", "/wfs/1.0.0/WFS-basic.xsd");
@@ -155,17 +153,18 @@ public class TestFeatureCollectionMessageBodyWriter {
         Schema schema = schemaFactory.newSchema(new Source[] {wfsSchemaSource, testSchemaSource});
 
         try {
-            schema.newValidator().validate(new StreamSource(new StringReader(actual)));
+            schema.newValidator()
+                    .validate(new StreamSource(new StringReader(actual)));
         } catch (Exception e) {
             fail("Generated GML Response does not conform to WFS Schema" + e.getMessage());
         }
     }
 
     @Test
-    public void testWriteToGeneratesExpectedNonBasicMetacard() throws IOException,
-            WebApplicationException, SAXException {
+    public void testWriteToGeneratesExpectedNonBasicMetacard()
+            throws IOException, WebApplicationException, SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getWfsFeatureCollection(), null, null, null, null, null, stream);
 
@@ -178,10 +177,10 @@ public class TestFeatureCollectionMessageBodyWriter {
     }
 
     @Test
-    public void testWriteToGeneratesExpectedBasicMetacard() throws IOException,
-            WebApplicationException, SAXException {
+    public void testWriteToGeneratesExpectedBasicMetacard()
+            throws IOException, WebApplicationException, SAXException {
 
-        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter(new SystemBaseUrl());
+        FeatureCollectionMessageBodyWriter wtr = new FeatureCollectionMessageBodyWriter();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         wtr.writeTo(getBasicWfsFeatureCollection(), null, null, null, null, null, stream);
 
@@ -219,8 +218,8 @@ public class TestFeatureCollectionMessageBodyWriter {
         Set<AttributeDescriptor> descriptors = new HashSet<AttributeDescriptor>();
 
         descriptors.addAll(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
-        descriptors.add(new AttributeDescriptorImpl(ID, false, false, false, false,
-                BasicTypes.LONG_TYPE));
+        descriptors.add(
+                new AttributeDescriptorImpl(ID, false, false, false, false, BasicTypes.LONG_TYPE));
         descriptors.add(new AttributeDescriptorImpl(TITLE, false, false, false, false,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(DATE_CREATED, false, false, false, false,

--- a/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
@@ -113,8 +113,6 @@ public class AtomTransformer implements QueryResponseTransformer {
         }
     }
 
-    private SystemInfo systemInfo;
-
     private MetacardTransformer metacardTransformer;
 
     private ActionProvider viewMetacardActionProvider;
@@ -124,10 +122,6 @@ public class AtomTransformer implements QueryResponseTransformer {
     private ActionProvider thumbnailActionProvider;
 
     private WKTReader reader = new WKTReader();
-
-    public AtomTransformer(SystemInfo info) {
-        this.systemInfo = info;
-    }
 
     public void setViewMetacardActionProvider(ActionProvider viewMetacardActionProvider) {
         this.viewMetacardActionProvider = viewMetacardActionProvider;
@@ -192,9 +186,9 @@ public class AtomTransformer implements QueryResponseTransformer {
          */
         feed.addLink("#", Link.REL_SELF);
 
-        if (!StringUtils.isEmpty(systemInfo.getOrganization())) {
+        if (!StringUtils.isEmpty(SystemInfo.getOrganization())) {
 
-            feed.addAuthor(systemInfo.getOrganization());
+            feed.addAuthor(SystemInfo.getOrganization());
         } else {
             feed.addAuthor(DEFAULT_AUTHOR);
         }
@@ -204,10 +198,10 @@ public class AtomTransformer implements QueryResponseTransformer {
          * the agent used to generate a feed, for debugging and other purposes." Generator is not
          * required in the atom:feed element.
          */
-        if (!StringUtils.isEmpty(systemInfo.getSiteName())) {
+        if (!StringUtils.isEmpty(SystemInfo.getSiteName())) {
 
             // text is required.
-            feed.setGenerator(null, systemInfo.getVersion(), systemInfo.getSiteName());
+            feed.setGenerator(null, SystemInfo.getVersion(), SystemInfo.getSiteName());
         }
 
         /*

--- a/catalog/transformer/catalog-transformer-service-atom/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-service-atom/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,14 +29,11 @@
 	<reference id="thumbnailActionProvider" interface="ddf.action.ActionProvider"
                filter="(id=catalog.data.metacard.thumbnail)" availability="optional"/>
 
-	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
 	<bean id="transformer" class="ddf.catalog.transformer.response.query.atom.AtomTransformer">
 		<property name="metacardTransformer" ref="metacardTransformer"/>
 		<property name="viewMetacardActionProvider" ref="viewMetacardActionProvider"/>
 		<property name="resourceActionProvider" ref="resourceActionProvider"/>
 		<property name="thumbnailActionProvider" ref="thumbnailActionProvider"/>
-		<argument ref="systemInfo"/>
 	</bean>
 
 	<service ref="transformer" interface="ddf.catalog.transform.QueryResponseTransformer">

--- a/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
@@ -170,7 +170,7 @@ public class TestAtomTransformer {
     @Test(expected = CatalogTransformerException.class)
     public void testNullInput() throws CatalogTransformerException {
 
-        new AtomTransformer(new SystemInfo()).transform(null, null);
+        new AtomTransformer().transform(null, null);
     }
 
     /**
@@ -187,34 +187,41 @@ public class TestAtomTransformer {
         // given
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
 
-        SystemInfo systemInfo = mock(SystemInfo.class);
-        when(systemInfo.getSiteName()).thenReturn("");
+        String currentSiteName = System.getProperty(SystemInfo.SITE_NAME);
 
-        AtomTransformer transformer = new AtomTransformer(systemInfo);
-        transformer.setMetacardTransformer(metacardTransformer);
-        SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
+        try {
+            System.setProperty(SystemInfo.SITE_NAME, "");
 
-        // when
-        BinaryContent binaryContent = transformer.transform(response, null);
+            AtomTransformer transformer = new AtomTransformer();
+            transformer.setMetacardTransformer(metacardTransformer);
+            SourceResponse response = getSourceResponseStub(SAMPLE_ID, null);
 
-        // then
-        assertThat(binaryContent.getMimeType(), is(AtomTransformer.MIME_TYPE));
+            // when
+            BinaryContent binaryContent = transformer.transform(response, null);
 
-        byte[] bytes = binaryContent.getByteArray();
+            // then
+            assertThat(binaryContent.getMimeType(), is(AtomTransformer.MIME_TYPE));
+
+            byte[] bytes = binaryContent.getByteArray();
 
         /* used to visualize */
-        IOUtils.write(bytes,
-                new FileOutputStream(new File(TARGET_FOLDER + getMethodName() + ATOM_EXTENSION)));
+            IOUtils.write(bytes,
+                    new FileOutputStream(new File(TARGET_FOLDER + getMethodName() + ATOM_EXTENSION)));
 
-        String output = new String(bytes);
+            String output = new String(bytes);
 
-        assertFeedCompliant(output);
-        assertEntryCompliant(output);
-        validateAgainstAtomSchema(bytes);
-        assertXpathNotExists("/atom:feed/atom:generator", output);
-        assertXpathEvaluatesTo(AtomTransformer.DEFAULT_AUTHOR, "/atom:feed/atom:author/atom:name",
-                output);
+            assertFeedCompliant(output);
+            assertEntryCompliant(output);
+            validateAgainstAtomSchema(bytes);
+            assertXpathNotExists("/atom:feed/atom:generator", output);
+            assertXpathEvaluatesTo(AtomTransformer.DEFAULT_AUTHOR, "/atom:feed/atom:author/atom:name",
+                    output);
 
+        } finally {
+            if (currentSiteName != null) {
+                System.setProperty(SystemInfo.SITE_NAME, currentSiteName);
+            }
+        }
     }
 
     @Test
@@ -491,7 +498,7 @@ public class TestAtomTransformer {
     public void testTotalResultsNegative()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
         setDefaultSystemConfiguration();
@@ -538,7 +545,7 @@ public class TestAtomTransformer {
     public void testItemsPerPageNegativeInteger()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
         setDefaultSystemConfiguration();
@@ -585,7 +592,7 @@ public class TestAtomTransformer {
     public void testNoCreatedDate()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
         setDefaultSystemConfiguration();
@@ -629,7 +636,7 @@ public class TestAtomTransformer {
     public void testNoModifiedDate()
             throws IOException, CatalogTransformerException, XpathException, SAXException {
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
         setDefaultSystemConfiguration();
@@ -733,7 +740,7 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
@@ -787,7 +794,7 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
@@ -887,7 +894,7 @@ public class TestAtomTransformer {
             throws IOException, CatalogTransformerException, XpathException, SAXException {
 
         // given
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         MetacardTransformer metacardTransformer = getXmlMetacardTransformerStub();
         transformer.setMetacardTransformer(metacardTransformer);
 
@@ -940,7 +947,7 @@ public class TestAtomTransformer {
         ActionProvider viewActionProvider = mock(ActionProvider.class);
         when(viewActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
 
         transformer.setViewMetacardActionProvider(viewActionProvider);
 
@@ -1039,7 +1046,7 @@ public class TestAtomTransformer {
         ActionProvider thumbnailActionProvider = mock(ActionProvider.class);
         when(thumbnailActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
 
         transformer.setViewMetacardActionProvider(viewActionProvider);
 
@@ -1135,7 +1142,7 @@ public class TestAtomTransformer {
     public void testGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer atomTransformer = new AtomTransformer();
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
@@ -1167,7 +1174,7 @@ public class TestAtomTransformer {
     public void testNoGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer atomTransformer = new AtomTransformer();
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
@@ -1191,7 +1198,7 @@ public class TestAtomTransformer {
     public void testBadGeo()
             throws CatalogTransformerException, IOException, XpathException, SAXException {
 
-        AtomTransformer atomTransformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer atomTransformer = new AtomTransformer();
 
         atomTransformer.setMetacardTransformer(getXmlMetacardTransformerStub());
 
@@ -1230,7 +1237,7 @@ public class TestAtomTransformer {
 
     protected AtomTransformer getConfiguredAtomTransformer(MetacardTransformer metacardTransformer,
             boolean setProperties) {
-        AtomTransformer transformer = new AtomTransformer(new SystemInfo());
+        AtomTransformer transformer = new AtomTransformer();
         transformer.setMetacardTransformer(metacardTransformer);
         if (setProperties) {
             setDefaultSystemConfiguration();

--- a/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
@@ -55,6 +55,7 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -144,6 +145,13 @@ public class TestAtomTransformer {
             LOGGER.warn("SAX exception creating validator", e);
         }
 
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(SystemInfo.ORGANIZATION);
+        System.clearProperty(SystemInfo.SITE_NAME);
+        System.clearProperty(SystemInfo.VERSION);
     }
 
     @BeforeClass

--- a/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
+++ b/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
@@ -39,7 +39,7 @@ public final class SystemBaseUrl {
 
     public static final String DEFAULT_PROTOCOL = "https://";
 
-    public SystemBaseUrl() {
+    private SystemBaseUrl() {
 
     }
 
@@ -48,7 +48,7 @@ public final class SystemBaseUrl {
      *
      * @return
      */
-    public String getPort() {
+    public static String getPort() {
         String port = System.getProperty(PORT);
         if (port == null) {
             port = getPort(getProtocol());
@@ -61,7 +61,7 @@ public final class SystemBaseUrl {
      *
      * @return
      */
-    public String getBaseUrl() {
+    public static String getBaseUrl() {
         return getBaseUrl(getProtocol());
     }
 
@@ -72,7 +72,7 @@ public final class SystemBaseUrl {
      *              cause the system default protocol to be used
      * @return
      */
-    public String getBaseUrl(String proto) {
+    public static String getBaseUrl(String proto) {
         return constructUrl(proto, null);
     }
 
@@ -82,7 +82,7 @@ public final class SystemBaseUrl {
      * @param context The context path to be appened to the end of the base url
      * @return
      */
-    public String constructUrl(String context) {
+    public static String constructUrl(String context) {
         return constructUrl(getProtocol(), context);
     }
 
@@ -94,7 +94,7 @@ public final class SystemBaseUrl {
      *                           included in the url.
      * @return
      */
-    public String constructUrl(String context, boolean includeRootContext) {
+    public static String constructUrl(String context, boolean includeRootContext) {
         return constructUrl(getProtocol(), context, includeRootContext);
     }
 
@@ -106,7 +106,7 @@ public final class SystemBaseUrl {
      * @param context The context path to be appened to the end of the base url
      * @return
      */
-    public String constructUrl(String proto, String context) {
+    public static String constructUrl(String proto, String context) {
         return constructUrl(proto, context, false);
     }
 
@@ -120,7 +120,7 @@ public final class SystemBaseUrl {
      *                           included in the url.
      * @return
      */
-    public String constructUrl(String proto, String context, boolean includeRootContext) {
+    public static String constructUrl(String proto, String context, boolean includeRootContext) {
         StringBuilder sb = new StringBuilder();
         String protocol = proto;
         if (protocol == null) {
@@ -160,7 +160,7 @@ public final class SystemBaseUrl {
      * @param proto protocol (http or https)
      * @return
      */
-    public String getPort(String proto) {
+    public static String getPort(String proto) {
         if (proto != null && !proto.startsWith("https")) {
             return getHttpPort();
         } else {
@@ -168,23 +168,23 @@ public final class SystemBaseUrl {
         }
     }
 
-    public String getHttpPort() {
+    public static String getHttpPort() {
         return System.getProperty(HTTP_PORT, DEFAULT_HTTP_PORT);
     }
 
-    public String getHttpsPort() {
+    public static String getHttpsPort() {
         return System.getProperty(HTTPS_PORT, DEFAULT_HTTPS_PORT);
     }
 
-    public String getHost() {
+    public static String getHost() {
         return System.getProperty(HOST, DEFAULT_HOST);
     }
 
-    public String getProtocol() {
+    public static String getProtocol() {
         return System.getProperty(PROTOCOL, DEFAULT_PROTOCOL);
     }
 
-    public String getRootContext() {
+    public static String getRootContext() {
         return System.getProperty(ROOT_CONTEXT, "");
     }
 }

--- a/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemInfo.java
+++ b/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemInfo.java
@@ -23,23 +23,23 @@ public class SystemInfo {
 
     public static final String ORGANIZATION = "org.codice.ddf.system.organization";
 
-    public SystemInfo() {
+    private SystemInfo() {
 
     }
 
-    public String getSiteName() {
+    public static String getSiteName() {
         return System.getProperty(SITE_NAME, "");
     }
 
-    public String getSiteContatct() {
+    public static String getSiteContatct() {
         return System.getProperty(SITE_CONTACT, "");
     }
 
-    public String getVersion() {
+    public static String getVersion() {
         return System.getProperty(VERSION, "");
     }
 
-    public String getOrganization() {
+    public static String getOrganization() {
         return System.getProperty(ORGANIZATION, "");
     }
 }

--- a/libs/common-system/src/test/java/org/codice/ddf/configuration/SystemBaseUrlTest.java
+++ b/libs/common-system/src/test/java/org/codice/ddf/configuration/SystemBaseUrlTest.java
@@ -31,86 +31,76 @@ public class SystemBaseUrlTest {
 
     @Test
     public void testPropertyRead() {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getProtocol(), equalTo("https://"));
-        assertThat(sbu.getHost(), equalTo("localhost"));
-        assertThat(sbu.getHttpPort(), equalTo("8181"));
-        assertThat(sbu.getHttpsPort(), equalTo("8993"));
+        assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
+        assertThat(SystemBaseUrl.getHost(), equalTo("localhost"));
+        assertThat(SystemBaseUrl.getHttpPort(), equalTo("8181"));
+        assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8993"));
     }
 
     @Test
     public void testGetPortHttps() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort(), equalTo("8993"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("8993"));
     }
 
     @Test
     public void testGetPortHttp() throws Exception {
         System.setProperty("org.codice.ddf.system.protocol", "http://");
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort(), equalTo("8181"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("8181"));
     }
 
     @Test
     public void testGetPortHttpsProtoHttp() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort("http"), equalTo("8181"));
+        assertThat(SystemBaseUrl.getPort("http"), equalTo("8181"));
     }
 
     @Test
     public void testGetPortHttpsBadProto() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort("asdf"), equalTo("8181"));
+        assertThat(SystemBaseUrl.getPort("asdf"), equalTo("8181"));
     }
 
     @Test
     public void testGetPortHttpsNullProto() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort(null), equalTo("8993"));
+        assertThat(SystemBaseUrl.getPort(null), equalTo("8993"));
     }
 
     @Test
     public void testGetPortNoProtocol() throws Exception {
         System.clearProperty("org.codice.ddf.system.protocol");
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getPort(), equalTo("8993"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("8993"));
     }
 
     @Test
     public void testGetBaseUrl() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getBaseUrl(), equalTo("https://localhost:8993"));
-        assertThat(sbu.getBaseUrl("http://"), equalTo("http://localhost:8181"));
-        assertThat(sbu.getBaseUrl("http"), equalTo("http://localhost:8181"));
+        assertThat(SystemBaseUrl.getBaseUrl(), equalTo("https://localhost:8993"));
+        assertThat(SystemBaseUrl.getBaseUrl("http://"), equalTo("http://localhost:8181"));
+        assertThat(SystemBaseUrl.getBaseUrl("http"), equalTo("http://localhost:8181"));
     }
 
     @Test
     public void testConstructUrl() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.constructUrl("/some/path"), equalTo("https://localhost:8993/some/path"));
-        assertThat(sbu.constructUrl(null, "/some/path"),
+        assertThat(SystemBaseUrl.constructUrl("/some/path"), equalTo("https://localhost:8993/some/path"));
+        assertThat(SystemBaseUrl.constructUrl(null, "/some/path"),
                 equalTo("https://localhost:8993/some/path"));
-        assertThat(sbu.constructUrl(null, "some/path"),
+        assertThat(SystemBaseUrl.constructUrl(null, "some/path"),
                 equalTo("https://localhost:8993/some/path"));
-        assertThat(sbu.constructUrl("https", "/some/path"),
+        assertThat(SystemBaseUrl.constructUrl("https", "/some/path"),
                 equalTo("https://localhost:8993/some/path"));
-        assertThat(sbu.constructUrl("http", "/some/path"),
+        assertThat(SystemBaseUrl.constructUrl("http", "/some/path"),
                 equalTo("http://localhost:8181/some/path"));
-        assertThat(sbu.constructUrl(null, null), equalTo("https://localhost:8993"));
-        assertThat(sbu.constructUrl("http", null), equalTo("http://localhost:8181"));
+        assertThat(SystemBaseUrl.constructUrl(null, null), equalTo("https://localhost:8993"));
+        assertThat(SystemBaseUrl.constructUrl("http", null), equalTo("http://localhost:8181"));
     }
 
     @Test
     public void testRootContext() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
-        assertThat(sbu.getRootContext(), equalTo(""));
+        assertThat(SystemBaseUrl.getRootContext(), equalTo(""));
         System.setProperty("org.codice.ddf.system.rootContext", "/services");
-        assertThat(sbu.getRootContext(), equalTo("/services"));
+        assertThat(SystemBaseUrl.getRootContext(), equalTo("/services"));
 
-        assertThat(sbu.constructUrl("/some/path", true),
+        assertThat(SystemBaseUrl.constructUrl("/some/path", true),
                 equalTo("https://localhost:8993/services/some/path"));
         System.setProperty("org.codice.ddf.system.rootContext", "services");
-        assertThat(sbu.constructUrl("/some/path", true),
+        assertThat(SystemBaseUrl.constructUrl("/some/path", true),
                 equalTo("https://localhost:8993/services/some/path"));
     }
 

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -65,6 +65,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
+++ b/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
@@ -28,8 +28,6 @@ import org.codice.ddf.configuration.SystemInfo;
  */
 public class ConfigurationWatcherImpl {
 
-    private SystemInfo systemInfo;
-
     public ConfigurationWatcherImpl() {
 
     }
@@ -78,7 +76,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with {@link SystemInfo#SITE_NAME} property name
      */
     public String getSiteName() {
-        return systemInfo.getSiteName();
+        return SystemInfo.getSiteName();
     }
 
     /**
@@ -87,7 +85,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with {@link SystemInfo#VERSION} property name
      */
     public String getVersion() {
-        return systemInfo.getVersion();
+        return SystemInfo.getVersion();
     }
 
     /**
@@ -96,7 +94,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with {@link SystemInfo#ORGANIZATION property name
      */
     public String getOrganization() {
-        return systemInfo.getOrganization();
+        return SystemInfo.getOrganization();
     }
 
     /**
@@ -105,7 +103,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with {@link SystemInfo#SITE_CONTACT} property name
      */
     public String getContactEmailAddress() {
-        return systemInfo.getSiteContatct();
+        return SystemInfo.getSiteContatct();
     }
 
     /**
@@ -117,13 +115,5 @@ public class ConfigurationWatcherImpl {
      */
     public String getConfigurationValue(String name) {
         return null;
-    }
-
-    public SystemInfo getSystemInfo() {
-        return systemInfo;
-    }
-
-    public void setSystemInfo(SystemInfo systemInfo) {
-        this.systemInfo = systemInfo;
     }
 }

--- a/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
+++ b/libs/platform-configuration-impl/src/main/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpl.java
@@ -28,8 +28,6 @@ import org.codice.ddf.configuration.SystemInfo;
  */
 public class ConfigurationWatcherImpl {
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SystemInfo systemInfo;
 
     public ConfigurationWatcherImpl() {
@@ -42,7 +40,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with {@link SystemBaseUrl#HOST} property name
      */
     public String getHostname() {
-        return systemBaseUrl.getHost();
+        return SystemBaseUrl.getHost();
     }
 
     /**
@@ -51,7 +49,7 @@ public class ConfigurationWatcherImpl {
      * @return the Integer value associated with the {@link SystemBaseUrl#HTTP_PORT} or {@link SystemBaseUrl#HTTPS_PORT} property depending on the protocol
      */
     public Integer getPort() {
-        return Integer.parseInt(systemBaseUrl.getPort());
+        return Integer.parseInt(SystemBaseUrl.getPort());
     }
 
     /**
@@ -60,7 +58,7 @@ public class ConfigurationWatcherImpl {
      * @return the value associated with the {@link SystemBaseUrl#PROTOCOL} property name
      */
     public String getProtocol() {
-        return systemBaseUrl.getProtocol();
+        return SystemBaseUrl.getProtocol();
     }
 
     /**
@@ -71,7 +69,7 @@ public class ConfigurationWatcherImpl {
      * {@link SystemBaseUrl#PROTOCOL} property name
      */
     public String getSchemeFromProtocol() {
-        return systemBaseUrl.getProtocol().split(":")[0];
+        return SystemBaseUrl.getProtocol().split(":")[0];
     }
 
     /**
@@ -119,14 +117,6 @@ public class ConfigurationWatcherImpl {
      */
     public String getConfigurationValue(String name) {
         return null;
-    }
-
-    public SystemBaseUrl getSystemBaseUrl() {
-        return systemBaseUrl;
-    }
-
-    public void setSystemBaseUrl(SystemBaseUrl systemBaseUrl) {
-        this.systemBaseUrl = systemBaseUrl;
     }
 
     public SystemInfo getSystemInfo() {

--- a/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
+++ b/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
@@ -24,7 +24,6 @@ public class ConfigurationWatcherImpTest {
     @Test
     public void testGetters() {
         ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-        configWatcher.setSystemInfo(new SystemInfo());
         configureProperties("http://", "hostValue", "8888", "/services", "siteNameValue",
                 "orgValue", "contactValue", "versionValue");
         assertEquals(configWatcher.getContactEmailAddress(), "contactValue");

--- a/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
+++ b/libs/platform-configuration-impl/src/test/java/org/codice/ddf/configuration/impl/ConfigurationWatcherImpTest.java
@@ -24,7 +24,6 @@ public class ConfigurationWatcherImpTest {
     @Test
     public void testGetters() {
         ConfigurationWatcherImpl configWatcher = new ConfigurationWatcherImpl();
-        configWatcher.setSystemBaseUrl(new SystemBaseUrl());
         configWatcher.setSystemInfo(new SystemInfo());
         configureProperties("http://", "hostValue", "8888", "/services", "siteNameValue",
                 "orgValue", "contactValue", "versionValue");

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -85,7 +85,11 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>type-parser,org.apache.felix.utils</Embed-Dependency>
+                        <Embed-Dependency>
+                            type-parser,
+                            org.apache.felix.utils,
+                            common-system
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/impl/SystemPropertiesAdmin.java
@@ -40,9 +40,7 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
 
     private ObjectName objectName;
 
-    private SystemBaseUrl baseUrl = new SystemBaseUrl();
-
-    private String oldHostName = baseUrl.getHost();
+    private String oldHostName = SystemBaseUrl.getHost();
 
     private static final String KARAF_ETC = "karaf.etc";
 
@@ -133,7 +131,7 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
         }
         // Get system.properties file
         //save off the current/old hostname before we make any changes
-        oldHostName = baseUrl.getHost();
+        oldHostName = SystemBaseUrl.getHost();
 
         String etcDir = System.getProperty(KARAF_ETC);
         String systemPropertyFilename = etcDir + File.separator + SYSTEM_PROPERTIES_FILE;

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
@@ -42,8 +42,6 @@ public class SystemPropertiesAdminTest {
 
     File userPropsFile = null;
 
-    SystemInfo info = null;
-
     int expectedSystemPropertiesCount = 0;
 
     @Before
@@ -74,8 +72,6 @@ public class SystemPropertiesAdminTest {
 
         systemPropsFile = new File(etcFolder, "system.properties");
         userPropsFile = new File(etcFolder, "users.properties");
-
-        info = new SystemInfo();
     }
 
     @Test
@@ -104,10 +100,10 @@ public class SystemPropertiesAdminTest {
         assertThat(SystemBaseUrl.getHttpPort(), equalTo("4567"));
         assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8901"));
         assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
-        assertThat(info.getOrganization(), equalTo("org"));
-        assertThat(info.getSiteContatct(), equalTo("contact"));
-        assertThat(info.getSiteName(), equalTo("site"));
-        assertThat(info.getVersion(), equalTo("version"));
+        assertThat(SystemInfo.getOrganization(), equalTo("org"));
+        assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));
+        assertThat(SystemInfo.getSiteName(), equalTo("site"));
+        assertThat(SystemInfo.getVersion(), equalTo("version"));
         assertThat(details.size(), is(expectedSystemPropertiesCount));
     }
 
@@ -131,10 +127,10 @@ public class SystemPropertiesAdminTest {
         assertThat(SystemBaseUrl.getHttpPort(), equalTo("4567"));
         assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8901"));
         assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
-        assertThat(info.getOrganization(), equalTo("org"));
-        assertThat(info.getSiteContatct(), equalTo("contact"));
-        assertThat(info.getSiteName(), equalTo("site"));
-        assertThat(info.getVersion(), equalTo("version"));
+        assertThat(SystemInfo.getOrganization(), equalTo("org"));
+        assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));
+        assertThat(SystemInfo.getSiteName(), equalTo("site"));
+        assertThat(SystemInfo.getVersion(), equalTo("version"));
         assertThat(details.size(), is(expectedSystemPropertiesCount));
 
         //only writes out the changed props

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
@@ -42,8 +42,6 @@ public class SystemPropertiesAdminTest {
 
     File userPropsFile = null;
 
-    SystemBaseUrl sbu = null;
-
     SystemInfo info = null;
 
     int expectedSystemPropertiesCount = 0;
@@ -77,7 +75,6 @@ public class SystemPropertiesAdminTest {
         systemPropsFile = new File(etcFolder, "system.properties");
         userPropsFile = new File(etcFolder, "users.properties");
 
-        sbu = new SystemBaseUrl();
         info = new SystemInfo();
     }
 
@@ -102,11 +99,11 @@ public class SystemPropertiesAdminTest {
         SystemPropertiesAdmin spa = new SystemPropertiesAdmin();
         spa.writeSystemProperties(null);
         List<SystemPropertyDetails> details = spa.readSystemProperties();
-        assertThat(sbu.getHost(), equalTo("host"));
-        assertThat(sbu.getPort(), equalTo("1234"));
-        assertThat(sbu.getHttpPort(), equalTo("4567"));
-        assertThat(sbu.getHttpsPort(), equalTo("8901"));
-        assertThat(sbu.getProtocol(), equalTo("https://"));
+        assertThat(SystemBaseUrl.getHost(), equalTo("host"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("1234"));
+        assertThat(SystemBaseUrl.getHttpPort(), equalTo("4567"));
+        assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8901"));
+        assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
         assertThat(info.getOrganization(), equalTo("org"));
         assertThat(info.getSiteContatct(), equalTo("contact"));
         assertThat(info.getSiteName(), equalTo("site"));
@@ -129,11 +126,11 @@ public class SystemPropertiesAdminTest {
         map.put(SystemBaseUrl.HOST, "newhost");
         spa.writeSystemProperties(map);
         List<SystemPropertyDetails> details = spa.readSystemProperties();
-        assertThat(sbu.getHost(), equalTo("newhost"));
-        assertThat(sbu.getPort(), equalTo("1234"));
-        assertThat(sbu.getHttpPort(), equalTo("4567"));
-        assertThat(sbu.getHttpsPort(), equalTo("8901"));
-        assertThat(sbu.getProtocol(), equalTo("https://"));
+        assertThat(SystemBaseUrl.getHost(), equalTo("newhost"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("1234"));
+        assertThat(SystemBaseUrl.getHttpPort(), equalTo("4567"));
+        assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8901"));
+        assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
         assertThat(info.getOrganization(), equalTo("org"));
         assertThat(info.getSiteContatct(), equalTo("contact"));
         assertThat(info.getSiteName(), equalTo("site"));

--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBean.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBean.java
@@ -26,7 +26,6 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,13 +45,17 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
 
     private static final String DEFAULT_TRUSTSTORE_PASSWORD = "changeit";
 
-    private static final String ISSUER_ENCRYPTION_PROPERTIES_FILE = "etc/ws-security/issuer/encryption.properties";
+    private static final String ISSUER_ENCRYPTION_PROPERTIES_FILE =
+            "etc/ws-security/issuer/encryption.properties";
 
-    private static final String ISSUER_SIGNATURE_PROPERTIES_FILE = "etc/ws-security/issuer/signature.properties";
+    private static final String ISSUER_SIGNATURE_PROPERTIES_FILE =
+            "etc/ws-security/issuer/signature.properties";
 
-    private static final String SERVER_ENCRYPTION_PROPERTIES_FILE = "etc/ws-security/server/encryption.properties";
+    private static final String SERVER_ENCRYPTION_PROPERTIES_FILE =
+            "etc/ws-security/server/encryption.properties";
 
-    private static final String SERVER_SIGNATURE_PROPERTIES_FILE = "etc/ws-security/server/signature.properties";
+    private static final String SERVER_SIGNATURE_PROPERTIES_FILE =
+            "etc/ws-security/server/signature.properties";
 
     private static final String USERS_PROPERTIES_FILE = "etc/users.properties";
 
@@ -68,11 +71,13 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
 
     private static final String KEYSTORE_SYSTEM_PROPERTY = "javax.net.ssl.keyStore";
 
-    private static final String KEYSTORE_PASSWORD_SYSTEM_PROPERTY = "javax.net.ssl.keyStorePassword";
+    private static final String KEYSTORE_PASSWORD_SYSTEM_PROPERTY =
+            "javax.net.ssl.keyStorePassword";
 
     private static final String TRUSTSTORE_SYSTEM_PROPERTY = "javax.net.ssl.trustStore";
 
-    private static final String TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY =
+            "javax.net.ssl.trustStorePassword";
 
     public static final String MBEAN_NAME =
             InsecureDefaultsServiceBean.class.getName() + ":service=insecure-defaults-service";
@@ -83,9 +88,9 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
 
     private List<Validator> validators;
 
-    public InsecureDefaultsServiceBean(SystemBaseUrl sbu) {
+    public InsecureDefaultsServiceBean() {
         validators = new ArrayList<>();
-        addValidators(sbu);
+        addValidators();
 
         try {
             objectName = new ObjectName(MBEAN_NAME);
@@ -103,11 +108,11 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
         LOGGER.debug("Found {} validator(s)", validators.size());
 
         for (Validator validator : validators) {
-            LOGGER.debug("{} is starting validation process.",
-                    validator.getClass().getSimpleName());
+            LOGGER.debug("{} is starting validation process.", validator.getClass()
+                    .getSimpleName());
             alerts.addAll(validator.validate());
-            LOGGER.debug("{} finished the validation process.",
-                    validator.getClass().getSimpleName());
+            LOGGER.debug("{} finished the validation process.", validator.getClass()
+                    .getSimpleName());
         }
 
         if (LOGGER.isDebugEnabled()) {
@@ -149,7 +154,7 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
         }
     }
 
-    void addValidators(SystemBaseUrl sbu) {
+    void addValidators() {
         addKeystoreValidator();
         addTruststoreValidator();
         addIssuerEncryptionPropertiesFileValidator();
@@ -158,7 +163,7 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
         addServerSignaturePropertiesFileValidator();
         addUsersPropertiesFileValidator();
         addPaxWebCfgFileValidator();
-        addPlatformGlobalConfigurationValidator(sbu);
+        addPlatformGlobalConfigurationValidator();
     }
 
     void setValidators(List<Validator> validatorsList) {
@@ -187,7 +192,8 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
     }
 
     private void addIssuerEncryptionPropertiesFileValidator() {
-        EncryptionPropertiesFileValidator encryptionPropertiesFileValidator = new EncryptionPropertiesFileValidator();
+        EncryptionPropertiesFileValidator encryptionPropertiesFileValidator =
+                new EncryptionPropertiesFileValidator();
         encryptionPropertiesFileValidator.setPath(Paths.get(ISSUER_ENCRYPTION_PROPERTIES_FILE));
         encryptionPropertiesFileValidator.setDefaultPassword(DEFAULT_KEYSTORE_PASSWORD);
         encryptionPropertiesFileValidator.setDefaultAlias(DEFAULT_KEYSTORE_ALIAS);
@@ -195,19 +201,21 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
     }
 
     private void addIssuerSignaturePropertiesFileValidator() {
-        SignaturePropertiesFileValidator issuerSignatureEncryptionPropertiesFileValidator = new SignaturePropertiesFileValidator();
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setPath(Paths.get(ISSUER_SIGNATURE_PROPERTIES_FILE));
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setDefaultPassword(DEFAULT_KEYSTORE_PASSWORD);
+        SignaturePropertiesFileValidator issuerSignatureEncryptionPropertiesFileValidator =
+                new SignaturePropertiesFileValidator();
+        issuerSignatureEncryptionPropertiesFileValidator.setPath(
+                Paths.get(ISSUER_SIGNATURE_PROPERTIES_FILE));
+        issuerSignatureEncryptionPropertiesFileValidator.setDefaultPassword(
+                DEFAULT_KEYSTORE_PASSWORD);
         issuerSignatureEncryptionPropertiesFileValidator.setDefaultAlias(DEFAULT_KEYSTORE_ALIAS);
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setDefaultPrivateKeyPassword(DEFAULT_KEY_PASSWORD);
+        issuerSignatureEncryptionPropertiesFileValidator.setDefaultPrivateKeyPassword(
+                DEFAULT_KEY_PASSWORD);
         validators.add(issuerSignatureEncryptionPropertiesFileValidator);
     }
 
     private void addServerEncryptionPropertiesFileValidator() {
-        EncryptionPropertiesFileValidator encryptionPropertiesFileValidator = new EncryptionPropertiesFileValidator();
+        EncryptionPropertiesFileValidator encryptionPropertiesFileValidator =
+                new EncryptionPropertiesFileValidator();
         encryptionPropertiesFileValidator.setPath(Paths.get(SERVER_ENCRYPTION_PROPERTIES_FILE));
         encryptionPropertiesFileValidator.setDefaultPassword(DEFAULT_KEYSTORE_PASSWORD);
         encryptionPropertiesFileValidator.setDefaultAlias(DEFAULT_KEYSTORE_ALIAS);
@@ -216,25 +224,27 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
     }
 
     private void addServerSignaturePropertiesFileValidator() {
-        SignaturePropertiesFileValidator issuerSignatureEncryptionPropertiesFileValidator = new SignaturePropertiesFileValidator();
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setPath(Paths.get(SERVER_SIGNATURE_PROPERTIES_FILE));
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setDefaultPassword(DEFAULT_KEYSTORE_PASSWORD);
+        SignaturePropertiesFileValidator issuerSignatureEncryptionPropertiesFileValidator =
+                new SignaturePropertiesFileValidator();
+        issuerSignatureEncryptionPropertiesFileValidator.setPath(
+                Paths.get(SERVER_SIGNATURE_PROPERTIES_FILE));
+        issuerSignatureEncryptionPropertiesFileValidator.setDefaultPassword(
+                DEFAULT_KEYSTORE_PASSWORD);
         issuerSignatureEncryptionPropertiesFileValidator.setDefaultAlias(DEFAULT_KEYSTORE_ALIAS);
-        issuerSignatureEncryptionPropertiesFileValidator
-                .setDefaultPrivateKeyPassword(DEFAULT_KEY_PASSWORD);
+        issuerSignatureEncryptionPropertiesFileValidator.setDefaultPrivateKeyPassword(
+                DEFAULT_KEY_PASSWORD);
         validators.add(issuerSignatureEncryptionPropertiesFileValidator);
     }
 
     private void addUsersPropertiesFileValidator() {
-        UsersPropertiesFileValidator userPropertiesFileValidator = new UsersPropertiesFileValidator();
+        UsersPropertiesFileValidator userPropertiesFileValidator =
+                new UsersPropertiesFileValidator();
         userPropertiesFileValidator.setPath(Paths.get(USERS_PROPERTIES_FILE));
         userPropertiesFileValidator.setDefaultAdminUser(DEFAULT_ADMIN_USER);
         userPropertiesFileValidator.setDefaultAdminUserPassword(DEFAULT_ADMIN_USER_PASSWORD);
         userPropertiesFileValidator.setDefaultCertificateUser(DEFAULT_CERTIFICATE_USER);
-        userPropertiesFileValidator
-                .setDefaultCertificateUserPassword(DEFAULT_CERTIFICATE_USER_PASSWORD);
+        userPropertiesFileValidator.setDefaultCertificateUserPassword(
+                DEFAULT_CERTIFICATE_USER_PASSWORD);
         validators.add(userPropertiesFileValidator);
     }
 
@@ -244,9 +254,9 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
         validators.add(paxWebCfgFileValidator);
     }
 
-    private void addPlatformGlobalConfigurationValidator(SystemBaseUrl sbu) {
-        PlatformGlobalConfigurationValidator platformGlobalConfigurationValidator = new PlatformGlobalConfigurationValidator(
-                sbu);
+    private void addPlatformGlobalConfigurationValidator() {
+        PlatformGlobalConfigurationValidator platformGlobalConfigurationValidator =
+                new PlatformGlobalConfigurationValidator();
         validators.add(platformGlobalConfigurationValidator);
     }
 

--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/PlatformGlobalConfigurationValidator.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/PlatformGlobalConfigurationValidator.java
@@ -26,13 +26,10 @@ public class PlatformGlobalConfigurationValidator implements Validator {
 
     private static final String HTTP_PROTOCOL = "http://";
 
-    private SystemBaseUrl systemBaseUrl;
-
     private List<Alert> alerts;
 
-    public PlatformGlobalConfigurationValidator(SystemBaseUrl sbu) {
+    public PlatformGlobalConfigurationValidator() {
         alerts = new ArrayList<>();
-        this.systemBaseUrl = sbu;
     }
 
     public List<Alert> validate() {
@@ -42,15 +39,10 @@ public class PlatformGlobalConfigurationValidator implements Validator {
     }
 
     private void validateHttpIsDisabled() {
-        if (systemBaseUrl != null) {
-            String protocol = systemBaseUrl.getProtocol();
+        String protocol = SystemBaseUrl.getProtocol();
 
-            if (StringUtils.equalsIgnoreCase(protocol, HTTP_PROTOCOL)) {
-                alerts.add(new Alert(Level.WARN, PROTCOL_IN_PLATFORM_GLOBAL_CONFIG_IS_HTTP));
-            }
-        } else {
-            String msg = "Unable to determine if Platform Global Configuration has insecure defaults. Cannot access Configuration Admin.";
-            alerts.add(new Alert(Level.WARN, msg));
+        if (StringUtils.equalsIgnoreCase(protocol, HTTP_PROTOCOL)) {
+            alerts.add(new Alert(Level.WARN, PROTCOL_IN_PLATFORM_GLOBAL_CONFIG_IS_HTTP));
         }
     }
 }

--- a/platform/admin/core/admin-core-insecuredefaults/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,13 +13,10 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
         >
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-
     <bean id="insecureDefaultsServiceMBean"
           class="org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean"
           init-method="init"
           destroy-method="destroy">
-        <argument ref="urlHelper"/>
     </bean>
 
 </blueprint>

--- a/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBeanTest.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBeanTest.java
@@ -26,7 +26,6 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import org.codice.ddf.admin.insecure.defaults.service.Alert.Level;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -138,8 +137,7 @@ public class InsecureDefaultsServiceBeanTest {
         System.setProperty(KEYSTORE_SYSTEM_PROPERTY, "TestKeystorePath");
         System.setProperty(TRUSTSTORE_SYSTEM_PROPERTY, "TestTruststorePath");
 
-        InsecureDefaultsServiceBean serviceBean = new InsecureDefaultsServiceBean(
-                new SystemBaseUrl());
+        InsecureDefaultsServiceBean serviceBean = new InsecureDefaultsServiceBean();
         List<Validator> result = serviceBean.getValidators();
         assertThat("Should create nine validators.", result.size(), is(9));
     }
@@ -162,9 +160,9 @@ public class InsecureDefaultsServiceBeanTest {
     }
 
     private InsecureDefaultsServiceBean createInsecureDefaultsServiceBean(int validatorCount) {
-        InsecureDefaultsServiceBean bean = new InsecureDefaultsServiceBean(null) {
+        InsecureDefaultsServiceBean bean = new InsecureDefaultsServiceBean() {
             @Override
-            void addValidators(SystemBaseUrl sbu) {
+            void addValidators() {
                 return;
             }
         };

--- a/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/PlatformGlobalConfigurationValidatorTest.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/PlatformGlobalConfigurationValidatorTest.java
@@ -35,8 +35,7 @@ public class PlatformGlobalConfigurationValidatorTest {
     public void testValidateWhenHttpIsEnabled() throws Exception {
         // Setup
         System.setProperty(SystemBaseUrl.PROTOCOL, HTTP_PROTOCOL);
-        PlatformGlobalConfigurationValidator pgc = new PlatformGlobalConfigurationValidator(
-                new SystemBaseUrl());
+        PlatformGlobalConfigurationValidator pgc = new PlatformGlobalConfigurationValidator();
 
         // Perform Test
         List<Alert> alerts = pgc.validate();
@@ -52,23 +51,12 @@ public class PlatformGlobalConfigurationValidatorTest {
         // Setup
 
         System.setProperty(SystemBaseUrl.PROTOCOL, HTTPS_PROTOCOL);
-        PlatformGlobalConfigurationValidator pgc = new PlatformGlobalConfigurationValidator(
-                new SystemBaseUrl());
+        PlatformGlobalConfigurationValidator pgc = new PlatformGlobalConfigurationValidator();
 
         // Perform Test
         List<Alert> alerts = pgc.validate();
 
         // Verify
         assertThat(alerts.size(), is(0));
-    }
-
-    @Test
-    public void testValidateWhenConfigAdminIsNull() throws Exception {
-        PlatformGlobalConfigurationValidator pgc = new PlatformGlobalConfigurationValidator(null);
-
-        List<Alert> result = pgc.validate();
-
-        assertThat("Should return a warning about null admin config.", result.get(0).getMessage(),
-                is(NULL_ADMIN_VALIDATE));
     }
 }

--- a/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rest/MetricsEndpoint.java
+++ b/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rest/MetricsEndpoint.java
@@ -62,7 +62,7 @@ import ddf.metrics.reporting.internal.MetricsRetriever;
 import ddf.metrics.reporting.internal.rrd4j.RrdMetricsRetriever;
 
 /**
- * This class provides an endpoint for a client, e.g., {@link MetricsWebConsolePlugin} to access the
+ * This class provides an endpoint for a client, e.g., {@code MetricsWebConsolePlugin} to access the
  * historical metrics data collected by DDF.
  * <p>
  * This endpoint provides a URL to retrieve the list of metrics collected by DDF, including their
@@ -126,8 +126,6 @@ public class MetricsEndpoint {
         TIME_RANGES.put("1y", ONE_YEAR_IN_SECONDS);
     }
 
-    private SystemInfo systemInfo;
-
     private final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
     private String metricsDir = DEFAULT_METRICS_DIR;
@@ -135,10 +133,6 @@ public class MetricsEndpoint {
     private MetricsRetriever metricsRetriever = new RrdMetricsRetriever();
 
     private double metricsMaxThreshold;
-
-    public MetricsEndpoint(SystemInfo info) {
-        this.systemInfo = info;
-    }
 
     /**
      * Retrieve data for the specified metric over the given time range. The URL to access this
@@ -509,7 +503,7 @@ public class MetricsEndpoint {
 
         // Generated name for metrics file (<DDF Sitename>_<Startdate>_<EndDate>.outputFormat)
         String dispositionString =
-                "attachment; filename=" + systemInfo.getSiteName() + "_" + startDate
+                "attachment; filename=" + SystemInfo.getSiteName() + "_" + startDate
                         .substring(0, 10) + "_" + endDate.substring(0, 10) + "." + outputFormat;
 
         try {

--- a/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rest/MetricsEndpoint.java
+++ b/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rest/MetricsEndpoint.java
@@ -126,8 +126,6 @@ public class MetricsEndpoint {
         TIME_RANGES.put("1y", ONE_YEAR_IN_SECONDS);
     }
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SystemInfo systemInfo;
 
     private final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
@@ -138,8 +136,7 @@ public class MetricsEndpoint {
 
     private double metricsMaxThreshold;
 
-    public MetricsEndpoint(SystemBaseUrl sbu, SystemInfo info) {
-        this.systemBaseUrl = sbu;
+    public MetricsEndpoint(SystemInfo info) {
         this.systemInfo = info;
     }
 
@@ -637,7 +634,7 @@ public class MetricsEndpoint {
                  * END: CXF bug
                  */
 
-                String metricsUrl = systemBaseUrl.getRootContext() + METRICS_SERVICE_BASE_URL + "/"
+                String metricsUrl = SystemBaseUrl.getRootContext() + METRICS_SERVICE_BASE_URL + "/"
                         + metricsName + "." + format + DATE_OFFSET_QUERY + timeRangeInSeconds;
 
                 // key=format

--- a/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,12 +24,9 @@
 		</jaxrs:serviceBeans>
 	</jaxrs:server>
 
-	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
 	<bean id="MetricsService" class="ddf.metrics.reporting.internal.rest.MetricsEndpoint">
 		<cm:managed-properties persistent-id="MetricsReporting"
                                update-strategy="container-managed"/>
-		<argument ref="systemInfo"/>
 		<property name="metricsMaxThreshold" value="4000000000"/>
 	</bean>
 

--- a/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/metrics/platform-metrics-reporting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,13 +24,11 @@
 		</jaxrs:serviceBeans>
 	</jaxrs:server>
 
-	<bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
 	<bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
 	<bean id="MetricsService" class="ddf.metrics.reporting.internal.rest.MetricsEndpoint">
 		<cm:managed-properties persistent-id="MetricsReporting"
                                update-strategy="container-managed"/>
-		<argument ref="urlHelper"/>
 		<argument ref="systemInfo"/>
 		<property name="metricsMaxThreshold" value="4000000000"/>
 	</bean>

--- a/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
+++ b/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
@@ -761,7 +761,7 @@ public class MetricsEndpointTest extends XMLTestCase {
     }
 
     private MetricsEndpoint getEndpoint() {
-        MetricsEndpoint me = new MetricsEndpoint(new SystemInfo());
+        MetricsEndpoint me = new MetricsEndpoint();
         System.setProperty(SystemBaseUrl.ROOT_CONTEXT, "/services");
         System.setProperty(SystemInfo.SITE_NAME, "siteName");
         return me;

--- a/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
+++ b/platform/metrics/platform-metrics-reporting/src/test/java/ddf/metrics/reporting/internal/rest/MetricsEndpointTest.java
@@ -761,7 +761,7 @@ public class MetricsEndpointTest extends XMLTestCase {
     }
 
     private MetricsEndpoint getEndpoint() {
-        MetricsEndpoint me = new MetricsEndpoint(new SystemBaseUrl(), new SystemInfo());
+        MetricsEndpoint me = new MetricsEndpoint(new SystemInfo());
         System.setProperty(SystemBaseUrl.ROOT_CONTEXT, "/services");
         System.setProperty(SystemInfo.SITE_NAME, "siteName");
         return me;

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/main/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePlugin.java
@@ -96,10 +96,7 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
     private static final int NUMBER_OF_YEARLY_REPORTS = 1;
 
-    private transient SystemBaseUrl systemBaseUrl;
-
-    public MetricsWebConsolePlugin(SystemBaseUrl sbu) {
-        this.systemBaseUrl = sbu;
+    public MetricsWebConsolePlugin() {
     }
 
     private static String urlEncodeDate(DateMidnight date) throws UnsupportedEncodingException {
@@ -107,8 +104,8 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
     }
 
     private static String urlEncodeDate(DateTime date) throws UnsupportedEncodingException {
-        return URLEncoder
-                .encode(date.toString(ISODateTimeFormat.dateTimeNoMillis()), CharEncoding.UTF_8);
+        return URLEncoder.encode(date.toString(ISODateTimeFormat.dateTimeNoMillis()),
+                CharEncoding.UTF_8);
     }
 
     public void start() {
@@ -153,7 +150,7 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
         final PrintWriter pw = response.getWriter();
 
-        String metricsServiceUrl = systemBaseUrl.constructUrl(METRICS_SERVICE_BASE_URL, true);
+        String metricsServiceUrl = SystemBaseUrl.constructUrl(METRICS_SERVICE_BASE_URL, true);
 
         // Call Metrics Endpoint REST service to get list of all of the monitored
         // metrics and their associated hyperlinks to graph their historical data.
@@ -198,9 +195,10 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
             // String4 = hyperlink for metric data in specific format, e.g.,
             // http://host:port/.../catalogQueries.png?dateOffset=900
             Map<String, Map<String, Map<String, String>>> json = new TreeMap(
-                    (Map<String, Map<String, Map<String, String>>>) parser
-                            .parse(metricsList, containerFactory));
-            Iterator iter = json.entrySet().iterator();
+                    (Map<String, Map<String, Map<String, String>>>) parser.parse(metricsList,
+                            containerFactory));
+            Iterator iter = json.entrySet()
+                    .iterator();
 
             // Create HTML table of Metric Name and hyperlinks to its associated
             // RRD graphs
@@ -211,8 +209,8 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
             // Column headers for the time ranges, e.g., 15m, 1h, 4h, etc.
             while (iter.hasNext()) {
                 Map.Entry entry = (Map.Entry) iter.next();
-                Map<String, Map<String, String>> timeRangeData = (Map<String, Map<String, String>>) entry
-                        .getValue();
+                Map<String, Map<String, String>> timeRangeData =
+                        (Map<String, Map<String, String>>) entry.getValue();
                 Set<String> timeRanges = timeRangeData.keySet();
                 for (String timeRange : timeRanges) {
                     pw.println("<th>" + timeRange + "</th>");
@@ -223,7 +221,8 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
             // List of metric names and associated hyperlinks per format per time range
             int rowCount = 1;
-            iter = json.entrySet().iterator();
+            iter = json.entrySet()
+                    .iterator();
             while (iter.hasNext()) {
                 Map.Entry entry = (Map.Entry) iter.next();
                 String metricName = (String) entry.getKey();
@@ -233,10 +232,11 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
                 }
                 pw.println("<tr class=\"" + tableStriping + " ui-state-default\">");
                 pw.println("<td>" + convertCamelCase(metricName) + "</td>");
-                Map<String, Map<String, String>> timeRangeData = (Map<String, Map<String, String>>) entry
-                        .getValue();
+                Map<String, Map<String, String>> timeRangeData =
+                        (Map<String, Map<String, String>>) entry.getValue();
 
-                Iterator metricDataIter = timeRangeData.entrySet().iterator();
+                Iterator metricDataIter = timeRangeData.entrySet()
+                        .iterator();
                 while (metricDataIter.hasNext()) {
                     Map.Entry entry2 = (Map.Entry) metricDataIter.next();
                     String timeRange = (String) entry2.getKey();
@@ -254,12 +254,12 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
                     LOGGER.debug("{} -> {}", timeRange, metricUrls);
                     pw.println("<td>");
 
-                    Iterator metricUrlsIter = metricUrls.entrySet().iterator();
+                    Iterator metricUrlsIter = metricUrls.entrySet()
+                            .iterator();
                     while (metricUrlsIter.hasNext()) {
                         Map.Entry metricUrl = (Map.Entry) metricUrlsIter.next();
-                        String metricUrlCell =
-                                "<a class=\"ui-state-default ui-corner-all\" href=\"" + metricUrl
-                                        .getValue() + "\">" + metricUrl.getKey() + "</a>&nbsp;";
+                        String metricUrlCell = "<a class=\"ui-state-default ui-corner-all\" href=\""
+                                + metricUrl.getValue() + "\">" + metricUrl.getKey() + "</a>&nbsp;";
                         pw.println(metricUrlCell);
                     }
                     pw.println("</td>");
@@ -311,7 +311,8 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
     private void configureHttps(WebClient client) {
         LOGGER.debug("Configuring client for HTTPS");
-        HTTPConduit conduit = WebClient.getConfig(client).getHttpConduit();
+        HTTPConduit conduit = WebClient.getConfig(client)
+                .getHttpConduit();
         if (null != conduit) {
             TLSClientParameters params = conduit.getTlsClientParameters();
 
@@ -344,14 +345,14 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
                 ksFIS = new FileInputStream(keyStoreFile);
                 keyStore.load(ksFIS, keyStorePassword.toCharArray());
 
-                TrustManagerFactory trustFactory = TrustManagerFactory
-                        .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm());
                 trustFactory.init(trustStore);
                 TrustManager[] tm = trustFactory.getTrustManagers();
                 params.setTrustManagers(tm);
 
-                KeyManagerFactory keyFactory = KeyManagerFactory
-                        .getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                KeyManagerFactory keyFactory = KeyManagerFactory.getInstance(
+                        KeyManagerFactory.getDefaultAlgorithm());
                 keyFactory.init(keyStore, keyStorePassword.toCharArray());
                 KeyManager[] km = keyFactory.getKeyManagers();
                 params.setKeyManagers(km);
@@ -404,13 +405,14 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
         for (int i = 1; i <= numWeeklyReports; i++) {
             try {
-                DateMidnight startOfLastWeek = new DateMidnight(
-                        input.minusWeeks(i).withDayOfWeek(DateTimeConstants.MONDAY));
+                DateMidnight startOfLastWeek = new DateMidnight(input.minusWeeks(i)
+                        .withDayOfWeek(DateTimeConstants.MONDAY));
                 String startDate = urlEncodeDate(startOfLastWeek);
                 LOGGER.debug("Previous Week {} (start):  {}", i, startDate);
 
                 DateTime endOfLastWeek = startOfLastWeek.plusDays(DateTimeConstants.DAYS_PER_WEEK)
-                        .toDateTime().minus(1 /* millisecond */);
+                        .toDateTime()
+                        .minus(1 /* millisecond */);
                 String endDate = urlEncodeDate(endOfLastWeek);
                 LOGGER.debug("Previous Week {} (end):  ", i, endDate);
 
@@ -435,13 +437,14 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
         for (int i = 1; i <= numMonthlyReports; i++) {
             try {
-                DateMidnight startOfLastMonth = new DateMidnight(
-                        input.minusMonths(i).withDayOfMonth(1));
+                DateMidnight startOfLastMonth = new DateMidnight(input.minusMonths(i)
+                        .withDayOfMonth(1));
                 String startDate = urlEncodeDate(startOfLastMonth);
                 LOGGER.debug("Previous Month (start):  {}   (ms = {})", startDate,
                         startOfLastMonth.getMillis());
 
-                DateTime endOfLastMonth = startOfLastMonth.plusMonths(1).toDateTime()
+                DateTime endOfLastMonth = startOfLastMonth.plusMonths(1)
+                        .toDateTime()
                         .minus(1 /* millisecond */);
                 String endDate = urlEncodeDate(endOfLastMonth);
                 LOGGER.debug("Previous Month (end):  {}   (ms = {})", endOfLastMonth,
@@ -464,13 +467,14 @@ public class MetricsWebConsolePlugin extends AbstractWebConsolePlugin {
 
         for (int i = 1; i <= numYearlyReports; i++) {
             try {
-                DateMidnight startOfLastYear = new DateMidnight(
-                        input.minusYears(1).withDayOfYear(1));
+                DateMidnight startOfLastYear = new DateMidnight(input.minusYears(1)
+                        .withDayOfYear(1));
                 String startDate = urlEncodeDate(startOfLastYear);
                 LOGGER.debug("Previous Year (start):  {}   (ms = {})", startOfLastYear,
                         startOfLastYear.getMillis());
 
-                DateTime endOfLastYear = startOfLastYear.plusYears(1).toDateTime()
+                DateTime endOfLastYear = startOfLastYear.plusYears(1)
+                        .toDateTime()
                         .minus(1 /* millisecond */);
                 String endDate = urlEncodeDate(endOfLastYear);
                 LOGGER.debug("Previous Year (end):  {},   (ms = {})", endOfLastYear,

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,11 +16,8 @@
 
     <reference id="MetricsAdminPluginService" interface="javax.servlet.Servlet"/>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-    
     <bean id="metricsWebConsolePlugin" class="ddf.metrics.plugin.webconsole.MetricsWebConsolePlugin"
           init-method="start" destroy-method="stop">
-        <argument ref="urlHelper"/>
     </bean>
     
     <service ref="metricsWebConsolePlugin" interface="javax.servlet.Servlet">

--- a/platform/metrics/platform-metrics-webconsole-plugin/src/test/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePluginTest.java
+++ b/platform/metrics/platform-metrics-webconsole-plugin/src/test/java/ddf/metrics/plugin/webconsole/MetricsWebConsolePluginTest.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 
 import javax.xml.transform.OutputKeys;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.platform.util.TransformerProperties;
 import org.codice.ddf.platform.util.XMLUtils;
 import org.custommonkey.xmlunit.HTMLDocumentBuilder;
@@ -64,19 +63,19 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
 
     @Test
     public void testTitle() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
         assertEquals("Metrics", metricsPlugin.getTitle());
     }
 
     @Test
     public void testLabel() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
         assertEquals("metrics", metricsPlugin.getLabel());
     }
 
     @Test
     public void testConvertCamelCase() throws Exception {
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
         assertEquals("Foo", metricsPlugin.convertCamelCase("foo"));
         assertEquals("Foo", metricsPlugin.convertCamelCase("Foo"));
         assertEquals("Foobar", metricsPlugin.convertCamelCase("foobar"));
@@ -146,7 +145,7 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
         Locale.setDefault(new Locale(language, country));
         StringWriter sw = new StringWriter();
 
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
         PrintWriter pw = new PrintWriter(sw);
 
         int numWeeklyReports = 3;
@@ -167,7 +166,7 @@ public class MetricsWebConsolePluginTest extends XMLTestCase {
         DateTimeZone.setDefault(DateTimeZone.forID(dateTimeZoneId));
         Locale.setDefault(new Locale(language, country));
 
-        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin(new SystemBaseUrl());
+        MetricsWebConsolePlugin metricsPlugin = new MetricsWebConsolePlugin();
 
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);

--- a/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
+++ b/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
@@ -20,23 +20,20 @@ import org.codice.ddf.configuration.SystemInfo;
 @Command(scope = PlatformCommands.NAMESPACE, name = "describe", description = "Provides a description of the platform")
 public class DescribeCommand extends PlatformCommands {
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SystemInfo systemInfo;
 
-    public DescribeCommand(SystemBaseUrl sbu, SystemInfo info) {
-        this.systemBaseUrl = sbu;
+    public DescribeCommand(SystemInfo info) {
         this.systemInfo = info;
     }
 
     @Override
     protected Object doExecute() throws Exception {
-        System.out.printf("%s=%s%n", "Protocol", systemBaseUrl.getProtocol());
-        System.out.printf("%s=%s%n", "Host", systemBaseUrl.getHost());
-        System.out.printf("%s=%s%n", "Port", systemBaseUrl.getPort());
-        System.out.printf("%s=%s%n", "Root Context", systemBaseUrl.getRootContext());
-        System.out.printf("%s=%s%n", "Http Port", systemBaseUrl.getHttpPort());
-        System.out.printf("%s=%s%n", "Https Port", systemBaseUrl.getHttpsPort());
+        System.out.printf("%s=%s%n", "Protocol", SystemBaseUrl.getProtocol());
+        System.out.printf("%s=%s%n", "Host", SystemBaseUrl.getHost());
+        System.out.printf("%s=%s%n", "Port", SystemBaseUrl.getPort());
+        System.out.printf("%s=%s%n", "Root Context", SystemBaseUrl.getRootContext());
+        System.out.printf("%s=%s%n", "Http Port", SystemBaseUrl.getHttpPort());
+        System.out.printf("%s=%s%n", "Https Port", SystemBaseUrl.getHttpsPort());
 
         System.out.printf("%s=%s%n", "Site Name", systemInfo.getSiteName());
         System.out.printf("%s=%s%n", "Organization", systemInfo.getOrganization());

--- a/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
+++ b/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
@@ -20,12 +20,6 @@ import org.codice.ddf.configuration.SystemInfo;
 @Command(scope = PlatformCommands.NAMESPACE, name = "describe", description = "Provides a description of the platform")
 public class DescribeCommand extends PlatformCommands {
 
-    private SystemInfo systemInfo;
-
-    public DescribeCommand(SystemInfo info) {
-        this.systemInfo = info;
-    }
-
     @Override
     protected Object doExecute() throws Exception {
         System.out.printf("%s=%s%n", "Protocol", SystemBaseUrl.getProtocol());
@@ -35,10 +29,10 @@ public class DescribeCommand extends PlatformCommands {
         System.out.printf("%s=%s%n", "Http Port", SystemBaseUrl.getHttpPort());
         System.out.printf("%s=%s%n", "Https Port", SystemBaseUrl.getHttpsPort());
 
-        System.out.printf("%s=%s%n", "Site Name", systemInfo.getSiteName());
-        System.out.printf("%s=%s%n", "Organization", systemInfo.getOrganization());
-        System.out.printf("%s=%s%n", "Contact", systemInfo.getSiteContatct());
-        System.out.printf("%s=%s%n", "Version", systemInfo.getVersion());
+        System.out.printf("%s=%s%n", "Site Name", SystemInfo.getSiteName());
+        System.out.printf("%s=%s%n", "Organization", SystemInfo.getOrganization());
+        System.out.printf("%s=%s%n", "Contact", SystemInfo.getSiteContatct());
+        System.out.printf("%s=%s%n", "Version", SystemInfo.getVersion());
         return null;
     }
 }

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -73,11 +73,8 @@
         <argument ref="defaultExportDirectoryPath"/>
     </bean>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
     <bean id="platformDescribeCommand" class="org.codice.ddf.commands.platform.DescribeCommand">
         <property name="bundleContext" ref="blueprintBundleContext"/>
-        <argument ref="systemInfo"/>
     </bean>
 
 </blueprint>

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -73,12 +73,10 @@
         <argument ref="defaultExportDirectoryPath"/>
     </bean>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
     <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
     <bean id="platformDescribeCommand" class="org.codice.ddf.commands.platform.DescribeCommand">
         <property name="bundleContext" ref="blueprintBundleContext"/>
-        <argument ref="urlHelper"/>
         <argument ref="systemInfo"/>
     </bean>
 

--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
@@ -130,8 +130,6 @@ public class ConfigurationManager {
 
     private static final String SSL_TRUSTSTORE_PASSWORD_JAVA_PROPERTY = "javax.net.ssl.trustStorePassword";
 
-    protected SystemBaseUrl systemBaseUrl;
-
     protected SystemInfo systemInfo;
 
     /**
@@ -179,11 +177,10 @@ public class ConfigurationManager {
      * @param configurationAdmin the OSGi Configuration Admin service handle
      */
     public ConfigurationManager(List<ConfigurationWatcher> services,
-            ConfigurationAdmin configurationAdmin, SystemBaseUrl sbu, SystemInfo info) {
+            ConfigurationAdmin configurationAdmin, SystemInfo info) {
         LOGGER.debug("ENTERING: ctor");
         this.services = services;
         this.configurationAdmin = configurationAdmin;
-        this.systemBaseUrl = sbu;
         this.systemInfo = info;
 
         this.readOnlySettings = new HashMap<>();
@@ -365,14 +362,14 @@ public class ConfigurationManager {
 
     private Map<String, String> getSystemProperties() {
         Map<String, String> map = new HashMap<>();
-        map.put(HTTP_PORT, systemBaseUrl.getHttpPort());
-        map.put(HOST, systemBaseUrl.getHost());
-        map.put(PROTOCOL, systemBaseUrl.getProtocol());
-        map.put(PORT, systemBaseUrl.getPort());
+        map.put(HTTP_PORT, SystemBaseUrl.getHttpPort());
+        map.put(HOST, SystemBaseUrl.getHost());
+        map.put(PROTOCOL, SystemBaseUrl.getProtocol());
+        map.put(PORT, SystemBaseUrl.getPort());
         map.put(SITE_NAME, systemInfo.getSiteName());
         map.put(VERSION, systemInfo.getVersion());
         map.put(ORGANIZATION, systemInfo.getOrganization());
-        map.put(SERVICES_CONTEXT_ROOT, systemBaseUrl.getRootContext());
+        map.put(SERVICES_CONTEXT_ROOT, SystemBaseUrl.getRootContext());
         return map;
     }
 }

--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/ConfigurationManager.java
@@ -130,8 +130,6 @@ public class ConfigurationManager {
 
     private static final String SSL_TRUSTSTORE_PASSWORD_JAVA_PROPERTY = "javax.net.ssl.trustStorePassword";
 
-    protected SystemInfo systemInfo;
-
     /**
      * List of DdfManagedServices to push the DDF system settings to.
      */
@@ -172,16 +170,14 @@ public class ConfigurationManager {
     /**
      * Constructs the list of DDF system Settings (read-only and configurable
      * settings) to be pushed to registered ConfigurationWatchers.
-     *
-     * @param services           the list of watchers of changes to the DDF System Settings
+     *  @param services           the list of watchers of changes to the DDF System Settings
      * @param configurationAdmin the OSGi Configuration Admin service handle
      */
     public ConfigurationManager(List<ConfigurationWatcher> services,
-            ConfigurationAdmin configurationAdmin, SystemInfo info) {
+            ConfigurationAdmin configurationAdmin) {
         LOGGER.debug("ENTERING: ctor");
         this.services = services;
         this.configurationAdmin = configurationAdmin;
-        this.systemInfo = info;
 
         this.readOnlySettings = new HashMap<>();
         if (System.getenv(DDF_HOME_ENVIRONMENT_VARIABLE) != null) {
@@ -366,9 +362,9 @@ public class ConfigurationManager {
         map.put(HOST, SystemBaseUrl.getHost());
         map.put(PROTOCOL, SystemBaseUrl.getProtocol());
         map.put(PORT, SystemBaseUrl.getPort());
-        map.put(SITE_NAME, systemInfo.getSiteName());
-        map.put(VERSION, systemInfo.getVersion());
-        map.put(ORGANIZATION, systemInfo.getOrganization());
+        map.put(SITE_NAME, SystemInfo.getSiteName());
+        map.put(VERSION, SystemInfo.getVersion());
+        map.put(ORGANIZATION, SystemInfo.getOrganization());
         map.put(SERVICES_CONTEXT_ROOT, SystemBaseUrl.getRootContext());
         return map;
     }

--- a/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,7 +38,6 @@
     <reference-list id="initialManagedServiceList" availability="optional"
                     interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
-    <bean id="urlHelper" class="org.codice.ddf.configuration.SystemBaseUrl"/>
     <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
 
     <bean id="ConfigurationManager" class="org.codice.ddf.configuration.ConfigurationManager"
@@ -47,7 +46,6 @@
                                update-strategy="component-managed" update-method="updated"/>
         <argument ref="initialManagedServiceList"/>
         <argument ref="configurationAdmin"/>
-        <argument ref="urlHelper"/>
         <argument ref="systemInfo"/>
     </bean>
 

--- a/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,15 +38,12 @@
     <reference-list id="initialManagedServiceList" availability="optional"
                     interface="org.codice.ddf.configuration.ConfigurationWatcher"/>
 
-    <bean id="systemInfo" class="org.codice.ddf.configuration.SystemInfo"/>
-
     <bean id="ConfigurationManager" class="org.codice.ddf.configuration.ConfigurationManager"
           init-method="init">
         <cm:managed-properties persistent-id="ddf.platform.config"
                                update-strategy="component-managed" update-method="updated"/>
         <argument ref="initialManagedServiceList"/>
         <argument ref="configurationAdmin"/>
-        <argument ref="systemInfo"/>
     </bean>
 
     <bean id="PlatformUiConfiguration" class="org.codice.ddf.configuration.PlatformUiConfiguration">

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
@@ -55,13 +55,12 @@ public class ConfigurationManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        SystemBaseUrl sbu = new SystemBaseUrl();
         SystemInfo info = new SystemInfo();
         key = ConfigurationManagerTest.class.getSimpleName() + "Key";
         mockWatcher = new MockConfigurationWatcher();
         List<ConfigurationWatcher> watchers = new ArrayList<ConfigurationWatcher>();
         watchers.add(mockWatcher);
-        ddfConfigMgr = new ConfigurationManager(watchers, null, sbu, info);
+        ddfConfigMgr = new ConfigurationManager(watchers, null, info);
         config1 = new HashMap<String, String>();
         config1.put(key, "config1");
         config2 = new HashMap<String, String>();

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/ConfigurationManagerTest.java
@@ -55,12 +55,11 @@ public class ConfigurationManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        SystemInfo info = new SystemInfo();
         key = ConfigurationManagerTest.class.getSimpleName() + "Key";
         mockWatcher = new MockConfigurationWatcher();
         List<ConfigurationWatcher> watchers = new ArrayList<ConfigurationWatcher>();
         watchers.add(mockWatcher);
-        ddfConfigMgr = new ConfigurationManager(watchers, null, info);
+        ddfConfigMgr = new ConfigurationManager(watchers, null);
         config1 = new HashMap<String, String>();
         config1.put(key, "config1");
         config2 = new HashMap<String, String>();

--- a/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
+++ b/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
@@ -135,8 +135,6 @@ public class LoginFilter implements Filter {
 
     private final Object lock = new Object();
 
-    private final SystemBaseUrl baseUrl;
-
     private SecurityManager securityManager;
 
     private String signaturePropertiesFile;
@@ -152,9 +150,8 @@ public class LoginFilter implements Filter {
      */
     private int expirationTime = 31;
 
-    public LoginFilter(SystemBaseUrl baseUrl) {
+    public LoginFilter() {
         super();
-        this.baseUrl = baseUrl;
     }
 
     /**
@@ -570,7 +567,7 @@ public class LoginFilter implements Filter {
                     new SecurityAssertionImpl(((SecurityToken) savedToken.getCredentials()));
 
             if (savedAssertion.getIssuer() != null && !savedAssertion.getIssuer()
-                    .equals(baseUrl.getHost())) {
+                    .equals(SystemBaseUrl.getHost())) {
                 return null;
             }
 

--- a/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,14 +19,11 @@
 
     <ext:property-placeholder/>
 
-    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl" />
-
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
     <bean id="filter" class="org.codice.ddf.security.filter.login.LoginFilter">
         <cm:managed-properties persistent-id="org.codice.ddf.security.filter.login.Session"
                                update-strategy="container-managed"/>
-        <argument ref="baseUrl" />
         <property name="securityManager" ref="securityManager"/>
         <property name="signaturePropertiesFile"
                   value="${ddf.home}/etc/ws-security/server/signature.properties"/>

--- a/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
+++ b/platform/security/filter/security-filter-login/src/test/java/org/codice/ddf/security/filter/login/LoginFilterTest.java
@@ -97,7 +97,7 @@ public class LoginFilterTest {
     @Test
     public void testNoSubject() {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         try {
             loginFilter.init(filterConfig);
@@ -132,7 +132,7 @@ public class LoginFilterTest {
     @Test
     public void testBadSubject() throws IOException, ServletException {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         try {
             loginFilter.init(filterConfig);
@@ -157,7 +157,7 @@ public class LoginFilterTest {
     @Test
     public void testValidEmptySubject() throws IOException, ServletException {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         loginFilter.init(filterConfig);
 
@@ -176,7 +176,7 @@ public class LoginFilterTest {
             throws IOException, XMLStreamException, ServletException, ParserConfigurationException,
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager =
                 mock(ddf.security.service.SecurityManager.class);
@@ -212,7 +212,7 @@ public class LoginFilterTest {
             throws IOException, XMLStreamException, ServletException, ParserConfigurationException,
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager =
                 mock(ddf.security.service.SecurityManager.class);
@@ -244,7 +244,7 @@ public class LoginFilterTest {
             throws IOException, XMLStreamException, ServletException, ParserConfigurationException,
             SAXException, SecurityServiceException {
         FilterConfig filterConfig = mock(FilterConfig.class);
-        LoginFilter loginFilter = new LoginFilter(null);
+        LoginFilter loginFilter = new LoginFilter();
         loginFilter.setSessionFactory(new HttpSessionFactory());
         ddf.security.service.SecurityManager securityManager = mock(SecurityManager.class);
         loginFilter.setSecurityManager(securityManager);

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -89,8 +89,6 @@ public class AssertionConsumerService {
 
     private final IdpMetadata idpMetadata;
 
-    private final SystemBaseUrl baseUrl;
-
     private final RelayStates<String> relayStates;
 
     @Context
@@ -107,11 +105,10 @@ public class AssertionConsumerService {
     }
 
     public AssertionConsumerService(SimpleSign simpleSign, IdpMetadata metadata,
-            SystemCrypto crypto, SystemBaseUrl systemBaseUrl, RelayStates<String> relayStates) {
+            SystemCrypto crypto, RelayStates<String> relayStates) {
         this.simpleSign = simpleSign;
         idpMetadata = metadata;
         systemCrypto = crypto;
-        baseUrl = systemBaseUrl;
         this.relayStates = relayStates;
     }
 
@@ -316,9 +313,9 @@ public class AssertionConsumerService {
         X509Certificate encryptionCert = findCertificate(systemCrypto.getEncryptionAlias(),
                 systemCrypto.getEncryptionCrypto());
 
-        String hostname = baseUrl.getHost();
-        String port = baseUrl.getPort();
-        String rootContext = baseUrl.getRootContext();
+        String hostname = SystemBaseUrl.getHost();
+        String port = SystemBaseUrl.getPort();
+        String rootContext = SystemBaseUrl.getRootContext();
 
         String entityId = String.format("https://%s:%s%s/saml", hostname, port, rootContext);
 

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -104,20 +104,17 @@ public class IdpHandler implements AuthenticationHandler {
 
     private final IdpMetadata idpMetadata;
 
-    private final SystemBaseUrl baseUrl;
-
     private final RelayStates<String> relayStates;
 
     private SessionFactory sessionFactory;
 
-    public IdpHandler(SimpleSign simpleSign, IdpMetadata metadata, SystemBaseUrl baseUrl,
+    public IdpHandler(SimpleSign simpleSign, IdpMetadata metadata,
             RelayStates<String> relayStates) throws IOException {
         LOGGER.debug("Creating IdP handler.");
 
         this.simpleSign = simpleSign;
         idpMetadata = metadata;
 
-        this.baseUrl = baseUrl;
         this.relayStates = relayStates;
 
         try (InputStream postFormStream = IdpHandler.class.getResourceAsStream("/post-binding.html")) {
@@ -241,9 +238,9 @@ public class IdpHandler implements AuthenticationHandler {
     private String createAuthnRequest(boolean isPost) throws ServletException {
 
         String spIssuerId = String.format("https://%s:%s%s/saml",
-                baseUrl.getHost(),
-                baseUrl.getHttpsPort(),
-                baseUrl.getRootContext());
+                SystemBaseUrl.getHost(),
+                SystemBaseUrl.getHttpsPort(),
+                SystemBaseUrl.getRootContext());
         String spAssertionConsumerServiceUrl = spIssuerId + "/sso";
 
         AuthnRequest authnRequest = authnRequestBuilder.buildObject();

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
@@ -58,13 +58,13 @@ public class IdpLogoutActionProvider implements ActionProvider {
 
                 String nameIdTimestamp = nameId + "\n" + System.currentTimeMillis();
                 nameIdTimestamp = encryptionService.encrypt(nameIdTimestamp);
-                logoutUrl = new URL(new SystemBaseUrl().constructUrl(
+                logoutUrl = new URL(SystemBaseUrl.constructUrl(
                         "/saml/logout/request?EncryptedNameIdTime=" + nameIdTimestamp,
                         true));
 
             } catch (MalformedURLException e) {
                 LOGGER.info("Unable to resolve URL: {}",
-                        new SystemBaseUrl().constructUrl("/logout/local"));
+                        SystemBaseUrl.constructUrl("/logout/local"));
             } catch (ClassCastException e) {
                 LOGGER.debug("Unable to cast parameter to Map<String, Subject>, {}",
                         realmSubjectMap,

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
@@ -90,8 +90,6 @@ public class LogoutRequestService {
 
     private String redirectPage;
 
-    private SystemBaseUrl baseUrl;
-
     private final RelayStates<String> relayStates;
 
     private EncryptionService encryptionService;
@@ -101,10 +99,9 @@ public class LogoutRequestService {
     private long logOutPageTimeOut = 3600000;
 
     public LogoutRequestService(SimpleSign simpleSign, IdpMetadata idpMetadata,
-            SystemBaseUrl systemBaseUrl, RelayStates<String> relayStates) {
+            RelayStates<String> relayStates) {
         this.simpleSign = simpleSign;
         this.idpMetadata = idpMetadata;
-        this.baseUrl = systemBaseUrl;
         this.relayStates = relayStates;
 
     }
@@ -374,9 +371,9 @@ public class LogoutRequestService {
     }
 
     private String getEntityId() {
-        String hostname = baseUrl.getHost();
-        String port = baseUrl.getPort();
-        String rootContext = baseUrl.getRootContext();
+        String hostname = SystemBaseUrl.getHost();
+        String port = SystemBaseUrl.getPort();
+        String rootContext = SystemBaseUrl.getRootContext();
 
         return String.format("https://%s:%s%s/saml", hostname, port, rootContext);
     }
@@ -448,7 +445,7 @@ public class LogoutRequestService {
     }
 
     private Response buildLogoutResponse(String message) {
-        UriBuilder uriBuilder = UriBuilder.fromUri(baseUrl.getBaseUrl());
+        UriBuilder uriBuilder = UriBuilder.fromUri(SystemBaseUrl.getBaseUrl());
         uriBuilder.path("logout/logout-response.html");
         uriBuilder.queryParam("msg", message);
         return Response.seeOther(uriBuilder.build())

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,8 +27,6 @@
 
     <ext:property-placeholder/>
 
-    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-
     <bean id="idpMetadata" class="org.codice.ddf.security.idp.client.IdpMetadata">
         <cm:managed-properties persistent-id="org.codice.ddf.security.idp.client.IdpMetadata"
                                update-strategy="container-managed"/>
@@ -56,7 +54,6 @@
                                update-strategy="container-managed"/>
         <argument ref="simpleSign"/>
         <argument ref="idpMetadata"/>
-        <argument ref="baseUrl"/>
         <argument ref="relayStates"/>
         <property name="sessionFactory" ref="sessionFactory"/>
     </bean>
@@ -68,7 +65,6 @@
         <argument ref="simpleSign"/>
         <argument ref="idpMetadata"/>
         <argument ref="crypto"/>
-        <argument ref="baseUrl"/>
         <argument ref="relayStates"/>
         <property name="loginFilter">
             <reference interface="javax.servlet.Filter"
@@ -83,7 +79,6 @@
                                update-strategy="container-managed"/>
         <argument ref="simpleSign"/>
         <argument ref="idpMetadata"/>
-        <argument ref="baseUrl"/>
         <argument ref="relayStates"/>
         <property name="logoutMessage">
             <reference interface="ddf.security.samlp.LogoutMessage" />

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
@@ -38,7 +38,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,8 +64,6 @@ public class AssertionConsumerServiceTest {
     private SystemCrypto systemCrypto;
 
     private RelayStates<String> relayStates;
-
-    private SystemBaseUrl baseUrl;
 
     private Filter loginFilter;
 
@@ -101,7 +98,6 @@ public class AssertionConsumerServiceTest {
         when(relayStates.encode("fubar")).thenReturn(RELAY_STATE_VAL);
         when(relayStates.decode(RELAY_STATE_VAL)).thenReturn(LOCATION);
         loginFilter = mock(javax.servlet.Filter.class);
-        baseUrl = new SystemBaseUrl();
         sessionFactory = mock(SessionFactory.class);
         httpRequest = mock(HttpServletRequest.class);
         when(httpRequest.getRequestURL()).thenReturn(new StringBuffer("fubar"));
@@ -111,7 +107,6 @@ public class AssertionConsumerServiceTest {
         assertionConsumerService = new AssertionConsumerService(simpleSign,
                 idpMetadata,
                 systemCrypto,
-                baseUrl,
                 relayStates);
         assertionConsumerService.setRequest(httpRequest);
         assertionConsumerService.setLoginFilter(loginFilter);

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/IdpHandlerTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/IdpHandlerTest.java
@@ -29,7 +29,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.security.handler.api.HandlerResult;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +43,6 @@ public class IdpHandlerTest {
     IdpHandler idpHandler;
 
     private RelayStates<String> relayStates;
-
-    private SystemBaseUrl baseUrl;
 
     private IdpMetadata idpMetadata;
 
@@ -73,7 +70,6 @@ public class IdpHandlerTest {
                 encryptionService);
         simpleSign = new SimpleSign(systemCrypto);
         idpMetadata = new IdpMetadata();
-        baseUrl = new SystemBaseUrl();
         relayStates = (RelayStates<String>) mock(RelayStates.class);
         when(relayStates.encode(anyString())).thenReturn(RELAY_STATE_VAL);
         when(relayStates.decode(RELAY_STATE_VAL)).thenReturn(LOCATION);
@@ -81,7 +77,7 @@ public class IdpHandlerTest {
         when(httpRequest.getRequestURL()).thenReturn(new StringBuffer("https://localhost:8993"));
         httpResponse = mock(HttpServletResponse.class);
 
-        idpHandler = new IdpHandler(simpleSign, idpMetadata, baseUrl, relayStates);
+        idpHandler = new IdpHandler(simpleSign, idpMetadata, relayStates);
 
         StringWriter writer = new StringWriter();
         InputStream inputStream = this.getClass()

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -80,8 +79,6 @@ public class LogoutRequestServiceTest {
 
     private IdpMetadata idpMetadata;
 
-    private SystemBaseUrl systemBaseUrl;
-
     private SimpleSign simpleSign;
 
     private HttpSession session;
@@ -93,8 +90,8 @@ public class LogoutRequestServiceTest {
     private class MockLogoutRequestService extends LogoutRequestService {
 
         public MockLogoutRequestService(SimpleSign simpleSign, IdpMetadata idpMetadata,
-                SystemBaseUrl systemBaseUrl, RelayStates<String> relayStates) {
-            super(simpleSign, idpMetadata, systemBaseUrl, relayStates);
+                RelayStates<String> relayStates) {
+            super(simpleSign, idpMetadata, relayStates);
         }
 
         @Override
@@ -109,7 +106,6 @@ public class LogoutRequestServiceTest {
     public void setup() {
         simpleSign = mock(SimpleSign.class);
         idpMetadata = mock(IdpMetadata.class);
-        systemBaseUrl = new SystemBaseUrl();
         relayStates = mock(RelayStates.class);
         sessionFactory = mock(SessionFactory.class);
         request = mock(HttpServletRequest.class);
@@ -120,7 +116,6 @@ public class LogoutRequestServiceTest {
 
         logoutRequestService = new MockLogoutRequestService(simpleSign,
                 idpMetadata,
-                systemBaseUrl,
                 relayStates);
         logoutRequestService.setEncryptionService(encryptionService);
         logoutRequestService.setLogOutPageTimeOut(LOGOUT_PAGE_TIMEOUT);
@@ -379,7 +374,6 @@ public class LogoutRequestServiceTest {
 
         LogoutRequestService lrs = new LogoutRequestService(simpleSign,
                 idpMetadata,
-                systemBaseUrl,
                 relayStates);
 
         lrs.setEncryptionService(encryptionService);
@@ -459,7 +453,6 @@ public class LogoutRequestServiceTest {
                 logoutResponse);
         LogoutRequestService lrs = new LogoutRequestService(simpleSign,
                 idpMetadata,
-                systemBaseUrl,
                 relayStates);
 
         lrs.setEncryptionService(encryptionService);

--- a/platform/security/idp/security-idp-server/pom.xml
+++ b/platform/security/idp/security-idp-server/pom.xml
@@ -223,6 +223,7 @@
                             antlr4-runtime,
                             commons-lang3,
                             guava,
+                            common-system
                         </Embed-Dependency>
                         <Import-Package>!org.abego.treelayout.*, *</Import-Package>
                         <Export-Package/>

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -124,8 +124,6 @@ public class IdpEndpoint implements Idp {
 
     protected CookieCache cookieCache = new CookieCache();
 
-    private SystemBaseUrl systemBaseUrl = new SystemBaseUrl();
-
     private PKIAuthenticationTokenFactory tokenFactory;
 
     private SecurityManager securityManager;
@@ -382,7 +380,7 @@ public class IdpEndpoint implements Idp {
             throws WSSecurityException, IOException, SimpleSign.SignatureException {
         LOGGER.debug("Creating SAML Response for error condition.");
         org.opensaml.saml.saml2.core.Response samlResponse = SamlProtocol.createResponse(
-                SamlProtocol.createIssuer(systemBaseUrl.constructUrl("/idp/login", true)),
+                SamlProtocol.createIssuer(SystemBaseUrl.constructUrl("/idp/login", true)),
                 SamlProtocol.createStatus(statusCode),
                 authnRequest.getID(),
                 null);
@@ -568,7 +566,7 @@ public class IdpEndpoint implements Idp {
         }
 
         LOGGER.debug("User log in successful.");
-        return SamlProtocol.createResponse(SamlProtocol.createIssuer(systemBaseUrl.constructUrl(
+        return SamlProtocol.createResponse(SamlProtocol.createIssuer(SystemBaseUrl.constructUrl(
                 "/idp/login",
                 true)), SamlProtocol.createStatus(statusCode), authnRequest.getID(), samlToken);
     }
@@ -688,15 +686,15 @@ public class IdpEndpoint implements Idp {
             encryptionCert = certs[0];
         }
         EntityDescriptor entityDescriptor =
-                SamlProtocol.createIdpMetadata(systemBaseUrl.constructUrl("/idp/login", true),
+                SamlProtocol.createIdpMetadata(SystemBaseUrl.constructUrl("/idp/login", true),
                         Base64.encodeBase64String(
                                 issuerCert != null ? issuerCert.getEncoded() : new byte[0]),
                         Base64.encodeBase64String(
                                 encryptionCert != null ? encryptionCert.getEncoded() : new byte[0]),
                         nameIdFormats,
-                        systemBaseUrl.constructUrl("/idp/login", true),
-                        systemBaseUrl.constructUrl("/idp/login", true),
-                        systemBaseUrl.constructUrl("/idp/logout", true));
+                        SystemBaseUrl.constructUrl("/idp/login", true),
+                        SystemBaseUrl.constructUrl("/idp/login", true),
+                        SystemBaseUrl.constructUrl("/idp/logout", true));
         Document doc = DOMUtils.createDocument();
         doc.appendChild(doc.createElement("root"));
         return Response.ok(DOM2Writer.nodeToString(OpenSAMLUtil.toDom(entityDescriptor,
@@ -930,7 +928,7 @@ public class IdpEndpoint implements Idp {
                 }
                 LogoutRequest logoutRequest =
                         logoutMessage.buildLogoutRequest(logoutState.getNameId(),
-                                systemBaseUrl.constructUrl("/idp/logout", true));
+                                SystemBaseUrl.constructUrl("/idp/logout", true));
                 logoutState.setCurrentRequestId(logoutRequest.getID());
                 logoutObject = logoutRequest;
                 samlType = SamlProtocol.Type.REQUEST;
@@ -941,7 +939,7 @@ public class IdpEndpoint implements Idp {
                 String status = logoutState.isPartialLogout() ?
                         StatusCode.PARTIAL_LOGOUT :
                         StatusCode.SUCCESS;
-                logoutObject = logoutMessage.buildLogoutResponse(systemBaseUrl.constructUrl(
+                logoutObject = logoutMessage.buildLogoutResponse(SystemBaseUrl.constructUrl(
                         "/idp/logout",
                         true), status, logoutState.getOriginalRequestId());
                 relay = logoutState.getInitialRelayState();

--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -138,7 +138,8 @@
                             httpclient,
                             httpcore,
                             httpmime,
-                            commons-lang3
+                            commons-lang3,
+                            common-system
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/KarafLogoutAction.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/KarafLogoutAction.java
@@ -39,10 +39,10 @@ public class KarafLogoutAction implements ActionProvider {
 
     static {
         try {
-            logoutUrl = new URL(new SystemBaseUrl().constructUrl("/logout/local"));
+            logoutUrl = new URL(SystemBaseUrl.constructUrl("/logout/local"));
         } catch (MalformedURLException e) {
             LOGGER.info("Unable to resolve URL: {}",
-                    new SystemBaseUrl().constructUrl("/logout/local"));
+                    SystemBaseUrl.constructUrl("/logout/local"));
         }
     }
 

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LdapLogoutAction.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LdapLogoutAction.java
@@ -39,10 +39,10 @@ public class LdapLogoutAction implements ActionProvider {
 
     static {
         try {
-            logoutUrl = new URL(new SystemBaseUrl().constructUrl("/logout/local"));
+            logoutUrl = new URL(SystemBaseUrl.constructUrl("/logout/local"));
         } catch (MalformedURLException e) {
             LOGGER.info("Unable to resolve URL: {}",
-                    new SystemBaseUrl().constructUrl("/logout/local"));
+                    SystemBaseUrl.constructUrl("/logout/local"));
         }
     }
 

--- a/platform/security/sts/security-sts-attributequeryclaimshandler/src/test/java/org/codice/ddf/security/claims/attributequery/TestAttributeQueryClaimsHandler.java
+++ b/platform/security/sts/security-sts-attributequeryclaimshandler/src/test/java/org/codice/ddf/security/claims/attributequery/TestAttributeQueryClaimsHandler.java
@@ -59,8 +59,6 @@ public class TestAttributeQueryClaimsHandler {
 
     private static final String ISSUER = "testIssuer";
 
-    private SystemBaseUrl systemBaseUrl;
-
     private String username = "CN=testCN, OU=testOU, O=testO, L=testL, ST=testST, C=testC";
 
     private String responseState = "ValidResponse";
@@ -124,7 +122,6 @@ public class TestAttributeQueryClaimsHandler {
 
     @Before
     public void setUp() throws IOException {
-        systemBaseUrl = new SystemBaseUrl();
         encryptionService = mock(EncryptionService.class);
         systemCrypto = new SystemCrypto("encryption.properties",
                 "signature.properties",
@@ -139,7 +136,7 @@ public class TestAttributeQueryClaimsHandler {
         attributeQueryClaimsHandler = new AttributeQueryClaimsHandlerTest();
         attributeQueryClaimsHandler.setSimpleSign(simpleSign);
         attributeQueryClaimsHandler.setSupportedClaims(supportedClaims);
-        attributeQueryClaimsHandler.setExternalAttributeStoreUrl(systemBaseUrl.getBaseUrl());
+        attributeQueryClaimsHandler.setExternalAttributeStoreUrl(SystemBaseUrl.getBaseUrl());
         attributeQueryClaimsHandler.setIssuer(ISSUER);
         attributeQueryClaimsHandler.setDestination(DESTINATION);
         attributeQueryClaimsHandler.setAttributeMapLocation(TestAttributeQueryClaimsHandler.class.getClassLoader()

--- a/platform/security/sts/security-sts-attributequeryclaimshandler/src/test/java/org/codice/ddf/security/claims/attributequery/TestAttributeQueryClient.java
+++ b/platform/security/sts/security-sts-attributequeryclaimshandler/src/test/java/org/codice/ddf/security/claims/attributequery/TestAttributeQueryClient.java
@@ -108,8 +108,6 @@ public class TestAttributeQueryClient {
 
     private int responseCode = 200;
 
-    private SystemBaseUrl systemBaseUrl;
-
     private AttributeQueryClient attributeQueryClient;
 
     private EncryptionService encryptionService;
@@ -134,14 +132,13 @@ public class TestAttributeQueryClient {
                 encryptionService);
         SimpleSign simpleSign = new SimpleSign(systemCrypto);
         spySimpleSign = spy(simpleSign);
-        systemBaseUrl = new SystemBaseUrl();
 
         attributeQueryClient = new AttributeQueryClientTest(spySimpleSign,
-                systemBaseUrl.getBaseUrl(),
+                SystemBaseUrl.getBaseUrl(),
                 ISSUER,
                 DESTINATION);
         attributeQueryClient.setSimpleSign(spySimpleSign);
-        attributeQueryClient.setExternalAttributeStoreUrl(systemBaseUrl.getBaseUrl());
+        attributeQueryClient.setExternalAttributeStoreUrl(SystemBaseUrl.getBaseUrl());
         attributeQueryClient.setIssuer(ISSUER);
         attributeQueryClient.setDestination(DESTINATION);
 

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/PropertyPlaceholderWrapper.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/PropertyPlaceholderWrapper.java
@@ -42,14 +42,14 @@ public class PropertyPlaceholderWrapper {
     private StaticSTSProperties stsProperties;
 
     public PropertyPlaceholderWrapper(DefaultConditionsProvider conditionsProvider,
-            StaticSTSProperties properties, SystemBaseUrl baseUrl) {
+            StaticSTSProperties properties) {
         samlConditionsProvider = conditionsProvider;
         stsProperties = properties;
         // set the default values in case there is no configuration
         samlConditionsProvider.setLifetime(DEFAULT_LIFETIME);
-        stsProperties.setSignatureUsername(baseUrl.getHost());
-        stsProperties.setIssuer(baseUrl.getHost());
-        stsProperties.setEncryptionUsername(baseUrl.getHost());
+        stsProperties.setSignatureUsername(SystemBaseUrl.getHost());
+        stsProperties.setIssuer(SystemBaseUrl.getHost());
+        stsProperties.setEncryptionUsername(SystemBaseUrl.getHost());
     }
 
     public void setLifetime(Long lifetime) {

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -246,12 +246,9 @@
                     interface="org.apache.cxf.sts.token.validator.TokenValidator"
                     availability="optional"/>
 
-    <bean id="baseUrl" class="org.codice.ddf.configuration.SystemBaseUrl"/>
-
     <bean id="propertyWrapper" class="ddf.security.sts.PropertyPlaceholderWrapper">
         <argument ref="SAMLConditionsProvider"/>
         <argument ref="STSProperties"/>
-        <argument ref="baseUrl"/>
         <cm:managed-properties persistent-id="ddf.security.sts"
                                update-strategy="container-managed"/>
         <property name="issuer" value="${org.codice.ddf.system.hostname}"/>

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/SolrServerFactory.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/SolrServerFactory.java
@@ -96,8 +96,6 @@ public final class SolrServerFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SolrServerFactory.class);
 
-    private static SystemBaseUrl systemBaseUrl = new SystemBaseUrl();
-
     private static ExecutorService pool = getThreadPool();
 
     /**
@@ -119,11 +117,11 @@ public final class SolrServerFactory {
     }
 
     public static String getDefaultHttpsAddress() {
-        return systemBaseUrl.constructUrl("https", "/solr");
+        return SystemBaseUrl.constructUrl("https", "/solr");
     }
 
     public static String getDefaultHttpAddress() {
-        return systemBaseUrl.constructUrl("http", "/solr");
+        return SystemBaseUrl.constructUrl("http", "/solr");
     }
 
     /**
@@ -159,7 +157,7 @@ public final class SolrServerFactory {
     public static Future<SolrServer> getHttpSolrServer(String url, String coreName,
             String configFile) {
         if (StringUtils.isBlank(url)) {
-            url = systemBaseUrl.constructUrl("/solr");
+            url = SystemBaseUrl.constructUrl("/solr");
         }
 
         String coreUrl = url + "/" + coreName;


### PR DESCRIPTION
`SystemBaseUrl` had incorrectly been passed between bundles and is best implemented as a static utility class; in the process of working on this issue, `SystemInfo` was noted to be used as an instance class as well when it was better implemented as a static utility class.

@rzwiefel 
@tbatie 
@ryeats 
@stustison 