### PR TITLE
DDF-1845 Added Product Retrieval Capability to CSW Endpoint

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswRecordCollection.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswRecordCollection.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.common;
 
@@ -21,6 +20,7 @@ import javax.xml.namespace.QName;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.resource.Resource;
 import net.opengis.cat.csw.v_2_0_2.ElementSetType;
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 import net.opengis.cat.csw.v_2_0_2.ResultType;
@@ -59,6 +59,8 @@ public class CswRecordCollection {
     private ResultType resultType;
 
     private boolean doWriteNamespaces;
+
+    private Resource resource;
 
     /**
      * Retrieves the request made that generated this set of CSW Records, if applicable
@@ -182,5 +184,13 @@ public class CswRecordCollection {
 
     public void setDoWriteNamespaces(boolean doWriteNamespaces) {
         this.doWriteNamespaces = doWriteNamespaces;
+    }
+
+    public void setResource(Resource resource) {
+        this.resource = resource;
+    }
+
+    public Resource getResource() {
+        return resource;
     }
 }

--- a/catalog/spatial/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
@@ -103,7 +103,6 @@ import ddf.catalog.util.impl.MaskableImpl;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import ddf.security.service.SecurityManager;
-
 import net.opengis.cat.csw.v_2_0_2.CapabilitiesType;
 import net.opengis.cat.csw.v_2_0_2.ElementSetNameType;
 import net.opengis.cat.csw.v_2_0_2.ElementSetType;
@@ -359,8 +358,8 @@ public class CswSource extends MaskableImpl
         consumerMap.put(CONNECTION_TIMEOUT_PROPERTY,
                 value -> cswSourceConfiguration.setConnectionTimeout((Integer) value));
 
-        consumerMap.put(RECEIVE_TIMEOUT_PROPERTY, value -> cswSourceConfiguration.setReceiveTimeout(
-                (Integer) value));
+        consumerMap.put(RECEIVE_TIMEOUT_PROPERTY,
+                value -> cswSourceConfiguration.setReceiveTimeout((Integer) value));
 
         consumerMap.put(OUTPUT_SCHEMA_PROPERTY,
                 value -> setConsumerOutputSchemaProperty((String) value));
@@ -1070,9 +1069,9 @@ public class CswSource extends MaskableImpl
             if (wrappedMetacard.getAttribute(Metacard.RESOURCE_DOWNLOAD_URL) != null &&
                     wrappedMetacard.getAttribute(Metacard.RESOURCE_DOWNLOAD_URL)
                             .getValue() != null) {
-                wrappedMetacard.setAttribute(Metacard.RESOURCE_URI, wrappedMetacard.getAttribute(
-                        Metacard.RESOURCE_DOWNLOAD_URL)
-                        .getValue());
+                wrappedMetacard.setAttribute(Metacard.RESOURCE_URI,
+                        wrappedMetacard.getAttribute(Metacard.RESOURCE_DOWNLOAD_URL)
+                                .getValue());
             }
             Metacard tranformedMetacard = wrappedMetacard;
             if (transformer != null) {
@@ -1462,11 +1461,9 @@ public class CswSource extends MaskableImpl
     }
 
     private boolean isOutputSchemaSupported() {
-        return this.cswSourceConfiguration.getOutputSchema() != null
-                && this.supportedOutputSchemas != null ?
-                this.supportedOutputSchemas.getValue()
-                        .contains(cswSourceConfiguration.getOutputSchema()) :
-                false;
+        return (this.cswSourceConfiguration.getOutputSchema() != null
+                && this.supportedOutputSchemas != null) && this.supportedOutputSchemas.getValue()
+                .contains(cswSourceConfiguration.getOutputSchema());
     }
 
     public void setAvailabilityTask(AvailabilityTask availabilityTask) {

--- a/catalog/spatial/docs/src/main/resources/_contents/intcontents.adoc
+++ b/catalog/spatial/docs/src/main/resources/_contents/intcontents.adoc
@@ -549,14 +549,21 @@ The `GetRecords` operation request retrieves the default representation of catal
 This operation presumes that a previous query has been performed in order to obtain the identifiers that may be used with this operation.
 For example, records returned by a `GetRecords` operation may contain references to other records in the catalog that may be retrieved using the `GetRecordById` operation.
 This operation is also a subset of the `GetRecords` operation and is included as a convenient short form for retrieving and linking to records in a catalog.
+
+Clients can also retrieve products from the catalog using the `GetRecordById` operation.
+The client sets the output schema to `http://www.iana.org/assignments/media-types/application/octet-stream` and the output format to `application/octet-stream` within the request.
+The endpoint will do the following: check that only one Id is provided, otherwise an error will occur as multiple products cannot be retrieved.
+If both output format and output schema are set to values mentioned above, the catalog framework will retrieve the resource for that Id.
+The HTTP content type is then set to the resource's MIME type and the data is sent out.
+
 There are two request types: one for `GET` and one for `POST`.
 Each request has the following common data parameters:
 
 Namespace:: In POST operations, namespaces are defined in the XML. In GET operations namespaces are defined in a comma separated list of the form: xmlns([prefix=]namespace-url)(,xmlns([prefix=]namespace-url))*
 Service:: The service being used, in this case it is fixed at "CSW"
 Version:: The version of the service being used (2.0.2).
-OutputFormat:: The requester wants the response to be in this intended output. Currently, only one format is supported (application/xml). If this parameter is supplied, it is validated against the known type. If this parameter is not supported, it passes through and returns the XML response upon success.
-OutputSchema:: This is the schema language from the request. This is validated against the known list of schema languages supported (refer to http://www.w3.org/XML/Schema).
+OutputFormat:: The requester wants the response to be in this intended output. Currently, two output formats are supported: `application/xml` for retrieving records, and `application/octet-stream` for retrieving a product. If this parameter is supplied, it is validated against the known type. If this parameter is not supported, it passes through and returns the XML response upon success.
+OutputSchema:: This is the schema language from the request. This is validated against the known list of schema languages supported (refer to http://www.w3.org/XML/Schema). Additionally the output schema `http://www.iana.org/assignments/media-types/application/octet-stream` is recognized and used to retrieve a product.
 ElementSetName:: CodeList with allowed values of “brief”, “summary”, or “full”. The default value is "summary". The predefined set names of “brief”, “summary”, and “full” represent different levels of detail for the source record. "Brief" represents the least amount of detail, and "full" represents all the metadata record elements.
 Id:: The Id parameter is a comma-separated list of record identifiers for the records that CSW returns to the client. In the XML encoding, one or more <Id> elements may be used to specify the record identifier to be retrieved.
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -93,7 +93,9 @@ public final class Library {
     }
 
     public static String getCswQuery(String propertyName, String literalValue) {
-        return getCswQuery(propertyName, literalValue, "application/xml",
+        return getCswQuery(propertyName,
+                literalValue,
+                "application/xml",
                 "http://www.opengis.net/cat/csw/2.0.2");
     }
 
@@ -262,6 +264,14 @@ public final class Library {
                 + "id=placeholder_id";
     }
 
+    public static String getGetRecordByIdProductRetrievalUrl() {
+        return "?service=CSW&version=2.0.2&request=GetRecordById&NAMESPACE=xmlns="
+                + "http://www.opengis.net/cat/csw/2.0.2&"
+                + "outputFormat=application/octet-stream&outputSchema="
+                + "http://www.iana.org/assignments/media-types/application/octet-stream&"
+                + "id=placeholder_id";
+    }
+
     public static String getGetRecordByIdXml() {
         return "<GetRecordById xmlns=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
                 + "xmlns:ogc=\"http://www.opengis.net/ogc\"\n"
@@ -271,5 +281,14 @@ public final class Library {
                 + "xsi:schemaLocation=\"http://www.opengis.net/cat/csw/2.0.2../../../csw/2.0.2/CSW-discovery.xsd\">\n"
                 + "  <ElementSetName>full</ElementSetName>\n" + "  <Id>placeholder_id_1</Id>\n"
                 + "  <Id>placeholder_id_2</Id>\n" + "</GetRecordById>";
+    }
+
+    public static String getGetRecordByIdProductRetrievalXml() {
+        return "<GetRecordById xmlns=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
+                + "xmlns:ogc=\"http://www.opengis.net/ogc\"\n"
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                + "service=\"CSW\" version=\"2.0.2\" outputFormat=\"application/octet-stream\"\n"
+                + "outputSchema=\"http://www.iana.org/assignments/media-types/application/octet-stream\">\n"
+                + "  <Id>placeholder_id_1</Id>\n" + "</GetRecordById>";
     }
 }


### PR DESCRIPTION
**A lot of the changes in the pull request are formatting.** 
The most important code changes are within getRecordById() of CSWEndpoint.java for POST and GET. Also added unit and integration tests for code coverage and stability.

**Description of the functionality:**
A user can now retrieve a product through the getRecordById operation. The client sets the output schema to "http://www.iana.org/assignments/media-types/application/octet-stream" and the output format to "application/octet-stream". The endpoint will do the following: check that only one Id is provided otherwise throw an exception as multiple products cannot be retrieved. If both output format and output schema are set as mentioned above, the catalog framework will retrieve the resource object for that Id. From that object, it gets the mime type and the actual data. It then tells the CswRecordCollectionMessageBodyWriter to send out the data and set the HTTP content type to the resource's MIME type.

**Examples of the request:**
![screen shot 2016-02-05 at 4 48 36 pm](https://cloud.githubusercontent.com/assets/5935039/12862387/632fa942-cc28-11e5-9082-f34b4c3f8adf.png)

@kcwire @ryeats @coyotesqrl @pklinef @tbatie @rzwiefel @bcwaters 
