### PR TITLE
DDF-899 Add check for URI type in setAttribute

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
@@ -710,7 +710,15 @@ public class MetacardImpl implements Metacard {
      *            the value of the {@link Attribute}
      */
     public void setAttribute(String name, Serializable value) {
-        setAttribute(new AttributeImpl(name, value));
+        if (value != null && name.equalsIgnoreCase(RESOURCE_URI)
+                && !String.class.isAssignableFrom(value.getClass())) {
+            if(LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Attribute " + RESOURCE_URI + " should be set with a string, not a URI.");
+            }
+            setAttribute(new AttributeImpl(name, value.toString()));
+        } else {
+            setAttribute(new AttributeImpl(name, value));
+        }
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
@@ -535,4 +535,15 @@ public class MetacardImplTest {
 
     }
 
+    /*
+     * Test when the resource uri is set with setAttribute() with a URI not a String
+     */
+    @Test
+    public void testSetAttributeResourceUriWithUriParameter() throws URISyntaxException {
+        MetacardImpl metacard = new MetacardImpl();
+        URI uri = new URI(nsUri.toString() + "/resource.html");
+        metacard.setAttribute("resource-uri", uri);
+        assertEquals(uri, metacard.getResourceURI());
+    }
+
 }


### PR DESCRIPTION
Added a check to make sure that the resource-uri was not being stored as
a URI. In the event that it setAttribute is given a URI instead of a
String,  it now converts the URI to a String and uses that as the value
parameter.