### PR TITLE
DDF-1972 add npm directories to mvn clean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,20 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>node_modules</directory>
+                            </fileset>
+                            <fileset>
+                                <directory>node</directory>
+                            </fileset>
+                        </filesets>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>3.0.0</version>


### PR DESCRIPTION
#### What does this PR do?
Remove `node` and `node_modules` during an `mvn clean`.
#### Who is reviewing it?
@djblue 
#### How should this be tested?
`mvn clean install` in a ui module, then `mvn clean`. Verify both directories are deleted. Could also do a full build/quickbuild of ddf to make sure nothing is broken.
#### Any background context you want to provide?
I ran into this while jumping between different commits and doing builds. Changes to npm dependencies were rendering my working copy un-buildable. This change solves that problem. Anyone trying to build after updates to npm dependencies could also run into this problem.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1972
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
