### PR TITLE
DDF-1877 Updates Admin UI to show human readable names for MSF configs

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/models/Service.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Service.js
@@ -16,6 +16,9 @@
 /* jshint -W024*/
 define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
 
+    function isServiceFactory(properties){
+        return properties.get('service.factoryPid');
+    }
 
     Backbone.Associations.SEPARATOR = '~';
 
@@ -212,6 +215,14 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
                     return defaults;
                 }, {}));
             return this;
+        },
+        getConfigurationDisplayName: function () {
+            var displayName = this.get('id');
+            var properties = this.get('properties');
+            if (isServiceFactory(properties)) {
+                displayName = properties.get('name') || properties.get('shortname') || properties.get('id') || displayName;
+            }
+            return displayName;
         }
     });
 

--- a/platform/admin/ui/src/main/webapp/js/views/configuration/Service.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/Service.view.js
@@ -62,6 +62,9 @@ define([
                     configuration.close();
                 });
             }
+        },
+        serializeData: function () {
+            return _.extend(this.model.toJSON(), {displayName: this.model.getConfigurationDisplayName()});
         }
     });
 

--- a/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
@@ -13,7 +13,7 @@
  --}}
 <td class="column1 indent">
     <a href='#{{uuid}}' class='editLink' data-toggle="modal">
-        {{properties.[service.pid]}}
+        {{displayName}}
     </a>
     <div class="config-modal-container">
         <div id="{{uuid}}" class="config-modal modal" tabindex="-1" role="dialog" aria-hidden="true">


### PR DESCRIPTION
 - Adds a method to the Service model that returns the human readable name for a configuration.
 - Updates the template for configurationRow to utilize the displayName property.
 - Updates the service view to call the new model method to get a human readable name, and to merge this data into the object that is given to the template (that way it can access the displayName property).