### PR TITLE
DDF-1907 Add ability to validate xml from the karaf console

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -109,6 +109,20 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-services-maven-plugin</artifactId>
+                <version>${karaf.version}</version>
+                <executions>
+                    <execution>
+                        <id>service-metadata-generate</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>service-metadata-generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
@@ -153,22 +167,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.21</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.13</minimum>
+                                            <minimum>0.25</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.11</minimum>
+                                            <minimum>0.25</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.23</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_CYAN;
+import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_DEFAULT;
+import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_RED;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.support.completers.FileCompleter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+
+/**
+ * Custom Karaf command to validate XML files against services that implement MetacardValidator
+ */
+@Command(scope = CatalogCommands.NAMESPACE, name = "validate", description = "Validates an XML file against all installed validators.")
+@Service
+public class ValidateCommand implements Action {
+
+    @Argument(index = 0, name = "fileName", description = "The path to the file that you want to validate", required = true, multiValued = false)
+    @Completion(FileCompleter.class)
+    String filename;
+
+    @Reference
+    List<MetacardValidator> validators;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidateCommand.class);
+
+    // Using system out for println is caught by our githooks to prevent bad practice.
+    // We actually need to use it here.
+    protected PrintStream console = System.out;
+
+    // These constants are to help in trying to make the output
+    // both uniform and readable.
+    private static final String INDENT =       "|   ";
+    private static final String LAST_INDENT =  "    ";
+    private static final String ELEMENT =      "+-- ";
+    private static final String LAST_ELEMENT = "`-- ";
+
+    private static final String WARNING_TITLE = "Warnings";
+    private static final String ERROR_TITLE =   "Errors";
+
+    private static final String WARNING_COLOR = COLOR_CYAN;
+    private static final String ERROR_COLOR =   COLOR_RED;
+
+    @Override
+    public Object execute() throws Exception {
+
+        if (fileExists() && hasValidators()) {
+            Metacard metacard = createMetacard();
+            if (metacard != null) {
+                runValidators(metacard);
+            }
+        }
+
+        // We must return an object per the Action contract which
+        // this class implements. It is sufficient to return null.
+        return null;
+    }
+
+    private boolean fileExists() {
+        File fileToValidate = new File(filename);
+        if (!fileToValidate.exists()) {
+            console.printf(ERROR_COLOR +
+                    "Unable to locate file '%s'. Double check the path is correct and the file exists.%n"
+                    + COLOR_DEFAULT, filename);
+            return false;
+        }
+
+        if (!fileToValidate.isFile()) {
+            console.printf(ERROR_COLOR + "'%s' is not a file.%n" + COLOR_DEFAULT, filename);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasValidators() {
+        if (validators == null || validators.size() < 1) {
+            console.println(ERROR_COLOR + "No validators have been configured" + COLOR_DEFAULT);
+            return false;
+        }
+        return true;
+    }
+
+    private Metacard createMetacard() {
+
+        // Although we are given XML, we need to put it in a metacard to work with the validators.
+        MetacardImpl metacard = null;
+        try {
+            String metadata = IOUtils.toString(new File(filename).toURI());
+            metacard = new MetacardImpl();
+            metacard.setMetadata(metadata);
+        } catch (IOException e) {
+            console.println(ERROR_COLOR + "Error reading file. Check the log for the stacktrace" + COLOR_DEFAULT);
+            LOGGER.error("Error trying to read file {}", filename, e);
+        }
+        return metacard;
+    }
+
+    private void runValidators(Metacard metacard) {
+
+        // In an effort to make the output of this command more readable on the console,
+        // we model it after the 'tree' command in Linux. We are printing a hierarchy of lists,
+        // so we want to make the last element of the list pronounced so that we can more
+        // easily see the groupings of the hierarchy. This is why we use an iterator
+        // and if-else rather than a more simple for-loop.
+        Iterator<MetacardValidator> iterator = validators.iterator();
+        while (iterator.hasNext()) {
+            MetacardValidator validator = iterator.next();
+            if (iterator.hasNext()) {
+                printValidator(validator, ELEMENT);
+                printErrorsAndWarnings(validator, metacard, INDENT);
+            } else {
+                printValidator(validator, LAST_ELEMENT);
+                printErrorsAndWarnings(validator, metacard, LAST_INDENT);
+            }
+        }
+    }
+
+    private void printValidator(MetacardValidator validator, String prefix) {
+        String name = validator.getClass().getName();
+        if (validator instanceof Describable && ((Describable) validator).getId() != null) {
+            name = ((Describable) validator).getId();
+        }
+        prettyPrint(prefix, name);
+    }
+
+    private void printErrorsAndWarnings(MetacardValidator validator, Metacard metacard, String prefix) {
+        try {
+            validator.validate(metacard);
+            prettyPrint(prefix + LAST_ELEMENT, "No errors or warnings");
+        } catch (ValidationException e) {
+
+            // The seemingly unnecessary complexity here is because we want the end result
+            // on the console to look good. We know that errors will come before warnings,
+            // so the whole error block uses the "indent" prefix. Further, we print
+            // errors and warnings with different
+            prettyPrint(prefix + ELEMENT, ERROR_TITLE);
+            if (e.getErrors() == null) {
+                prettyPrint(prefix + INDENT + LAST_ELEMENT, "None");
+            } else {
+                printList(prefix + INDENT, e.getErrors(), ERROR_COLOR);
+            }
+
+            // We know that warnings come last, so we format each line knowing that it's the last
+            // in its hierarchy.
+            prettyPrint(prefix + LAST_ELEMENT, WARNING_TITLE);
+            if (e.getWarnings() == null) {
+                prettyPrint(prefix + LAST_INDENT + LAST_ELEMENT, "None");
+            } else {
+                printList(prefix + LAST_INDENT, e.getWarnings(), WARNING_COLOR);
+            }
+
+        } catch (RuntimeException e) {
+            prettyPrint(prefix + LAST_ELEMENT,
+                    "Unhandled exception while running validator. Check the log for the stack trace and fix the validator.",
+                    ERROR_COLOR);
+            LOGGER.error("Unhandled exception while trying to validate.", e);
+        }
+    }
+
+    private void prettyPrint(String prefix, String message) {
+        prettyPrint(prefix, message, COLOR_DEFAULT);
+    }
+
+    private void prettyPrint(String prefix, String message, String color) {
+
+        // We want to get rid of all whitespace and newlines to make everything look uniform.
+        console.println(prefix + color + message.replaceAll("[\r\n\t ]+", " ") + COLOR_DEFAULT);
+    }
+
+    private void printList(String prefix, List<String> messages, String color) {
+
+        // Using an iterator instead of a for loop to make sure the last element
+        // in the list is printed differently for console readability.
+        Iterator<String> iterator = messages.iterator();
+        while (iterator.hasNext()) {
+            String message = iterator.next();
+            if (iterator.hasNext()) {
+                prettyPrint(prefix + ELEMENT, message, color);
+            } else {
+                prettyPrint(prefix + LAST_ELEMENT, message, color);
+            }
+        }
+    }
+}

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/ValidateCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/ValidateCommandTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+
+public class ValidateCommandTest {
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        testFolder.newFile("empty.xml");
+    }
+
+    @Test
+    public void testWithPassingValidator() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        validators.add(mock(MetacardValidator.class));
+        assertThat(execute(validators), containsString("No errors or warnings"));
+    }
+
+    @Test
+    public void testWithInvalidPath() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        validators.add(mock(MetacardValidator.class));
+        assertThat(execute(validators, "not_a_real_file.xml"), containsString("Unable to locate"));
+    }
+
+    @Test
+    public void testWithWarning() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        MockValidatorWithException mockValidatorWithException = new MockValidatorWithException();
+        mockValidatorWithException.warnings = new ArrayList<>(Arrays.asList("sample warning"));
+        validators.add(mockValidatorWithException.getValidator());
+        assertThat(execute(validators), containsString("sample warning"));
+    }
+
+    @Test
+    public void testWithError() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        MockValidatorWithException mockValidatorWithException = new MockValidatorWithException();
+        mockValidatorWithException.errors = new ArrayList<>(Arrays.asList("sample error"));
+        validators.add(mockValidatorWithException.getValidator());
+        assertThat(execute(validators), containsString("sample error"));
+    }
+
+    @Test
+    public void testWithMultipleValidators() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        MockValidatorWithException mockValidatorWithException1 = new MockValidatorWithException();
+        MockValidatorWithException mockValidatorWithException2 = new MockValidatorWithException();
+        mockValidatorWithException1.id = "validator 1";
+        mockValidatorWithException2.id = "validator 2";
+        validators.add(mockValidatorWithException1.getValidator());
+        validators.add(mockValidatorWithException2.getValidator());
+        assertThat(execute(validators), containsString("validator 1"));
+        assertThat(execute(validators), containsString("validator 2"));
+    }
+
+    @Test
+    public void testWithErrorsAndWarnings() throws Exception {
+        List<MetacardValidator> validators = new ArrayList<>();
+        MockValidatorWithException mockValidatorWithException = new MockValidatorWithException();
+        mockValidatorWithException.errors = new ArrayList<>(Arrays.asList("error 1", "error 2"));
+        mockValidatorWithException.warnings = new ArrayList<>(Arrays.asList("warning 1", "warning 2"));
+        validators.add(mockValidatorWithException.getValidator());
+        assertThat(execute(validators), containsString("error 1"));
+        assertThat(execute(validators), containsString("error 2"));
+        assertThat(execute(validators), containsString("warning 1"));
+        assertThat(execute(validators), containsString("warning 2"));
+    }
+
+    @Test
+    public void testWithValidatorsEqualNull() throws Exception {
+        assertThat(execute(null), containsString("No validators have been configured"));
+    }
+
+    @Test
+    public void testWithValidatorsSizeZero() throws Exception {
+        assertThat(execute(new ArrayList<>()), containsString("No validators have been configured"));
+    }
+
+    private String execute(List<MetacardValidator> validators) throws Exception {
+        return execute(validators, "empty.xml");
+    }
+
+    private String execute(List<MetacardValidator> validators, String filename) throws Exception {
+        ConsoleOutput consoleOutput = new ConsoleOutput();
+        consoleOutput.interceptSystemOut();
+
+        ValidateCommand command = new ValidateCommand();
+        command.filename = Paths.get(testFolder.getRoot().getAbsolutePath(), filename).toString();
+        command.validators = validators;
+        command.execute();
+        consoleOutput.resetSystemOut();
+        return consoleOutput.getOutput();
+    }
+
+    private class MockValidatorWithException {
+        String id;
+        List<String> warnings;
+        List<String> errors;
+
+        MetacardValidator getValidator() throws ValidationException {
+            ValidationException validationException = mock(ValidationException.class);
+            when(validationException.getErrors()).thenReturn(errors);
+            when(validationException.getWarnings()).thenReturn(warnings);
+            MetacardValidator metacardValidator = mock(MetacardValidator.class, withSettings().extraInterfaces(Describable.class));
+            when(((Describable) metacardValidator).getId()).thenReturn(id);
+            doThrow(validationException).when(metacardValidator).validate(any(Metacard.class));
+            return metacardValidator;
+        }
+    }
+}

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -115,7 +115,7 @@ public class SchematronValidationService implements MetacardValidator, Describab
         Templates template;
         File schematronFile = new File(schematronFileName);
         if (!schematronFile.exists()) {
-            throw new SchematronInitializationException("Could not locate schematron file" + schematronFileName);
+            throw new SchematronInitializationException("Could not locate schematron file " + schematronFileName);
         }
 
         try {
@@ -135,8 +135,9 @@ public class SchematronValidationService implements MetacardValidator, Describab
             DOMResult stage3Result = performStage(stage2Output, getClass().getClassLoader().getResource("iso-schematron/iso_svrl_for_xslt2.xsl"));
             DOMSource stage3Output = new DOMSource(stage3Result.getNode());
 
-            // Setting the system ID let's us resolve relative paths in the schematron files.
-            stage3Output.setSystemId(schematronFileName);
+            // Setting the system ID lets us resolve relative paths in the schematron files.
+            // We need the URI string so that the string is properly formatted (e.g. space = %20).
+            stage3Output.setSystemId(schematronFile.toURI().toString());
             template = transformerFactory.newTemplates(stage3Output);
         } catch (Exception e) {
             throw new SchematronInitializationException(

--- a/distribution/docs/src/main/resources/_contents/running-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/running-contents.adoc
@@ -268,7 +268,7 @@ No pre/post plugins are executed and no message validation is performed if the `
 ----
 catalog:describe     catalog:dump         catalog:envlist      catalog:ingest       catalog:inspect
 catalog:latest       catalog:migrate      catalog:range        catalog:remove       catalog:removeall
-catalog:replicate    catalog:search       catalog:spatial
+catalog:replicate    catalog:search       catalog:spatial      catalog:validate
 ----
 
 .Command Descriptions
@@ -321,6 +321,9 @@ Provides a list of environment variables.
 
 |`spatial`
 |Searches spatially the local Catalog.
+
+|`validate`
+|Validates an XML file against all installed validators and prints out human readable errors and warnings.
 
 |===
 


### PR DESCRIPTION
This PR adds the ability to validate xml from the karaf console.

This command will go through any validators you have configured and will help ensure the quality and validity of ingested data by providing feedback about where your data fails validation.

You can test it out by:
1) configuring a validator (e.g. DDF Catalog -> Configuration -> Schematron Validation Services)
2) Running "validate" on an xml file

@AzGoalie will hero.
@kcwire 
@brianfelix 