### PR TITLE
DDF-1879 - updated logic to determine how product retrieval should be…

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswSourceBase.java
+++ b/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswSourceBase.java
@@ -436,7 +436,6 @@ public class TestCswSourceBase {
         DomainType getRecordByIdOutputSchema = new DomainType();
         getRecordByIdOutputSchema.setName(CswConstants.OUTPUT_SCHEMA_PARAMETER);
         List<String> outputSchemas = new ArrayList<>();
-        outputSchemas.add("http://www.iana.org/assignments/media-types/application/octet-stream");
         outputSchemas.add(CswConstants.CSW_OUTPUT_SCHEMA);
         getRecordByIdOutputSchema.setValue(outputSchemas);
         getRecordByIdParameters.add(getRecordByIdOutputSchema);


### PR DESCRIPTION
… done and added unit tests

#### What's this PR do?
Updates logic to determine how a resource should be retrieved. (Adds null checking mostly).
#### Who is reviewing it?
@coyotesqrl @pklinef @ryeats @bcwaters (hero) @tbatie @jckilmer
#### How should this be tested?
Verify Unit tests & Integration Tests pass
Federate to current DDF and an old DDF and successfully retrieved a product to ensure backward compatibility.
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
DDF-1879
#### Screenshots (if appropriate)
N/A
#### Questions:
- Does the documentation need an update?
No