### PR TITLE
DDF-1698 Fix catalog:removeall command

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.ProcessingDetails;
@@ -287,11 +288,23 @@ public class RemoveAllCommand extends CatalogCommands {
 
     private QueryRequest getIntendedQuery(FilterBuilder filterBuilder, boolean isRequestForTotal)
             throws InterruptedException {
-
-        Filter filter = filterBuilder.attribute(Metacard.ID)
-                .is()
-                .like()
-                .text(WILDCARD);
+        Filter filter = filterBuilder.allOf(filterBuilder.attribute(Metacard.ID)
+                        .is()
+                        .like()
+                        .text(WILDCARD),
+                filterBuilder.anyOf(filterBuilder.attribute(BasicTypes.VALIDATION_ERRORS)
+                                .is()
+                                .empty(),
+                        filterBuilder.attribute(BasicTypes.VALIDATION_ERRORS)
+                                .is()
+                                .like()
+                                .text(WILDCARD)),
+                filterBuilder.anyOf(filterBuilder.attribute(BasicTypes.VALIDATION_WARNINGS)
+                                .is()
+                                .empty(),
+                        filterBuilder.attribute(BasicTypes.VALIDATION_WARNINGS)
+                                .is()
+                                .like()
 
         if (expired) {
             filter = filterBuilder.attribute(Metacard.EXPIRATION)
@@ -313,11 +326,24 @@ public class RemoveAllCommand extends CatalogCommands {
 
     private QueryRequest getAlternateQuery(FilterBuilder filterBuilder, boolean isRequestForTotal)
             throws InterruptedException {
-
-        Filter filter = filterBuilder.attribute(Metacard.ANY_TEXT)
-                .is()
-                .like()
-                .text(WILDCARD);
+        Filter filter = filterBuilder.allOf(filterBuilder.attribute(Metacard.ANY_TEXT)
+                        .is()
+                        .like()
+                        .text(WILDCARD),
+                filterBuilder.anyOf(filterBuilder.attribute(BasicTypes.VALIDATION_ERRORS)
+                                .is()
+                                .empty(),
+                        filterBuilder.attribute(BasicTypes.VALIDATION_ERRORS)
+                                .is()
+                                .like()
+                                .text(WILDCARD)),
+                filterBuilder.anyOf(filterBuilder.attribute(BasicTypes.VALIDATION_WARNINGS)
+                                .is()
+                                .empty(),
+                        filterBuilder.attribute(BasicTypes.VALIDATION_WARNINGS)
+                                .is()
+                                .like()
+                                .text(WILDCARD)));
 
         if (expired) {
             DateTime twoThousandYearsAgo = new DateTime().minusYears(2000);

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -210,6 +210,10 @@ public class DynamicSchemaResolver {
             if (metacard.getAttribute(ad.getName()) != null) {
                 List<Serializable> attributeValues = metacard.getAttribute(ad.getName())
                         .getValues();
+                if (ad.getType()
+                        .equals(BasicTypes.STRING_TYPE)) {
+                    fieldsCache.add(ad.getName() + SchemaFields.TEXT_SUFFIX);
+                }
 
                 if (attributeValues != null && attributeValues.size() > 0
                         && attributeValues.get(0) != null) {

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -156,6 +156,8 @@ public class DynamicSchemaResolver {
                 .map(stringDescriptor -> stringDescriptor.getName() + SchemaFields.TEXT_SUFFIX)
                 .collect(Collectors.toSet());
         anyTextFieldsCache.addAll(basicTextAttributes);
+        fieldsCache.add(BasicTypes.VALIDATION_ERRORS + SchemaFields.TEXT_SUFFIX);
+        fieldsCache.add(BasicTypes.VALIDATION_WARNINGS + SchemaFields.TEXT_SUFFIX);
     }
 
     /**
@@ -210,10 +212,6 @@ public class DynamicSchemaResolver {
             if (metacard.getAttribute(ad.getName()) != null) {
                 List<Serializable> attributeValues = metacard.getAttribute(ad.getName())
                         .getValues();
-                if (ad.getType()
-                        .equals(BasicTypes.STRING_TYPE)) {
-                    fieldsCache.add(ad.getName() + SchemaFields.TEXT_SUFFIX);
-                }
 
                 if (attributeValues != null && attributeValues.size() > 0
                         && attributeValues.get(0) != null) {
@@ -324,8 +322,7 @@ public class DynamicSchemaResolver {
     /**
      * Returns the best approximation as to what {@link AttributeFormat} this Solr Field is.
      *
-     * @param solrFieldName
-     *            name of the Solr field
+     * @param solrFieldName name of the Solr field
      * @return the {@link AttributeFormat} associated with the Solr field
      */
     public AttributeFormat getType(String solrFieldName) {
@@ -386,7 +383,7 @@ public class DynamicSchemaResolver {
 
     /**
      * PRE-CONDITION is that fieldname cannot be null.
-     *
+     * <p>
      * The convention is that we add a suffix starting with an underscore, so if we find the last
      * underscore, then we can return the original field name.
      *
@@ -410,10 +407,9 @@ public class DynamicSchemaResolver {
     /**
      * Attempts to resolve the name of a field without being given an {@link AttributeFormat}
      *
-     * @param field
-     *            user given field name
+     * @param field user given field name
      * @return a list of possible Solr field names that match the given field. If none are found,
-     *         then an empty list is returned
+     * then an empty list is returned
      */
     public List<String> getAnonymousField(String field) {
         ArrayList<String> list = new ArrayList<>();
@@ -432,14 +428,11 @@ public class DynamicSchemaResolver {
     /**
      * Attempts to find the fieldName for the given propertyName value.
      *
-     * @param propertyName
-     *            property name provided by user
-     * @param format
-     *            {@link AttributeFormat} that describes the type of {@link ddf.catalog.data.Attribute} the field is
-     * @param isSearchedAsExactValue
-     *            specifies if any special index suffixes need to be added to the field
+     * @param propertyName           property name provided by user
+     * @param format                 {@link AttributeFormat} that describes the type of {@link ddf.catalog.data.Attribute} the field is
+     * @param isSearchedAsExactValue specifies if any special index suffixes need to be added to the field
      * @return the proper schema field name. If a schema name cannot be found in cache, returns a
-     *         schema field name that matches the dynamic field type formatting.
+     * schema field name that matches the dynamic field type formatting.
      */
     public String getField(String propertyName, AttributeFormat format,
             boolean isSearchedAsExactValue) {

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
@@ -60,6 +60,10 @@ public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
                         filterBuilder.attribute(VALIDATION_WARNINGS)
                                 .is()
                                 .empty()));
+                query.setPageSize(input.getQuery()
+                        .getPageSize());
+                query.setRequestsTotalResultsCount(input.getQuery()
+                        .requestsTotalResultsCount());
                 queryRequest = new QueryRequestImpl(query,
                         input.isEnterprise(),
                         input.getSourceIds(),


### PR DESCRIPTION
[DDF-1698](https://codice.atlassian.net/browse/DDF-1698) introduced a bug where when this new feature (catalog-plugin-metacard-validation) is on, `catalog:removeall` fails to remove all records. This was caused by a disparity between the expected batch size and the actual page size.

Most of the changes in this PR are formatting changes. The actual code changes are:
RemoveAllCommand:
line 37
line 292-309
line 332-349

DynamicSchemaResolver:
line 195-198

MetacardValidityCheckerPlugin:
line 60-63

@AzGoalie @brendan-hofmann @ahoffer 