### PR TITLE
DDF-1953 Create endpoint to consume events from a CSW subscription

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
@@ -63,6 +63,10 @@ public class CswSourceConfiguration {
 
     private String queryTypePrefix;
 
+    private String eventServiceAddress;
+
+    private boolean registerForEvents;
+
     private Map<String, Set<String>> securityAttributes = new HashMap<>();
 
     private Map<String, Set<String>> schemaToTagsMapping = new HashMap<>();
@@ -270,5 +274,21 @@ public class CswSourceConfiguration {
             schemaToTagsMapping.putAll(Permissions.parsePermissionsFromString(
                     schemaToTagsMappingStrings));
         }
+    }
+
+    public boolean isRegisterForEvents() {
+        return registerForEvents;
+    }
+
+    public void setRegisterForEvents(Boolean registerForEvents) {
+        this.registerForEvents = registerForEvents;
+    }
+
+    public String getEventServiceAddress() {
+        return eventServiceAddress;
+    }
+
+    public void setEventServiceAddress(String eventServiceAddress) {
+        this.eventServiceAddress = eventServiceAddress;
     }
 }

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSubscribe.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSubscribe.java
@@ -25,21 +25,22 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import net.opengis.cat.csw.v_2_0_2.GetRecordsResponseType;
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 
 /**
- * JAX-RS Interface to define an OGC Catalogue Service for Web (CSW).
+ * JAX-RS Interface to define an CSW Subscription service.
  */
-@Path("/subscription")
-public interface Subscribe {
+@Path("/")
+public interface CswSubscribe {
 
     /**
      * Deletes an active subscription
      *
      * @param requestId the requestId of the subscription to be removed
-     * @return Acknowledgment   returns a CSW Acknowledgment message with the subscription that was
+     * @return Response will contain a  CSW Acknowledgment message with the subscription that was
      * deleted or an empty 404 if none are found
-     * @throws CswException
+     * @throws CswException for validation errors returns a 400
      */
     @DELETE
     @Path("/{requestId}")
@@ -51,9 +52,9 @@ public interface Subscribe {
      * Get an active subscription
      *
      * @param requestId the requestId of the subscription to get
-     * @return Acknowledgment   returns a CSW Acknowledgment message with the subscription that was
+     * @return returns a response containing a CSW Acknowledgment message with the subscription that was
      * found or an empty 404 if none are found
-     * @throws CswException
+     * @throws CswException for validation errors returns a 400
      */
     @GET
     @Path("/{requestId}")
@@ -69,9 +70,9 @@ public interface Subscribe {
      *                  handle the CswRecordCollection response messages. When a create, update
      *                  or delete event is received a CswRecordCollection will be sent via a
      *                  POST, PUT or DELETE to the ResponseHandler URL.
-     * @return Acknowledgment   returns a CSW Acknowledgment message with the subscription that was
+     * @return Response will contain a  CSW Acknowledgment message with the subscription that was
      * updated or added
-     * @throws CswException
+     * @throws CswException for validation errors returns a 400
      */
     @PUT
     @Path("/{requestId}")
@@ -88,9 +89,9 @@ public interface Subscribe {
      *                handle the CswRecordCollection response messages. When a create, update
      *                or delete event is received a CswRecordCollection will be sent via a
      *                POST, PUT or DELETE to the ResponseHandler URL.
-     * @return Acknowledgment   returns a CSW Acknowledgment message with the subscription that was
+     * @return Response will contain a  CSW Acknowledgment message with the subscription that was
      * added
-     * @throws CswException
+     * @throws CswException for validation errors returns a 400
      */
     @GET
     @Produces({MediaType.WILDCARD})
@@ -105,12 +106,52 @@ public interface Subscribe {
      *                handle the CswRecordCollection response messages. When a create, update
      *                or delete event is received a CswRecordCollection will be sent via a
      *                POST, PUT or DELETE to the ResponseHandler URL
-     * @return Acknowledgment   returns a CSW Acknowledgment message with the subscription that was
+     * @return Response will contain a CSW Acknowledgment message with the subscription that was
      * added
-     * @throws CswException
+     * @throws CswException for validation errors returns a 400
      */
     @POST
     @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
     @Produces({MediaType.WILDCARD})
     Response createRecordsSubscription(GetRecordsType request) throws CswException;
+
+    /**
+     * Consume a create event
+     *
+     * @param recordsResponse the GetRecordsResponseType search results must be urn:catalog:metacard
+     *                        format
+     * @throws CswException for validation errors returns a 400
+     */
+    @POST
+    @Path("/event")
+    @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    Response createEvent(GetRecordsResponseType recordsResponse) throws CswException;
+
+    /**
+     * Consume an update event
+     *
+     * @param recordsResponse the GetRecordsResponseType search results must be urn:catalog:metacard
+     *                        format with two metacards the updated one being the first and the
+     *                        previous version being the seconds
+     * @throws CswException for validation errors returns a 400
+     */
+    @PUT
+    @Path("/event")
+    @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    Response updateEvent(GetRecordsResponseType recordsResponse) throws CswException;
+
+    /**
+     * Consume a delete event
+     *
+     * @param recordsResponse the GetRecordsResponseType search results must be urn:catalog:metacard
+     *                        format
+     * @throws CswException for validation errors returns a 400
+     */
+    @DELETE
+    @Path("/event")
+    @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+    Response deleteEvent(GetRecordsResponseType recordsResponse) throws CswException;
 }

--- a/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
@@ -112,16 +112,21 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
+            <groupId>ddf.platform.security</groupId>
+            <artifactId>security-rest-cxfwrapper</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util-unavailableurls</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -158,8 +163,10 @@
                             gt-cql,
                             catalog-core-api-impl,
                             platform-util,
-                            httpclient,
-                            httpcore
+                            security-rest-cxfwrapper,
+                            ddf-security-common,
+                            platform-util,
+                            platform-util-unavailableurls,
                         </Embed-Dependency>
                         <Private-Package>
                             org.codice.ddf.spatial.ogc.csw.catalog.endpoint.*

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
@@ -64,7 +64,8 @@ import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.DeleteAction;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.InsertAction;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.UpdateAction;
 import org.codice.ddf.spatial.ogc.csw.catalog.transformer.TransformerManager;
-import org.osgi.framework.BundleContext;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -223,8 +224,6 @@ public class CswEndpoint implements Csw {
 
     private final TransformerManager inputTransformerManager;
 
-    private BundleContext context;
-
     private CatalogFramework framework;
 
     private CapabilitiesType capabilitiesType;
@@ -239,11 +238,10 @@ public class CswEndpoint implements Csw {
     /**
      * JAX-RS Server that represents a CSW v2.0.2 Server.
      */
-    public CswEndpoint(BundleContext context, CatalogFramework ddf,
-            TransformerManager mimeTypeManager, TransformerManager schemaManager,
-            TransformerManager inputManager, Validator validator, CswQueryFactory queryFactory) {
+    public CswEndpoint(CatalogFramework ddf, TransformerManager mimeTypeManager,
+            TransformerManager schemaManager, TransformerManager inputManager, Validator validator,
+            CswQueryFactory queryFactory) {
         LOGGER.trace("Entering: CSW Endpoint constructor.");
-        this.context = context;
         this.framework = ddf;
         this.mimeTypeTransformerManager = mimeTypeManager;
         this.schemaTransformerManager = schemaManager;
@@ -926,8 +924,7 @@ public class CswEndpoint implements Csw {
     }
 
     private Element loadDocElementFromResourcePath(String resourcePath) throws CswException {
-        URL recordUrl = context.getBundle()
-                .getResource(resourcePath);
+        URL recordUrl = getBundle().getResource(resourcePath);
 
         DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
         docBuilderFactory.setNamespaceAware(true);
@@ -1240,10 +1237,6 @@ public class CswEndpoint implements Csw {
                 .add(createDomainType(CswConstants.FEDERATED_CATALOGS, sourceIds));
     }
 
-    private void notImplemented(final String methodName) throws CswException {
-        throw new CswException("The method " + methodName + " is not yet implemented.");
-    }
-
     private CswException createUnknownTypeException(final String type) {
         return new CswException("The type '" + type + "' is not known to this service.",
                 CswConstants.INVALID_PARAMETER_VALUE,
@@ -1328,4 +1321,7 @@ public class CswEndpoint implements Csw {
         this.uri = uri;
     }
 
+    Bundle getBundle() {
+        return FrameworkUtil.getBundle(this.getClass());
+    }
 }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/Validator.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/Validator.java
@@ -27,6 +27,9 @@ import org.codice.ddf.spatial.ogc.csw.catalog.transformer.TransformerManager;
 
 import net.opengis.cat.csw.v_2_0_2.QueryType;
 
+/**
+ * Validator provides methods to validate Requests for CSW 2.0.2
+ */
 public class Validator {
 
     private static final List<String> ELEMENT_NAMES = Arrays.asList("brief", "summary", "full");
@@ -106,7 +109,8 @@ public class Validator {
 
     }
 
-    public void validateOutputSchema(String schema, TransformerManager schemaTransformerManager) throws CswException {
+    public void validateOutputSchema(String schema, TransformerManager schemaTransformerManager)
+            throws CswException {
         if (schema == null || schemaTransformerManager.getTransformerBySchema(schema) != null
                 || schema.equals(OCTET_STREAM_OUTPUT_SCHEMA)) {
             return;

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscription.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscription.java
@@ -42,6 +42,16 @@ public class CswSubscription extends SubscriptionImpl {
                 query.isEnterprise());
     }
 
+    public static CswSubscription getFilterlessSubscription(
+            TransformerManager mimeTypeTransformerManager, GetRecordsType request,
+            QueryRequest query) throws CswException {
+        return new CswSubscription(request,
+                Filter.INCLUDE,
+                new SendEvent(mimeTypeTransformerManager, request, query),
+                null,
+                false);
+    }
+
     public GetRecordsType getOriginalRequest() {
         return originalRequest;
     }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -127,11 +127,11 @@
     </bean>
 
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+    <reference id="eventProcessor" interface="ddf.catalog.event.EventProcessor"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
     <bean id="CswSvc" class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswEndpoint">
-        <argument ref="blueprintBundleContext"/>
         <argument ref="catalogFramework"/>
         <argument ref="queryResponseTransformerManager"/>
         <argument ref="metacardTransformerManager"/>
@@ -166,10 +166,12 @@
         </property>
     </bean>
 
-    <bean id="CswSubscriptionSvc" class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswSubscriptionEndpoint">
-        <argument ref="blueprintBundleContext"/>
+    <bean id="CswSubscriptionSvc"
+          class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswSubscriptionEndpoint">
+        <argument ref="eventProcessor"/>
         <argument ref="queryResponseTransformerManager"/>
         <argument ref="metacardTransformerManager"/>
+        <argument ref="inputTransformerManager"/>
         <argument ref="validator"/>
         <argument ref="cswFilterFactory"/>
     </bean>
@@ -194,9 +196,9 @@
 
 
     <cm:managed-service-factory id="cswSubscriptionFactory" factory-pid="CSW_Subscription"
-                                interface="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.event.CswSubscriptionConfigFactory">
-
-        <cm:managed-component class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.event.CswSubscriptionConfigFactory">
+                                interface="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.event.CswSubscriptionConfigFactory" >
+        <cm:managed-component
+                class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.event.CswSubscriptionConfigFactory" init-method="restore">
             <argument ref="CswSubscriptionSvc"/>
             <property name="filterXml" value=""/>
             <property name="subscriptionId" value=""/>
@@ -205,5 +207,7 @@
         </cm:managed-component>
 
     </cm:managed-service-factory>
+
+    <service ref="CswSubscriptionSvc" interface="ddf.catalog.event.Subscriber"/>
 
 </blueprint>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/TestCswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/TestCswEndpoint.java
@@ -197,7 +197,6 @@ public class TestCswEndpoint {
             FederationException, ParseException, IngestException {
         URI mockUri = new URI("http://example.com/services/csw");
         when(mockUriInfo.getBaseUri()).thenReturn(mockUri);
-        when(mockContext.getBundle()).thenReturn(mockBundle);
         URL resourceUrl = TestCswEndpoint.class.getResource("/record.xsd");
         URL resourceUrlDot = TestCswEndpoint.class.getClass()
                 .getResource(".");
@@ -205,13 +204,13 @@ public class TestCswEndpoint {
         when(mockBundle.getResource("csw/2.0.2/record.xsd")).thenReturn(resourceUrl);
         when(mockBundle.getResource(".")).thenReturn(resourceUrlDot);
 
-        csw = new CswEndpoint(mockContext,
-                catalogFramework,
+        csw = new CswEndpointStub(catalogFramework,
                 mockMimeTypeManager,
                 mockSchemaManager,
                 mockInputManager,
                 validator,
-                queryFactory);
+                queryFactory,
+                mockBundle);
         csw.setUri(mockUriInfo);
         when(mockMimeTypeManager.getAvailableMimeTypes()).
                 thenReturn(Arrays.asList(MediaType.APPLICATION_XML));
@@ -1881,6 +1880,23 @@ public class TestCswEndpoint {
         when(resourceResponse.getResource()).thenReturn(resource);
         when(catalogFramework.getLocalResource(any(ResourceRequest.class))).thenReturn(
                 resourceResponse);
+    }
+
+    public static class CswEndpointStub extends CswEndpoint {
+
+        private Bundle bundle;
+
+        public CswEndpointStub(CatalogFramework ddf, TransformerManager mimeTypeManager,
+                TransformerManager schemaManager, TransformerManager inputManager,
+                Validator validator, CswQueryFactory queryFactory, Bundle bundle) {
+            super(ddf, mimeTypeManager, schemaManager, inputManager, validator, queryFactory);
+            this.bundle = bundle;
+        }
+
+        @Override
+        Bundle getBundle() {
+            return bundle;
+        }
     }
 
 }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscriptionConfigFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscriptionConfigFactoryTest.java
@@ -55,6 +55,7 @@ public class CswSubscriptionConfigFactoryTest {
         cswSubscriptionConfigFactory.setDeliveryMethodUrl(DELIVERY_URL);
         cswSubscriptionConfigFactory.setSubscriptionId(SUBSCRIPTION_ID);
         cswSubscriptionConfigFactory.setFilterXml(filterXml);
+        cswSubscriptionConfigFactory.restore();
         verify(subscriptionService).addOrUpdateSubscription(any(GetRecordsType.class), eq(false));
 
     }
@@ -65,6 +66,7 @@ public class CswSubscriptionConfigFactoryTest {
         cswSubscriptionConfigFactory.setDeliveryMethodUrl(DELIVERY_URL);
         cswSubscriptionConfigFactory.setSubscriptionId(SUBSCRIPTION_ID);
         cswSubscriptionConfigFactory.setFilterXml(filterXml);
+        cswSubscriptionConfigFactory.restore();
         verify(subscriptionService, never()).addOrUpdateSubscription(any(GetRecordsType.class),
                 anyBoolean());
 

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEventTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEventTest.java
@@ -15,15 +15,15 @@ package org.codice.ddf.spatial.ogc.csw.catalog.endpoint.event;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
 
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.cxf.jaxrs.client.WebClient;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswException;
 import org.codice.ddf.spatial.ogc.csw.catalog.transformer.TransformerManager;
@@ -65,7 +65,7 @@ public class SendEventTest {
 
     private BinaryContent binaryContent;
 
-    private CloseableHttpClient httpClient;
+    private WebClient webclient;
 
     @Before
     public void setUp() throws Exception {
@@ -87,19 +87,19 @@ public class SendEventTest {
         when(transformerManager.getTransformerBySchema(Matchers.contains(CswConstants.CSW_OUTPUT_SCHEMA))).thenReturn(
                 transformer);
         when(transformer.transform(any(SourceResponse.class), anyMap())).thenReturn(binaryContent);
-        when(binaryContent.getByteArray()).thenReturn("byte array with message contents".getBytes());
+        when(binaryContent.getByteArray()).thenReturn("byte array with message contents" .getBytes());
         query = mock(QueryRequest.class);
 
         metacard = mock(Metacard.class);
-        httpClient = mock(CloseableHttpClient.class);
+        webclient = mock(WebClient.class);
 
-        sendEvent = new SendEventExtension(transformerManager, request, query, httpClient);
+        sendEvent = new SendEventExtension(transformerManager, request, query, webclient);
 
     }
 
     public void verifyResults() throws Exception {
         verify(transformer).transform(any(SourceResponse.class), anyMap());
-        verify(httpClient).execute(any(HttpUriRequest.class), any(ResponseHandler.class));
+        verify(webclient).invoke(anyString(), anyObject());
     }
 
     @Test
@@ -128,17 +128,11 @@ public class SendEventTest {
     }
 
     private class SendEventExtension extends SendEvent {
-        CloseableHttpClient httpClient;
 
         public SendEventExtension(TransformerManager transformerManager, GetRecordsType request,
-                QueryRequest query, CloseableHttpClient httpClient) throws CswException {
+                QueryRequest query, WebClient httpClient) throws CswException {
             super(transformerManager, request, query);
-            this.httpClient = httpClient;
-        }
-
-        @Override
-        CloseableHttpClient getClosableHttpClient() {
-            return httpClient;
+            webClient = httpClient;
         }
 
     }

--- a/catalog/spatial/csw/spatial-csw-source/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source/pom.xml
@@ -128,10 +128,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -68,6 +68,9 @@
                     <value>http://www.opengis.net/cat/wrs/1.0=registry</value>
                 </array>
             </property>
+            <property name="eventServiceAddress" value=""/>
+            <property name="registerForEvents" value="false"/>
+
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>
@@ -107,6 +110,9 @@
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
             <property name="securityManager" ref="securityManager"/>
+            <property name="eventServiceAddress" value=""/>
+            <property name="registerForEvents" value="false"/>
+
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,6 +22,15 @@
         <AD description="URL to the endpoint implementing the Catalogue Service for Web (CSW) spec"
             name="CSW URL" id="cswUrl" required="true" type="String"/>
 
+        <AD name="Event Service Address" id="eventServiceAddress" required="false" type="String"
+            description="DDF Event Service endpoint. Do NOT include .wsdl or ?wsdl.">
+        </AD>
+
+        <AD name="Register for Events" id="registerForEvents" required="false" type="Boolean"
+            default="false"
+            description="Check to register for events from this connected source.">
+        </AD>
+
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
@@ -134,6 +143,15 @@
 
         <AD description="URL to the endpoint implementing the Catalogue Service for Web (CSW) spec"
             name="CSW URL" id="cswUrl" required="true" type="String"/>
+
+        <AD name="Event Service Address" id="eventServiceAddress" required="false" type="String"
+            description="DDF Event Service endpoint. Do NOT include .wsdl or ?wsdl.">
+        </AD>
+
+        <AD name="Register for Events" id="registerForEvents" required="false" type="Boolean"
+            default="false"
+            description="Check to register for events from this connected source.">
+        </AD>
 
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>

--- a/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSourceStub.java
+++ b/catalog/spatial/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSourceStub.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.csw.catalog.source;
+
+import static org.mockito.Mockito.mock;
+
+import org.codice.ddf.cxf.SecureCxfClientFactory;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSubscribe;
+import org.codice.ddf.spatial.ogc.csw.catalog.converter.CswTransformProvider;
+import org.osgi.framework.BundleContext;
+
+import ddf.security.Subject;
+
+public class CswSourceStub extends CswSource {
+
+    Subject subject = mock(Subject.class);
+
+    public CswSourceStub(BundleContext mockContext, CswSourceConfiguration cswSourceConfiguration,
+            CswTransformProvider mockProvider, SecureCxfClientFactory mockFactory) {
+        super(mockContext, cswSourceConfiguration, mockProvider, mockFactory);
+        super.subscribeClientFactory = mock(SecureCxfClientFactory.class);
+    }
+
+    @Override
+    protected void initSubscribeClientFactory() {
+
+    }
+
+    @Override
+    protected Subject getSystemSubject() {
+        return subject;
+    }
+
+    public Subject getSubject() {
+        return subject;
+    }
+
+    public SecureCxfClientFactory<CswSubscribe> getSubscriberClientFactory() {
+        return subscribeClientFactory;
+    }
+}

--- a/catalog/spatial/docs/src/main/resources/_contents/integrating-contents.adoc
+++ b/catalog/spatial/docs/src/main/resources/_contents/integrating-contents.adoc
@@ -1278,7 +1278,7 @@ The following is an example of an `application/xml` response to the Transaction 
 The subscription `GetRecords` operation is very similar to the `GetRecords` operation used to search the catalog but it subscribes to a search and sends events to a `ResponseHandler` endpoint as metacards are ingested matching the GetRecords request used in the subscription.
 The response to a `GetRecords` request on the subscription url will be an acknowledgement containing the original GetRecords request and a requestId
 The client will be assigned a requestId (URN).
-A distributed search argument will be ignored in this context. It will only send events for metacards ingested locally.
+A Subscription listens for events from federated sources if the `DistributedSearch` element is present and the catalog is a member of a federation.
 
 
 ===== Subscription `GetRecords` `HTTP GET`
@@ -1315,7 +1315,7 @@ ConstraintLanguage=CQL_TEXT&constraint=Text Like '%25'
         <Constraint version="1.1.0">
             <ogc:Filter>
                 <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
-                    <ogc:PropertyName>AnyText</ogc:PropertyName>
+                    <ogc:PropertyName>xml</ogc:PropertyName>
                     <ogc:Literal>%</ogc:Literal>
                 </ogc:PropertyIsLike>
             </ogc:Filter>
@@ -1363,7 +1363,7 @@ The following is an example of an `application/xml` response to the `GetRecords`
             <Constraint version="1.1.0">
                 <ogc:Filter>
                     <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
-                        <ogc:PropertyName>AnyText</ogc:PropertyName>
+                        <ogc:PropertyName>xml</ogc:PropertyName>
                         <ogc:Literal>%</ogc:Literal>
                     </ogc:PropertyIsLike>
                 </ogc:Filter>
@@ -1437,7 +1437,7 @@ The following is an example `HTTP GET` Response retrieving an active subscriptio
             <Constraint version="1.1.0">
                 <ogc:Filter>
                     <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
-                        <ogc:PropertyName>AnyText</ogc:PropertyName>
+                        <ogc:PropertyName>xml</ogc:PropertyName>
                         <ogc:Literal>%</ogc:Literal>
                     </ogc:PropertyIsLike>
                 </ogc:Filter>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -244,6 +244,9 @@ public abstract class AbstractIntegrationTest {
     public static final DynamicUrl CSW_SUBSCRIPTION_PATH = new DynamicUrl(SERVICE_ROOT,
             "/csw/subscription");
 
+    public static final DynamicUrl CSW_EVENT_PATH = new DynamicUrl(SERVICE_ROOT,
+            "/csw/subscription/event");
+
     public static final DynamicUrl ADMIN_ALL_SOURCES_PATH = new DynamicUrl(SECURE_ROOT,
             HTTPS_PORT,
             "/jolokia/exec/org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean:service=admin-source-poller-service/allSourceInfo");

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -143,7 +143,9 @@ public final class Library {
     }
 
     public static String getCswIngest() {
-        return getCswInsert("csw:Record", getCswRecord(UUID.randomUUID().toString()));
+        return getCswInsert("csw:Record",
+                getCswRecord(UUID.randomUUID()
+                        .toString()));
     }
 
     public static String getCswRecord(String id) {
@@ -333,5 +335,9 @@ public final class Library {
                 + "service=\"CSW\" version=\"2.0.2\" outputFormat=\"application/octet-stream\"\n"
                 + "outputSchema=\"http://www.iana.org/assignments/media-types/application/octet-stream\">\n"
                 + "  <Id>placeholder_id_1</Id>\n" + "</GetRecordById>";
+    }
+
+    public static String getCswRecordResponse() throws IOException {
+        return IOUtils.toString(Library.class.getResourceAsStream("/get-records-response.xml"));
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/get-records-response.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/get-records-response.xml
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<csw:GetRecordsResponse xmlns:dct="http://purl.org/dc/terms/" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0.2">
+    <csw:SearchStatus timestamp="2016-03-03T14:46:42.479-07:00"/>
+    <csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0" recordSchema="urn:catalog:metacard" elementSet="full">
+        <metacard xmlns="urn:catalog:metacard" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:smillang="http://www.w3.org/2001/SMIL20/Language" gml:id="5b1688fa85fd46268e4ab7402a1750e0">
+            <type>ddf.metacard</type>
+            <source>ddf.distribution</source>
+            <dateTime name="created">
+                <value>2012-09-01T00:09:19.368+00:00</value>
+
+            </dateTime>
+            <string name="resource-uri">
+                <value>http://cabinets-fleets-gushier-splintering-crayoning-robuster-nonsecular.com</value>
+
+            </string>
+            <string name="metadata-content-type">
+                <value>myType</value>
+
+            </string>
+            <string name="metacard-tags">
+                <value>resource</value>
+
+            </string>
+            <string name="title">
+                <value>cabinets fleets gushier splintering crayoning robuster nonsecular</value>
+
+            </string>
+            <geometry xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml" xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/" xmlns:ns5="http://www.w3.org/2001/SMIL20/Language" name="location">
+                <value>
+                    <ns2:Point>
+                        <ns2:pos>175.0 -54.0</ns2:pos>
+
+                    </ns2:Point>
+
+                </value>
+            </geometry>
+            <string name="metadata-content-type-version">
+                <value>myVersion</value>
+
+            </string>
+            <string name="resource-download-url">
+                <value>https://localhost:8993/services/catalog/sources/ddf.distribution/5b1688fa85fd46268e4ab7402a1750e0?transform=resource</value>
+
+            </string>
+            <base64Binary name="thumbnail">
+                <value>CA==</value>
+
+            </base64Binary>
+            <dateTime name="modified">
+                <value>2012-09-01T00:09:19.368+00:00</value>
+
+            </dateTime>
+            <dateTime name="effective">
+                <value>2016-03-03T20:28:35.691+00:00</value>
+
+            </dateTime>
+            <stringxml name="metadata">
+                <value>
+                    <xml>
+                        <title>cabinets fleets gushier splintering crayoning robuster nonsecular</title>
+                        <uri>cabinets-fleets-gushier-splintering-crayoning-robuster-nonsecular.com</uri>
+                    </xml>
+                </value>
+
+            </stringxml>
+        </metacard>
+    </csw:SearchResults>
+</csw:GetRecordsResponse>


### PR DESCRIPTION
#### What does this PR do?
 Adds endpoints to the subscription service to handle incoming events from federated sources.  
Update CSW source so that it can be configured to subscribe to events for that source.
#### Who is reviewing it?
@roelens8 @bcwaters @coyotesqrl @tbatie @pklinef 
#### How should this be tested?
1. Start up two DDF's
2. Federate from one DDF to another selecting register for events and filling out the event endpoint
3. Post a subscription to the DDF that has the federated source with the response handler pointing to a jetty server that will display the output.
4. Ingest metacards into the federated DDF and verify that events are exchanged between the servers. 

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
