### PR TITLE
DDF-1648 Update the manner in which the ConfigurationAdmin properties are updated at initial boot.

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -416,7 +416,6 @@
                             ddf.catalog.resource.download,
                             ddf.catalog.resource.impl,
                             ddf.catalog.resourceretriever,
-                            ddf.catalog.core.impl,
                             org.codice.ddf.platform.util
                         </Private-Package>
                         <Export-Package>

--- a/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
@@ -151,7 +151,6 @@
                             org.objectweb.asm.tree,
                             org.objectweb.asm.tree.analysis,
                             org.objectweb.asm.util,
-                            ddf.catalog.impl,
                             ddf.catalog.data.impl,
                             ddf.catalog.operation.impl,
                             ddf.catalog.util.impl,


### PR DESCRIPTION
Instead of updating the properties during a property set, attaches a service listener on initial boot waiting for the `BootFinished` service. When that service is published by Karaf, the boot sequence has completed and the config properties can safely be updated. On subsequent boots of the system, the listener is not attached.

@kcwire 
@pklinef 
@roelens8 Please hero - this will require multiple clean installations followed by reboots of the system.