### PR TITLE
DDF-1932: DDF builds not using Codice NPM and Node.js as proxy anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,7 @@
                             <configuration>
                                 <nodeVersion>${node.version}</nodeVersion>
                                 <npmVersion>${npm.version}</npmVersion>
+                                <downloadRoot>http://artifacts.codice.org/nodejs/dist/</downloadRoot>
                             </configuration>
                         </execution>
                         <execution>


### PR DESCRIPTION
#### What does this PR do?
Change frontend-maven-plugin configuration to use Codice NPM and Node.js proxy

#### Who is reviewing it?
@stustison @oconnormi @oscaritoro @linkmjb

#### How should this be tested?
Full build.

#### Any background context you want to provide?
Was removed when the Codice proxy was having issues and needed to be added back in.

#### What are the relevant tickets?
DDF-1932, DDF-1648

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Added <downloadRoot> back in the frontend-maven-plugin configuration.