### PR TITLE
DDF-1930: Fixed branding logos which weren't being read from fragment bundles

### DIFF
--- a/platform/branding-resources/src/main/java/org/codice/ddf/branding/impl/BrandingResourceProviderImpl.java
+++ b/platform/branding-resources/src/main/java/org/codice/ddf/branding/impl/BrandingResourceProviderImpl.java
@@ -28,7 +28,7 @@ public class BrandingResourceProviderImpl implements BrandingResourceProvider {
     public byte[] getResourceAsBytes(String path) throws IOException {
         Bundle bundle = getBundle(WebConsoleUtil.class);
         if (bundle != null) {
-            URL entry = bundle.getEntry(path);
+            URL entry = bundle.getResource(path);
             if (entry != null) {
                 return IOUtils.toByteArray(entry.openConnection()
                         .getInputStream());

--- a/platform/branding-resources/src/test/java/org/codice/ddf/branding/impl/TestBrandingResourceProviderImpl.java
+++ b/platform/branding-resources/src/test/java/org/codice/ddf/branding/impl/TestBrandingResourceProviderImpl.java
@@ -53,7 +53,7 @@ public class TestBrandingResourceProviderImpl {
         Bundle bundle = mock(Bundle.class);
         URL url = this.getClass()
                 .getResource("/logo.png");
-        when(bundle.getEntry(TEST_PATH)).thenReturn(url);
+        when(bundle.getResource(TEST_PATH)).thenReturn(url);
         TestImpl impl = new TestImpl(bundle);
         assertThat(impl.getResourceAsBytes(TEST_PATH).length, is(equalTo(22490)));
     }


### PR DESCRIPTION


Changed getEntry to getResource because getEntry is not finding resources in the bundle fragments since karaf 4.0.4 upgrade