### PR TITLE
DDF-1933 Reverted metacard groomer to always generate metacard id

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -42,13 +42,10 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
     protected void applyCreatedOperationRules(CreateRequest createRequest, Metacard aMetacard,
             Date now) {
         LOGGER.debug("Applying standard rules on CreateRequest");
-
-        if (aMetacard.getId() == null) {
-            aMetacard.setAttribute(new AttributeImpl(Metacard.ID,
-                    UUID.randomUUID()
-                            .toString()
-                            .replaceAll("-", "")));
-        }
+        aMetacard.setAttribute(new AttributeImpl(Metacard.ID,
+                UUID.randomUUID()
+                        .toString()
+                        .replaceAll("-", "")));
 
         if (aMetacard.getCreatedDate() == null) {
             aMetacard.setAttribute(new AttributeImpl(Metacard.CREATED, now));


### PR DESCRIPTION
#### What does this PR do?
Reverts the metacard groomer to its original logic to always generate a metacard id
#### Who is reviewing it?
@pklinef 
#### How should this be tested?
Unit and Itests should be sufficient
#### Any background context you want to provide?
This was originally changed for registry but we will be doing things differently now
#### What are the relevant tickets?
DDF-1933
