### PR TITLE
DDF-1779 - Changed Base64 to use java.util

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswMarshallHelper.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswMarshallHelper.java
@@ -16,6 +16,7 @@
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
 import java.io.Serializable;
+import java.util.Base64;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -29,7 +30,6 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.QName;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.spatial.ogc.catalog.common.converter.XmlNode;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
@@ -268,7 +268,7 @@ class CswMarshallHelper {
 
         switch (attrFormat) {
         case BINARY:
-            xmlValue = Base64.encodeBase64String((byte[]) value);
+            xmlValue = Base64.getEncoder().encodeToString((byte[]) value);
             break;
         case DATE:
             GregorianCalendar cal = new GregorianCalendar();

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/converter/impl/GenericFeatureConverterWfs20.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/converter/impl/GenericFeatureConverterWfs20.java
@@ -18,13 +18,13 @@ package org.codice.ddf.spatial.ogc.wfs.v2_0_0.catalog.converter.impl;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
 
 import javax.xml.namespace.QName;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.codice.ddf.spatial.ogc.catalog.common.converter.XmlNode;
@@ -154,7 +154,7 @@ public class GenericFeatureConverterWfs20 extends AbstractFeatureConverterWfs20 
                 XmlNode.writeGeometry(name, context, writer, XmlNode.readGeometry((String) value));
                 break;
             case BINARY:
-                xmlValue = Base64.encodeBase64String((byte[]) value);
+                xmlValue = Base64.getEncoder().encodeToString((byte[]) value);
                 break;
             case DATE:
                 Date date = (Date) value;

--- a/catalog/spatial/wfs/spatial-wfs-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/converter/impl/GenericFeatureConverter.java
+++ b/catalog/spatial/wfs/spatial-wfs-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/converter/impl/GenericFeatureConverter.java
@@ -18,13 +18,13 @@ package org.codice.ddf.spatial.ogc.wfs.catalog.converter.impl;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
 
 import javax.xml.namespace.QName;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.codice.ddf.spatial.ogc.catalog.common.converter.XmlNode;
@@ -152,7 +152,7 @@ public class GenericFeatureConverter extends AbstractFeatureConverter {
                 XmlNode.writeGeometry(name, context, writer, XmlNode.readGeometry((String) value));
                 break;
             case BINARY:
-                xmlValue = Base64.encodeBase64String((byte[]) value);
+                xmlValue = Base64.getEncoder().encodeToString((byte[]) value);
                 break;
             case DATE:
                 Date date = (Date) value;

--- a/catalog/transformer/catalog-transformer-service-xslt/src/main/java/ddf/catalog/services/xsltlistener/XsltResponseQueueTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-xslt/src/main/java/ddf/catalog/services/xsltlistener/XsltResponseQueueTransformer.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URLConnection;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.osgi.framework.Bundle;
@@ -172,7 +172,7 @@ public class XsltResponseQueueTransformer extends AbstractXsltTransformer
                             metacardElement.appendChild(createElement(doc,
                                     XML_RESULTS_NAMESPACE,
                                     "thumbnail",
-                                    Base64.encodeBase64String(metacard.getThumbnail())));
+                                    Base64.getEncoder().encodeToString(metacard.getThumbnail())));
                             try {
                                 String mimeType =
                                         URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
@@ -21,6 +21,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -28,7 +29,6 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
-import org.apache.xerces.impl.dv.util.Base64;
 import org.codice.ddf.parser.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,11 +204,11 @@ public class MetacardMarshallerImpl implements MetacardMarshaller {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 try (ObjectOutput output = new ObjectOutputStream(bos)) {
                     output.writeObject(attribute.getValue());
-                    xmlValue = Base64.encode(bos.toByteArray());
+                    xmlValue = Base64.getEncoder().encodeToString(bos.toByteArray());
                 }
                 break;
             case BINARY:
-                xmlValue = Base64.encode((byte[]) value);
+                xmlValue = Base64.getEncoder().encodeToString((byte[]) value);
                 break;
             case XML:
                 xmlValue = value.toString().replaceAll("[<][?]xml.*[?][>]", "");

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlInputTransformer.java
@@ -25,10 +25,10 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import org.codice.ddf.parser.xml.XmlParser;
-import org.geotools.data.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -132,7 +132,7 @@ public class TestXmlInputTransformer {
 
         assertEquals("Title!", metacard.getAttribute(Metacard.TITLE).getValue());
 
-        assertArrayEquals(Base64.decode(
+        assertArrayEquals(Base64.getDecoder().decode(
                         "AAABAAABAQEAAQAAAQEBAAEAAAEBAQABAAABAQEAAQAAAQEBAAEAAAEBAQABAAABAQE="),
                 (byte[]) metacard.getAttribute(Metacard.THUMBNAIL).getValue());
 
@@ -180,7 +180,7 @@ public class TestXmlInputTransformer {
 
         assertThat("Title!", is(metacard.getAttribute(Metacard.TITLE).getValue()));
 
-        assertArrayEquals(Base64.decode(
+        assertArrayEquals(Base64.getDecoder().decode(
                         "AAABAAABAQEAAQAAAQEBAAEAAAEBAQABAAABAQEAAQAAAQEBAAEAAAEBAQABAAABAQE="),
                 (byte[]) metacard.getAttribute(Metacard.THUMBNAIL).getValue());
 

--- a/platform/error/platform-error-impl/src/main/java/org/codice/ddf/platform/error/handler/impl/DefaultErrorHandler.java
+++ b/platform/error/platform-error-impl/src/main/java/org/codice/ddf/platform/error/handler/impl/DefaultErrorHandler.java
@@ -17,6 +17,7 @@ import static org.boon.Boon.toJson;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,7 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.cxf.common.util.Base64Utility;
 import org.codice.ddf.platform.error.handler.ErrorHandler;
 import org.eclipse.jetty.util.ByteArrayISO8859Writer;
 import org.osgi.framework.Bundle;
@@ -73,7 +73,7 @@ public class DefaultErrorHandler implements ErrorHandler {
         jsonMap.put("throwable", stack);
         jsonMap.put("uri", uri);
         String data = toJson(jsonMap);
-        String encodedBytes = Base64Utility.encode(data.getBytes(StandardCharsets.UTF_8));
+        String encodedBytes = Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
 
         String localIndexHtml = indexHtml.replace("WINDOW_DATA", "\"" + encodedBytes + "\"");
 

--- a/platform/landing-page/src/main/java/org/codice/ddf/landing/LandingPage.java
+++ b/platform/landing-page/src/main/java/org/codice/ddf/landing/LandingPage.java
@@ -18,6 +18,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -32,7 +33,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.webconsole.BrandingPlugin;
 import org.codice.ddf.branding.BrandingResourceProvider;
@@ -149,7 +149,7 @@ public class LandingPage extends HttpServlet {
     private String getBase64(String productImage) throws IOException {
         byte[] resourceAsBytes = provider.getResourceAsBytes(productImage);
         if (resourceAsBytes.length > 0) {
-            return Base64.encodeBase64String(resourceAsBytes);
+            return Base64.getEncoder().encodeToString(resourceAsBytes);
         }
         return "";
     }

--- a/platform/landing-page/src/test/java/org/codice/ddf/landing/TestLandingPage.java
+++ b/platform/landing-page/src/test/java/org/codice/ddf/landing/TestLandingPage.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.felix.webconsole.BrandingPlugin;
 import org.codice.ddf.branding.BrandingResourceProvider;
 import org.junit.BeforeClass;
@@ -72,7 +72,7 @@ public class TestLandingPage {
         assertThat(landingPage.getTitle(), is(equalTo(productName)));
         assertThat(landingPage.getFavicon(), is(equalTo("")));
         assertThat(landingPage.getProductImage(),
-                is(equalTo(Base64.encodeBase64String(fakeImg.getBytes()))));
+                is(equalTo(Base64.getEncoder().encodeToString(fakeImg.getBytes()))));
     }
 
     @Test

--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
@@ -14,12 +14,12 @@
 package org.codice.ddf.configuration;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.webconsole.BrandingPlugin;
 import org.codice.ddf.branding.BrandingResourceProvider;
@@ -134,7 +134,7 @@ public class PlatformUiConfiguration {
     private String getBase64(String productImage) throws IOException {
         byte[] resourceAsBytes = provider.getResourceAsBytes(productImage);
         if (resourceAsBytes.length > 0) {
-            return Base64.encodeBase64String(resourceAsBytes);
+            return Base64.getEncoder().encodeToString(resourceAsBytes);
         }
         return "";
     }

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.felix.webconsole.BrandingPlugin;
 import org.codice.ddf.branding.BrandingResourceProvider;
 import org.junit.Test;
@@ -70,9 +70,9 @@ public class PlatformUiConfigurationTest {
         assertEquals("background", jsonObject.get(PlatformUiConfiguration.BACKGROUND));
         assertEquals("color", jsonObject.get(PlatformUiConfiguration.COLOR));
         assertEquals("product", jsonObject.get(PlatformUiConfiguration.VERSION));
-        assertEquals("image", new String(Base64.decodeBase64(
+        assertEquals("image", new String(Base64.getMimeDecoder().decode(
                 (String) jsonObject.get(PlatformUiConfiguration.PRODUCT_IMAGE))));
-        assertEquals("fav", new String(Base64.decodeBase64(
+        assertEquals("fav", new String(Base64.getMimeDecoder().decode(
                 (String) jsonObject.get(PlatformUiConfiguration.FAV_ICON))));
     }
 

--- a/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
+++ b/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
@@ -42,6 +42,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -76,7 +77,6 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
-import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -290,7 +290,7 @@ public class KeystoreEditor implements KeystoreEditorMBean {
     private boolean validKeystoreAlias(String alias, String keystorePassword, String keystoreData,
             String keystoreFileName) throws KeystoreEditorException {
         boolean valid = false;
-        try (InputStream inputStream = new ByteArrayInputStream(Base64.decode(keystoreData))) {
+        try (InputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(keystoreData))) {
             if (StringUtils.isBlank(alias)) {
                 throw new IllegalArgumentException("Alias cannot be null.");
             }
@@ -316,7 +316,7 @@ public class KeystoreEditor implements KeystoreEditorMBean {
             String data, String type, String fileName, String path, String storepass,
             KeyStore store) throws KeystoreEditorException {
         OutputStream fos = null;
-        try (InputStream inputStream = new ByteArrayInputStream(Base64.decode(data))) {
+        try (InputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(data))) {
             if (StringUtils.isBlank(alias)) {
                 throw new IllegalArgumentException("Alias cannot be null.");
             }

--- a/platform/security/certificate/security-certificate-keystoreeditor/src/test/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditorTest.java
+++ b/platform/security/certificate/security-certificate-keystoreeditor/src/test/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditorTest.java
@@ -18,11 +18,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
-import org.bouncycastle.util.encoders.Base64;
 import org.hamcrest.core.AnyOf;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
@@ -249,7 +249,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("asdf",
                 password,
                 "",
-                new String(Base64.encode(keyBytes)),
+                Base64.getEncoder().encodeToString(keyBytes),
                 type,
                 keyFile.toString());
     }
@@ -262,7 +262,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("asdf",
                 password,
                 "",
-                new String(Base64.encode(crtBytes)),
+                Base64.getEncoder().encodeToString(crtBytes),
                 KeystoreEditor.PEM_TYPE,
                 chainFile.toString());
     }
@@ -276,7 +276,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("asdf",
                 password,
                 password,
-                new String(Base64.encode(keyBytes)),
+                Base64.getEncoder().encodeToString(keyBytes),
                 "",
                 jksFile.toString());
         List<Map<String, Object>> keystore = keystoreEditor.getKeystore();
@@ -297,7 +297,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("asdf",
                 password,
                 password,
-                new String(Base64.encode(keyBytes)),
+                Base64.getEncoder().encodeToString(keyBytes),
                 KeystoreEditor.PKCS12_TYPE,
                 pkcs12StoreFile.toString());
         List<Map<String, Object>> keystore = keystoreEditor.getKeystore();
@@ -318,7 +318,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("localhost",
                 password,
                 "",
-                new String(Base64.encode(crtBytes)),
+                Base64.getEncoder().encodeToString(crtBytes),
                 KeystoreEditor.PEM_TYPE,
                 localhostCrtFile.toString());
         List<Map<String, Object>> keystore = keystoreEditor.getKeystore();
@@ -334,7 +334,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey("localhost",
                 password,
                 "",
-                new String(Base64.encode(keyBytes)),
+                Base64.getEncoder().encodeToString(keyBytes),
                 "",
                 localhostKeyFile.toString());
         keystore = keystoreEditor.getKeystore();
@@ -359,9 +359,9 @@ public class KeystoreEditorTest {
                 FileInputStream truststoreInputStream = new FileInputStream(systemTruststoreFile);
         ) {
             byte[] keystoreCrtBytes = IOUtils.toByteArray(keystoreInputStream);
-            byte[] keystoreEncodedBytes = Base64.encode(keystoreCrtBytes);
+            byte[] keystoreEncodedBytes = Base64.getEncoder().encode(keystoreCrtBytes);
             byte[] truststoreCrtBytes = IOUtils.toByteArray(truststoreInputStream);
-            byte[] truststoreEncodedBytes = Base64.encode(truststoreCrtBytes);
+            byte[] truststoreEncodedBytes = Base64.getEncoder().encode(truststoreCrtBytes);
             List<String> errors = keystoreEditor.replaceSystemStores("localhost",
                     password,
                     password,
@@ -407,9 +407,9 @@ public class KeystoreEditorTest {
                 FileInputStream truststoreInputStream = new FileInputStream(systemTruststoreFile)
         ) {
             byte[] keystoreCrtBytes = IOUtils.toByteArray(keystoreInputStream);
-            byte[] keystoreEncodedBytes = Base64.encode(keystoreCrtBytes);
+            byte[] keystoreEncodedBytes = Base64.getEncoder().encode(keystoreCrtBytes);
             byte[] truststoreCrtBytes = IOUtils.toByteArray(truststoreInputStream);
-            byte[] truststoreEncodedBytes = Base64.encode(truststoreCrtBytes);
+            byte[] truststoreEncodedBytes = Base64.getEncoder().encode(truststoreCrtBytes);
             List<String> errors = keystoreEditor.replaceSystemStores(fqdn,
                     password,
                     password,
@@ -478,7 +478,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addTrustedCertificate("asdf",
                 password,
                 "",
-                new String(Base64.encode(crtBytes)),
+                new String(Base64.getEncoder().encode(crtBytes)),
                 KeystoreEditor.PEM_TYPE,
                 crtFile.toString());
         List<Map<String, Object>> truststore = keystoreEditor.getTruststore();
@@ -511,7 +511,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addTrustedCertificate("asdf",
                 password,
                 "",
-                new String(Base64.encode(crtBytes)),
+                new String(Base64.getEncoder().encode(crtBytes)),
                 KeystoreEditor.PEM_TYPE,
                 crtFile.toString());
         List<Map<String, Object>> truststore = keystoreEditor.getTruststore();
@@ -552,7 +552,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addTrustedCertificate("asdf",
                 password,
                 "",
-                new String(Base64.encode(crtBytes)),
+                new String(Base64.getEncoder().encode(crtBytes)),
                 KeystoreEditor.PEM_TYPE,
                 p7bFile.toString());
         List<Map<String, Object>> truststore = keystoreEditor.getTruststore();
@@ -567,7 +567,7 @@ public class KeystoreEditorTest {
     @Test(expected = KeystoreEditor.KeystoreEditorException.class)
     public void testBadData() throws KeystoreEditor.KeystoreEditorException {
         KeystoreEditor keystoreEditor = new KeystoreEditor();
-        keystoreEditor.addPrivateKey("asdf", password, password, "", "", "file.pem");
+        keystoreEditor.addPrivateKey("asdf", password, password, "*$%^*", "", "file.pem");
     }
 
     @Test(expected = KeystoreEditor.KeystoreEditorException.class)
@@ -615,7 +615,7 @@ public class KeystoreEditorTest {
         keystoreEditor.addPrivateKey(alias,
                 password,
                 "blah",
-                new String(Base64.encode(keyBytes)),
+                new String(Base64.getEncoder().encode(keyBytes)),
                 "",
                 file.toString());
     }

--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -75,10 +75,6 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
         </dependency>

--- a/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
+++ b/platform/security/filter/security-filter-login/src/main/java/org/codice/ddf/security/filter/login/LoginFilter.java
@@ -24,6 +24,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -43,7 +44,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.rs.security.saml.sso.SAMLProtocolResponseValidator;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
@@ -484,7 +484,7 @@ public class LoginFilter implements Filter {
                         if (dataNode.getLocalName()
                                 .equals("X509Certificate")) {
                             String textContent = dataText.getTextContent();
-                            byte[] byteValue = Base64.decodeBase64(textContent);
+                            byte[] byteValue = Base64.getMimeDecoder().decode(textContent);
                             try {
                                 CertificateFactory cf = CertificateFactory.getInstance("X.509");
                                 X509Certificate cert =
@@ -528,7 +528,7 @@ public class LoginFilter implements Filter {
                                 .equals("X509SKI")) {
                             String textContent = dataText.getTextContent();
                             byte[] tlsSKI = tlsCertificate.getExtensionValue("2.5.29.14");
-                            byte[] assertionSKI = Base64.decodeBase64(textContent);
+                            byte[] assertionSKI = Base64.getMimeDecoder().decode(textContent);
                             if (tlsSKI != null && tlsSKI.length > 0) {
                                 ASN1OctetString tlsOs = ASN1OctetString.getInstance(tlsSKI);
                                 ASN1OctetString assertionOs = ASN1OctetString.getInstance(

--- a/platform/security/handler/security-handler-basic/src/test/java/org/codice/ddf/security/handler/basic/BasicAuthenticationHandlerTest.java
+++ b/platform/security/handler/security-handler-basic/src/test/java/org/codice/ddf/security/handler/basic/BasicAuthenticationHandlerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
 
-import org.apache.geronimo.mail.util.Base64;
 import org.codice.ddf.security.handler.api.BaseAuthenticationToken;
 import org.codice.ddf.security.handler.api.HandlerResult;
 import org.codice.ddf.security.handler.api.UPAuthenticationToken;
@@ -63,10 +63,14 @@ public class BasicAuthenticationHandlerTest {
         assertNotNull(result);
         assertEquals(HandlerResult.Status.REDIRECTED, result.getStatus());
         // confirm that the proper responses were sent through the HttpResponse
-        Mockito.verify(response).setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"karaf\"");
-        Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        Mockito.verify(response).setContentLength(0);
-        Mockito.verify(response).flushBuffer();
+        Mockito.verify(response)
+                .setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"karaf\"");
+        Mockito.verify(response)
+                .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        Mockito.verify(response)
+                .setContentLength(0);
+        Mockito.verify(response)
+                .flushBuffer();
     }
 
     /**
@@ -83,22 +87,32 @@ public class BasicAuthenticationHandlerTest {
         FilterChain chain = mock(FilterChain.class);
 
         when(request.getAttribute(anyString())).thenReturn("TestRealm");
-        when(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .thenReturn("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())));
+        when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Basic " + Base64.getEncoder()
+                .encodeToString(CREDENTIALS.getBytes()));
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 
         assertNotNull(result);
         assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
-        assertEquals("admin", result.getToken().getPrincipal());
-        assertEquals("password", result.getToken().getCredentials());
-        assertEquals("TestRealm", result.getToken().getRealm());
+        assertEquals("admin",
+                result.getToken()
+                        .getPrincipal());
+        assertEquals("password",
+                result.getToken()
+                        .getCredentials());
+        assertEquals("TestRealm",
+                result.getToken()
+                        .getRealm());
 
         // confirm that no responses were sent through the HttpResponse
-        Mockito.verify(response, never()).setHeader(anyString(), anyString());
-        Mockito.verify(response, never()).setStatus(anyInt());
-        Mockito.verify(response, never()).setContentLength(anyInt());
-        Mockito.verify(response, never()).flushBuffer();
+        Mockito.verify(response, never())
+                .setHeader(anyString(), anyString());
+        Mockito.verify(response, never())
+                .setStatus(anyInt());
+        Mockito.verify(response, never())
+                .setContentLength(anyInt());
+        Mockito.verify(response, never())
+                .flushBuffer();
     }
 
     /**
@@ -114,14 +128,16 @@ public class BasicAuthenticationHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain chain = mock(FilterChain.class);
 
-        when(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .thenReturn("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())));
+        when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Basic " + Base64.getEncoder()
+                .encodeToString(CREDENTIALS.getBytes()));
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, true);
 
         assertNotNull(result);
         assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
-        assertEquals("admin", result.getToken().getPrincipal());
+        assertEquals("admin",
+                result.getToken()
+                        .getPrincipal());
     }
 
     /**
@@ -156,57 +172,56 @@ public class BasicAuthenticationHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain chain = mock(FilterChain.class);
 
-        when(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .thenReturn("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())));
+        when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Basic " + Base64.getEncoder()
+                .encodeToString(CREDENTIALS.getBytes()));
 
         HandlerResult result = handler.getNormalizedToken(request, response, chain, false);
 
         assertNotNull(result);
         assertEquals(HandlerResult.Status.COMPLETED, result.getStatus());
-        assertEquals("admin", result.getToken().getPrincipal());
+        assertEquals("admin",
+                result.getToken()
+                        .getPrincipal());
     }
 
     @Test
     public void testExtractAuthInfo() {
         BasicAuthenticationHandler handler = new BasicAuthenticationHandler();
-        UPAuthenticationToken result = (UPAuthenticationToken) handler
-                .extractAuthInfo("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())),
-                        "TestRealm");
+        UPAuthenticationToken result = (UPAuthenticationToken) handler.extractAuthInfo(
+                "Basic " + Base64.getEncoder()
+                        .encodeToString(CREDENTIALS.getBytes()), "TestRealm");
         assertNotNull(result);
         assertEquals("admin", result.getUsername());
         assertEquals("password", result.getPassword());
         assertEquals("TestRealm", result.getRealm());
 
         WssBasicAuthenticationHandler wssHandler = new WssBasicAuthenticationHandler();
-        BaseAuthenticationToken wssResult = wssHandler
-                .extractAuthInfo("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())),
-                        "TestRealm");
+        BaseAuthenticationToken wssResult = wssHandler.extractAuthInfo(
+                "Basic " + Base64.getEncoder()
+                        .encodeToString(CREDENTIALS.getBytes()), "TestRealm");
         assertNotNull(wssResult);
         assertEquals("", wssResult.getRealm());
 
-        result = (UPAuthenticationToken) handler
-                .extractAuthInfo("Basic " + new String(Base64.encode(":password".getBytes())),
-                        "TestRealm");
+        result = (UPAuthenticationToken) handler.extractAuthInfo("Basic " + Base64.getEncoder()
+                .encodeToString(":password".getBytes()), "TestRealm");
         assertNotNull(result);
         assertEquals("", result.getUsername());
         assertEquals("password", result.getPassword());
         assertEquals("TestRealm", result.getRealm());
 
-        result = (UPAuthenticationToken) handler
-                .extractAuthInfo("Basic " + new String(Base64.encode("user:".getBytes())),
-                        "TestRealm");
+        result = (UPAuthenticationToken) handler.extractAuthInfo("Basic " + Base64.getEncoder()
+                .encodeToString("user:".getBytes()), "TestRealm");
         assertNotNull(result);
         assertEquals("user", result.getUsername());
         assertEquals("", result.getPassword());
         assertEquals("TestRealm", result.getRealm());
 
-        result = (UPAuthenticationToken) handler
-                .extractAuthInfo("Basic " + new String(Base64.encode("user/password".getBytes())),
-                        "TestRealm");
+        result = (UPAuthenticationToken) handler.extractAuthInfo("Basic " + Base64.getEncoder()
+                .encodeToString("user/password".getBytes()), "TestRealm");
         assertNull(result);
 
-        result = (UPAuthenticationToken) handler
-                .extractAuthInfo("Basic " + new String(Base64.encode("".getBytes())), "TestRealm");
+        result = (UPAuthenticationToken) handler.extractAuthInfo("Basic " + Base64.getEncoder()
+                .encodeToString("".getBytes()), "TestRealm");
         assertNull(result);
     }
 
@@ -216,12 +231,12 @@ public class BasicAuthenticationHandlerTest {
         BasicAuthenticationHandler handler = new BasicAuthenticationHandler();
         HttpServletRequest request = mock(HttpServletRequest.class);
 
-        when(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .thenReturn("Basic " + new String(Base64.encode(CREDENTIALS.getBytes())));
+        when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Basic " + Base64.getEncoder()
+                .encodeToString(CREDENTIALS.getBytes()));
         when(request.getAttribute(anyString())).thenReturn("karaf");
 
-        UPAuthenticationToken result = (UPAuthenticationToken) handler
-                .extractAuthenticationInfo(request);
+        UPAuthenticationToken result = (UPAuthenticationToken) handler.extractAuthenticationInfo(
+                request);
         assertNotNull(result);
         assertEquals("admin", result.getUsername());
         assertEquals("password", result.getPassword());

--- a/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/CrlCheckerTest.java
+++ b/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/CrlCheckerTest.java
@@ -21,9 +21,9 @@ import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Properties;
 
-import org.jasypt.contrib.org.apache.commons.codec_1_3.binary.Base64;
 import org.junit.Test;
 
 public class CrlCheckerTest {
@@ -144,7 +144,7 @@ public class CrlCheckerTest {
      */
     private X509Certificate[] extractX509CertsFromString(String certString)
             throws CertificateException {
-        InputStream stream = new ByteArrayInputStream(Base64.decodeBase64(certString.getBytes()));
+        InputStream stream = new ByteArrayInputStream(Base64.getMimeDecoder().decode(certString.getBytes()));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) factory.generateCertificate(stream);
         X509Certificate[] certs = new X509Certificate[1];

--- a/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
+++ b/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -36,7 +37,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.codice.ddf.security.handler.api.HandlerResult;
 import org.codice.ddf.security.handler.api.PKIAuthenticationTokenFactory;
-import org.jasypt.contrib.org.apache.commons.codec_1_3.binary.Base64;
 import org.junit.Test;
 
 public class PKIHandlerTest {
@@ -213,7 +213,7 @@ public class PKIHandlerTest {
         String certificateString = getTestCertString();
 
         InputStream stream = new ByteArrayInputStream(
-                Base64.decodeBase64(certificateString.getBytes()));
+                Base64.getMimeDecoder().decode(certificateString.getBytes()));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) factory.generateCertificate(stream);
         X509Certificate[] certs = new X509Certificate[1];

--- a/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/WssPKIHandlerTest.java
+++ b/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/WssPKIHandlerTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -35,7 +36,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.codice.ddf.security.handler.api.HandlerResult;
 import org.codice.ddf.security.handler.api.PKIAuthenticationTokenFactory;
-import org.jasypt.contrib.org.apache.commons.codec_1_3.binary.Base64;
 import org.junit.Test;
 
 public class WssPKIHandlerTest {
@@ -94,7 +94,7 @@ public class WssPKIHandlerTest {
         String certificateString = getTestCertString();
 
         InputStream stream = new ByteArrayInputStream(
-                Base64.decodeBase64(certificateString.getBytes()));
+                Base64.getMimeDecoder().decode(certificateString.getBytes()));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) factory.generateCertificate(stream);
         X509Certificate[] certs = new X509Certificate[1];

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -22,6 +22,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Map;
 
 import javax.servlet.Filter;
@@ -40,7 +41,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.stream.XMLStreamException;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.staxutils.StaxUtils;
@@ -329,8 +329,8 @@ public class AssertionConsumerService {
                 rootContext);
 
         EntityDescriptor entityDescriptor = SamlProtocol.createSpMetadata(entityId,
-                Base64.encodeBase64String(issuerCert.getEncoded()),
-                Base64.encodeBase64String(encryptionCert.getEncoded()),
+                Base64.getEncoder().encodeToString(issuerCert.getEncoded()),
+                Base64.getEncoder().encodeToString(encryptionCert.getEncoded()),
                 logoutLocation,
                 assertionConsumerServiceLocation,
                 assertionConsumerServiceLocation);
@@ -373,7 +373,7 @@ public class AssertionConsumerService {
     }
 
     private String decodeBase64(String encoded) {
-        return new String(Base64.decodeBase64(encoded.getBytes(StandardCharsets.UTF_8)),
+        return new String(Base64.getMimeDecoder().decode(encoded.getBytes(StandardCharsets.UTF_8)),
                 StandardCharsets.UTF_8);
     }
 

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.UUID;
 
 import javax.servlet.FilterChain;
@@ -31,7 +32,6 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
@@ -305,7 +305,7 @@ public class IdpHandler implements AuthenticationHandler {
     }
 
     private String encodePostRequest(String request) throws WSSecurityException, IOException {
-        return new String(Base64.encodeBase64(request.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(request.getBytes(StandardCharsets.UTF_8));
     }
 
     private String recreateFullRequestUrl(HttpServletRequest request) {

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/LogoutRequestService.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -33,7 +34,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.stream.XMLStreamException;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
@@ -187,8 +187,8 @@ public class LogoutRequestService {
         simpleSign.signSamlObject(logoutRequest);
         LOGGER.debug("Converting SAML Request to DOM");
         String assertionResponse = DOM2Writer.nodeToString(OpenSAMLUtil.toDom(logoutRequest, doc));
-        String encodedSamlRequest = new String(Base64.encodeBase64(assertionResponse.getBytes(
-                StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        String encodedSamlRequest = Base64.getEncoder().encodeToString(assertionResponse.getBytes(
+                StandardCharsets.UTF_8));
         String singleLogoutLocation = idpMetadata.getSingleLogoutLocation();
         String submitFormUpdated = String.format(submitForm,
                 singleLogoutLocation,
@@ -415,8 +415,8 @@ public class LogoutRequestService {
         simpleSign.signSamlObject(samlResponse);
         LOGGER.debug("Converting SAML Response to DOM");
         String assertionResponse = DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlResponse, doc));
-        String encodedSamlResponse = new String(Base64.encodeBase64(assertionResponse.getBytes(
-                StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        String encodedSamlResponse = Base64.getEncoder().encodeToString(assertionResponse.getBytes(
+                StandardCharsets.UTF_8));
 
         return Response.ok(HtmlResponseTemplate.getPostPage(idpMetadata.getSingleLogoutLocation(),
                 SamlProtocol.Type.RESPONSE,
@@ -440,8 +440,7 @@ public class LogoutRequestService {
     }
 
     private String decodeBase64(String encoded) {
-        return new String(Base64.decodeBase64(encoded.getBytes(StandardCharsets.UTF_8)),
-                StandardCharsets.UTF_8);
+        return Base64.getMimeEncoder().encodeToString(encoded.getBytes(StandardCharsets.UTF_8));
     }
 
     private Response buildLogoutResponse(String message) {

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.util.Base64;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -36,7 +37,6 @@ import javax.ws.rs.core.Response;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -125,9 +125,8 @@ public class AssertionConsumerServiceTest {
 
     @Test
     public void testPostSamlResponse() throws Exception {
-        Response response =
-                assertionConsumerService.postSamlResponse(new String(Base64.encodeBase64(this.cannedResponse.getBytes())),
-                        RELAY_STATE_VAL);
+        Response response = assertionConsumerService.postSamlResponse(Base64.getEncoder()
+                .encodeToString(this.cannedResponse.getBytes()), RELAY_STATE_VAL);
         assertThat("The http response was not 303 SEE OTHER",
                 response.getStatus(),
                 is(HttpStatus.SC_SEE_OTHER));
@@ -140,9 +139,8 @@ public class AssertionConsumerServiceTest {
     @Test
     public void testPostSamlResponseNotSecure() throws Exception {
         when(httpRequest.isSecure()).thenReturn(false);
-        Response response =
-                assertionConsumerService.postSamlResponse(new String(Base64.encodeBase64(this.cannedResponse.getBytes())),
-                        RELAY_STATE_VAL);
+        Response response = assertionConsumerService.postSamlResponse(Base64.getEncoder()
+                .encodeToString(this.cannedResponse.getBytes()), RELAY_STATE_VAL);
         assertThat("The http response was not 500 ERROR",
                 response.getStatus(),
                 is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
@@ -376,12 +374,12 @@ public class AssertionConsumerServiceTest {
                 .toString());
         assertThat("SingleLogoutService Binding attribute was not the expected HTTP-Redirect",
                 document,
-                hasXPath("//urn:oasis:names:tc:SAML:2.0:metadata:SingleLogoutService/@Binding", is(
-                        equalTo("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"))));
+                hasXPath("//urn:oasis:names:tc:SAML:2.0:metadata:SingleLogoutService/@Binding",
+                        is(equalTo("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"))));
         assertThat("SingleLogoutService Binding attribute was not the expected HTTP-Redirect",
                 document,
-                hasXPath("//urn:oasis:names:tc:SAML:2.0:metadata:SingleLogoutService/@Location", is(
-                        equalTo("https://localhost:8993/logout"))));
+                hasXPath("//urn:oasis:names:tc:SAML:2.0:metadata:SingleLogoutService/@Location",
+                        is(equalTo("https://localhost:8993/logout"))));
         assertThat("The http response was not 200 OK", response.getStatus(), is(HttpStatus.SC_OK));
         assertThat("Response entity was null", response.getEntity(), notNullValue());
 
@@ -401,8 +399,9 @@ public class AssertionConsumerServiceTest {
     @Test
     public void testGetLoginFilter() throws Exception {
         Filter filter = assertionConsumerService.getLoginFilter();
-        assertThat("Returned login filter was not the same as the one set", filter, equalTo(
-                loginFilter));
+        assertThat("Returned login filter was not the same as the one set",
+                filter,
+                equalTo(loginFilter));
     }
 
 }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
@@ -16,8 +16,8 @@ package org.codice.ddf.security.idp.binding.post;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
@@ -39,7 +39,7 @@ public class PostRequestDecoder implements RequestDecoder {
         if (StringUtils.isEmpty(samlRequest)) {
             throw new IllegalArgumentException("Missing SAMLRequest on IdP request.");
         }
-        String decodedRequest = new String(Base64.decodeBase64(samlRequest), StandardCharsets.UTF_8);
+        String decodedRequest = new String(Base64.getMimeDecoder().decode(samlRequest), StandardCharsets.UTF_8);
         ByteArrayInputStream tokenStream = new ByteArrayInputStream(decodedRequest.getBytes(StandardCharsets.UTF_8));
         Document authnDoc;
         try {

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
@@ -14,12 +14,12 @@
 package org.codice.ddf.security.idp.binding.post;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
@@ -56,8 +56,8 @@ public class PostResponseCreator extends ResponseCreatorImpl implements Response
         getSimpleSign().signSamlObject(samlResponse);
         LOGGER.debug("Converting SAML Response to DOM");
         String assertionResponse = DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlResponse, doc));
-        String encodedSamlResponse = new String(Base64.encodeBase64(assertionResponse.getBytes(
-                StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        String encodedSamlResponse = Base64.getEncoder().encodeToString(assertionResponse.getBytes(
+                StandardCharsets.UTF_8));
         String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
         String submitFormUpdated = responseTemplate.replace("{{" + Idp.ACS_URL + "}}",
                 assertionConsumerServiceURL);

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.stream.XMLStreamException;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.rs.security.saml.sso.SSOConstants;
@@ -687,9 +687,9 @@ public class IdpEndpoint implements Idp {
         }
         EntityDescriptor entityDescriptor =
                 SamlProtocol.createIdpMetadata(SystemBaseUrl.constructUrl("/idp/login", true),
-                        Base64.encodeBase64String(
+                        Base64.getEncoder().encodeToString(
                                 issuerCert != null ? issuerCert.getEncoded() : new byte[0]),
-                        Base64.encodeBase64String(
+                        Base64.getEncoder().encodeToString(
                                 encryptionCert != null ? encryptionCert.getEncoded() : new byte[0]),
                         nameIdFormats,
                         SystemBaseUrl.constructUrl("/idp/login", true),
@@ -1018,8 +1018,8 @@ public class IdpEndpoint implements Idp {
         new SimpleSign(systemCrypto).signSamlObject(samlObject);
         LOGGER.debug("Converting SAML Response to DOM");
         String assertionResponse = DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlObject, doc));
-        String encodedSamlResponse = new String(Base64.encodeBase64(assertionResponse.getBytes(
-                StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        String encodedSamlResponse = Base64.getEncoder().encodeToString(assertionResponse.getBytes(
+                StandardCharsets.UTF_8));
         return Response.ok(HtmlResponseTemplate.getPostPage(targetUrl,
                 samlType,
                 encodedSamlResponse,

--- a/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
+++ b/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
@@ -32,6 +32,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -45,7 +46,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
@@ -667,7 +667,7 @@ public class IdpEndpointTest {
                 signature,
                 request);
         String responseStr = StringUtils.substringBetween(response.getEntity()
-                .toString(), "SAMLResponse=", "RelayState");
+                .toString(), "SAMLResponse=", "&RelayState");
         responseStr = URLDecoder.decode(responseStr, "UTF-8");
         responseStr = RestSecurity.inflateBase64(responseStr);
 
@@ -734,8 +734,7 @@ public class IdpEndpointTest {
         Response response = idpEndpoint.showPostLogin(samlRequest, relayState, request);
         String responseStr = StringUtils.substringBetween(response.getEntity()
                 .toString(), "SAMLResponse\" value=\"", "\" />");
-        responseStr = URLDecoder.decode(responseStr, "UTF-8");
-        responseStr = new String(Base64.decodeBase64(responseStr));
+        responseStr = new String(Base64.getDecoder().decode(responseStr));
 
         //the only cookie that should exist is the "1" cookie so "2" should send us to the login webapp
         assertThat(responseStr, containsString("status:RequestUnsupported"));
@@ -777,7 +776,7 @@ public class IdpEndpointTest {
                 signature,
                 request);
         String responseStr = StringUtils.substringBetween(response.getEntity()
-                .toString(), "SAMLResponse=", "RelayState");
+                .toString(), "SAMLResponse=", "&RelayState");
         responseStr = URLDecoder.decode(responseStr, "UTF-8");
         responseStr = RestSecurity.inflateBase64(responseStr);
 

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SimpleSignTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SimpleSignTest.java
@@ -25,12 +25,12 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
+import java.util.Base64;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
 import org.apache.cxf.staxutils.StaxUtils;
@@ -101,7 +101,6 @@ public class SimpleSignTest {
         dsaCert = writer.toString()
                 .replace("-----BEGIN CERTIFICATE-----", "")
                 .replace("-----END CERTIFICATE-----", "");
-
     }
 
     @Test
@@ -232,7 +231,7 @@ public class SimpleSignTest {
             tokenStream.write(value.getBytes(StandardCharsets.UTF_8));
             tokenStream.close();
 
-            return new String(Base64.encodeBase64(valueBytes.toByteArray()));
+            return Base64.getEncoder().encodeToString(valueBytes.toByteArray());
         }
     }
 

--- a/platform/security/sts/security-sts-crlinterceptor/src/test/java/org/codice/ddf/security/sts/crl/CrlInterceptorTest.java
+++ b/platform/security/sts/security-sts-crlinterceptor/src/test/java/org/codice/ddf/security/sts/crl/CrlInterceptorTest.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -30,7 +31,6 @@ import org.apache.cxf.interceptor.security.AccessDeniedException;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.codice.ddf.security.handler.pki.CrlChecker;
-import org.jasypt.contrib.org.apache.commons.codec_1_3.binary.Base64;
 import org.junit.Test;
 
 /**
@@ -85,7 +85,7 @@ public class CrlInterceptorTest {
 
         // add in certificate
         InputStream stream = new ByteArrayInputStream(
-                Base64.decodeBase64(certificateString.getBytes()));
+                Base64.getMimeDecoder().decode(certificateString.getBytes()));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) factory.generateCertificate(stream);
         X509Certificate[] certs = new X509Certificate[] {cert};
@@ -98,7 +98,7 @@ public class CrlInterceptorTest {
         String certificateString = getTestCertString();
 
         InputStream stream = new ByteArrayInputStream(
-                Base64.decodeBase64(certificateString.getBytes()));
+                Base64.getMimeDecoder().decode(certificateString.getBytes()));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) factory.generateCertificate(stream);
         X509Certificate[] certs = new X509Certificate[1];


### PR DESCRIPTION
Modified codebase to use java.util.Base64 instead of the plethora of other libraries. 
@pklinef @kcwire @coyotesqrl @roelens8 @tbatie @wbarnie @jckilmer @ryeats @bcwaters