### PR TITLE
DDF-1820: As an Administrator, I want to be able to specify the directory where my configurations are exported

### DIFF
--- a/distribution/docs/src/main/resources/_contents/mancontents.adoc
+++ b/distribution/docs/src/main/resources/_contents/mancontents.adoc
@@ -4093,8 +4093,8 @@ The Configuration Export/Import capability allows administrators to export the c
 
 To export the current {branding} configuration:
 
-. Using the {branding} Command Line Console, type in `platform:config-export`. This command creates the exported configuration files that are saved to `<DDF_HOME>/etc/exported`.
-. Zip up the exported files in `<DDF_HOME>/etc/exported`
+. Using the {branding} Command Line Console, type in `migration:export <directory>`. This command creates the exported configuration files that are saved to the specified directory. If no directory is specified it will default to `<DDF_HOME>/etc/exported`
+. Zip up the exported files in the export directory.
 ----
 cd  <DDF_HOME>/etc/exported
 zip exportedFiles.zip *
@@ -4105,7 +4105,7 @@ zip exportedFiles.zip *
 Some system configuration files contain paths to other configuration files. For instance, the `system.properties` file contains the `javax.net.ssl.keyStore`
 property which provides the path to system key store.
 The files referred to in the system configuration files will be included in the export process only if the path is relative to `DDF_HOME`.
-Using absolute paths and/or symbolic links in those cases will cause the `platform:config-export` command to display warnings about those files and exclude them from the export process.
+Using absolute paths and/or symbolic links in those cases will cause the `migration:export` command to display warnings about those files and exclude them from the export process.
 The export process itself will not be aborted.
 ====
 
@@ -4119,7 +4119,7 @@ To import a previously exported configuration:
 . If needed, manually update system configuration files such as `system.properties`, `users.properties`. keystores, etc.
 . Launch the newly installed {branding}.
 . Step through the installation process. The newly installed {branding} will have the previous {branding}'s settings imported.
-. To get a status of the import, run the `platform:config-status` from the Command Line Console.
+. To get a status of the import, run the `migration:status` from the Command Line Console.
 
 
 === Starting {branding}
@@ -4818,7 +4818,7 @@ The Platform Commands are installed when the Platform application is installed.
 
 ----
 ddf@local>platform:
-platform:config-export    platform:config-status    platform:describe    platform:envlist
+platform:describe    platform:envlist
 ----
 
 [cols="2" options="header"]
@@ -4826,12 +4826,6 @@ platform:config-export    platform:config-status    platform:describe    platfor
 
 |Command
 |Description
-
-|config-export
-|Exports the current configurations.
-
-|config-status
-|Lists import status of configuration files.
 
 |describe
 |Shows the current platform configuration.

--- a/platform/migration/platform-migration-commands/pom.xml
+++ b/platform/migration/platform-migration-commands/pom.xml
@@ -1,27 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
+        <artifactId>migration</artifactId>
         <groupId>ddf.platform</groupId>
-        <artifactId>platform</artifactId>
         <version>2.9.0-SNAPSHOT</version>
     </parent>
-    <artifactId>platform-commands</artifactId>
-    <name>DDF Platform Commands</name>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ddf.platform.migration</groupId>
+    <artifactId>platform-migration-commands</artifactId>
     <packaging>bundle</packaging>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
@@ -29,14 +34,30 @@
             <version>${karaf.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <groupId>ddf.platform.migration</groupId>
+            <artifactId>platform-migration</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-configuration</artifactId>
+            <groupId>ddf.platform.migration</groupId>
+            <artifactId>platform-migratable-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -46,6 +67,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>common-system,validation-api,commons-lang3</Embed-Dependency>
                         <Export-Package />
                         <Import-Package>
                             org.apache.felix.service.command,
@@ -75,22 +97,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.68</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/migration/platform-migration-commands/src/main/java/org/codice/ddf/migration/commands/MigrationCommands.java
+++ b/platform/migration/platform-migration-commands/src/main/java/org/codice/ddf/migration/commands/MigrationCommands.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.migration.commands;
+
+import java.io.PrintStream;
+
+import org.apache.karaf.shell.console.OsgiCommandSupport;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Attribute;
+
+/**
+ * Parent object to all Platform Commands. Provides common methods and instance variables that
+ * Platform Commands can use.
+ */
+public abstract class MigrationCommands extends OsgiCommandSupport {
+
+    public static final String NAMESPACE = "migration";
+
+    protected void outputErrorMessage(String message) {
+        String colorAsString = Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.RED).toString();
+        PrintStream console = getConsole();
+        console.print(colorAsString);
+        console.print(message);
+        console.println(Ansi.ansi().a(Attribute.RESET).toString());
+    }
+
+    protected void outputWarningMessage(String message) {
+        String colorAsString = Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.YELLOW).toString();
+        PrintStream console = getConsole();
+        console.print(colorAsString);
+        console.print(message);
+        console.println(Ansi.ansi().a(Attribute.RESET).toString());
+    }
+
+    protected void outputInfoMessage(String message) {
+        String colorAsString = Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.WHITE).toString();
+        PrintStream console = getConsole();
+        console.print(colorAsString);
+        console.print(message);
+        console.println(Ansi.ansi().a(Attribute.RESET).toString());
+    }
+
+    protected void outputSuccessMessage(String message) {
+        String colorAsString = Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).toString();
+        PrintStream console = getConsole();
+        console.print(colorAsString);
+        console.print(message);
+        console.println(Ansi.ansi().a(Attribute.RESET).toString());
+    }
+
+    PrintStream getConsole() {
+        return System.out;
+    }
+}

--- a/platform/migration/platform-migration-commands/src/main/java/org/codice/ddf/migration/commands/MigrationStatusCommand.java
+++ b/platform/migration/platform-migration-commands/src/main/java/org/codice/ddf/migration/commands/MigrationStatusCommand.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.commands.platform;
+package org.codice.ddf.migration.commands;
 
 import static org.apache.commons.lang.Validate.notNull;
 
@@ -24,8 +24,10 @@ import org.apache.felix.gogo.commands.Command;
 import org.codice.ddf.configuration.status.ConfigurationStatusService;
 import org.codice.ddf.migration.MigrationWarning;
 
-@Command(scope = PlatformCommands.NAMESPACE, name = "config-status", description = "Lists import status of configuration files.")
-public class ConfigStatusCommand extends PlatformCommands {
+@Command(scope = MigrationCommands.NAMESPACE, name = "status", description = "Lists import status of configuration files "
+        + "that were imported through the Migration Service. Files that failed to import correctly will be moved to the "
+        + "etc/failed directory. All successful imports will be moved to the etc/processed directory")
+public class MigrationStatusCommand extends MigrationCommands {
 
     static final String SUCCESSFUL_IMPORT_MESSAGE = "All config files imported successfully.";
 
@@ -35,7 +37,7 @@ public class ConfigStatusCommand extends PlatformCommands {
 
     private ConfigurationStatusService configStatusService;
 
-    public ConfigStatusCommand(@NotNull ConfigurationStatusService configStatusService) {
+    public MigrationStatusCommand(@NotNull ConfigurationStatusService configStatusService) {
         notNull(configStatusService, "Configuration Status Service cannot be null");
         this.configStatusService = configStatusService;
     }

--- a/platform/migration/platform-migration-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/migration/platform-migration-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,65 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
+
+
+        <command name="migration/status">
+            <action
+                    class="org.codice.ddf.migration.commands.MigrationStatusCommand">
+                <argument ref="configStatusService"/>
+            </action>
+        </command>
+        <command name="migration/export">
+            <action class="org.codice.ddf.migration.commands.ExportCommand">
+                <argument ref="configurationMigrationService"/>
+                <argument ref="defaultExportDirectoryPath"/>
+            </action>
+        </command>
+
+    </command-bundle>
+
+    <reference id="configStatusService"
+               interface="org.codice.ddf.configuration.status.ConfigurationStatusService"/>
+
+    <reference id="configurationMigrationService"
+               interface="org.codice.ddf.configuration.migration.ConfigurationMigrationService"/>
+
+    <!-- Base URI for DDF home -->
+    <bean id="ddfHomeFile" class="java.io.File">
+        <argument value="${ddf.home}"/>
+    </bean>
+
+    <bean id="ddfHomeUri" class="java.net.URI" factory-ref="ddfHomeFile" factory-method="toURI"/>
+
+    <!-- Default Directory Export Path -->
+    <bean id="defaultExportDirectoryUri" class="java.nio.file.Uri" factory-ref="ddfHomeUri"
+          factory-method="resolve">
+        <argument value="etc/exported"/>
+    </bean>
+
+    <bean id="defaultExportDirectoryPath" class="java.nio.file.Paths" factory-method="get">
+        <argument ref="defaultExportDirectoryUri"/>
+    </bean>
+
+    <bean id="platformExportCommand" class="org.codice.ddf.migration.commands.ExportCommand">
+        <argument ref="configurationMigrationService"/>
+        <argument ref="defaultExportDirectoryPath"/>
+    </bean>
+
+</blueprint>

--- a/platform/migration/platform-migration-commands/src/test/java/org/codice/ddf/migration/commands/ConfigStatusCommandTest.java
+++ b/platform/migration/platform-migration-commands/src/test/java/org/codice/ddf/migration/commands/ConfigStatusCommandTest.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.commands.platform;
+package org.codice.ddf.migration.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -81,7 +81,7 @@ public class ConfigStatusCommandTest {
         // Setup
         when(mockConfigStatusService.getFailedConfigurationFiles()).thenReturn(
                 CONFIG_STATUS_MSGS);
-        ConfigStatusCommand configStatusCommand = new ConfigStatusCommand(mockConfigStatusService) {
+        MigrationStatusCommand migrationStatusCommand = new MigrationStatusCommand(mockConfigStatusService) {
             @Override
             PrintStream getConsole() {
                 return mockConsole;
@@ -89,7 +89,7 @@ public class ConfigStatusCommandTest {
         };
 
         // Perform Test
-        configStatusCommand.doExecute();
+        migrationStatusCommand.doExecute();
 
         // Verify
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
@@ -98,12 +98,12 @@ public class ConfigStatusCommandTest {
         assertThat(values.get(0), is(ERROR_RED));
         assertThat(
                 values.get(1),
-                is(String.format(ConfigStatusCommand.FAILED_IMPORT_MESSAGE,
+                is(String.format(MigrationStatusCommand.FAILED_IMPORT_MESSAGE,
                         FAILED_CONFIG_FILE1.toString())));
         assertThat(values.get(0), is(ERROR_RED));
         assertThat(
                 values.get(3),
-                is(String.format(ConfigStatusCommand.FAILED_IMPORT_MESSAGE,
+                is(String.format(MigrationStatusCommand.FAILED_IMPORT_MESSAGE,
                         FAILED_CONFIG_FILE2.toString())));
     }
 
@@ -111,7 +111,7 @@ public class ConfigStatusCommandTest {
     public void testDoExecuteNoFailedImports() throws Exception {
         // Setup
         when(mockConfigStatusService.getFailedConfigurationFiles()).thenReturn(new ArrayList<>(0));
-        ConfigStatusCommand configStatusCommand = new ConfigStatusCommand(mockConfigStatusService) {
+        MigrationStatusCommand migrationStatusCommand = new MigrationStatusCommand(mockConfigStatusService) {
             @Override
             PrintStream getConsole() {
                 return mockConsole;
@@ -119,21 +119,21 @@ public class ConfigStatusCommandTest {
         };
 
         // Perform Test
-        configStatusCommand.doExecute();
+        migrationStatusCommand.doExecute();
 
         // Verify
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(mockConsole, times(2)).print(argument.capture());
         List<String> values = argument.getAllValues();
         assertThat(values.get(0), is(SUCCESS_GREEN));
-        assertThat(values.get(1), is(ConfigStatusCommand.SUCCESSFUL_IMPORT_MESSAGE));
+        assertThat(values.get(1), is(MigrationStatusCommand.SUCCESSFUL_IMPORT_MESSAGE));
     }
 
     @Test
     public void testDoExecuteRuntimeExceptionWhileReadingFailedDirectory() throws Exception {
         // Setup
         doThrow(new RuntimeException()).when(mockConfigStatusService).getFailedConfigurationFiles();
-        ConfigStatusCommand configStatusCommand = new ConfigStatusCommand(mockConfigStatusService) {
+        MigrationStatusCommand migrationStatusCommand = new MigrationStatusCommand(mockConfigStatusService) {
             @Override
             PrintStream getConsole() {
                 return mockConsole;
@@ -141,7 +141,7 @@ public class ConfigStatusCommandTest {
         };
 
         // Perform Test
-        configStatusCommand.doExecute();
+        migrationStatusCommand.doExecute();
 
         // Verify
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
@@ -156,7 +156,7 @@ public class ConfigStatusCommandTest {
     public void testDoExecuteNullConfigurationStatus() throws Exception {
         // Setup
         when(mockConfigStatusService.getFailedConfigurationFiles()).thenReturn(null);
-        ConfigStatusCommand configStatusCommand = new ConfigStatusCommand(mockConfigStatusService) {
+        MigrationStatusCommand migrationStatusCommand = new MigrationStatusCommand(mockConfigStatusService) {
             @Override
             PrintStream getConsole() {
                 return mockConsole;
@@ -164,18 +164,18 @@ public class ConfigStatusCommandTest {
         };
 
         // Perform Test
-        configStatusCommand.doExecute();
+        migrationStatusCommand.doExecute();
 
         // Verify
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(mockConsole, times(2)).print(argument.capture());
         List<String> values = argument.getAllValues();
         assertThat(values.get(0), is(ERROR_RED));
-        assertThat(values.get(1), is(ConfigStatusCommand.NO_CONFIG_STATUS_MESSAGE));
+        assertThat(values.get(1), is(MigrationStatusCommand.NO_CONFIG_STATUS_MESSAGE));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorNullConfigurationStatusService() {
-        new ConfigStatusCommand(null);
+        new MigrationStatusCommand(null);
     }
 }

--- a/platform/migration/platform-migration-commands/src/test/java/org/codice/ddf/migration/commands/ExportCommandTest.java
+++ b/platform/migration/platform-migration-commands/src/test/java/org/codice/ddf/migration/commands/ExportCommandTest.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.commands.platform;
+package org.codice.ddf.migration.commands;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/platform/migration/pom.xml
+++ b/platform/migration/pom.xml
@@ -25,5 +25,6 @@
     <modules>
         <module>platform-migratable-api</module>
         <module>platform-migration</module>
+        <module>platform-migration-commands</module>
     </modules>
 </project>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -644,6 +644,11 @@
         <bundle>mvn:ddf.platform.migration/platform-migration/${project.version}</bundle>
     </feature>
 
+    <feature name="platform-migration-commands" install="manual" version="${project.version}"
+             description="Migration Command line tools">
+        <bundle>mvn:ddf.platform.migration/platform-migration-commands/${project.version}</bundle>
+    </feature>
+
     <feature name="platform-scheduler" install="manual" version="${project.version}"
              description="Schedules tasks">
         <bundle>mvn:ddf.platform/platform-scheduler/${project.version}</bundle>
@@ -938,6 +943,7 @@
         <feature>common-libraries</feature>
         <feature>platform-migratable-api</feature>
         <feature>platform-migration</feature>
+        <feature>platform-migration-commands</feature>
         <feature>platform-security-session</feature>
         <feature>cxf</feature>
         <feature>camel</feature>

--- a/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,7 +13,6 @@
 -->
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
@@ -24,54 +23,8 @@
         <command name="platform/envlist">
             <action class="org.codice.ddf.commands.platform.EnvListCommand"/>
         </command>
-        <command name="platform/config-status">
-            <action
-                    class="org.codice.ddf.commands.platform.ConfigStatusCommand">
-                <argument ref="configStatusService"/>
-            </action>
-        </command>
-        <command name="platform/config-export">
-            <action class="org.codice.ddf.commands.platform.ExportCommand">
-                <argument ref="configurationMigrationService"/>
-                <argument ref="defaultExportDirectoryPath"/>
-            </action>
-        </command>
 
     </command-bundle>
-
-    <ext:property-placeholder>
-        <ext:default-properties>
-            <ext:property name="defaultExportDirectory" value="${ddf.home}/etc/exported"/>
-        </ext:default-properties>
-    </ext:property-placeholder>
-
-    <reference id="configStatusService"
-               interface="org.codice.ddf.configuration.status.ConfigurationStatusService"/>
-
-    <reference id="configurationMigrationService"
-               interface="org.codice.ddf.configuration.migration.ConfigurationMigrationService"/>
-
-    <!-- Base URI for DDF home -->
-    <bean id="ddfHomeFile" class="java.io.File">
-        <argument value="${ddf.home}"/>
-    </bean>
-
-    <bean id="ddfHomeUri" class="java.net.URI" factory-ref="ddfHomeFile" factory-method="toURI"/>
-
-    <!-- Default Directory Export Path -->
-    <bean id="defaultExportDirectoryUri" class="java.nio.file.Uri" factory-ref="ddfHomeUri"
-          factory-method="resolve">
-        <argument value="etc/exported"/>
-    </bean>
-
-    <bean id="defaultExportDirectoryPath" class="java.nio.file.Paths" factory-method="get">
-        <argument ref="defaultExportDirectoryUri"/>
-    </bean>
-
-    <bean id="platformExportCommand" class="org.codice.ddf.commands.platform.ExportCommand">
-        <argument ref="configurationMigrationService"/>
-        <argument ref="defaultExportDirectoryPath"/>
-    </bean>
 
     <bean id="platformDescribeCommand" class="org.codice.ddf.commands.platform.DescribeCommand">
         <property name="bundleContext" ref="blueprintBundleContext"/>


### PR DESCRIPTION
* Changed command namespace from `platform` to `migration`
* Renamed `config-export` to `export` and `config-status` to `status`
* Moved migration commands to the migration module
* Added argument for export directory

 
@garrettfreibott, @Lambeaux, @figliold, @lessarderic, @andrewkfiedler