### PR TITLE
DDF-1937 Added registry-id field to RegistryObjectMetacardType

### DIFF
--- a/catalog/registry/catalog-registry-common/src/main/java/ddf/catalog/registry/common/metacard/RegistryObjectMetacardType.java
+++ b/catalog/registry/catalog-registry-common/src/main/java/ddf/catalog/registry/common/metacard/RegistryObjectMetacardType.java
@@ -67,6 +67,8 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
     //list of bindingType fields from all the service bindings
     public static final String SERVICE_BINDING_TYPES = "service-binding-types";
 
+    public static final String REGISTRY_ID = "registry-id";
+
     public RegistryObjectMetacardType() {
         this(REGISTRY_METACARD_TYPE_NAME, null);
     }
@@ -104,6 +106,7 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
         addQueryableString(DATA_TYPES, true);
         addQueryableString(SERVICE_BINDINGS, true);
         addQueryableString(SERVICE_BINDING_TYPES, true);
+        addQueryableString(REGISTRY_ID, false);
     }
 
     /**

--- a/catalog/registry/catalog-registry-cswinputtransformer/src/main/java/ddf/catalog/registry/converter/RegistryPackageConverter.java
+++ b/catalog/registry/catalog-registry-cswinputtransformer/src/main/java/ddf/catalog/registry/converter/RegistryPackageConverter.java
@@ -331,7 +331,7 @@ public class RegistryPackageConverter {
             if (StringUtils.isNotBlank(id)) {
                 Matcher matcher = ID_PATTERN.matcher(id);
                 if (matcher.find()) {
-                    metacard.setId(matcher.group(1));
+                    metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, matcher.group(1));
                 }
             }
         }

--- a/catalog/registry/catalog-registry-cswinputtransformer/src/test/java/ddf/catalog/registry/transformer/RegistryTransformerTest.java
+++ b/catalog/registry/catalog-registry-cswinputtransformer/src/test/java/ddf/catalog/registry/transformer/RegistryTransformerTest.java
@@ -129,7 +129,7 @@ public class RegistryTransformerTest {
         RegistryMetacardImpl meta = convert("/csw-basic-info.xml");
         assertRegistryMetacard(meta);
 
-        assertThat(meta.getId(), is("2014ca7f59ac46f495e32b4a67a51276"));
+        assertThat(meta.getAttribute(RegistryObjectMetacardType.REGISTRY_ID).getValue(), is("2014ca7f59ac46f495e32b4a67a51276"));
         assertThat(meta.getTitle(), is("my service"));
         assertThat(meta.getDescription(), is("something"));
         assertThat(meta.getContentTypeVersion(), is("0.0.0"));


### PR DESCRIPTION
#### What does this PR do?
Add registry-id field to RegistryObjectMetacardType and populate it in the registry transformer with the top level id that is currently being used for the metacard id. The metacard id should no longer be populated in the registry transformer.
#### Who is reviewing it?
@clockard @gordocanchola @brianfelix @oscaritoro @stustison 
#### How should this be tested?
Inspect the changes, attempt to build.
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests