### PR TITLE
DDF-1588 updated the URLResourceReader to follow redirects by default

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -95,6 +95,8 @@ public class URLResourceReader implements ResourceReader {
 
     private Set<String> rootResourceDirectories = new HashSet<>();
 
+    private boolean followRedirects = false;
+
     /**
      * Default URLResourceReader constructor.
      */
@@ -204,6 +206,32 @@ public class URLResourceReader implements ResourceReader {
     }
 
     /**
+     * Specifies whether the code should follow server issued redirection (HTTP
+     * Response codes between 300 and 400)
+     *
+     * @param redirect
+     *            true - follow redirections automatically false - do not follow
+     *            server issued redirections
+     */
+    public void setFollowRedirects(Boolean redirect) {
+        LOGGER.debug("{}: Setting follow URL redirects (HTTP 300 codes) to {}",
+                URLResourceReader.class.getName(), redirect);
+        if (redirect != null) {
+            this.followRedirects = redirect;
+        }
+    }
+
+    /**
+     * Gets the autoRedirect property
+     * 
+     * @return true if the server issued redirections should be automatically
+     *         followed
+     */
+    public Boolean getFollowRedirects() {
+        return followRedirects;
+    }
+
+    /**
      * Retrieves a {@link ddf.catalog.resource.Resource} based on a {@link URI} and provided
      * arguments. A connection is made to the {@link URI} to obtain the
      * {@link ddf.catalog.resource.Resource}'s {@link InputStream} and build a
@@ -223,7 +251,6 @@ public class URLResourceReader implements ResourceReader {
     public ResourceResponse retrieveResource(URI resourceURI, Map<String, Serializable> properties)
             throws IOException, ResourceNotFoundException {
         String bytesToSkip = null;
-
         if (resourceURI == null) {
             LOGGER.warn("Resource URI was null");
             throw new ResourceNotFoundException("Unable to find resource");
@@ -480,9 +507,11 @@ public class URLResourceReader implements ResourceReader {
         return false;
     }
 
-    /* Added for Unit Testing */
     protected WebClient getWebClient(String uri) {
-        return WebClient.create(uri);
+        WebClient client = WebClient.create(uri);
+        WebClient.getConfig(client).getHttpConduit().getClient()
+                .setAutoRedirect(getFollowRedirects());
+        return client;
     }
 
     @Override

--- a/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,6 +18,11 @@
         <OCD name="URL Resource Reader"
          id="ddf.catalog.resource.impl.URLResourceReader">
                 <AD
+                description="Check the box if you want the Resource Reader to automatically follow server issued redirects (HTTP Response Code 300 series)"
+                name="Follow Server Redirects" id="followRedirects" required="true"
+                type="Boolean" default="false"/>
+         
+                <AD
                 description="List of root resource directories. A relative path is relative to ddf.home. Specifies the only directories the URLResourceReader has access to when attempting to download resources linked using file-based URLs."
                 name="Root Resource Directories" id="rootResourceDirectories" required="true" cardinality="100"
                 type="String" default="data/products"/>

--- a/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/ResourceReaderTest.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/ResourceReaderTest.java
@@ -16,6 +16,8 @@ package ddf.catalog.resource.impl;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -56,8 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
-
-import junit.framework.Assert;
 
 import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.resource.Resource;
@@ -374,7 +374,7 @@ public class ResourceReaderTest {
                 null);
 
         // verify that we got the entire resource
-        Assert.assertEquals(5,
+        assertEquals(5,
                 response.getResource()
                         .getByteArray().length);
     }
@@ -401,7 +401,7 @@ public class ResourceReaderTest {
                 bytesToSkip);
 
         // verify that we got the entire resource
-        Assert.assertEquals(3,
+        assertEquals(3,
                 response.getResource()
                         .getByteArray().length);
     }
@@ -574,6 +574,25 @@ public class ResourceReaderTest {
         // Verify
         Set<String> rootResourceDirectories = resourceReader.getRootResourceDirectories();
         assertThat(rootResourceDirectories.size(), is(1));
+    }
+
+    @Test
+    public void testSetRedirect() throws Exception {
+        URLResourceReader resourceReader = new URLResourceReader(mimeTypeMapper);
+        WebClient client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
+                + JPEG_FILE_NAME_1);
+        assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
+
+        resourceReader.setFollowRedirects(true);
+        client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
+                + JPEG_FILE_NAME_1);
+        assertTrue(WebClient.getConfig(client).getHttpConduit().getClient()
+                .isAutoRedirect());
+
+        resourceReader.setFollowRedirects(false);
+        client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
+                + JPEG_FILE_NAME_1);
+        assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
     }
 
     private void verifyFile(String filePath, String filename, String expectedMimeType,


### PR DESCRIPTION
This PR sets the CXF setting to HTTP redirects by default (DDF-1588).  There are unit tests that verify the proper setting of the CFX property to follow redirects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/ddf/635)
<!-- Reviewable:end -->
