### PR TITLE
DDF-1855 Fixed csw xpath queries with namespaces

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
@@ -133,22 +135,22 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.79</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/DefaultCswRecordMap.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/DefaultCswRecordMap.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -101,28 +101,30 @@ public class DefaultCswRecordMap {
         qNameMap.put(CswRecordMetacardType.CSW_TABLE_OF_CONTENTS_QNAME, Metacard.DESCRIPTION);
         qNameMap.put(CswRecordMetacardType.CSW_DESCRIPTION_QNAME, Metacard.DESCRIPTION);
 
-
         CSW_RECORD_QNAME_MAPPING = Collections.unmodifiableMap(qNameMap);
 
         Map<String, List<QName>> metacardMap = new HashMap<String, List<QName>>();
 
-        metacardMap.put(Metacard.ID, Arrays.asList(CswRecordMetacardType.CSW_IDENTIFIER_QNAME,
-                CswRecordMetacardType.CSW_BIBLIOGRAPHIC_CITATION_QNAME));
-        metacardMap.put(Metacard.TITLE, Arrays.asList(CswRecordMetacardType.CSW_TITLE_QNAME,
-                CswRecordMetacardType.CSW_ALTERNATIVE_QNAME));
+        metacardMap.put(Metacard.ID,
+                Arrays.asList(CswRecordMetacardType.CSW_IDENTIFIER_QNAME,
+                        CswRecordMetacardType.CSW_BIBLIOGRAPHIC_CITATION_QNAME));
+        metacardMap.put(Metacard.TITLE,
+                Arrays.asList(CswRecordMetacardType.CSW_TITLE_QNAME,
+                        CswRecordMetacardType.CSW_ALTERNATIVE_QNAME));
         metacardMap.put(Metacard.CONTENT_TYPE, Arrays.asList(CswRecordMetacardType.CSW_TYPE_QNAME));
-        metacardMap.put(Metacard.MODIFIED, Arrays.asList(CswRecordMetacardType.CSW_DATE_QNAME,
-                CswRecordMetacardType.CSW_MODIFIED_QNAME,
-                CswRecordMetacardType.CSW_DATE_SUBMITTED_QNAME,
-                CswRecordMetacardType.CSW_ISSUED_QNAME));
+        metacardMap.put(Metacard.MODIFIED,
+                Arrays.asList(CswRecordMetacardType.CSW_DATE_QNAME,
+                        CswRecordMetacardType.CSW_MODIFIED_QNAME,
+                        CswRecordMetacardType.CSW_DATE_SUBMITTED_QNAME,
+                        CswRecordMetacardType.CSW_ISSUED_QNAME));
 
         metacardMap.put(Metacard.CREATED, Arrays.asList(CswRecordMetacardType.CSW_CREATED_QNAME));
         metacardMap.put(Metacard.EFFECTIVE,
                 Arrays.asList(CswRecordMetacardType.CSW_DATE_ACCEPTED_QNAME,
                         CswRecordMetacardType.CSW_DATE_COPYRIGHTED_QNAME));
         metacardMap.put(Metacard.EXPIRATION, Arrays.asList(CswRecordMetacardType.CSW_VALID_QNAME));
-        metacardMap
-                .put(Metacard.RESOURCE_URI, Arrays.asList(CswRecordMetacardType.CSW_SOURCE_QNAME));
+        metacardMap.put(Metacard.RESOURCE_URI,
+                Arrays.asList(CswRecordMetacardType.CSW_SOURCE_QNAME));
         metacardMap.put(Metacard.POINT_OF_CONTACT,
                 Arrays.asList(CswRecordMetacardType.CSW_PUBLISHER_QNAME,
                         CswRecordMetacardType.CSW_CONTRIBUTOR_QNAME,
@@ -142,12 +144,12 @@ public class DefaultCswRecordMap {
         prefixMapping.put(XMLConstants.XML_NS_PREFIX, XMLConstants.XML_NS_URI);
         prefixMapping.put(CswConstants.XML_SCHEMA_INSTANCE_NAMESPACE_PREFIX,
                 XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
-        prefixMapping
-                .put(CswConstants.XML_SCHEMA_NAMESPACE_PREFIX, XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        prefixMapping.put(CswConstants.XML_SCHEMA_NAMESPACE_PREFIX,
+                XMLConstants.W3C_XML_SCHEMA_NS_URI);
         prefixMapping.put(CswConstants.OWS_NAMESPACE_PREFIX, CswConstants.OWS_NAMESPACE);
         prefixMapping.put(CswConstants.CSW_NAMESPACE_PREFIX, CswConstants.CSW_OUTPUT_SCHEMA);
-        prefixMapping
-                .put(CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX, CswConstants.DUBLIN_CORE_SCHEMA);
+        prefixMapping.put(CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX,
+                CswConstants.DUBLIN_CORE_SCHEMA);
         prefixMapping.put(CswConstants.DUBLIN_CORE_TERMS_NAMESPACE_PREFIX,
                 CswConstants.DUBLIN_CORE_TERMS_SCHEMA);
 
@@ -200,7 +202,7 @@ public class DefaultCswRecordMap {
 
     public static boolean hasDefaultMetacardFieldForPrefixedString(String propertyName,
             NamespaceSupport namespaceSupport) {
-        if (propertyName.contains(":")) {
+        if (propertyName.contains(":") && !isXpathPropertyName(propertyName)) {
             String prefix = propertyName.substring(0, propertyName.indexOf(":"));
             String localName = propertyName.substring(propertyName.indexOf(":") + 1);
             if (namespaceSupport != null && namespaceSupport.getURI(prefix) != null) {
@@ -215,6 +217,10 @@ public class DefaultCswRecordMap {
         }
     }
 
+    private static boolean isXpathPropertyName(String propertyName) {
+        return propertyName.contains("/") || propertyName.contains("@");
+    }
+
     public static String getDefaultMetacardFieldForPrefixedString(String name) {
         return getDefaultMetacardFieldForPrefixedString(name, null);
     }
@@ -222,7 +228,8 @@ public class DefaultCswRecordMap {
     public static String getDefaultMetacardFieldForPrefixedString(String propertyName,
             NamespaceSupport namespaceSupport) {
         String name;
-        if (propertyName.contains(":")) {
+
+        if (propertyName.contains(":") && !isXpathPropertyName(propertyName)) {
             String prefix = propertyName.substring(0, propertyName.indexOf(":"));
             String localName = propertyName.substring(propertyName.indexOf(":") + 1);
             if (namespaceSupport != null && namespaceSupport.getURI(prefix) != null) {

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestDefaultCswRecordMap.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestDefaultCswRecordMap.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.Test;
+
+public class TestDefaultCswRecordMap {
+
+    @Test
+    public void testNamespacePrefixedQueriesWithoutXpath() {
+
+        String propertyNameWihoutXpath = "dc:title";
+        String propertyNameWihoutNamespace = "title";
+
+        assertThat(DefaultCswRecordMap.getDefaultMetacardFieldForPrefixedString(
+                propertyNameWihoutXpath), is("title"));
+        assertThat(DefaultCswRecordMap.getDefaultMetacardFieldForPrefixedString(
+                propertyNameWihoutNamespace), is("title"));
+
+        assertThat(DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(
+                propertyNameWihoutXpath), is(true));
+        assertThat(DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(
+                propertyNameWihoutNamespace), is(true));
+
+    }
+
+    @Test
+    public void testNamespacePrefixedQueriesWithXpath() {
+
+        String propertyNameWithXpath = "/csw:Record/dc:title";
+        String propertyNameXpathWithoutNamespace = "/Record/title";
+
+        assertThat(DefaultCswRecordMap.getDefaultMetacardFieldForPrefixedString(
+                propertyNameWithXpath), is("/csw:Record/dc:title"));
+        assertThat(DefaultCswRecordMap.getDefaultMetacardFieldForPrefixedString(
+                propertyNameXpathWithoutNamespace), is("/Record/title"));
+
+        //Sortby does not support Xpath
+        assertThat(DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(
+                propertyNameWithXpath), is(false));
+        assertThat(DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(
+                propertyNameXpathWithoutNamespace), is(false));
+
+    }
+
+}


### PR DESCRIPTION
Updated the DefaultCswRecordMap so that xpath queries remain
unchanged when checking for namespace prefixes.  Unit tests have
been included to demonstrate the intended functionality is
implemented.

@tbatie @ryeats @roelens8 @rzwiefel @kcwire 