### PR TITLE
DDF-1868 Allow admins to toggle catalog search to include invalid met…

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPlugin.java
@@ -39,6 +39,8 @@ public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
 
     protected final FilterAdapter filterAdapter;
 
+    private boolean showInvalidMetacards;
+
     public MetacardValidityCheckerPlugin(FilterBuilder filterBuilder, FilterAdapter filterAdapter) {
         this.filterBuilder = filterBuilder;
         this.filterAdapter = filterAdapter;
@@ -49,7 +51,8 @@ public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
             throws PluginExecutionException, StopProcessingException {
         QueryRequest queryRequest;
         try {
-            if (!filterAdapter.adapt(input.getQuery(), new ValidationQueryDelegate())) {
+            if (!showInvalidMetacards && !filterAdapter.adapt(input.getQuery(),
+                    new ValidationQueryDelegate())) {
                 QueryImpl query = new QueryImpl(filterBuilder.allOf(input.getQuery(),
                         filterBuilder.attribute(VALIDATION_ERRORS)
                                 .is()
@@ -62,6 +65,7 @@ public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
                         input.getSourceIds(),
                         input.getProperties());
             } else {
+                // return the existing query with invalid metacards
                 queryRequest = input;
             }
         } catch (UnsupportedQueryException e) {
@@ -69,5 +73,13 @@ public class MetacardValidityCheckerPlugin implements PreQueryPlugin {
             throw new StopProcessingException(e.getMessage());
         }
         return queryRequest;
+    }
+
+    public boolean getShowInvalidMetacards() {
+        return showInvalidMetacards;
+    }
+
+    public void setShowInvalidMetacards(boolean showInvalidMetacards) {
+        this.showInvalidMetacards = showInvalidMetacards;
     }
 }

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,7 +31,6 @@
     <reference id="filterAdapter"
                interface="ddf.catalog.filter.FilterAdapter"/>
 
-
     <!-- Pre-Ingest Metacard Validation Marker Plugin -->
     <bean id="pre-ingest-plugin"
           class="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
@@ -48,14 +47,13 @@
     <!-- Pre-Query Metacard Validity Checker Plugin -->
     <bean id="pre-query-plugin"
           class="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
-        <!--<cm:managed-properties-->
-        <!--persistent-id="MetacardValidityCheckerPlugin"-->
-        <!--update-strategy="container-managed"/>-->
+        <cm:managed-properties
+                persistent-id="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin"
+                update-strategy="container-managed"/>
         <argument ref="filterBuilder"/>
         <argument ref="filterAdapter"/>
-
+        <property name="showInvalidMetacards" value="false"/>
     </bean>
-
 
     <!-- Post-Query Metacard Validity Filter Plugin -->
     <bean id="post-query-plugin"

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -33,6 +33,15 @@
                 default="" cardinality="100"/>
     </OCD>
 
+    <OCD name="Metacard Validation Checker Plugin"
+         id="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
+        <AD
+                description="Show invalid metacards in search results"
+                name="Show Invalid Metacards" id="showInvalidMetacards" required="true"
+                type="Boolean"
+                default="false"/>
+    </OCD>
+
     <Designate
             pid="ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin">
         <Object
@@ -43,6 +52,12 @@
             pid="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin">
         <Object
                 ocdref="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin"/>
+    </Designate>
+
+    <Designate
+            pid="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin">
+        <Object
+                ocdref="ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin"/>
     </Designate>
 
 </metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityCheckerPluginTest.java
@@ -87,6 +87,38 @@ public class MetacardValidityCheckerPluginTest {
     }
 
     @Test
+    public void testSearchAnyAndShow()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        metacardValidityCheckerPlugin.setShowInvalidMetacards(true);
+        QueryImpl query = new QueryImpl(filterBuilder.attribute(Metacard.MODIFIED)
+                .is()
+                .equalTo()
+                .text("sample"));
+        assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(false));
+        QueryRequest sendQuery = new QueryRequestImpl(query);
+        QueryRequest returnQuery = metacardValidityCheckerPlugin.process(sendQuery);
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(false));
+        assertThat(sendQuery, is(returnQuery));
+    }
+
+    @Test
+    public void testSearchInvalidAndNotShow()
+            throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
+        metacardValidityCheckerPlugin.setShowInvalidMetacards(false);
+        QueryImpl query = new QueryImpl(filterBuilder.attribute(VALIDATION_WARNINGS)
+                .is()
+                .equalTo()
+                .text("sample"));
+        assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(true));
+        QueryRequest sendQuery = new QueryRequestImpl(query);
+        QueryRequest returnQuery = metacardValidityCheckerPlugin.process(sendQuery);
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+        assertThat(sendQuery, is(returnQuery));
+    }
+
+    @Test
     public void testSearchBoth()
             throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
         QueryImpl query = new QueryImpl(filterBuilder.allOf(filterBuilder.attribute(
@@ -670,6 +702,12 @@ public class MetacardValidityCheckerPluginTest {
     @Test
     public void testRelative() {
         assertThat(testValidationQueryDelegate.relative(Metacard.ANY_TEXT, (long) 0), is(false));
+    }
+
+    @Test
+    public void testGetShowInvalidMetacards() {
+        metacardValidityCheckerPlugin.setShowInvalidMetacards(true);
+        assertThat(metacardValidityCheckerPlugin.getShowInvalidMetacards(), is(true));
     }
 
 }


### PR DESCRIPTION
This change is intended to allow admins to toggle on / off invalid metacards in search results. It does not modify metacards or change their validation statuses.

The integration test added is based off of the `testValidation*` tests in the TestCatalog class with  the `invalid-state=system-admin` removed.

@NGoss hero
@harrison-tarr @AzGoalie 