### PR TITLE
DDF-1970: As an Integrator, I want information on Migratables.

### DIFF
--- a/catalog/core/catalog-core-migratable/src/main/java/org/codice/ddf/catalog/migratable/impl/MetacardsMigratable.java
+++ b/catalog/core/catalog-core-migratable/src/main/java/org/codice/ddf/catalog/migratable/impl/MetacardsMigratable.java
@@ -25,8 +25,8 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
-import org.codice.ddf.migration.AbstractDescribable;
 import org.codice.ddf.migration.DataMigratable;
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.ExportMigrationException;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
@@ -51,9 +51,9 @@ import ddf.catalog.source.UnsupportedQueryException;
  * Implementation of the {@link org.codice.ddf.migration.DataMigratable} interface used to migrate
  * the current catalog framework's {@link Metacard}s.
  */
-public class CatalogMigratableImpl extends AbstractDescribable implements DataMigratable {
+public class MetacardsMigratable extends DescribableBean implements DataMigratable {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogMigratableImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetacardsMigratable.class);
 
     private static final String DEFAULT_FAILURE_MESSAGE = "Catalog could not export metacards";
 
@@ -70,53 +70,38 @@ public class CatalogMigratableImpl extends AbstractDescribable implements DataMi
     /**
      * Basic constructor with minimum required components.
      *
-     * @param description   description of this migratable
+     * @param info          container for description data on this migratable
      * @param framework     framework used to retrieve the metacards to export
      * @param filterBuilder builder used to create query filters
      * @param config        export configuration information
-     * @param version       version of this migratable
-     * @param id            id of this migratable
-     * @param title         title of this migratable
-     * @param organization  organization of this migratable
      */
-    public CatalogMigratableImpl(@NotNull CatalogFramework framework,
+    public MetacardsMigratable(@NotNull DescribableBean info, @NotNull CatalogFramework framework,
             @NotNull FilterBuilder filterBuilder, @NotNull MigrationFileWriter fileWriter,
-            @NotNull CatalogMigratableConfig config, @NotNull String version, @NotNull String id,
-            @NotNull String title, @NotNull String description, @NotNull String organization) {
+            @NotNull CatalogMigratableConfig config) {
 
-        this(framework,
+        this(info,
+                framework,
                 filterBuilder,
                 fileWriter,
                 config,
-                new MigrationTaskManager(config, fileWriter),
-                version,
-                id,
-                title,
-                description,
-                organization);
+                new MigrationTaskManager(config, fileWriter));
 
     }
 
     /**
      * Constructor that allows the caller choice of {@link MigrationTaskManager} to be injected.
      *
+     * @param info          container for description data on this migratable
      * @param framework     framework used to retrieve the metacards to export
      * @param filterBuilder builder used to create query filters
      * @param config        export configuration information
      * @param taskManager   the manager responsible for submitting file writing jobs during export
-     * @param version       version of this migratable
-     * @param id            id of this migratable
-     * @param title         title of this migratable
-     * @param description   description of this migratable
-     * @param organization  organization of this migratable
      */
-    public CatalogMigratableImpl(@NotNull CatalogFramework framework,
+    public MetacardsMigratable(@NotNull DescribableBean info, @NotNull CatalogFramework framework,
             @NotNull FilterBuilder filterBuilder, @NotNull MigrationFileWriter fileWriter,
-            @NotNull CatalogMigratableConfig config, @NotNull MigrationTaskManager taskManager,
-            @NotNull String version, @NotNull String id, @NotNull String title,
-            @NotNull String description, @NotNull String organization) {
+            @NotNull CatalogMigratableConfig config, @NotNull MigrationTaskManager taskManager) {
 
-        super(version, id, title, description, organization);
+        super(info);
 
         notNull(framework, "CatalogFramework cannot be null");
         notNull(filterBuilder, "FilterBuilder cannot be null");

--- a/catalog/core/catalog-core-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,16 +26,21 @@
     </bean>
 
     <bean id="catalogMigratable"
-          class="org.codice.ddf.catalog.migratable.impl.CatalogMigratableImpl">
+          class="org.codice.ddf.catalog.migratable.impl.MetacardsMigratable">
+        <argument ref="catalogDescribable"/>
         <argument ref="catalogFramework"/>
         <argument ref="filterBuilder"/>
         <argument ref="catalogFileWriter"/>
         <argument ref="catalogMigratableConfig"/>
+    </bean>
+
+    <bean id="catalogDescribable"
+          class="org.codice.ddf.migration.DescribableBean">
         <argument value="1.0"/>
-        <argument value="org.codice.ddf.catalog"/>
-        <argument value="Catalog Migration"/>
+        <argument value="ddf.metacards"/>
+        <argument value="Metacard Migration"/>
         <argument value="Exports Catalog metacards"/>
-        <argument value="DDF"/>
+        <argument value="Codice"/>
     </bean>
 
     <bean id="catalogFileWriter"

--- a/catalog/core/catalog-core-migratable/src/test/java/org/codice/ddf/catalog/migratable/impl/MetacardsMigratableTest.java
+++ b/catalog/core/catalog-core-migratable/src/test/java/org/codice/ddf/catalog/migratable/impl/MetacardsMigratableTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.ExportMigrationException;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
@@ -55,7 +56,7 @@ import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CatalogMigratableImplTest {
+public class MetacardsMigratableTest {
 
     private static final Path EXPORT_PATH = Paths.get("etc", "exported");
 
@@ -68,6 +69,12 @@ public class CatalogMigratableImplTest {
     private static final String TITLE = "title";
 
     private static final String ORGANIZATION = "organization";
+
+    private static final DescribableBean DESCRIBABLE_BEAN = new DescribableBean(VERSION,
+            ID,
+            TITLE,
+            DESCRIPTION,
+            ORGANIZATION);
 
     @Captor
     private ArgumentCaptor<QueryRequest> argQueryRequest;
@@ -84,7 +91,7 @@ public class CatalogMigratableImplTest {
     @Mock
     private MigrationTaskManager mockTaskManager;
 
-    private CatalogMigratableImpl migratable;
+    private MetacardsMigratable migratable;
 
     private CatalogMigratableConfig config;
 
@@ -95,16 +102,12 @@ public class CatalogMigratableImplTest {
         config = new CatalogMigratableConfig();
         config.setExportQueryPageSize(2);
 
-        migratable = new CatalogMigratableImpl(mockFramework,
+        migratable = new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
                 mockFilterBuilder,
                 mockFileWriter,
                 config,
-                mockTaskManager,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
 
         when(mockFilterBuilder.attribute(Metacard.ANY_TEXT)
                 .is()
@@ -119,68 +122,63 @@ public class CatalogMigratableImplTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructorWithNullDescription() {
-        new CatalogMigratableImpl(mockFramework,
+    public void constructorWithNullDescribable() {
+        new MetacardsMigratable(null,
+                mockFramework,
                 mockFilterBuilder,
                 mockFileWriter,
                 config,
-                VERSION,
-                ID,
-                TITLE,
-                null,
-                ORGANIZATION);
+                mockTaskManager);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructorWithNullProvider() {
-        new CatalogMigratableImpl(null,
+    public void constructorWithNullFramework() {
+        new MetacardsMigratable(DESCRIBABLE_BEAN,
+                null,
                 mockFilterBuilder,
                 mockFileWriter,
                 config,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorWithNullFilterBuilder() {
-        new CatalogMigratableImpl(mockFramework,
+        new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
                 null,
                 mockFileWriter,
                 config,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorWithNullFileWriter() {
-        new CatalogMigratableImpl(mockFramework,
+        new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
                 mockFilterBuilder,
                 null,
                 config,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorWithNullConfig() {
-        new CatalogMigratableImpl(mockFramework,
+        new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
                 mockFilterBuilder,
                 mockFileWriter,
                 null,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithNullTaskManager() {
+        new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
+                mockFilterBuilder,
+                mockFileWriter,
+                config,
+                null);
     }
 
     @Test
@@ -281,15 +279,12 @@ public class CatalogMigratableImplTest {
     public void exportWhenProviderQueryFails() throws Exception {
         when(mockFramework.query(any())).thenThrow(new UnsupportedQueryException(""));
 
-        CatalogMigratableImpl migratable = new CatalogMigratableImpl(mockFramework,
+        MetacardsMigratable migratable = new MetacardsMigratable(DESCRIBABLE_BEAN,
+                mockFramework,
                 mockFilterBuilder,
                 mockFileWriter,
                 config,
-                VERSION,
-                ID,
-                TITLE,
-                DESCRIPTION,
-                ORGANIZATION);
+                mockTaskManager);
 
         migratable.export(EXPORT_PATH);
     }

--- a/distribution/docs/src/main/resources/_contents/extending-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/extending-contents.adoc
@@ -678,6 +678,25 @@ A KAR file is a Karaf-specific archive format (*K*araf *AR*chive).
 It is a jar file that contains a feature descriptor file and one or more OSGi bundle jar files.
 The feature descriptor file identifies the application's name, the set of bundles that need to be installed, and any dependencies on other features that may need to be installed.
 
+==== Describing Application Services
+
+Given the modular nature of OSGi, some applications perform operations on the services themselves.
+In order to present, identify, and manipulate the services, they need descriptive identifying information.
+Any service that implements the `Describable` interface in `org.codice.ddf.platform.services.common` will
+have an obligation to provide this information. The relevant fields are as follows:
+
+* ID: a unique identifier for the service
+* Title: the informal name for the service
+* Description: a short, human-consumable description of the service
+* Organization: the name of the organization that wrote the service
+* Version: the current version of the service (example: 1.0)
+
+The only field with stringent requirements is the ID field. Format should be `[*product*].[*component*]`
+such as `ddf.metacards` or `ddf.platform`; while the [*component*] within a [*product*] may simply be
+a module or bundle name, the [*product*] itself should be the unique name of the plug-in or integration
+that belongs to the organization provided. Note that `ddf` as a [*product*] is reserved for core features
+only and is not meant to be used during extension or integration.
+
 ==== Creating a KAR File
 
 The recommended method for creating a KAR file is to use the `features-maven-plugin`, which has a `create-kar` goal.

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -699,20 +699,20 @@ public class TestConfiguration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testExportCatalog() throws Exception {
+    public void testExportMetacards() throws Exception {
         resetInitialState();
 
         List<String> metacardIds = ingestMetacardsForExport();
 
         console.runCommand(EXPORT_COMMAND);
 
-        assertExportCatalog(getDefaultExportDirectory().resolve("org.codice.ddf.catalog"));
+        assertExportCatalog(getDefaultExportDirectory().resolve("ddf.metacards"));
 
         console.runCommand(CATALOG_REMOVE_ALL_COMMAND, new RolePrincipal("admin"));
 
         console.runCommand(String.format("%s %s",
                 CATALOG_INGEST_COMMAND,
-                getDefaultExportDirectory().resolve("org.codice.ddf.catalog")),
+                getDefaultExportDirectory().resolve("ddf.metacards")),
                 new RolePrincipal("admin"));
 
         assertMetacardsIngested(metacardIds.size());

--- a/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/DescribableBean.java
+++ b/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/DescribableBean.java
@@ -20,7 +20,17 @@ import javax.validation.constraints.NotNull;
 
 import org.codice.ddf.platform.services.common.Describable;
 
-public abstract class AbstractDescribable implements Describable {
+/**
+ * This class may serve as a base for any service that provides the {@link Describable} methods
+ * from injectable data. It is not abstract; otherwise it could not neatly be created in the
+ * blueprint files or reduce the count of constructor args on its children.
+ * <p>
+ * The class is referred to as a 'Bean' since it only wraps data and provides no significant
+ * business logic.
+ * <p>
+ * {@inheritDoc}
+ */
+public class DescribableBean implements Describable {
 
     private String version;
 
@@ -41,8 +51,8 @@ public abstract class AbstractDescribable implements Describable {
      * @param description  description of this describable
      * @param organization organization where this describable belongs
      */
-    public AbstractDescribable(@NotNull String version, @NotNull String id, @NotNull String title, @NotNull String description,
-            @NotNull String organization) {
+    public DescribableBean(@NotNull String version, @NotNull String id, @NotNull String title,
+            @NotNull String description, @NotNull String organization) {
 
         notNull(description, "description cannot be null");
         notNull(organization, "organization cannot be null");
@@ -58,28 +68,44 @@ public abstract class AbstractDescribable implements Describable {
 
     }
 
+    /**
+     * Copy constructor to support simplicity of child object constructors.
+     *
+     * @param describableInfo object containing required info to be copied into
+     *                        this describable.
+     */
+    public DescribableBean(@NotNull DescribableBean describableInfo) {
+        notNull(describableInfo, "describable info cannot be null");
+
+        this.version = describableInfo.getVersion();
+        this.id = describableInfo.getId();
+        this.title = describableInfo.getTitle();
+        this.description = describableInfo.getDescription();
+        this.organization = describableInfo.getOrganization();
+    }
+
     @Override
-    @NotNull public String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @Override
-    @NotNull public String getId() {
+    public String getId() {
         return id;
     }
 
     @Override
-    @NotNull public String getTitle() {
+    public String getTitle() {
         return title;
     }
 
     @Override
-    @NotNull public String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @Override
-    @NotNull public String getOrganization() {
+    public String getOrganization() {
         return organization;
     }
 

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
@@ -38,10 +38,12 @@ import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
 import org.codice.ddf.migration.MigrationWarning;
 import org.codice.ddf.migration.UnexpectedMigrationException;
+import org.codice.ddf.platform.services.common.Describable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Implementation of the {@link ConfigurationMigrationService} that allows migration of
@@ -138,6 +140,11 @@ public class ConfigurationMigrationManager
         notNull(exportDirectory, "Export directory cannot be null");
 
         return export(Paths.get(exportDirectory));
+    }
+
+    @Override
+    public Collection<Describable> getOptionalMigratableInfo() {
+        return ImmutableList.copyOf(dataMigratables);
     }
 
     private Collection<MigrationWarning> exportMigratable(Migratable migratable,

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerMBean.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerMBean.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotNull;
 
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationWarning;
+import org.codice.ddf.platform.services.common.Describable;
 
 /**
  * Interface to expose {@link ConfigurationMigrationManager} as an MBean.
@@ -34,4 +35,12 @@ public interface ConfigurationMigrationManagerMBean {
      * @throws MigrationException thrown if one or more Configurations couldn't be exported
      */
     Collection<MigrationWarning> export(@NotNull String exportDirectory) throws MigrationException;
+
+    /**
+     * Gets detailed information about all the {@link org.codice.ddf.migration.DataMigratable}
+     * services currently registered.
+     *
+     * @return A collection of type {@link Describable}.
+     */
+    Collection<Describable> getOptionalMigratableInfo();
 }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationService.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationService.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.NotNull;
 
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationWarning;
+import org.codice.ddf.platform.services.common.Describable;
 
 /**
  * Service that provides a way to migrate configurations from one instance of DDF to another.  This
@@ -32,8 +33,16 @@ public interface ConfigurationMigrationService {
      * Exports configurations to specified path
      *
      * @param exportDirectory path to export configurations
-     * @throws MigrationException thrown if one or more Configurations couldn't be exported
      * @return MigrationWarning returned if there were non-fatal issues when exporting
+     * @throws MigrationException thrown if one or more Configurations couldn't be exported
      */
     Collection<MigrationWarning> export(@NotNull Path exportDirectory) throws MigrationException;
+
+    /**
+     * Gets detailed information about all the {@link org.codice.ddf.migration.DataMigratable}
+     * services currently registered.
+     *
+     * @return A collection of type {@link Describable}.
+     */
+    Collection<Describable> getOptionalMigratableInfo();
 }

--- a/platform/platform-api/src/main/java/org/codice/ddf/platform/services/common/Describable.java
+++ b/platform/platform-api/src/main/java/org/codice/ddf/platform/services/common/Describable.java
@@ -13,13 +13,10 @@
  */
 package org.codice.ddf.platform.services.common;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * Describable is used to capture a basic description of a service. This provides valuable runtime
  * information to the user regarding the application bundles and OSGi.
- *
- * This interface is not meant to be a concrete store of data and does not have a default implementation.
+ * <p>
  * It is expected that the children are services that perform specific tasks.
  */
 public interface Describable {
@@ -28,17 +25,23 @@ public interface Describable {
      *
      * @return the version of the item being described (example: 1.0)
      */
-    @NotNull String getVersion();
+    String getVersion();
 
     /**
      * Returns the name, aka ID, of the describable item. The name should be unique for each
-     * instance with the scope of a service or a component. For example, this is unique for any
+     * instance within the scope of a service or a component. For example, this is unique for any
      * Migratable in a set of Migratables. It is not necessarily unique between Migratables and
      * Metacards.
+     * <p>
+     * Format should be [<b>product</b>].[<b>component</b>] such as ddf.metacards, or ddf.platform;
+     * while the [<b>component</b>] within a [<b>product</b>] may simply be a module or bundle name,
+     * the [<b>product</b>] itself should be the unique name of the plug-in or integration that
+     * belongs to the organization listed in {@link Describable#getOrganization()}. Note that 'ddf'
+     * as a [<b>product</b>] is reserved for core features only.
      *
      * @return ID of the item
      */
-    @NotNull String getId();
+    String getId();
 
     /**
      * Returns the title of the describable item. It is generally more verbose than the name (aka
@@ -46,19 +49,19 @@ public interface Describable {
      *
      * @return title of the item (example: File System Provider)
      */
-    @NotNull String getTitle();
+    String getTitle();
 
     /**
      * Returns a description of the describable item.
      *
      * @return description of the item (example: Provider that returns back static results)
      */
-    @NotNull String getDescription();
+    String getDescription();
 
     /**
      * Returns the organization associated with the describable item.
      *
      * @return organizational name or acronym (example: USAF)
      */
-    @NotNull String getOrganization();
+    String getOrganization();
 }

--- a/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
+++ b/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 
 import javax.validation.constraints.NotNull;
 
-import org.codice.ddf.migration.AbstractDescribable;
 import org.codice.ddf.migration.ConfigurationMigratable;
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
 import org.codice.ddf.migration.MigrationWarning;
@@ -31,11 +31,10 @@ import org.codice.ddf.migration.util.MigratableUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * This class handles the export process for all Platform system files.
  */
-public class PlatformMigratable extends AbstractDescribable implements ConfigurationMigratable {
+public class PlatformMigratable extends DescribableBean implements ConfigurationMigratable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlatformMigratable.class);
 
@@ -54,11 +53,10 @@ public class PlatformMigratable extends AbstractDescribable implements Configura
 
     private final MigratableUtil migratableUtil;
 
-    public PlatformMigratable(@NotNull String description, @NotNull MigratableUtil migratableUtil,
-            @NotNull String organization, @NotNull String title, @NotNull String id,
-            @NotNull String version) {
+    public PlatformMigratable(@NotNull DescribableBean info,
+            @NotNull MigratableUtil migratableUtil) {
 
-        super(version, id, title, description, organization);
+        super(info);
 
         notNull(migratableUtil, "migratable utility should not be null");
         this.migratableUtil = migratableUtil;

--- a/platform/platform-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,12 +17,17 @@
     <bean id="migrationUtil" class="org.codice.ddf.migration.util.MigratableUtil" />
     
     <bean id="platformMigratable" class="org.codice.ddf.platform.migratable.impl.PlatformMigratable">
-        <argument value="Exports Platform system files" />
+        <argument ref="platformDescribable" />
         <argument ref="migrationUtil" />
+    </bean>
+
+    <bean id="platformDescribable"
+          class="org.codice.ddf.migration.DescribableBean">
         <argument value="1.0"/>
-        <argument value="org.codice.ddf.catalog"/>
-        <argument value="Catalog Migration"/>
-        <argument value="DDF"/>
+        <argument value="ddf.platform"/>
+        <argument value="Platform Migration"/>
+        <argument value="Exports Platform system files" />
+        <argument value="Codice"/>
     </bean>
 
     <service id="platformMigratableService" ref="platformMigratable"

--- a/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
+++ b/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
 import org.codice.ddf.migration.MigrationWarning;
@@ -71,6 +72,12 @@ public class PlatformMigratableTest {
 
     private static final String VERSION = "version";
 
+    private static final DescribableBean DESCRIBABLE_BEAN = new DescribableBean(VERSION,
+            ID,
+            TITLE,
+            DESCRIPTION,
+            ORGANIZATION);
+
     private Path ddfHome;
 
     private Path exportDirectory;
@@ -85,12 +92,8 @@ public class PlatformMigratableTest {
     public void testExportValidRelativePaths() throws Exception {
         // Setup
         MigratableUtil mockMigratableUtil = mock(MigratableUtil.class);
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform Test
         platformMigratable.export(exportDirectory);
@@ -126,12 +129,8 @@ public class PlatformMigratableTest {
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
 
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform Test
         MigrationMetadata migrationMetadata = platformMigratable.export(exportDirectory);
@@ -160,12 +159,8 @@ public class PlatformMigratableTest {
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
 
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform Test
         MigrationMetadata migrationMetadata = platformMigratable.export(exportDirectory);
@@ -188,12 +183,8 @@ public class PlatformMigratableTest {
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
 
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform Test
         MigrationMetadata migrationMetadata = platformMigratable.export(exportDirectory);
@@ -211,12 +202,8 @@ public class PlatformMigratableTest {
                 .copyFile(any(Path.class),
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
         platformMigratable.export(exportDirectory);
@@ -230,12 +217,8 @@ public class PlatformMigratableTest {
                 .copyDirectory(any(Path.class),
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
         platformMigratable.export(exportDirectory);
@@ -249,12 +232,8 @@ public class PlatformMigratableTest {
                 .copyFileFromSystemPropertyValue(any(String.class),
                         eq(exportDirectory),
                         Matchers.<Collection<MigrationWarning>>any());
-        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        PlatformMigratable platformMigratable = new PlatformMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
         platformMigratable.export(exportDirectory);

--- a/platform/security/security-migratable/src/main/java/org/codice/ddf/security/migratable/impl/SecurityMigratable.java
+++ b/platform/security/security-migratable/src/main/java/org/codice/ddf/security/migratable/impl/SecurityMigratable.java
@@ -24,8 +24,8 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.migration.AbstractDescribable;
 import org.codice.ddf.migration.ConfigurationMigratable;
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.ExportMigrationException;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * This class handles the export process for all Security system files
  */
-public class SecurityMigratable extends AbstractDescribable implements ConfigurationMigratable {
+public class SecurityMigratable extends DescribableBean implements ConfigurationMigratable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SecurityMigratable.class);
 
@@ -57,11 +57,10 @@ public class SecurityMigratable extends AbstractDescribable implements Configura
 
     private final MigratableUtil migratableUtil;
 
-    public SecurityMigratable(@NotNull String description, MigratableUtil migratableUtil,
-            @NotNull String organization, @NotNull String title, @NotNull String id,
-            @NotNull String version) {
+    public SecurityMigratable(@NotNull DescribableBean info,
+            @NotNull MigratableUtil migratableUtil) {
 
-        super(version, id, title, description, organization);
+        super(info);
 
         notNull(migratableUtil);
         this.migratableUtil = migratableUtil;

--- a/platform/security/security-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/security-migratable/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,12 +18,17 @@
 
     <bean id="securityMigratable"
           class="org.codice.ddf.security.migratable.impl.SecurityMigratable">
-        <argument value="Exports Security system files"/>
+        <argument ref="securityDescribable"/>
         <argument ref="migratableUtil"/>
+    </bean>
+
+    <bean id="securityDescribable"
+          class="org.codice.ddf.migration.DescribableBean">
         <argument value="1.0"/>
-        <argument value="org.codice.ddf.catalog"/>
-        <argument value="Catalog Migration"/>
-        <argument value="DDF"/>
+        <argument value="ddf.security"/>
+        <argument value="Security Migration"/>
+        <argument value="Exports Security system files"/>
+        <argument value="Codice"/>
     </bean>
 
     <service id="securityMigratableService" ref="securityMigratable"

--- a/platform/security/security-migratable/src/test/java/org/codice/ddf/security/migratable/impl/SecurityMigratableTest.java
+++ b/platform/security/security-migratable/src/test/java/org/codice/ddf/security/migratable/impl/SecurityMigratableTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 
+import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMetadata;
 import org.codice.ddf.migration.MigrationWarning;
@@ -56,6 +57,12 @@ public class SecurityMigratableTest {
     private static final String ID = "id";
 
     private static final String VERSION = "version";
+
+    private static final DescribableBean DESCRIBABLE_BEAN = new DescribableBean(VERSION,
+            ID,
+            TITLE,
+            DESCRIPTION,
+            ORGANIZATION);
 
     private static final Path SERVER_ENCRYPTION_PROPERTIES_PATH = Paths.get("etc",
             "ws-security",
@@ -113,12 +120,8 @@ public class SecurityMigratableTest {
                 CRL_PROP_KEY)).thenReturn(EXPECTED_ISSUER_ENCRYPTION_CRL_PATH.toString());
         when(mockMigratableUtil.getJavaPropertyValue(ISSUER_SIGNATURE_PROPERTIES_PATH,
                 CRL_PROP_KEY)).thenReturn(EXPECTED_ISSUER_SIGNATURE_CRL_PATH.toString());
-        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform Test
         securityMigratable.export(EXPORT_DIRECTORY);
@@ -137,12 +140,8 @@ public class SecurityMigratableTest {
                         eq(EXPORT_DIRECTORY),
                         Matchers.<Collection<MigrationWarning>>any());
 
-        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIPTION,
-                migratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                migratableUtil);
         MigrationMetadata migrationMetadata = securityMigratable.export(EXPORT_DIRECTORY);
 
         assertThat(migrationMetadata.getMigrationWarnings(), containsInAnyOrder(expectedWarning));
@@ -156,14 +155,10 @@ public class SecurityMigratableTest {
                 .copyDirectory(any(Path.class),
                         eq(EXPORT_DIRECTORY),
                         Matchers.<Collection<MigrationWarning>>any());
-        SecurityMigratable platformMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
-        platformMigratable.export(EXPORT_DIRECTORY);
+        securityMigratable.export(EXPORT_DIRECTORY);
     }
 
     @Test(expected = MigrationException.class)
@@ -176,15 +171,11 @@ public class SecurityMigratableTest {
                 .copyFile(any(Path.class),
                         eq(EXPORT_DIRECTORY),
                         Matchers.<Collection<MigrationWarning>>any());
-        SecurityMigratable platformMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
-        platformMigratable.export(EXPORT_DIRECTORY);
+        securityMigratable.export(EXPORT_DIRECTORY);
     }
 
     @Test
@@ -193,15 +184,11 @@ public class SecurityMigratableTest {
         MigratableUtil mockMigratableUtil = mock(MigratableUtil.class);
         when(mockMigratableUtil.getJavaPropertyValue(SERVER_ENCRYPTION_PROPERTIES_PATH,
                 CRL_PROP_KEY)).thenReturn(null);
-        SecurityMigratable platformMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
-        MigrationMetadata migrationMetadata = platformMigratable.export(EXPORT_DIRECTORY);
+        MigrationMetadata migrationMetadata = securityMigratable.export(EXPORT_DIRECTORY);
 
         // Verify
         verify(mockMigratableUtil, never()).copyFile(eq(EXPECTED_SERVER_ENCRYPTION_CRL_PATH),
@@ -217,15 +204,11 @@ public class SecurityMigratableTest {
         MigratableUtil mockMigratableUtil = mock(MigratableUtil.class);
         when(mockMigratableUtil.getJavaPropertyValue(SERVER_ENCRYPTION_PROPERTIES_PATH,
                 CRL_PROP_KEY)).thenReturn("");
-        SecurityMigratable platformMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
-        platformMigratable.export(EXPORT_DIRECTORY);
+        securityMigratable.export(EXPORT_DIRECTORY);
     }
 
     @Test(expected = MigrationException.class)
@@ -234,15 +217,11 @@ public class SecurityMigratableTest {
         MigratableUtil mockMigratableUtil = mock(MigratableUtil.class);
         doThrow(MigrationException.class).when(mockMigratableUtil)
                 .getJavaPropertyValue(SERVER_ENCRYPTION_PROPERTIES_PATH, CRL_PROP_KEY);
-        SecurityMigratable platformMigratable = new SecurityMigratable(DESCRIPTION,
-                mockMigratableUtil,
-                ORGANIZATION,
-                TITLE,
-                ID,
-                VERSION);
+        SecurityMigratable securityMigratable = new SecurityMigratable(DESCRIBABLE_BEAN,
+                mockMigratableUtil);
 
         // Perform test
-        platformMigratable.export(EXPORT_DIRECTORY);
+        securityMigratable.export(EXPORT_DIRECTORY);
     }
 
     private void assertCrlExport(MigratableUtil mockMigratableUtil) {


### PR DESCRIPTION
#### What does this PR do?
Extends `platform-migration` to look-up and return migratables that also implement describable. Warnings are logged when migratables are found that do not conform to this criteria.  

#### Who is reviewing it?
@lessarderic @garrettfreibott @oconnormi @figliold 

#### How should this be tested?
Full build - make sure DDF starts and that `migration:export` works. No need to ingest anything. 

#### Any background context you want to provide?
We are exposing functionality for later consumption in the CLI and GUI. 

#### What are the relevant tickets?
DDF-1970

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

