### PR TITLE
DDF-1778 Remove *;resolution:=optional imports in pom files

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>core</artifactId>
@@ -126,10 +128,6 @@
                         </Private-Package>
                         <Export-Package/>
                         <Import-Package>
-                            ddf.catalog.filter,
-                            org.apache.felix.service.command,
-                            org.apache.felix.gogo.commands,
-                            org.apache.karaf.shell.console,
                             org.osgi.framework;version="[1.5,2)",
                             *
                         </Import-Package>

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>core</artifactId>
@@ -67,6 +69,35 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>${solr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -91,15 +122,54 @@
                             solr-factory,
                             httpclient,
                             httpcore,
-                            httpmime
+                            httpmime,
+                            commons-io,
+                            commons-lang,
+                            lucene-core,
+                            joda-time
                         </Embed-Dependency>
                         <Private-Package>
                             org.codice.ddf.commands.solr
                         </Private-Package>
                         <Export-Package/>
                         <Import-Package>
+                            javax.crypto,
+                            javax.crypto.spec,
+                            javax.management,
+                            javax.management.openmbean,
+                            javax.management.remote,
+                            javax.naming,
+                            javax.naming.directory,
+                            javax.naming.ldap,
+                            javax.net,
+                            javax.net.ssl,
+                            javax.script,
+                            javax.security.auth.x500,
+                            javax.servlet,
+                            javax.servlet.http,
+                            javax.xml.bind,
+                            javax.xml.namespace,
+                            javax.xml.parsers,
+                            javax.xml.stream,
+                            javax.xml.transform,
+                            javax.xml.transform.dom,
+                            javax.xml.transform.sax,
+                            javax.xml.transform.stream,
+                            javax.xml.xpath,
+                            org.apache.commons.codec.binary,
                             org.apache.commons.logging; version="[1.1.0,2.0.0)",
-                            *;resolution:=optional
+                            org.apache.felix.gogo.commands,
+                            org.apache.karaf.shell.console,
+                            org.codice.ddf.configuration,
+                            org.eclipse.jetty.*,
+                            org.fusesource.jansi,
+                            org.osgi.framework;version="[1.5,2)",
+                            org.osgi.service.blueprint;version="[1.0.0,2.0.0)",
+                            org.osgi.service.cm,
+                            org.slf4j;version="[1.6,2)",
+                            org.w3c.dom,
+                            org.xml.sax,
+                            org.xml.sax.ext
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>core</artifactId>
@@ -292,6 +294,54 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.measure</groupId>
+            <artifactId>measure-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.mime.core</groupId>
+            <artifactId>mime-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -301,7 +351,8 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency><!-- Start of Solr cache dependencies -->
+                        <Embed-Dependency>
+                            <!-- Start of Solr cache dependencies -->
                             lux,
                             solr-xpath,
                             Saxon-HE,
@@ -341,7 +392,8 @@
                             guava,
                             notifications,
                             activities,
-                            hazelcast;scope=runtime|compile
+                            hazelcast;scope=runtime|compile,
+                            commons-collections
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>
@@ -365,21 +417,33 @@
                             ddf.catalog.resourceretriever,
                             ddf.catalog.resource.data
                         </Export-Package>
-                        <Import-Package><!-- Start of Solr imports -->
+                        <Import-Package>
                             com.vividsolutions.jts.algorithm,
                             com.vividsolutions.jts.geom,
+                            com.vividsolutions.jts.geom.impl,
+                            com.vividsolutions.jts.geom.prep,
                             com.vividsolutions.jts.io,
                             com.vividsolutions.jts.operation.union,
                             com.vividsolutions.jts.operation.valid,
                             com.vividsolutions.jts.simplify,
                             com.vividsolutions.jts.util,
-                            <!-- Remember, this is the same as saying, 2.0 or higher, not solely 2.0 -->
+                            ddf.action;version="1.0",
+                            ddf.catalog;version="2.0",
+                            ddf.catalog.event;version="2.0",
+                            ddf.catalog.pubsub;version="2.0",
+                            ddf.catalog.transform;version="2.0",
                             ddf.catalog.data;version="2.0",
+                            ddf.catalog.federation;version="2.0",
                             ddf.catalog.filter;version="2.0",
                             ddf.catalog.operation;version="2.0",
+                            ddf.catalog.plugin;version="2.0",
+                            ddf.catalog.resource;version="2.0",
                             ddf.catalog.source;version="2.0",
                             ddf.catalog.util;version="2.0",
                             ddf.measure;version="2.0",
+                            ddf.mime,
+                            ddf.security,
+                            javax.activation,
                             javax.annotation,
                             javax.crypto,
                             javax.crypto.spec,
@@ -388,7 +452,11 @@
                             javax.management.openmbean,
                             javax.management.remote,
                             javax.naming,
+                            javax.naming.directory,
+                            javax.naming.ldap,
+                            javax.net,
                             javax.net.ssl,
+                            javax.script,
                             javax.security.auth,
                             javax.security.auth.callback,
                             javax.security.auth.kerberos,
@@ -397,6 +465,11 @@
                             javax.security.auth.x500,
                             javax.security.sasl,
                             javax.servlet;version="2.5",
+                            javax.servlet.http,
+                            javax.ws.rs,
+                            javax.ws.rs.core,
+                            javax.xml.bind,
+                            javax.xml.datatype,
                             javax.xml.namespace,
                             javax.xml.parsers,
                             javax.xml.stream,
@@ -405,21 +478,42 @@
                             javax.xml.transform,
                             javax.xml.transform.dom,
                             javax.xml.transform.sax,
+                            javax.xml.transform.stax,
                             javax.xml.transform.stream,
                             javax.xml.xpath,
+                            jline,
                             org.apache.commons.logging;version="[1.1,2)",
+                            org.apache.cxf.jaxrs.client,
+                            org.apache.cxf.jaxrs.ext.multipart,
+                            org.apache.shiro,
+                            org.apache.shiro.subject,
+                            org.apache.tika,
+                            org.apache.xerces.parsers,
+                            org.apache.xerces.xni.parser,
+                            org.apache.xml.resolver,
+                            org.apache.xml.resolver.helpers,
+                            org.codice.ddf.platform.util,
+                            org.eclipse.jetty.server.*,
+                            org.eclipse.jetty.servlet,
+                            org.eclipse.jetty.util.*,
+                            org.geotools.filter.visitor,
+                            org.joda.convert,
+                            org.opengis.annotation,
                             org.opengis.filter,
                             org.opengis.filter.expression,
                             org.opengis.filter.sort,
+                            org.opengis.filter.temporal,
+                            org.opengis.temporal,
                             org.osgi.framework;version="[1.5,2)",
                             org.osgi.service.blueprint;version="[1.0.0,2.0.0)",
+                            org.osgi.service.blueprint.container,
+                            org.osgi.service.event,
                             org.slf4j;version="[1.6,2)",
+                            org.slf4j.ext,
                             org.w3c.dom,
                             org.xml.sax,
                             org.xml.sax.ext,
-                            org.xml.sax.helpers,
-                            *;resolution:=optional
-                            <!-- End of Solr imports -->
+                            org.xml.sax.helpers
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/catalog/solr/catalog-solr-external-provider/pom.xml
+++ b/catalog/solr/catalog-solr-external-provider/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>solr</artifactId>
@@ -212,6 +214,38 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.measure</groupId>
+            <artifactId>measure-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/ui/search-ui/search-endpoint/pom.xml
+++ b/catalog/ui/search-ui/search-endpoint/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>search-ui</artifactId>
         <groupId>ddf.ui.search</groupId>
@@ -317,6 +319,50 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -326,7 +372,8 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency><!-- Start of Solr dependencies -->
+                        <Embed-Dependency>
+                            <!-- Start of Solr dependencies -->
                             lux,
                             solr-xpath,
                             Saxon-HE,
@@ -362,7 +409,6 @@
                             noggit,
                             zookeeper,
                             <!-- End of Solr dependencies -->
-
                             gt-cql,
                             bayeux-api,
                             catalog-core-api-impl,
@@ -372,7 +418,8 @@
                             notifications,
                             activities,
                             jackson-mapper-asl,
-                            jackson-core-asl
+                            jackson-core-asl,
+                            commons-collections
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Web-ContextPath>/search/cometd</Web-ContextPath>
@@ -387,9 +434,112 @@
                         <Export-Package/>
                         <Import-Package>
                             com.google.*,
-                            org.joda.convert;resolution:=optional,
+                            com.vividsolutions.jts.algorithm,
+                            com.vividsolutions.jts.geom,
+                            com.vividsolutions.jts.geom.impl,
+                            com.vividsolutions.jts.geom.prep,
+                            com.vividsolutions.jts.io,
+                            com.vividsolutions.jts.operation.union,
+                            com.vividsolutions.jts.operation.valid,
+                            com.vividsolutions.jts.util,
+                            ddf.action,
+                            ddf.catalog,
+                            ddf.catalog.data,
+                            ddf.catalog.event,
+                            ddf.catalog.federation,
+                            ddf.catalog.filter,
+                            ddf.catalog.operation,
+                            ddf.catalog.plugin,
+                            ddf.catalog.resource,
+                            ddf.catalog.source,
+                            ddf.catalog.transform,
+                            ddf.catalog.transformer.metacard.geojson,
+                            ddf.catalog.util,
+                            ddf.catalog.validation,
+                            ddf.measure,
+                            ddf.security,
+                            ddf.security.assertion,
+                            ddf.security.service,
+                            javax.activation,
+                            javax.annotation,
+                            javax.crypto,
+                            javax.crypto.spec,
+                            javax.inject,
+                            javax.management,
+                            javax.management.openmbean,
+                            javax.management.remote,
+                            javax.naming,
+                            javax.naming.directory,
+                            javax.naming.ldap,
+                            javax.net,
+                            javax.net.ssl,
+                            javax.script,
+                            javax.security.auth,
+                            javax.security.auth.callback,
+                            javax.security.auth.kerberos,
+                            javax.security.auth.login,
+                            javax.security.auth.spi,
+                            javax.security.auth.x500,
+                            javax.security.sasl,
+                            javax.servlet,
+                            javax.servlet.http,
+                            javax.xml.bind,
+                            javax.xml.datatype,
+                            javax.xml.namespace,
+                            javax.xml.parsers,
+                            javax.xml.stream,
+                            javax.xml.stream.events,
+                            javax.xml.stream.util,
+                            javax.xml.transform,
+                            javax.xml.transform.dom,
+                            javax.xml.transform.sax,
+                            javax.xml.transform.stax,
+                            javax.xml.transform.stream,
+                            javax.xml.xpath,
+                            jline,
+                            org.apache.shiro,
+                            org.apache.shiro.subject,
+                            org.apache.xerces.parsers,
+                            org.apache.xerces.xni.parser,
+                            org.apache.xml.resolver,
+                            org.apache.xml.resolver.helpers,
+                            org.codice.ddf.configuration,
+                            org.codice.ddf.persistence,
+                            org.codice.ddf.platform.util,
                             org.eclipse.jetty.*; version="[7.6.0,9.0.0)",
-                            *;resolution:=optional
+                            org.geotools.factory,
+                            org.geotools.filter,
+                            org.geotools.filter.capability,
+                            org.geotools.referencing.crs,
+                            org.geotools.temporal.object,
+                            org.geotools.util,
+                            org.geotools.util.logging,
+                            org.joda.convert;resolution:=optional,
+                            org.json.simple,
+                            org.opengis.annotation,
+                            org.opengis.feature.simple,
+                            org.opengis.feature.type,
+                            org.opengis.filter,
+                            org.opengis.filter.capability,
+                            org.opengis.filter.expression,
+                            org.opengis.filter.identity,
+                            org.opengis.filter.sort,
+                            org.opengis.filter.spatial,
+                            org.opengis.filter.temporal,
+                            org.opengis.parameter,
+                            org.opengis.temporal,
+                            org.osgi.framework,
+                            org.osgi.service.blueprint,
+                            org.osgi.service.blueprint.container,
+                            org.osgi.service.event,
+                            org.slf4j,
+                            org.slf4j.ext,
+                            org.w3c.dom,
+                            org.w3c.dom.bootstrap,
+                            org.w3c.dom.ls,
+                            org.xml.sax,
+                            org.xml.sax.ext,
+                            org.xml.sax.helpers
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -412,7 +562,8 @@
                                     <version>${project.version}</version>
                                     <type>test-jar</type>
                                     <excludes>META-INF/**</excludes>
-                                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/test-classes
+                                    </outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/platform/persistence/platform-persistence-core-impl/pom.xml
+++ b/platform/persistence/platform-persistence-core-impl/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.persistence</groupId>
@@ -159,6 +161,46 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -179,7 +221,11 @@
                             solr-factory,
                             noggit,
                             zookeeper,
-                            common-system
+                            common-system,
+                            commons-lang,
+                            commons-io,
+                            joda-time,
+                            commons-codec
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>
@@ -187,9 +233,67 @@
                         </Private-Package>
                         <Import-Package>
                             com.google.*,
+                            com.vividsolutions.jts.geom,
+                            com.vividsolutions.jts.io,
+                            ddf.security.encryption,
+                            javax.crypto,
+                            javax.crypto.spec,
+                            javax.management,
+                            javax.management.openmbean,
+                            javax.management.remote,
+                            javax.naming,
+                            javax.naming.directory,
+                            javax.naming.ldap,
+                            javax.net,
+                            javax.net.ssl,
+                            javax.script,
+                            javax.security.auth,
+                            javax.security.auth.callback,
+                            javax.security.auth.kerberos,
+                            javax.security.auth.login,
+                            javax.security.auth.spi,
+                            javax.security.auth.x500,
+                            javax.security.sasl,
+                            javax.servlet,
+                            javax.servlet.http,
+                            javax.xml.bind,
+                            javax.xml.namespace,
+                            javax.xml.parsers,
+                            javax.xml.stream,
+                            javax.xml.transform,
+                            javax.xml.transform.dom,
+                            javax.xml.transform.sax,
+                            javax.xml.transform.stream,
+                            javax.xml.xpath,
+                            jline,
+                            org.apache.commons.logging,
                             org.codice.ddf.persistence;version=1.0.0-SNAPSHOT,
+                            org.eclipse.jetty.*,
+                            org.geotools.factory,
+                            org.geotools.filter,
+                            org.geotools.filter.capability,
+                            org.geotools.filter.visitor,
+                            org.geotools.referencing.crs,
+                            org.geotools.temporal.object,
+                            org.geotools.util,
+                            org.geotools.util.logging,
+                            org.opengis.feature.simple,
+                            org.opengis.feature.type,
                             org.opengis.filter,
-                            *;resolution:=optional
+                            org.opengis.filter.capability,
+                            org.opengis.filter.expression,
+                            org.opengis.filter.identity,
+                            org.opengis.filter.spatial,
+                            org.opengis.filter.temporal,
+                            org.opengis.parameter,
+                            org.opengis.temporal,
+                            org.osgi.framework,
+                            org.osgi.service.blueprint,
+                            org.slf4j,
+                            org.w3c.dom,
+                            org.xml.sax,
+                            org.xml.sax.ext,
+                            org.xml.sax.helpers
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/platform/persistence/platform-persistence-core-listeners/pom.xml
+++ b/platform/persistence/platform-persistence-core-listeners/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>persistence</artifactId>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf</groupId>
@@ -283,6 +285,11 @@
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>3.1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vividsolutions</groupId>
+                <artifactId>jts</artifactId>
+                <version>1.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
@coyotesqrl @roelens8 @ryeats @rzwiefel @tbatie @wbarnie 

Removed "*;resolution:=optional" imports from all pom files with the exception of ddf.catalog.transformer:catalog-responsequeuetransformer-html and ddf.test.thirdparty:rest-assured.

For the most part the required packages were explicitly imported, please comment if you think any of them should instead be embedded.