### PR TITLE
DDF-1832 Updates the sleep in a test from 10 to 11 seconds

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -584,7 +584,7 @@ public class TestConfiguration extends AbstractIntegrationTest {
                 containsString(String.format(FAILED_IMPORT_MESSAGE, invalidConfigFileName)));
         assertThat(Files.exists(getPathToFailedDirectory().resolve(invalidConfigFileName)),
                 is(true));
-        SECONDS.sleep(10);
+        SECONDS.sleep(11);
         addConfigurationFileAndWaitForSuccessfulProcessing(VALID_CONFIG_FILE_1,
                 getResourceAsStream(VALID_CONFIG_FILE_1));
         String output2 = console.runCommand(STATUS_COMMAND);


### PR DESCRIPTION
 - No real way to test this other than to try it for a week and see if the inconsistent test failures go away.  10 seconds is the polling time, so 11 seconds should always work.  We couldn't increase the polling frequency because the means to do so are still internal to sun.  See here for why: https://github.com/frohoff/jdk8u-jdk/blob/master/src/share/classes/sun/nio/fs/PollingWatchService.java#L108