### PR TITLE
DDF-1792 Make Metacards handle multivalued attributes

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
@@ -727,7 +727,15 @@ public class MetacardImpl implements Metacard {
             Serializable value = attribute.getValue();
             if (name != null) {
                 if (value != null) {
-                    map.put(name, attribute);
+                    Attribute tmpAttr = map.get(name);
+                    if (tmpAttr == null) {
+                        map.put(name, attribute);
+                    } else {
+                        List<Serializable> tmpAttrValues = tmpAttr.getValues();
+                        tmpAttrValues.addAll(attribute.getValues());
+                        tmpAttr = new AttributeImpl(name, tmpAttrValues);
+                        map.put(name, tmpAttr);
+                    }
                 } else {
                     map.remove(name);
                 }


### PR DESCRIPTION
Before, when adding an attribute to a metacard, the new attribute would wipe out the old attribute.
Now, the new attribute will get added to the old attribute.

This PR is for a fix to MetacardImpl. It is a part of DDF-1792, but can be merged separately and improves multivalued capabilities.

@brendan-hofmann @ahoffer @zryan3 