### PR TITLE
DDF-1956 Missing dependencies for content-core-directorymonitor

### DIFF
--- a/catalog/content/core/content-core-directorymonitor/pom.xml
+++ b/catalog/content/core/content-core-directorymonitor/pom.xml
@@ -64,6 +64,15 @@
             <artifactId>security-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util-unavailableurls</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.security</groupId>
             <artifactId>ddf-security-common</artifactId>
             <version>${project.version}</version>
@@ -89,11 +98,17 @@
     <build>
         <plugins>
             <plugin>
+
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            ddf-security-common,
+                            platform-util,
+                            platform-util-unavailableurls
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
#### What does this PR do?
Adds missing dependencies to a broken bundle.

#### Who is reviewing it?
@jckilmer @ryeats @roelens8 @bcwaters 

#### How should this be tested?
DDF should be deployed and the content app started. If the app starts successfully, the dependencies will have been resolved.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-1956](https://codice.atlassian.net/browse/DDF-1956)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated N/A
- [ ] Update / Add Unit Tests N/A
- [ ] Update / Add Integration Tests N/A

The content app won't start because this bundle is missing several embedded dependencies.