### PR TITLE
DDF-1879 CSW Source now uses true product retrieval

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswConstants.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswConstants.java
@@ -60,6 +60,8 @@ public interface CswConstants {
 
     String FEDERATED_CATALOGS = "FederatedCatalogs";
 
+    String PRODUCT_RETRIEVAL_HTTP_HEADER = "X-Csw-Product";
+
     /*
      * typeName vs typeNames: typeName applies to DescribeRecord, where typeNames applies to
      * getRecords. However, throughout the csw 2.0.2 specification, in particular in section 10.8,

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
@@ -482,7 +482,7 @@ public class CswEndpoint implements Csw {
 
             LOGGER.debug("{} is attempting to retrieve records: {}", request.getService(), ids);
             CswRecordCollection response = queryById(ids);
-            response.setOutputSchema(request.getOutputSchema());
+            response.setOutputSchema(outputSchema);
             if (StringUtils.isNotBlank(request.getElementSetName())) {
                 response.setElementSetType(ElementSetType.fromValue(request.getElementSetName()));
             } else {
@@ -525,7 +525,7 @@ public class CswEndpoint implements Csw {
 
             LOGGER.debug("{} is attempting to retrieve records: {}", request.getService(), ids);
             CswRecordCollection response = queryById(ids);
-            response.setOutputSchema(request.getOutputSchema());
+            response.setOutputSchema(outputSchema);
             if (request.isSetElementSetName() && request.getElementSetName()
                     .getValue() != null) {
                 response.setElementSetType(request.getElementSetName()
@@ -536,6 +536,7 @@ public class CswEndpoint implements Csw {
             LOGGER.debug("{} successfully retrieved record(s): {}",
                     request.getService(),
                     request.getId());
+
             return response;
         } else {
             throw new CswException("A GetRecordById Query must contain an ID.",

--- a/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswSourceBase.java
+++ b/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswSourceBase.java
@@ -76,7 +76,6 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.security.sts.client.configuration.STSClientConfiguration;
-
 import net.opengis.cat.csw.v_2_0_2.AbstractRecordType;
 import net.opengis.cat.csw.v_2_0_2.BriefRecordType;
 import net.opengis.cat.csw.v_2_0_2.CapabilitiesType;
@@ -414,11 +413,11 @@ public class TestCswSourceBase {
         DomainType typeNames = new DomainType();
         typeNames.setName(CswConstants.TYPE_NAMES_PARAMETER);
         getRecordsParameters.add(typeNames);
-        DomainType outputSchema = new DomainType();
-        outputSchema.setName(CswConstants.OUTPUT_SCHEMA_PARAMETER);
-        outputSchema.getValue()
+        DomainType getRecordsOutputSchema = new DomainType();
+        getRecordsOutputSchema.setName(CswConstants.OUTPUT_SCHEMA_PARAMETER);
+        getRecordsOutputSchema.getValue()
                 .add(CswConstants.CSW_OUTPUT_SCHEMA);
-        getRecordsParameters.add(outputSchema);
+        getRecordsParameters.add(getRecordsOutputSchema);
         DomainType constraintLang = new DomainType();
         constraintLang.setName(CswConstants.CONSTRAINT_LANGUAGE_PARAMETER);
         constraintLang.setValue(Collections.singletonList(CswConstants.CONSTRAINT_LANGUAGE_FILTER));
@@ -433,11 +432,24 @@ public class TestCswSourceBase {
         elementSetName.setName(CswConstants.ELEMENT_SET_NAME_PARAMETER);
         getRecordsParameters.add(elementSetName);
 
+        List<DomainType> getRecordByIdParameters = new ArrayList<>();
+        DomainType getRecordByIdOutputSchema = new DomainType();
+        getRecordByIdOutputSchema.setName(CswConstants.OUTPUT_SCHEMA_PARAMETER);
+        List<String> outputSchemas = new ArrayList<>();
+        outputSchemas.add("http://www.iana.org/assignments/media-types/application/octet-stream");
+        outputSchemas.add(CswConstants.CSW_OUTPUT_SCHEMA);
+        getRecordByIdOutputSchema.setValue(outputSchemas);
+        getRecordByIdParameters.add(getRecordByIdOutputSchema);
+
         Operation getRecords = new Operation();
         getRecords.setName(CswConstants.GET_RECORDS);
         getRecords.setParameter(getRecordsParameters);
-        List<Operation> operations = new ArrayList<>(1);
+        Operation getRecordById = new Operation();
+        getRecordById.setName(CswConstants.GET_RECORD_BY_ID);
+        getRecordById.setParameter(getRecordByIdParameters);
+        List<Operation> operations = new ArrayList<>(2);
         operations.add(getRecords);
+        operations.add(getRecordById);
 
         OperationsMetadata mockOperationsMetadata = mock(OperationsMetadata.class);
         mockOperationsMetadata.setOperation(operations);

--- a/catalog/spatial/csw/spatial-csw-source/src/test/resources/getCapabilities.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/test/resources/getCapabilities.xml
@@ -127,6 +127,10 @@
 					<ows:Post xlink:href="http://www.cubewerx.com/cwcsg.cgi"/>
 				</ows:HTTP>
 			</ows:DCP>
+			<ows:Parameter name="outputSchema">
+				<ows:Value>http://www.opengis.net/cat/csw/2.0.2</ows:Value>
+				<ows:Value>http://www.iana.org/assignments/media-types/application/octet-stream</ows:Value>
+			</ows:Parameter>
 			<ows:Parameter name="ElementSetName">
 				<ows:Value>brief</ows:Value>
 				<ows:Value>summary</ows:Value>


### PR DESCRIPTION
-CswSource now uses the new product retrieval implemented through GetRecordById.

-Added a new custom HTTP header called: "X-Csw-Product," when returning the product data. 
Since the GetRecordsMessageBodyReader expects the response of the GetRecordById to be XML of the record, there needs to be a way to distinguish whether the response is the product data or the XML of the record. The custom header is checked to determine if the data coming in is a product.

@coyotesqrl @pklinef @kcwire @ryeats @bcwaters (hero) @tbatie @jckilmer @wbarnie 