### PR TITLE
DDF-1862 Process backup commands asynchronously

### DIFF
--- a/catalog/core/catalog-core-backupplugin/pom.xml
+++ b/catalog/core/catalog-core-backupplugin/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
@@ -26,6 +28,16 @@
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -65,7 +77,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/core/catalog-core-backupplugin/src/main/java/ddf/catalog/backup/CatalogBackupPlugin.java
+++ b/catalog/core/catalog-core-backupplugin/src/main/java/ddf/catalog/backup/CatalogBackupPlugin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,14 +14,16 @@
 package ddf.catalog.backup;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,75 +33,52 @@ import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.Update;
 import ddf.catalog.operation.UpdateResponse;
-import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.PostIngestPlugin;
-import ddf.catalog.util.impl.Requests;
 
 /**
  * The CatalogBackupPlugin backups up metacards to the file system. It is a
  * PostIngestPlugin, so it processes CreateResponses, DeleteResponses, and
  * UpdateResponses.
- * <p>
+ * <p/>
  * The root backup directory and subdirectory levels can be configured in the
  * Backup Post-Ingest Plugin section in the admin console.
- * <p>
+ * <p/>
  * This feature can be installed/uninstalled with the following commands:
- * <p>
- * ddf@local>features:install catalog-core-backupplugin
- * ddf@local>features:uninstall catalog-core-backupplugin
+ * <p/>
+ * ddf@local>feature:install catalog-core-backupplugin
+ * ddf@local>feature:uninstall catalog-core-backupplugin
  */
 
 public class CatalogBackupPlugin implements PostIngestPlugin {
+
+    public static final String CREATE = "CREATE";
+
+    public static final String DELETE = "DELETE";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogBackupPlugin.class);
 
     private static final String TEMP_FILE_EXTENSION = ".tmp";
 
-    private File rootBackupDir;
+    private long terminationTimeoutSeconds;
 
-    private int subDirLevels;
+    private int subDirLevels = 0;
 
-    private boolean enableBackupPlugin = true;
+    private String rootBackupDir;
 
-    public CatalogBackupPlugin() {
-        subDirLevels = 0;
-    }
+    private ExecutorService executor;
+
+    private File rootDirOjbect;
 
     /**
      * Backs up created metacards to the file system backup.
      *
      * @param input the {@link CreateResponse} to process
-     * @return
-     * @throws PluginExecutionException
+     * @return {@link CreateResponse}
      */
     @Override
-    public CreateResponse process(CreateResponse input) throws PluginExecutionException {
-        if (enableBackupPlugin && Requests.isLocal(input.getRequest())) {
-            LOGGER.debug("Performing backup of metacards in CreateResponse.");
+    public CreateResponse process(CreateResponse input) {
 
-            if (rootBackupDir == null) {
-                throw new PluginExecutionException("No root backup directory configured.");
-            }
-
-            List<String> errors = new ArrayList<String>();
-
-            List<Metacard> metacards = input.getCreatedMetacards();
-
-            for (Metacard metacard : metacards) {
-                try {
-                    backupMetacard(metacard);
-                } catch (IOException e) {
-                    errors.add(metacard.getId());
-                }
-            }
-
-            if (errors.size() > 0) {
-                throw new PluginExecutionException(getExceptionMessage(CreateResponse.class.getSimpleName(),
-                        null,
-                        errors,
-                        OPERATION.CREATE));
-            }
-        }
+        execute(() -> create(input.getCreatedMetacards()));
         return input;
     }
 
@@ -107,59 +86,20 @@ public class CatalogBackupPlugin implements PostIngestPlugin {
      * Backs up updated metacards to the file system backup.
      *
      * @param input the {@link UpdateResponse} to process
-     * @return
-     * @throws PluginExecutionException
+     * @return {@link UpdateResponse}
      */
     @Override
-    public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
-        if (enableBackupPlugin && Requests.isLocal(input.getRequest())) {
-            LOGGER.debug("Updating metacards contained in UpdateResponse in backup.");
-
-            if (rootBackupDir == null) {
-                throw new PluginExecutionException("No root backup directory configured.");
-            }
-
-            List<String> deleteErrors = new ArrayList<String>();
-            List<String> backupErrors = new ArrayList<String>();
-
-            List<Update> updates = input.getUpdatedMetacards();
-
-            for (Update update : updates) {
-                try {
-                    deleteMetacard(update.getOldMetacard());
-                } catch (IOException e) {
-                    deleteErrors.add(update.getOldMetacard()
-                            .getId());
-                }
-
-                try {
-                    backupMetacard(update.getNewMetacard());
-                } catch (IOException e) {
-                    backupErrors.add(update.getNewMetacard()
-                            .getId());
-                }
-            }
-
-            String exceptionMessage = null;
-
-            if (deleteErrors.size() > 0) {
-                exceptionMessage = getExceptionMessage(UpdateResponse.class.getSimpleName(),
-                        exceptionMessage,
-                        deleteErrors,
-                        OPERATION.DELETE);
-            }
-
-            if (backupErrors.size() > 0) {
-                exceptionMessage = getExceptionMessage(UpdateResponse.class.getSimpleName(),
-                        exceptionMessage,
-                        backupErrors,
-                        OPERATION.CREATE);
-            }
-
-            if (deleteErrors.size() > 0 || backupErrors.size() > 0) {
-                throw new PluginExecutionException(exceptionMessage);
-            }
+    public UpdateResponse process(UpdateResponse input) {
+        int size = input.getUpdatedMetacards()
+                .size();
+        List<Metacard> toDelete = new ArrayList<>(size);
+        List<Metacard> toCreate = new ArrayList<>(size);
+        for (Update update : input.getUpdatedMetacards()) {
+            toDelete.add(update.getOldMetacard());
+            toCreate.add(update.getNewMetacard());
         }
+        execute(() -> delete(toDelete));
+        execute(() -> create(toCreate));
         return input;
     }
 
@@ -167,57 +107,189 @@ public class CatalogBackupPlugin implements PostIngestPlugin {
      * Removes deleted metacards from the file system backup.
      *
      * @param input the {@link DeleteResponse} to process
-     * @return
-     * @throws PluginExecutionException
+     * @return {@link DeleteResponse}
      */
     @Override
-    public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
-        if (enableBackupPlugin && Requests.isLocal(input.getRequest())) {
-            LOGGER.debug("Deleting metacards contained in DeleteResponse from backup.");
+    public DeleteResponse process(DeleteResponse input) {
 
-            if (rootBackupDir == null) {
-                throw new PluginExecutionException("No root backup directory configured.");
-            }
-
-            List<String> errors = new ArrayList<String>();
-
-            List<Metacard> metacards = input.getDeletedMetacards();
-
-            for (Metacard metacard : metacards) {
-                try {
-                    deleteMetacard(metacard);
-                } catch (IOException e) {
-                    errors.add(metacard.getId());
-                }
-            }
-
-            if (errors.size() > 0) {
-                throw new PluginExecutionException(getExceptionMessage(DeleteResponse.class.getSimpleName(),
-                        null,
-                        errors,
-                        OPERATION.DELETE));
-            }
-        }
+        execute(() -> delete(input.getDeletedMetacards()));
         return input;
     }
 
-    public void setEnableBackupPlugin(boolean enablePlugin) {
-        enableBackupPlugin = enablePlugin;
+    /**
+     * @throws IllegalStateException will be thrown if the tasks in the queue have not
+     *                               completed before the awaitTermination message times out
+     */
+    public void shutdown() {
+
+        getExecutor().shutdown();
+        if (!executor.isShutdown()) {
+            try {
+                executor.awaitTermination(getTerminationTimeoutSeconds(), TimeUnit.SECONDS);
+                // If the remaining jobs in the queue are not completed TERMINATION_TIMEOUT elapses
+                // The JVM will throw an Interrupted Exception.
+            } catch (InterruptedException e) {
+                LOGGER.warn(
+                        "Backup of metacards interrupted. Some metacards might not be backed up.");
+                throw new IllegalStateException(e);
+            }
+            final List<Runnable> failures = executor.shutdownNow();
+            if (failures.size() > 0) {
+                LOGGER.warn(
+                        "Cancelled tasks to backup metacards. Some metacards might not be backed up.");
+            }
+        }
+    }
+
+    ExecutorService getExecutor() {
+        return executor;
+    }
+
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    private void execute(Runnable task) {
+
+        executor.execute(task);
+    }
+
+    private void create(List<Metacard> metacards) {
+
+        List<String> errors = new ArrayList<>();
+        for (Metacard metacard : metacards) {
+            try {
+                createFile(metacard);
+            } catch (RuntimeException | IOException e) {
+                errors.add(metacard.getId());
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            LOGGER.warn(getExceptionMessage(errors, CREATE));
+        }
+    }
+
+    private void delete(List<Metacard> cards) {
+        List<String> errors = new ArrayList<>();
+        for (Metacard metacard : cards) {
+            try {
+                deleteFile(metacard);
+            } catch (IOException | RuntimeException e) {
+                errors.add(metacard.getId());
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            LOGGER.warn(getExceptionMessage(errors, DELETE));
+        }
+    }
+
+    private void renameTempFile(File source) throws IOException {
+        File destination = new File(StringUtils.removeEnd(source.getAbsolutePath(),
+                TEMP_FILE_EXTENSION));
+        boolean success = source.renameTo(destination);
+        if (!success) {
+            LOGGER.warn("Failed to move {} to {}.",
+                    source.getAbsolutePath(),
+                    destination.getAbsolutePath());
+        }
+    }
+
+    private String getExceptionMessage(List<String> metacardsIdsInError, String operation) {
+
+        return "Catalog Backup Plugin processing error." + " " + "Unable to " + operation
+                + " metacard(s) [" + StringUtils.join(metacardsIdsInError, ",") + "]. ";
+    }
+
+    private void createFile(Metacard metacard) throws IOException {
+
+        // Metacards written to temp files. Each temp file is renamed when the write is
+        // complete. This makes it easy to find and remove failed files.
+        File tempFile = getFile(metacard.getId(), TEMP_FILE_EXTENSION);
+
+        try (ObjectOutputStream oos = new ObjectOutputStream(FileUtils.openOutputStream(tempFile))) {
+            oos.writeObject(new MetacardImpl(metacard));
+        }
+
+        renameTempFile(tempFile);
+    }
+
+    private void deleteFile(Metacard metacard) throws IOException {
+
+        File metacardToDelete = getFile(metacard.getId(), "");
+        FileUtils.forceDelete(metacardToDelete);
+    }
+
+    private File getFile(String id, String extension) throws IOException {
+
+        int depth = getDepth(id.length());
+        return new File(getCompleteDirectory(depth, id), id + extension);
+    }
+
+    private File getCompleteDirectory(int depth, String id) throws IOException {
+
+        File parent = getRootDirObject();
+        for (int i = 0; i < depth; i++) {
+            parent = new File(parent, id.substring(i * 2, i * 2 + 2));
+        }
+
+        return parent;
+    }
+
+    private int getDepth(int idLength) {
+        int levels = getSubDirLevels();
+        if (idLength == 1 || idLength < getSubDirLevels() * 2) {
+            levels = idLength / 2;
+        }
+        return levels;
+    }
+
+    private File getRootDirObject() throws IOException {
+        if (rootDirOjbect == null) {
+            Validate.notNull(getRootBackupDir());
+            File directory = new File(getRootBackupDir());
+            FileUtils.forceMkdir(directory);
+            validateDirectory(directory);
+            rootDirOjbect = directory;
+        }
+        return rootDirOjbect;
+    }
+
+    private void validateDirectory(File directory) {
+
+        if (!(directory.isDirectory() && directory.canWrite())) {
+            throw new IllegalArgumentException("Directory " + directory.getAbsolutePath()
+                    + " does not exist or is not writable");
+        }
+    }
+
+    public long getTerminationTimeoutSeconds() {
+        return terminationTimeoutSeconds;
+    }
+
+    public void setTerminationTimeoutSeconds(long terminationTimeoutSeconds) {
+        this.terminationTimeoutSeconds = terminationTimeoutSeconds;
+    }
+
+    public String getRootBackupDir() {
+        return rootBackupDir;
     }
 
     /**
-     * Sets the root file system backup directory.
+     * Sets the root file system backup directory. The directory will be created when
+     * it is needed. Do not validate the existence of the directory until then.
      *
      * @param dir absolute path for the root file system backup directory.
      */
     public void setRootBackupDir(String dir) {
-        if (StringUtils.isBlank(dir)) {
-            LOGGER.error("The root backup directory is blank.");
-            return;
-        }
 
-        this.rootBackupDir = new File(dir);
-        LOGGER.debug("Set root backup directory to: {}", this.rootBackupDir.toString());
+        rootBackupDir = dir;
+        rootDirOjbect = null;
+    }
+
+    public int getSubDirLevels() {
+        return subDirLevels;
     }
 
     /**
@@ -227,137 +299,10 @@ public class CatalogBackupPlugin implements PostIngestPlugin {
      * @param levels number of subdirectory levels to create
      */
     public void setSubDirLevels(int levels) {
+        Validate.isTrue(levels >= 0,
+                "Depth of directory hierarchy for the catalog backup plugin must be zero or greater. Actual value was ",
+                levels);
         this.subDirLevels = levels;
-        LOGGER.debug("Set subdirectory levels to: {}", this.subDirLevels);
     }
-
-    private void backupMetacard(Metacard metacard) throws IOException {
-
-        // Write metacard to a temp file. When write is complete, rename (remove
-        // temp extension).
-        File tempFile = getTempFile(metacard);
-
-        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(tempFile))) {
-            LOGGER.debug("Writing temp metacard [{}] to [{}].",
-                    tempFile.getName(),
-                    tempFile.getParent());
-            oos.writeObject(new MetacardImpl(metacard));
-        }
-
-        removeTempExtension(tempFile);
-    }
-
-    /**
-     * Deletes metacard from file system backup.
-     *
-     * @param metacard the metacard to be deleted.
-     * @throws IOException
-     */
-    private void deleteMetacard(Metacard metacard) throws IOException {
-        File metacardToDelete = getBackupFile(metacard);
-        FileUtils.forceDelete(metacardToDelete);
-    }
-
-    /**
-     * While metacards are being written to the file system for backup, they are
-     * written to temp files. Each temp file is renamed when the write is
-     * complete. This makes it easy to find and remove failed files.
-     *
-     * @param metacard the metacard to create a temp file for.
-     * @return
-     * @throws IOException
-     */
-    private File getTempFile(Metacard metacard) throws IOException {
-        return new File(getBackupFile(metacard).getAbsolutePath() + TEMP_FILE_EXTENSION);
-    }
-
-    private File getBackupFile(Metacard metacard) throws IOException {
-
-        String metacardId = metacard.getId();
-        File parent = rootBackupDir;
-        int levels = this.subDirLevels;
-
-        if (this.subDirLevels < 0) {
-            levels = 0;
-        } else if (metacardId.length() == 1 || metacardId.length() < this.subDirLevels * 2) {
-            levels = (int) Math.floor(metacardId.length() / 2);
-        }
-
-        for (int i = 0; i < levels; i++) {
-            parent = new File(parent, metacardId.substring(i * 2, i * 2 + 2));
-            FileUtils.forceMkdir(parent);
-        }
-
-        LOGGER.debug("Backup directory for metacard  [{}] is [{}].",
-                metacard.getId(),
-                parent.getAbsolutePath());
-        return new File(parent, metacardId);
-    }
-
-    /**
-     * Removed the temp file extension off of the backed up metacard.
-     *
-     * @param source the backed up metacard file in which the temp file extension
-     *               is to be removed.
-     * @throws IOException
-     */
-    private void removeTempExtension(File source) throws IOException {
-        LOGGER.debug("Removing {} file extension.", TEMP_FILE_EXTENSION);
-        File destination = new File(StringUtils.removeEnd(source.getAbsolutePath(),
-                TEMP_FILE_EXTENSION));
-        boolean success = source.renameTo(destination);
-        if (success) {
-            LOGGER.debug("Moved {} to {}.",
-                    source.getAbsolutePath(),
-                    destination.getAbsolutePath());
-        } else {
-            LOGGER.debug("Failed to move {} to {}.",
-                    source.getAbsolutePath(),
-                    destination.getAbsolutePath());
-        }
-    }
-
-    /**
-     * Gets an exception message
-     *
-     * @param previousExceptionMessage the previous exception message that we wish to append to
-     * @param metacardsIdsInError      the metacard IDs that processed in error
-     * @param operation                the operation being performed
-     * @return the updated exception message
-     */
-    private String getExceptionMessage(String responseType, String previousExceptionMessage,
-            List<String> metacardsIdsInError, OPERATION operation) {
-        StringBuilder builder = new StringBuilder();
-
-        if (StringUtils.isNotBlank(previousExceptionMessage)) {
-            builder.append(previousExceptionMessage);
-            builder.append(" ");
-        }
-
-        builder.append("Error processing ");
-        builder.append(responseType);
-        builder.append(". ");
-
-        switch (operation) {
-        case CREATE:
-            builder.append("Unable to backup metacard(s) [");
-            builder.append(StringUtils.join(metacardsIdsInError, ","));
-            builder.append("]. ");
-            break;
-        case DELETE:
-            builder.append("Unable to delete metacard(s) [");
-            builder.append(StringUtils.join(metacardsIdsInError, ","));
-            builder.append("] from backup. ");
-            break;
-        default:
-            LOGGER.debug("No specific error message details for operation {}", operation);
-        }
-        return builder.toString();
-    }
-
-    private enum OPERATION {
-        CREATE,
-        DELETE
-    }
-
 }
+

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,10 +14,19 @@
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <bean id="catalogBackupPlugin" class="ddf.catalog.backup.CatalogBackupPlugin">
+
+    <bean id="executorService" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadExecutor">
+    </bean>
+
+
+    <bean id="catalogBackupPlugin" class="ddf.catalog.backup.CatalogBackupPlugin"
+          destroy-method="shutdown">
         <cm:managed-properties persistent-id="plugin.backup" update-strategy="container-managed"/>
         <property name="rootBackupDir" value="data/backup"/>
         <property name="subDirLevels" value="2"/>
+        <property name="terminationTimeoutSeconds" value="30"/>
+        <property name="executor" ref="executorService"/>
     </bean>
 
     <service ref="catalogBackupPlugin" interface="ddf.catalog.plugin.PostIngestPlugin"/>

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
                 description="Enable the Backup Ingest plugin which will write each result to a directory"
                 name="Enable Backup Plugin" id="enableBackupPlugin"
                 required="false" type="Boolean" default="true"/>
-        
+
         <AD
                 description="Root backup directory for Metacards. A relative path is relative to ddf.home."
                 name="Root backup directory path" id="rootBackupDir" required="true" type="String"

--- a/catalog/core/catalog-core-backupplugin/src/test/java/ddf/catalog/backup/CatalogBackupPluginTest.java
+++ b/catalog/core/catalog-core-backupplugin/src/test/java/ddf/catalog/backup/CatalogBackupPluginTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,10 +14,13 @@
 package ddf.catalog.backup;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static junit.framework.Assert.fail;
 
@@ -28,6 +31,12 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,82 +65,31 @@ public class CatalogBackupPluginTest {
     private static final String BASE_NEW_TITLE = "newTitle";
 
     @Rule
-    public TemporaryFolder rootBackupDir = new TemporaryFolder();
+    public TemporaryFolder backupDirObject = new TemporaryFolder();
 
-    /**
-     * Verify no NullPointerException
-     */
     @Test
-    public void testNullBackupDir() {
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setRootBackupDir(null);
-    }
+    public void testCreateResponseNotNull() throws PluginExecutionException {
 
-    @Test(expected = PluginExecutionException.class)
-    public void testProcessCreateResponseRootBackupDirBlank() throws Exception {
-        // Setup
-        int subDirLevels = 3;
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(null);
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        // Perform Test
-        catalogBackupPlugin.process(mockCreateResponse);
+        assertThat(getPlugin().process(getCreateResponse(METACARD_IDS)), is(notNullValue()));
     }
 
     @Test
-    public void testProcessCreateResponseSubdirectoryLevelsIsZero() throws Exception {
+    public void testCreateResponseSubdirectoryLevelsIsZero() throws Exception {
         // Setup
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
-
         int subDirLevels = 0;
 
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        // Perform Test
-        CreateResponse postPluginCreateResponse = catalogBackupPlugin.process(mockCreateResponse);
+        // Perform test
+        getPlugin(0).process(getCreateResponse(METACARD_IDS));
 
         // Verify
-        assertThat(postPluginCreateResponse, is(notNullValue()));
-
-        for (String metacardId : METACARD_IDS) {
-            File backedupMetacard = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(metacardId, 0) + metacardId);
-            assertThat(backedupMetacard.exists(), is(Boolean.TRUE));
-        }
+        assertFilesExist(METACARD_IDS, subDirLevels);
     }
 
-    @Test
-    public void testProcessCreateResponseSubdirectoryLevelsIsNegative() throws Exception {
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateResponseSubdirectoryLevelsIsNegative() throws Exception {
         // Setup
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
+        getPlugin(-1).process(getCreateResponse(METACARD_IDS));
 
-        int subDirLevels = -5;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        // Perform Test
-        CreateResponse postPluginCreateResponse = catalogBackupPlugin.process(mockCreateResponse);
-
-        // Verify
-        assertThat(postPluginCreateResponse, is(notNullValue()));
-
-        for (String metacardId : METACARD_IDS) {
-            File backedupMetacard = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(metacardId, 0) + metacardId);
-            assertThat(backedupMetacard.exists(), is(Boolean.TRUE));
-        }
     }
 
     /**
@@ -140,245 +98,146 @@ public class CatalogBackupPluginTest {
      * as many subdirectories as it can for each metacardId.
      */
     @Test
-    public void testProcessCreateResponseSubdirectoryLevelsTooBigForMetacardId() throws Exception {
-        // Setup
-        String[] metacardIds = {"6c38", "0283"};
+    public void testCreateResponseSubdirectoryLevelsTooBigForMetacardId() throws Exception {
+        //Setup
+        String[] ids = {"6c38", "0283"};
+        getPlugin(1000).process(getCreateResponse(ids));
 
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(metacardIds));
-
-        int subDirLevels = 1000;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        // Perform Test
-        CreateResponse postPluginCreateResponse = catalogBackupPlugin.process(mockCreateResponse);
-
-        // Verify
-        assertThat(postPluginCreateResponse, is(notNullValue()));
-
-        for (String metacardId : metacardIds) {
-            File backedupMetacard = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(metacardId, 2) + metacardId);
-            assertThat(backedupMetacard.exists(), is(Boolean.TRUE));
-        }
+        //Verify
+        assertFilesExist(ids, 2);
     }
 
     @Test
-    public void testProcessCreateResponseCreateSuccessful() throws Exception {
-        // Setup
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
+    public void testCreateResponseCreateSuccessful() throws Exception {
 
         int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        // Perform Test
-        CreateResponse postPluginCreateResponse = catalogBackupPlugin.process(mockCreateResponse);
-
-        // Verify
-        assertThat(postPluginCreateResponse, is(notNullValue()));
-
-        for (String metacardId : METACARD_IDS) {
-            File backedupMetacard = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(metacardId, 3) + metacardId);
-            assertThat(backedupMetacard.exists(), is(Boolean.TRUE));
-        }
+        getPlugin(subDirLevels).process(getCreateResponse(METACARD_IDS));
+        assertFilesExist(METACARD_IDS, subDirLevels);
     }
 
     @Test
-    public void testProcessDeleteResponseDeleteSuccessful() throws Exception {
-        // Setup
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
+    public void testDeleteResponseDeleteSuccessful() throws Exception {
 
+        // Setup
+        int subDirLevels = 3;
+        CatalogBackupPlugin plugin = getPlugin(subDirLevels);
         DeleteResponse mockDeleteResponse = getDeleteResponse(Arrays.asList(METACARD_IDS));
+        plugin.process(getCreateResponse(METACARD_IDS));
 
-        int subDirLevels = 3;
+        // Delete files
+        DeleteResponse postPluginDeleteResponse = plugin.process(mockDeleteResponse);
 
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        catalogBackupPlugin.process(mockCreateResponse);
-
-        // Perform Test
-        DeleteResponse postPluginDeleteResponse = catalogBackupPlugin.process(mockDeleteResponse);
-
-        // Verify
+        // Ensure files were deleted
         assertThat(postPluginDeleteResponse, is(notNullValue()));
-
-        for (String metacardId : METACARD_IDS) {
-            File deletedMetacards = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(metacardId, 3) + metacardId);
-            assertThat(deletedMetacards.exists(), is(Boolean.FALSE));
-        }
+        assertFilesDoNotExist(METACARD_IDS, subDirLevels);
     }
 
     @Test
-    public void testProcessDeleteResponseFailToDeleteAllMetacards() {
-        // Setup
+    public void testDeleteResponseFailToDeleteAllMetacards() {
+
         DeleteResponse mockDeleteResponse = getDeleteResponse(Arrays.asList(METACARD_IDS));
-
-        int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
 
         // Perform Test
-        try {
-            catalogBackupPlugin.process(mockDeleteResponse);
-        } catch (PluginExecutionException e) {
-            // Verify
-            for (int i = 0; i < METACARD_IDS.length; i++) {
-                assertThat(e.getMessage(), containsString(METACARD_IDS[i]));
-            }
-        }
+        getPlugin().process(mockDeleteResponse);
     }
 
     @Test
-    public void testProcessDeleteResponseFailToDeleteOneMetacard() {
-        // Setup
-        String[] createdMetacardIds = {METACARD_IDS[0]};
+    public void testDeleteResponseFailToDeleteOneMetacard() throws PluginExecutionException {
 
-        CreateResponse mockCreateResponse =
-                getMockCreateResponse(Arrays.asList(createdMetacardIds));
+        //Verify assumptions about hard-codes indexes
+        assertThat("The list of metacard IDs has changed sized", METACARD_IDS, arrayWithSize(2));
 
-        int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        try {
-            catalogBackupPlugin.process(mockCreateResponse);
-        } catch (PluginExecutionException e) {
-            fail();
-        }
-
+        CatalogBackupPlugin plugin = getPlugin();
         DeleteResponse mockDeleteResponse = getDeleteResponse(Arrays.asList(METACARD_IDS));
 
-        try {
-            // Perform Test
-            catalogBackupPlugin.process(mockDeleteResponse);
-        } catch (PluginExecutionException e) {
-            // Verify
-            for (int i = 1; i < METACARD_IDS.length; i++) {
-                assertThat(e.getMessage(), containsString(METACARD_IDS[i]));
-            }
-        }
+        // Perform Test
+        plugin.process(getCreateResponse(new String[] {METACARD_IDS[0]}));
+        plugin.process(mockDeleteResponse);
+
     }
 
     @Test
-    public void testProcessUpdateResponseUpdateSuccessful() throws Exception {
+    public void testUpdateResponseUpdateSuccessful() throws Exception {
         // Setup
-        CreateResponse mockCreateResponse = getMockCreateResponse(Arrays.asList(METACARD_IDS));
-
         int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        catalogBackupPlugin.process(mockCreateResponse);
-
+        CatalogBackupPlugin plugin = getPlugin(3);
+        plugin.process(getCreateResponse(METACARD_IDS));
         UpdateResponse mockUpdateResponse = getUpdateResponse(Arrays.asList(METACARD_IDS));
 
         // Perform Test
-        UpdateResponse postPluginUpdateResponse = catalogBackupPlugin.process(mockUpdateResponse);
+        UpdateResponse postPluginUpdateResponse = plugin.process(mockUpdateResponse);
 
         // Verify
         assertThat(postPluginUpdateResponse, is(notNullValue()));
 
-        int j = 0;
-        for (Metacard oldMetacard : mockCreateResponse.getCreatedMetacards()) {
-            File updatedMetacardFile = new File(rootBackupDir.getRoot()
-                    .getAbsolutePath() + getMetacardPath(oldMetacard.getId(), subDirLevels)
-                    + oldMetacard.getId());
-            Metacard updatedMetacard = readMetacard(updatedMetacardFile);
-            assertThat(updatedMetacardFile.exists(), is(Boolean.TRUE));
-            // Verify that the metacard id has not changed (from newMetacard to
-            // oldMetacard)
-            assertThat(updatedMetacard.getId(), is(oldMetacard.getId()));
-            // Verify that the metacard title has been updated to "newTitle" + j
-            assertThat((String) updatedMetacard.getAttribute(Metacard.TITLE)
-                    .getValue(), is(BASE_NEW_TITLE + j));
+        IntStream.range(0, METACARD_IDS.length)
+                .forEach(index -> {
+                    String oldId = METACARD_IDS[index];
 
-            j++;
-        }
+                    // Perform test
+                    File updatedFile = getFileFor(oldId, subDirLevels);
+                    Metacard updatedCard = readMetacard(updatedFile);
+
+                    // Verify expected file exists
+                    assertThat(updatedFile.exists(), is(Boolean.TRUE));
+
+                    // Verify that the metacard id has not changed
+                    assertThat(updatedCard.getId(), is(oldId));
+
+                    // Verify that the metacard title has been updated to "newTitle" + index
+                    assertThat(updatedCard.getAttribute(Metacard.TITLE)
+                            .getValue(), is(BASE_NEW_TITLE + index));
+
+                });
     }
 
     @Test
-    public void testProcessUpdateUpdateFailsForAllMetacards() {
+    public void testUpdatingAllMissingMetacards() {
         // Setup
-        int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
         UpdateResponse mockUpdateResponse = getUpdateResponse(Arrays.asList(METACARD_IDS));
 
         // Perform Test
-        try {
-            catalogBackupPlugin.process(mockUpdateResponse);
-        } catch (PluginExecutionException e) {
-            // Verify
-            for (int i = 0; i < METACARD_IDS.length; i++) {
-                assertThat(e.getMessage(), containsString(METACARD_IDS[i]));
-            }
-        }
+        getPlugin().process(mockUpdateResponse);
     }
 
     @Test
-    public void testProcessUpdateUpdateFailsForOneMetacard() {
+    public void testUpdatingOneMissingMetacard() throws PluginExecutionException {
+        assertThat("The list of metacard IDs has changed sized", METACARD_IDS, arrayWithSize(2));
         // Setup
-        String[] createdMetacardIds = {METACARD_IDS[0]};
-
-        CreateResponse mockCreateResponse =
-                getMockCreateResponse(Arrays.asList(createdMetacardIds));
-
-        int subDirLevels = 3;
-
-        CatalogBackupPlugin catalogBackupPlugin = new CatalogBackupPlugin();
-        catalogBackupPlugin.setEnableBackupPlugin(true);
-        catalogBackupPlugin.setRootBackupDir(rootBackupDir.getRoot()
-                .getAbsolutePath());
-        catalogBackupPlugin.setSubDirLevels(subDirLevels);
-
-        try {
-            catalogBackupPlugin.process(mockCreateResponse);
-        } catch (PluginExecutionException e) {
-            fail();
-        }
-
+        CatalogBackupPlugin plugin = getPlugin();
+        plugin.process(getCreateResponse(new String[] {METACARD_IDS[0]}));
         UpdateResponse mockUpdateResponse = getUpdateResponse(Arrays.asList(METACARD_IDS));
 
         // Perform Test
+        plugin.process(mockUpdateResponse);
+
+    }
+
+    @Test
+    public void testShutdownAndTermination() throws InterruptedException {
+
+        CatalogBackupPlugin plugin = getSpecialMock();
+        ExecutorService executor = plugin.getExecutor();
+        when(executor.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+        plugin.shutdown();
+
+        verify(executor).shutdown();
+        verify(executor).awaitTermination(plugin.getTerminationTimeoutSeconds(), TimeUnit.SECONDS);
+        verify(executor).shutdownNow();
+    }
+
+    @Test
+    public void testInterruptedExecution() throws InterruptedException {
+        CatalogBackupPlugin plugin = getSpecialMock();
+        ExecutorService executor = plugin.getExecutor();
+        when(executor.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException());
+
         try {
-            catalogBackupPlugin.process(mockUpdateResponse);
-        } catch (PluginExecutionException e) {
-            // Verify
-            for (int i = 1; i < METACARD_IDS.length; i++) {
-                assertThat(e.getMessage(), containsString(METACARD_IDS[i]));
-            }
+            plugin.shutdown();
+            fail("Should have thrown exception");
+        } catch (IllegalStateException e) {
         }
     }
 
@@ -386,17 +245,21 @@ public class CatalogBackupPluginTest {
      * Helper Methods
      */
 
-    private CreateResponse getMockCreateResponse(List<String> metacardIds) {
-        List<Metacard> createdMetacards = new ArrayList<Metacard>(metacardIds.size());
-        for (String metacardId : metacardIds) {
-            Metacard metacard = getMetacard(metacardId, BASE_OLD_TITLE);
-            createdMetacards.add(metacard);
-        }
-        CreateRequest request = mock(CreateRequest.class);
-        CreateResponse mockCreateResponse = mock(CreateResponse.class);
-        when(mockCreateResponse.getCreatedMetacards()).thenReturn(createdMetacards);
-        when(mockCreateResponse.getRequest()).thenReturn(request);
+    private List<Metacard> getMetacards(String[] ids, String title) {
 
+        return Arrays.asList(ids)
+                .stream()
+                .map(m -> getMetacard(m, title))
+                .collect(Collectors.toList());
+
+    }
+
+    private CreateResponse getCreateResponse(String[] ids) {
+
+        CreateResponse mockCreateResponse = mock(CreateResponse.class);
+        when(mockCreateResponse.getCreatedMetacards()).thenReturn(getMetacards(ids,
+                BASE_OLD_TITLE));
+        when(mockCreateResponse.getRequest()).thenReturn(mock(CreateRequest.class));
         return mockCreateResponse;
     }
 
@@ -404,7 +267,7 @@ public class CatalogBackupPluginTest {
         MetacardType mockMetacardType = mock(MetacardType.class);
         when(mockMetacardType.getName()).thenReturn(MetacardType.DEFAULT_METACARD_TYPE_NAME);
 
-        List<Metacard> deletedMetacards = new ArrayList<Metacard>(metacardIds.size());
+        List<Metacard> deletedMetacards = new ArrayList<>(metacardIds.size());
 
         for (String metacardId : metacardIds) {
             Metacard mockMetacard = mock(Metacard.class);
@@ -422,7 +285,7 @@ public class CatalogBackupPluginTest {
     }
 
     private UpdateResponse getUpdateResponse(List<String> oldMetacardIds) {
-        List<Update> updatedMetacards = new ArrayList<Update>(oldMetacardIds.size());
+        List<Update> updatedMetacards = new ArrayList<>(oldMetacardIds.size());
         int i = 0;
         for (String oldMetacardId : oldMetacardIds) {
             Metacard oldMetacard = getMetacard(oldMetacardId, BASE_OLD_TITLE + i);
@@ -470,14 +333,77 @@ public class CatalogBackupPluginTest {
         return builder.toString();
     }
 
-    private Metacard readMetacard(File file) throws ClassNotFoundException, IOException {
-        Metacard metacard = null;
+    private Metacard readMetacard(File file) {
 
+        Metacard metacard = null;
         try (FileInputStream fis = new FileInputStream(file);
                 ObjectInputStream ois = new ObjectInputStream(fis)) {
             metacard = (Metacard) ois.readObject();
+        } catch (ClassNotFoundException | IOException e) {
+            fail();
         }
 
         return metacard;
     }
+
+    private File getFileFor(String metacardId, int subDirLevels) {
+        return new File(backupDirObject.getRoot()
+                .getAbsolutePath() + getMetacardPath(metacardId, subDirLevels) + metacardId);
+    }
+
+    private void assertFilesDoNotExist(String[] metacardIds, int subDirLevels) {
+        assertFiles(Boolean.FALSE, metacardIds, subDirLevels);
+
+    }
+
+    private void assertFilesExist(String[] metacardIds, int subDirLevels) {
+        assertFiles(Boolean.TRUE, metacardIds, subDirLevels);
+    }
+
+    private void assertFiles(Boolean test, String[] metacardIds, int subDirLevels) {
+        for (String id : metacardIds) {
+            assertThat(getFileFor(id, subDirLevels).exists(), is(test));
+        }
+    }
+
+    private CatalogBackupPlugin getPlugin() {
+
+        return getPlugin(3);
+    }
+
+    private CatalogBackupPlugin getPlugin(int level) {
+        CatalogBackupPlugin plugin = new CatalogBackupPlugin();
+        plugin.setExecutor(getSynchronousExecutor());
+        plugin.setRootBackupDir(backupDirObject.getRoot()
+                .getAbsolutePath());
+        plugin.setSubDirLevels(level);
+        return plugin;
+    }
+
+    private CatalogBackupPlugin getSpecialMock() {
+
+        CatalogBackupPlugin plugin = getPlugin();
+        List<Runnable> failedItems = new ArrayList<>();
+        failedItems.add(() -> {
+        });
+        ExecutorService executor = mock(ExecutorService.class);
+        plugin.setTerminationTimeoutSeconds((long) 0);
+        plugin.setExecutor(executor);
+        when(executor.isShutdown()).thenReturn(false);
+        when(executor.shutdownNow()).thenReturn(failedItems);
+        return plugin;
+    }
+
+    private ExecutorService getSynchronousExecutor() {
+        //Create an executor that synchronously executes the task.
+        return new ThreadPoolExecutor(1, 1, 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>()) {
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        };
+    }
+
 }
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf</groupId>
     <artifactId>ddf</artifactId>
@@ -379,7 +381,8 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <bottom><![CDATA[This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License<a>.]]></bottom>
+                        <bottom>
+                            <![CDATA[This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License<a>.]]></bottom>
                         <failOnError>false</failOnError>
                         <aggregate>true</aggregate>
                         <show>protected</show>
@@ -723,7 +726,8 @@
                             <executions>
                                 <execution>
                                     <configuration>
-                                        <descriptor>${project.basedir}/src/assembly/bin.xml</descriptor>
+                                        <descriptor>${project.basedir}/src/assembly/bin.xml
+                                        </descriptor>
                                         <outputDirectory>${project.build.directory}/documentation
                                         </outputDirectory>
                                     </configuration>
@@ -735,7 +739,8 @@
                                 </execution>
                                 <execution>
                                     <configuration>
-                                        <descriptor>${project.basedir}/src/assembly/asciidocs.xml</descriptor>
+                                        <descriptor>${project.basedir}/src/assembly/asciidocs.xml
+                                        </descriptor>
                                         <outputDirectory>${project.build.directory}/adoc-files
                                         </outputDirectory>
                                     </configuration>
@@ -986,15 +991,16 @@
       -->
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
+            <!--Hamcrest first, then JUnit, then Mockito. See http://goo.gl/e5bJA5-->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
#### What does this PR do?
This PR changes the Catalog Backup Plugin to create and delete metacards asynchronously. 
Creating metacards synchronously slows the ingest process. The changes all the calling thread
to return as soon as it hands work to the plugin. The plugin's executor service
process requests in order of submission.
#### Who is reviewing it?
@AzGoalie 
@lessarderic 
@harrison-tarr  
#### How should this be tested?

**Performance test**
1. Ingest a large set of XML files with the master version of the plugin installed. Compute the average or take the median time to process the files.
2. Uninstall the master version of the plugin. Install the PR version of the plugin.
3. Repeat the ingest and computer average/median time. The expected results is the ingest is faster with the PR plugin.

**Functional test**
1. Delete all the backup files (data/backup directory)
2. Ingest a set of files.
3. Recursive count all the files created in the data/backup directory.
4. The number of backup files is expected to match the number of ingested files.

#### Any background context you want to provide?

We want ingest to run faster.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
Performance comparison over 3 ingests of the reuters set.

Before:
![syncsample](https://cloud.githubusercontent.com/assets/133284/13482390/23230290-e0aa-11e5-9fb3-d7e39c4dc514.png)

After:
![asynchsample](https://cloud.githubusercontent.com/assets/133284/13482396/29e92866-e0aa-11e5-8f73-79a969271597.png)

The execution time spent in the CatalogBackupPlugin dropped from about 1.5% of the time to almost 0% of the time. Also, the backup process now runs in a different thread than the ingest process. Theoretically, the processes are decoupled and the time spent backing up metacards would not influence the time spent in the ingest command. As measured from the console, there is no significance difference in the rate at which metacards are ingested before and after the code change.

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf/587)
<!-- Reviewable:end -->

