### PR TITLE
DDF-1944 Removes DynamicImport-Package directives in bundles.

### DIFF
--- a/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
@@ -156,7 +156,6 @@
                             ddf.catalog.util.impl,
                             ddf.catalog.endpoint.impl
                         </Private-Package>
-                        <DynamicImport-Package>javax.ws.rs.*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -106,7 +106,10 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>json-smart,catalog-core-api-impl,common-system,platform-util</Embed-Dependency>
-                        <DynamicImport-Package>javax.ws.rs.*</DynamicImport-Package>
+                        <Import-Package>
+                            javax.ws.rs.*,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/security/platform-security-session/pom.xml
+++ b/platform/security/platform-security-session/pom.xml
@@ -38,10 +38,11 @@
                         <Fragment-Host>org.ops4j.pax.web.pax-web-jetty;bundle-version="[4,5)"
                         </Fragment-Host>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <DynamicImport-Package>
+                        <Import-Package>
                             org.eclipse.jetty.server.session,
-                            javax.servlet.http
-                        </DynamicImport-Package>
+                            javax.servlet.http,
+                            *
+                        </Import-Package>
                         <Import-Package/>
                         <Export-Package/>
                     </instructions>

--- a/platform/security/sts/security-sts-ldaplogin/pom.xml
+++ b/platform/security/sts/security-sts-ldaplogin/pom.xml
@@ -41,16 +41,21 @@
                         <Import-Package>
                             org.osgi.service.blueprint,
                             org.osgi.framework,
+                            javax.security.auth.callback,
                             javax.security.auth.login,
                             javax.net.ssl,
                             javax.naming,
                             org.apache.karaf.jaas.config,
-                            org.apache.karaf.jaas.modules.ldap
+                            org.apache.karaf.jaas.modules,
+                            ddf.security.common.audit,
+                            ddf.security.sts,
+                            ddf.security.encryption,
+                            org.codice.ddf.configuration,
+                            org.slf4j
                         </Import-Package>
                         <Private-Package>
                             org.apache.karaf.jaas.config.impl
                         </Private-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -122,6 +127,11 @@
         <dependency>
             <groupId>ddf.platform</groupId>
             <artifactId>platform-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.sts</groupId>
+            <artifactId>security-sts-server</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.org.forgerock.opendj</groupId>


### PR DESCRIPTION
#### What does this PR do?
This PR updates pom files that had been using `DynamicImport-Package`, removing that directive and importing the packages directly.

#### Who is reviewing it?
@kcwire @pklinef @stustison 

#### How should this be tested?
1. The application should be built and itests run. 
2. The application should be deployed and the installation process should be run.
3. Finally, the `security-sts-ldaplogin` bundle (or the feature that contains it) should be installed to ensure that it works correctly.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-1944](https://codice.atlassian.net/browse/DDF-1944)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated N/A
- [ ] Update / Add Unit Tests N/A
- [ ] Update / Add Integration Tests N/A