### PR TITLE
DDF-1841 Allow new source types to be added to existing sources

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
@@ -94,54 +94,44 @@ define(function (require) {
 
         makeEnableCall: function(){
             var model = this;
-            var deferred = $.Deferred();
             var pid = model.get('id');
             var url = [model.configUrl, "enableConfiguration", pid].join("/");
-            if(pid){
-                $.ajax({
+            if (pid) {
+                return $.ajax({
                     url: url,
                     dataType: 'json'
-                }).then(function(){
-                        // massage some data to match the new backend pid.
-                        model.trigger('enabled');
-                        //enabling the model means the PID will be regenerated. This model no longer exists on the server.
-                        model.destroy();
-                        deferred.resolve();
-                    }).fail(function(){
-                        deferred.reject(new Error('Could not enable configuratoin ' + pid));
-                        deferred.resolve();
-                    });
-            } else {
-                deferred.fail(new Error("Cannot enable since this model has no pid."));
+                }).done(function(){
+                    // massage some data to match the new backend pid.
+                    model.trigger('enabled');
+                    //enabling the model means the PID will be regenerated. This model no longer exists on the server.
+                    model.destroy();
+                }).fail(function(){
+                    new Error('Could not enable configuratoin ' + pid);
+                });
             }
 
-            return deferred;
+            return $.Deferred().fail(new Error("Cannot enable since this model has no pid."));
 
         },
 
         makeDisableCall: function(){
             var model = this;
-            var deferred = $.Deferred();
             var pid = model.get('id');
             var url = [model.configUrl, "disableConfiguration", pid].join("/");
-            if(pid){
-                $.ajax({
+            if (pid) {
+                return $.ajax({
                     url: url,
                     dataType: 'json'
-                }).then(function(){
-                        model.trigger('disabled');
-                        //disabling the model means the PID will be regenerated. This model no longer exists on the server.
-                        model.destroy();
-                        deferred.resolve();
-                    }).fail(function(){
-                        deferred.reject(new Error('Could not disable configuration ' + pid));
-                        deferred.resolve();
-                    });
-            } else {
-                deferred.reject(new Error("Cannot enable since this model has no pid."));
+                }).done(function(){
+                    model.trigger('disabled');
+                    //disabling the model means the PID will be regenerated. This model no longer exists on the server.
+                    model.destroy();
+                }).fail(function(){
+                    new Error('Could not disable configuration ' + pid);
+                });
             }
 
-            return deferred;
+            return $.Deferred().reject(new Error("Cannot enable since this model has no pid."));
         },
 
         // Used to make a call to the backend to disable the service that corresponds to the pid.

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -37,7 +37,7 @@ function (wreqr, Service, Backbone, _, poller, Status) {
             this.set('disabledConfigurations', new Source.ConfigurationList());
         },
         addDisabledConfiguration: function(configuration) {
-            if(this.get("disabledConfigurations")) {
+            if(this.get("disabledConfigurations") && !this.get("disabledConfigurations").contains(configuration)) {
                 this.get("disabledConfigurations").add(configuration);
             }
         },


### PR DESCRIPTION
- All source types now shown when editing existing sources.
- Fixed duplicate source types when passing an initial model to
  getSourceModelWithServices.
- Fixed race condition when switching source types from the dropdown.

@stustison @andrewkfiedler @codice/ui 