### PR TITLE
DDF-1976: Added GmdMetacardTransformer

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswConstants.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswConstants.java
@@ -217,12 +217,6 @@ public interface CswConstants {
 
     String OWS_LOWER_CORNER = "LowerCorner";
 
-    String GMD_PREFIX = "gmd";
-
-    String GMD_RECORD_LOCAL_NAME = "MD_Metadata";
-
-    String GMD_METADATA_TYPE = GMD_PREFIX + ":" + GMD_RECORD_LOCAL_NAME;
-
     double DEGREES_TO_RADIANS = Math.PI / 180.0;
 
     double RADIANS_TO_DEGREES = 1 / DEGREES_TO_RADIANS;

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswJAXBElementProvider.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswJAXBElementProvider.java
@@ -57,6 +57,8 @@ public class CswJAXBElementProvider<T> extends JAXBElementProvider<T> {
         prefixes.put(CswConstants.DUBLIN_CORE_SCHEMA, CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX);
         prefixes.put(CswConstants.DUBLIN_CORE_TERMS_SCHEMA,
                 CswConstants.DUBLIN_CORE_TERMS_NAMESPACE_PREFIX);
+        prefixes.put(GmdMetacardType.GMD_NAMESPACE,
+                GmdMetacardType.GMD_PREFIX);
 
         setNamespaceMapperPropertyName(NS_MAPPER_PROPERTY_RI);
         setNamespacePrefixes(prefixes);

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/GmdMetacardType.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/GmdMetacardType.java
@@ -14,9 +14,7 @@
 package org.codice.ddf.spatial.ogc.csw.catalog.common;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.xml.namespace.QName;
 
@@ -24,56 +22,57 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 
+/**
+ * Metacard to GMD MD_Metadata Mapping
+ * <p/>
+ * {@value ddf.catalog.data.Metacard#ID} -> {@link #FILE_IDENTIFIER_PATH}
+ * {@value ddf.catalog.data.Metacard#TITLE} -> {@link #TITLE_PATH}
+ * {@value ddf.catalog.data.Metacard#DESCRIPTION} -> {@link #ABSTRACT_PATH}
+ * {@value ddf.catalog.data.Metacard#CREATED} -> {@link #CODE_LIST_VALUE_PATH}
+ * {@value ddf.catalog.data.Metacard#MODIFIED} -> {@link #CODE_LIST_VALUE_PATH}
+ * {@value ddf.catalog.data.Metacard#EFFECTIVE} -> {@link #CODE_LIST_VALUE_PATH}
+ * {@value ddf.catalog.data.Metacard#CONTENT_TYPE} -> {@link #CODE_LIST_VALUE_PATH}
+ * {@value org.codice.ddf.spatial.ogc.csw.catalog.common.GmdMetacardType#GMD_CRS} -> urn:ogc:def:crs:{@link #CRS_AUTHORITY_PATH}:{@link #CRS_CODE_PATH}:{@link #CRS_VERSION_PATH}
+ * {@value ddf.catalog.data.Metacard#METADATA} -> entire GMD MD_Metadata document
+ * {@value ddf.catalog.data.Metacard#POINT_OF_CONTACT} -> {@link #POINT_OF_CONTACT_PATH}
+ * {@value org.codice.ddf.spatial.ogc.csw.catalog.common.GmdMetacardType#GMD_PUBLISHER} ->  {@link #POINT_OF_CONTACT_PATH}
+ * {@value org.codice.ddf.spatial.ogc.csw.catalog.common.GmdMetacardType#GMD_FORMAT} ->  {@link #FORMAT_PATH}
+ * {@value ddf.catalog.data.Metacard#RESOURCE_URI} -> {@link #LINKAGE_URI_PATH}
+ * {@value org.codice.ddf.spatial.ogc.csw.catalog.common.GmdMetacardType#GMD_SUBJECT} ->  {@link #KEYWORD_PATH} and {@link #TOPIC_CATEGORY_PATH}
+ * {@value ddf.catalog.data.Metacard#RESOURCE_SIZE} -> (unmapped)
+ * {@value ddf.catalog.data.Metacard#EXPIRATION} -> (unmapped)
+ */
 public class GmdMetacardType extends MetacardTypeImpl {
 
-    private static final String GMD_ATTRIBUTE_PREFIX = "gmd.";
+    public static final String GMD_PREFIX = "gmd";
 
-    public static final String GMD_METACARD_TYPE_NAME = "gmd:MD_Metadata";
+    public static final String GMD_LOCAL_NAME = "MD_Metadata";
+
+    public static final String GMD_METACARD_TYPE_NAME = GMD_PREFIX + "." + GMD_LOCAL_NAME;
 
     public static final String GMD_NAMESPACE = "http://www.isotc211.org/2005/gmd";
 
-    // attributes
-    public static final String GMD_SUBJECT = GMD_ATTRIBUTE_PREFIX + "subject";
+    public static final String GCO_NAMESPACE = "http://www.isotc211.org/2005/gco";
 
-    public static final String GMD_TITLE = GMD_ATTRIBUTE_PREFIX + "title";
+    public static final String GCO_PREFIX = "gco";
 
-    public static final String GMD_ABSTRACT = GMD_ATTRIBUTE_PREFIX + "abstract";
+    public static final String METACARD_URI = "urn:catalog:metacard";
 
-    public static final String GMD_FORMAT = GMD_ATTRIBUTE_PREFIX + "format";
-
-    public static final String GMD_IDENTIFIER = GMD_ATTRIBUTE_PREFIX + "Identifier";
-
-    public static final String GMD_MODIFIED = GMD_ATTRIBUTE_PREFIX + "modified";
-
-    public static final String GMD_TYPE = GMD_ATTRIBUTE_PREFIX + "type";
-
-    public static final String GMD_BOUNDING_BOX = GMD_ATTRIBUTE_PREFIX + "BoundingBox";
-
-    public static final String GMD_CRS = GMD_ATTRIBUTE_PREFIX + "crs";
-
-    public static final String GMD_PUBLISHER = GMD_ATTRIBUTE_PREFIX + "publisher";
-
-    public static final String APISO_PREFIX = "apiso:";
-
-    public static final String APISO_SUBJECT = APISO_PREFIX + "subject";
-
-    public static final String APISO_TITLE = APISO_PREFIX + "title";
-
-    public static final String APISO_ABSTRACT = APISO_PREFIX + "abstract";
-
-    public static final String APISO_FORMAT = APISO_PREFIX + "format";
-
-    public static final String APISO_IDENTIFIER = APISO_PREFIX + "Identifier";
-
-    public static final String APISO_MODIFIED = APISO_PREFIX + "modified";
-
-    public static final String APISO_TYPE = APISO_PREFIX + "type";
+    public static final String APISO_PREFIX = "apiso.";
 
     public static final String APISO_BOUNDING_BOX = APISO_PREFIX + "BoundingBox";
 
-    public static final String APISO_CRS = APISO_PREFIX + "crs";
+    // attributes
+    public static final String GMD_SUBJECT = GMD_PREFIX + ".subject";
 
-    public static final String APISO_ANYTEXT = APISO_PREFIX + CswConstants.ANY_TEXT;
+    public static final String GMD_FORMAT = GMD_PREFIX + "format";
+
+    public static final String GMD_CRS = GMD_PREFIX + ".crs";
+
+    public static final String FILE_IDENTIFIER_PATH =
+            "/MD_Metadata/fileIdentifier/gco:CharacterString";
+
+    public static final String GMD_PUBLISHER = GMD_PREFIX + "publisher";
 
     public static final List<QName> QNAME_LIST;
 
@@ -111,6 +110,78 @@ public class GmdMetacardType extends MetacardTypeImpl {
         QNAME_LIST = Arrays.asList(GMD_REVISION_DATE_QNAME, GMD_ALTERNATE_TITLE_QNAME);
     }
 
+    public static final String DATE_TIME_STAMP_PATH = "/MD_Metadata/dateStamp/gco:DateTime";
+
+    public static final String DATE_STAMP_PATH = "/MD_Metadata/dateStamp/gco:Date";
+
+    public static final String CODE_LIST_VALUE_PATH =
+            "/MD_Metadata/hierarchyLevel/MD_ScopeCode/@codeListValue";
+
+    public static final String CODE_LIST_PATH =
+            "/MD_Metadata/hierarchyLevel/MD_ScopeCode/@codeList";
+
+    public static final String CRS_AUTHORITY_PATH =
+            "/MD_Metadata/referenceSystemInfo/MD_ReferenceSystem/referenceSystemIdentifier/RS_Identifier/codeSpace/gco:CharacterString";
+
+    public static final String CRS_VERSION_PATH =
+            "/MD_Metadata/referenceSystemInfo/MD_ReferenceSystem/referenceSystemIdentifier/RS_Identifier/version";
+
+    public static final String CRS_CODE_PATH =
+            "/MD_Metadata/referenceSystemInfo/MD_ReferenceSystem/referenceSystemIdentifier/RS_Identifier/code/gco:CharacterString";
+
+    public static final String TITLE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/title/gco:CharacterString";
+
+    public static final String CREATED_DATE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/date/CI_Date/date/gco:DateTime";
+
+    public static final String CREATED_DATE_TYPE_CODE_VALUE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/date/CI_Date/dateType/CI_DateTypeCode/@codeListValue";
+
+    public static final String CREATED_DATE_TYPE_CODE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/date/CI_Date/dateType/CI_DateTypeCode/@codeList";
+
+    public static final String ABSTRACT_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/abstract/gco:CharacterString";
+
+    public static final String FORMAT_PATH =
+            "/MD_Metadata/distributionInfo/MD_Distribution/distributionFormat/MD_Format/name/gco:CharacterString";
+
+    public static final String DISTRIBUTOR_CONTACT_PATH =
+            "/MD_Metadata/distributionInfo/MD_Distribution/distributor/MD_Distributor/distributorContact";
+
+    public static final String LINKAGE_URI_PATH =
+            "/MD_Metadata/distributionInfo/MD_Distribution/transferOptions/MD_DigitalTransferOptions/onLine/CI_OnlineResource/linkage/URL";
+
+    public static final String KEYWORD_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/descriptiveKeywords/MD_Keywords/keyword/gco:CharacterString";
+
+    public static final String TOPIC_CATEGORY_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/topicCategory/MD_TopicCategoryCode";
+
+    public static final String BBOX_WEST_LON_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/extent/EX_Extent/geographicElement/EX_GeographicBoundingBox/westBoundLongitude/gco:Decimal";
+
+    public static final String BBOX_EAST_LON_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/extent/EX_Extent/geographicElement/EX_GeographicBoundingBox/eastBoundLongitude/gco:Decimal";
+
+    public static final String BBOX_SOUTH_LAT_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/extent/EX_Extent/geographicElement/EX_GeographicBoundingBox/southBoundLatitude/gco:Decimal";
+
+    public static final String BBOX_NORTH_LAT_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/extent/EX_Extent/geographicElement/EX_GeographicBoundingBox/northBoundLatitude/gco:Decimal";
+
+    public static final String POINT_OF_CONTACT_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/pointOfContact/CI_ResponsibleParty/organisationName/gco:CharacterString";
+
+    public static final String POINT_OF_CONTACT_ROLE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/pointOfContact/CI_ResponsibleParty/role";
+
+    public static final String LANGUAGE_PATH =
+            "/MD_Metadata/identificationInfo/MD_DataIdentification/language/gco:CharacterString";
+
+    public static final String CONTACT_PATH = "/MD_Metadata/contact";
+
     /**
      * Indicates Metacard Type's attribute is queryable, i.e., is indexed.
      */
@@ -118,14 +189,11 @@ public class GmdMetacardType extends MetacardTypeImpl {
 
     private static final long serialVersionUID = 1L;
 
-    private Map<String, String> attributeMap = new HashMap<>();
-
     public GmdMetacardType() {
         super(GMD_METACARD_TYPE_NAME, null);
 
         addDdfMetacardAttributes();
         addGmdMetacardAttributes();
-        addApisoMetacardAttributes();
     }
 
     public GmdMetacardType(String sourceId) {
@@ -133,7 +201,6 @@ public class GmdMetacardType extends MetacardTypeImpl {
 
         addDdfMetacardAttributes();
         addGmdMetacardAttributes();
-        addApisoMetacardAttributes();
     }
 
     private void addDdfMetacardAttributes() {
@@ -153,20 +220,6 @@ public class GmdMetacardType extends MetacardTypeImpl {
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
 
-        descriptors.add(new AttributeDescriptorImpl(GMD_TITLE,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                true /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(GMD_ABSTRACT,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
         descriptors.add(new AttributeDescriptorImpl(GMD_PUBLISHER,
                 QUERYABLE /* indexed */,
                 true /* stored */,
@@ -181,34 +234,6 @@ public class GmdMetacardType extends MetacardTypeImpl {
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
 
-        descriptors.add(new AttributeDescriptorImpl(GMD_IDENTIFIER,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(GMD_MODIFIED,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.DATE_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(GMD_TYPE,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(GMD_BOUNDING_BOX,
-                QUERYABLE /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.GEO_TYPE));
-
         descriptors.add(new AttributeDescriptorImpl(GMD_CRS,
                 QUERYABLE /* indexed */,
                 true /* stored */,
@@ -218,91 +243,7 @@ public class GmdMetacardType extends MetacardTypeImpl {
 
     }
 
-    /**
-     * Adds APISO specific attributes to metacard type. These are the core queryable attributes.
-     * Note: queryable attributes defined in "OpenGIS® Catalogue Services Specification 2.0.2 -
-     ISO Metadata Application Profile" Table 6 and Table 9
-     */
-    private void addApisoMetacardAttributes() {
-        descriptors.add(new AttributeDescriptorImpl(APISO_SUBJECT,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_TITLE,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_ABSTRACT,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_FORMAT,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_IDENTIFIER,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_MODIFIED,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.DATE_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_TYPE,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_BOUNDING_BOX,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.GEO_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_CRS,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-        descriptors.add(new AttributeDescriptorImpl(APISO_ANYTEXT,
-                QUERYABLE /* indexed */,
-                false /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-
-
-    }
-
-    public String attributeToGmdMetadataField(final String attributeName) {
-        return attributeMap.get(attributeName);
-
-    }
-
     private static QName createGMDQName(final String field) {
-        return new QName(GMD_NAMESPACE, field, CswConstants.GMD_PREFIX);
+        return new QName(GMD_NAMESPACE, field, GmdMetacardType.GMD_PREFIX);
     }
 }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
@@ -222,7 +222,7 @@ public class CswEndpoint implements Csw {
             "Unable to retrieve product for ID: %s";
 
     private static final List<String> TYPE_NAMES_LIST = Arrays.asList(CswConstants.CSW_RECORD,
-            CswConstants.GMD_METADATA_TYPE);
+            GmdMetacardType.GMD_METACARD_TYPE_NAME);
 
     private static Map<String, Element> documentElements = new HashMap<>();
 
@@ -862,7 +862,7 @@ public class CswEndpoint implements Csw {
             }
 
             if (types.contains(new QName(GmdMetacardType.GMD_NAMESPACE,
-                    CswConstants.GMD_RECORD_LOCAL_NAME))) {
+                    GmdMetacardType.GMD_LOCAL_NAME))) {
                 schemas.add(getSchemaComponentType(GmdMetacardType.GMD_NAMESPACE));
             }
         }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
@@ -185,7 +185,7 @@ public class CswQueryFactory {
                 CswConstants.CSW_RECORD_LOCAL_NAME,
                 CswConstants.CSW_NAMESPACE_PREFIX));
         boolean isTypeNameGmd = typeNames.contains(new QName(GmdMetacardType.GMD_NAMESPACE,
-                CswConstants.GMD_RECORD_LOCAL_NAME));
+                GmdMetacardType.GMD_LOCAL_NAME));
 
         if (isTypeNameCsw || isTypeNameGmd) {
             try {

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/Validator.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/Validator.java
@@ -70,7 +70,7 @@ public class Validator {
         if (types.size() == 1) {
             QName typeName = types.get(0);
             QName cswOutputSchema = new QName(CswConstants.CSW_OUTPUT_SCHEMA, CswConstants.CSW_RECORD_LOCAL_NAME);
-            QName gmdOutputSchema = new QName(GmdMetacardType.GMD_NAMESPACE, CswConstants.GMD_RECORD_LOCAL_NAME);
+            QName gmdOutputSchema = new QName(GmdMetacardType.GMD_NAMESPACE, GmdMetacardType.GMD_LOCAL_NAME);
             if (!typeName.equals(cswOutputSchema) && !typeName.equals(gmdOutputSchema)) {
                 throw createUnknownTypeException(types.get(0)
                         .toString());

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/TestCswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/TestCswEndpoint.java
@@ -658,7 +658,7 @@ public class TestCswEndpoint {
     public void testPostDescribeRecordRequestGMDTypePassed() {
         DescribeRecordType drt = createDefaultDescribeRecordType();
         List<QName> typeNames = new ArrayList<>();
-        typeNames.add(new QName(GmdMetacardType.GMD_NAMESPACE, CswConstants.GMD_RECORD_LOCAL_NAME, CswConstants.GMD_PREFIX));
+        typeNames.add(new QName(GmdMetacardType.GMD_NAMESPACE, GmdMetacardType.GMD_LOCAL_NAME, GmdMetacardType.GMD_PREFIX));
         drt.setTypeName(typeNames);
         DescribeRecordResponseType drrt = null;
 
@@ -1093,7 +1093,7 @@ public class TestCswEndpoint {
         grr.setResultType(ResultType.RESULTS);
         QueryType query = new QueryType();
         List<QName> typeNames = new ArrayList<>();
-        typeNames.add(new QName(GmdMetacardType.GMD_NAMESPACE, CswConstants.GMD_RECORD_LOCAL_NAME, CswConstants.GMD_PREFIX));
+        typeNames.add(new QName(GmdMetacardType.GMD_NAMESPACE, GmdMetacardType.GMD_LOCAL_NAME, GmdMetacardType.GMD_PREFIX));
         query.setTypeNames(typeNames);
         QueryConstraintType constraint = new QueryConstraintType();
         constraint.setCqlText(GMD_CONTEXTUAL_LIKE_QUERY);
@@ -1970,7 +1970,7 @@ public class TestCswEndpoint {
                             assertThat(parameter.getValue(), contains(CswConstants.CSW_RECORD));
                         } else {
                             assertThat(parameter.getValue(), hasItems(CswConstants.CSW_RECORD,
-                                    CswConstants.GMD_METADATA_TYPE));
+                                    GmdMetacardType.GMD_METACARD_TYPE_NAME));
                         }
                     }
                 }

--- a/catalog/spatial/csw/spatial-csw-source-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/pom.xml
@@ -187,7 +187,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswAbstractFilterDelegate.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswAbstractFilterDelegate.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -126,5 +126,9 @@ public abstract class CswAbstractFilterDelegate<T> extends FilterDelegate<T> {
 
     protected Set<ResultType> getResultTypes() {
         return resultTypes;
+    }
+
+    protected boolean isPropertyQueryable(String propertyName) {
+        return true;
     }
 }

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswFilterDelegate.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswFilterDelegate.java
@@ -1176,9 +1176,6 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
     }
 
     protected String mapPropertyName(String propertyName) {
-        if (isContentTypeVersion(propertyName)){
-            return null;
-        }
         if (isAnyText(propertyName) || isMetadata(propertyName)) {
             propertyName = CswConstants.ANY_TEXT;
         } else if (isAnyGeo(propertyName)) {
@@ -1396,19 +1393,6 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
             globalGeometryOperands = geometryOperandsType.getGeometryOperand();
             LOGGER.debug("globalGeometryOperands: {}", globalGeometryOperands);
         }
-    }
-
-    protected boolean isPropertyQueryable(String propertyName) {
-        if (propertyName != null && (propertyName.equalsIgnoreCase(CswConstants.ANY_TEXT) || (
-                metacardType.getAttributeDescriptor(propertyName) != null
-                        && metacardType.getAttributeDescriptor(propertyName)
-                        .isIndexed()))) {
-            LOGGER.debug("Property [{}] is queryable.", propertyName);
-            return true;
-        }
-
-        LOGGER.debug("Property [{}]  is NOT queryable.", propertyName);
-        return false;
     }
 
     public GeometryOperandsType getGeoOpsForSpatialOp(SpatialOperatorNameType name) {

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswCqlFilter.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswCqlFilter.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,9 +13,7 @@
  */
 package org.codice.ddf.spatial.ogc.csw.catalog.common.source;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -742,21 +740,6 @@ public class TestCswCqlFilter {
     }
 
     @Test
-    public void testPropertyIsEqualToStringLiteralNonQueryableProperty()
-            throws UnsupportedQueryException {
-        /**
-         * See CswRecordMetacardType.java for queryable and non-queryable properties.
-         */
-        String nonQueryableProperty = Metacard.METADATA;
-        FilterType filterType = cswFilterDelegate.propertyIsEqualTo(nonQueryableProperty,
-                stringLiteral,
-                isCaseSensitive);
-        String cqlText = CswCqlTextFilter.getInstance()
-                .getCqlText(filterType);
-        assertThat(cqlText, equalTo(propertyIsEqualToAnyText));
-    }
-
-    @Test
     public void testPropertyIsEqualToStringLiteralType() throws UnsupportedQueryException {
         FilterType filterType = cswFilterDelegate.propertyIsEqualTo(Metacard.CONTENT_TYPE,
                 contentTypeLiteral,
@@ -1293,9 +1276,8 @@ public class TestCswCqlFilter {
 
     @Test
     public void testFeatureId() throws UnsupportedQueryException {
-        FilterType filter = cswFilterDelegate.propertyIsEqualTo(Metacard.ID,
-                String.valueOf(CSW_RECORD_ID),
-                false);
+        FilterType filter = cswFilterDelegate.propertyIsEqualTo(Metacard.ID, String.valueOf(
+                CSW_RECORD_ID), false);
 
         String cqlText = CswCqlTextFilter.getInstance()
                 .getCqlText(filter);

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswFilterDelegate.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswFilterDelegate.java
@@ -661,15 +661,13 @@ public class TestCswFilterDelegate {
 
     private final String configurableApisoTypeMappingXml = createComparisonFilterString(
             ComparisonOperator.PROPERTY_IS_EQUAL_TO,
-            GmdMetacardType.APISO_TYPE,
+            APISO_TYPE,
             "myContentType");
 
     private final String configurableApisoAnyTextMappingXml = createComparisonFilterString(
             ComparisonOperator.PROPERTY_IS_LIKE,
-            GmdMetacardType.APISO_ANYTEXT,
+            APISO_ANYTEXT,
             "myContentType");
-
-    private final String emptyFilterXml = getXmlHeaderString() + getXmlFooterString();
 
     private StringWriter writer = null;
 
@@ -709,6 +707,29 @@ public class TestCswFilterDelegate {
                     + " 30.000616830158776 30.00092315157021"
                     + " 30.000424880003134 30.00102575106595"
                     + " 30.000216601947248 30.00108893152347" + " 30.0 30.001110264953223");
+
+
+    private static final String APISO_PREFIX = "apiso:";
+
+    private static final String APISO_SUBJECT = APISO_PREFIX + "subject";
+
+    private static final String APISO_TITLE = APISO_PREFIX + "title";
+
+    private static final String APISO_ABSTRACT = APISO_PREFIX + "abstract";
+
+    private static final String APISO_FORMAT = APISO_PREFIX + "format";
+
+    private static final String APISO_IDENTIFIER = APISO_PREFIX + "Identifier";
+
+    private static final String APISO_MODIFIED = APISO_PREFIX + "modified";
+
+    private static final String APISO_TYPE = APISO_PREFIX + "type";
+
+    private static final String APISO_BOUNDING_BOX = APISO_PREFIX + "BoundingBox";
+
+    private static final String APISO_CRS = APISO_PREFIX + "crs";
+
+    private static final String APISO_ANYTEXT = APISO_PREFIX + CswConstants.ANY_TEXT;
 
     @BeforeClass
     public static void setupTestClass() throws JAXBException, ParseException {
@@ -1371,14 +1392,14 @@ public class TestCswFilterDelegate {
 
         // Setup
         CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
-        cswSourceConfiguration.putMetacardCswMapping(Metacard.ID, GmdMetacardType.APISO_IDENTIFIER);
+        cswSourceConfiguration.putMetacardCswMapping(Metacard.ID, APISO_IDENTIFIER);
         cswSourceConfiguration.putMetacardCswMapping(Metacard.MODIFIED,
-                GmdMetacardType.APISO_MODIFIED);
+                APISO_MODIFIED);
         cswSourceConfiguration.putMetacardCswMapping(Metacard.CONTENT_TYPE,
-                GmdMetacardType.APISO_TYPE);
-        cswSourceConfiguration.putMetacardCswMapping(Metacard.TITLE, GmdMetacardType.APISO_TITLE);
+                APISO_TYPE);
+        cswSourceConfiguration.putMetacardCswMapping(Metacard.TITLE, APISO_TITLE);
         cswSourceConfiguration.putMetacardCswMapping(CswConstants.ANY_TEXT,
-                GmdMetacardType.APISO_ANYTEXT);
+                APISO_ANYTEXT);
 
         cswSourceConfiguration.setCswAxisOrder(CswAxisOrder.LAT_LON);
         cswSourceConfiguration.setUsePosList(false);

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
@@ -640,15 +640,15 @@ public class TestCswSource extends TestCswSourceBase {
         GetRecordsType getRecordsType = captor.getValue();
 
         String xml = getGetRecordsTypeAsXml(getRecordsType);
-        Diff xmlDiff = new Diff(getRecordsControlXml202ContentTypeMappedToFormat, xml);
+        Diff xmlDiff = new Diff(getRecordsControlXml202ConteTypeAndVersion, xml);
 
         if (!xmlDiff.similar()) {
             LOGGER.error("Unexpected XML request sent");
-            LOGGER.error("Expected: {}", getRecordsControlXml202ContentTypeMappedToFormat);
-            LOGGER.error("Actual: {}", xml);
+            LOGGER.error("Expected:\n {}", getRecordsControlXml202ConteTypeAndVersion);
+            LOGGER.error("Actual:\n {}", xml);
         }
 
-        assertXMLEqual(getRecordsControlXml202ContentTypeMappedToFormat, xml);
+        assertXMLEqual(getRecordsControlXml202ConteTypeAndVersion, xml);
     }
 
     @Test

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSourceBase.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSourceBase.java
@@ -202,6 +202,31 @@ public class TestCswSourceBase {
                     + "    </Query>" // Line break
                     + "</GetRecords>";
 
+    protected String getRecordsControlXml202ConteTypeAndVersion =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                    + "<csw:GetRecords xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
+                    + "    xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\"\n"
+                    + "    xmlns:ns4=\"http://www.w3.org/1999/xlink\" xmlns:ns5=\"http://www.w3.org/2001/SMIL20/\"\n"
+                    + "    xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:ows=\"http://www.opengis.net/ows\"\n"
+                    + "    xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:ns9=\"http://www.w3.org/2001/SMIL20/Language\"\n"
+                    + "    resultType=\"results\" outputFormat=\"application/xml\"\n"
+                    + "    outputSchema=\"http://www.opengis.net/cat/csw/2.0.2\" startPosition=\"1\" maxRecords=\"10\"\n"
+                    + "    service=\"CSW\" version=\"2.0.2\">\n"
+                    + "    <csw:Query typeNames=\"csw:Record\">\n"
+                    + "        <csw:ElementSetName>full</csw:ElementSetName>\n"
+                    + "        <csw:Constraint version=\"1.1.0\">\n" + "            <ogc:Filter>\n"
+                    + "                <ogc:And>\n"
+                    + "                    <ogc:PropertyIsEqualTo matchCase=\"true\">\n"
+                    + "                        <ogc:PropertyName>"+CswRecordMetacardType.CSW_FORMAT+"</ogc:PropertyName>\n"
+                    + "                        <ogc:Literal>myContentType</ogc:Literal>\n"
+                    + "                    </ogc:PropertyIsEqualTo>\n"
+                    + "                    <ogc:PropertyIsLike wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">\n"
+                    + "                        <ogc:PropertyName>metadata-content-type-version</ogc:PropertyName>\n"
+                    + "                        <ogc:Literal>2.0</ogc:Literal>\n"
+                    + "                    </ogc:PropertyIsLike>\n" + "                </ogc:And>\n"
+                    + "            </ogc:Filter>\n" + "        </csw:Constraint>\n"
+                    + "    </csw:Query>\n" + "</csw:GetRecords>";
+
     @BeforeClass
     public static void init() {
         // The magic setting - besides ignoring whitespace, this setting configures XMLUnit to

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -52,7 +52,8 @@
             default="false"/>
 
         <AD description="Mapping of the Metacad Attribute names to their CSW property names. The format should be 'title=dc:title'."
-            name="Metacard Mappings" id="metacardMappings" required="false" type="String" cardinality="100"
+            name="Metacard Mappings" id="metacardMappings" required="false" type="String"
+            cardinality="100"
             default="effective=created,created=dateSubmitted,modified=modified,thumbnail=references,content-type=type,id=identifier,resource-uri=source">
         </AD>
 
@@ -144,7 +145,8 @@
             default="false"/>
 
         <AD description="Mapping of the Metacad Attribute names to their CSW property names. The format should be 'title=dc:title'."
-            name="Metacard Mappings" id="metacardMappings" required="false" type="String" cardinality="100"
+            name="Metacard Mappings" id="metacardMappings" required="false" type="String"
+            cardinality="100"
             default="effective=created,created=dateSubmitted,modified=modified,thumbnail=references,content-type=type,id=identifier,resource-uri=source">
         </AD>
 
@@ -193,7 +195,8 @@
         </AD>
     </OCD>
 
-    <OCD name="GMD CSW Federated Source" id="Gmd_Csw_Federated_Source" description="GMD CSW Federated Source">
+    <OCD name="GMD CSW Federated Source" id="Gmd_Csw_Federated_Source"
+         description="CSW Federated Source using the Geographic MetaData (GMD) format (ISO 19115:2003)">
 
         <AD description="The unique name of the Source" name="Source ID" id="id" required="true"
             type="String"/>
@@ -222,8 +225,9 @@
             default="false"/>
 
         <AD description="Mapping of the Metacad Attribute names to their CSW property names. The format should be 'title=dc:title'."
-            name="Metacard Mappings" id="metacardMappings" required="false" type="String" cardinality="100"
-            default="effective=apiso:PublicationDate,created=apiso:CreationDate,modified=apiso:RevisionDate,title=apiso:AlternateTitle,AnyText=apiso:AnyText,ows:BoundingBox=apiso:BoundingBox">
+            name="Metacard Mappings" id="metacardMappings" required="false" type="String"
+            cardinality="100"
+            default="id=apiso:Identifier,effective=apiso:PublicationDate,created=apiso:CreationDate,modified=apiso:RevisionDate,title=apiso:AlternateTitle,AnyText=apiso:AnyText,ows:BoundingBox=apiso:BoundingBox">
         </AD>
 
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverter.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.GmdMetacardType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.io.naming.NoNameCoder;
+import com.thoughtworks.xstream.io.path.Path;
+import com.thoughtworks.xstream.io.path.PathTracker;
+import com.thoughtworks.xstream.io.path.PathTrackingWriter;
+import com.thoughtworks.xstream.io.xml.Xpp3Driver;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class GmdConverter implements Converter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GmdConverter.class);
+
+    static final DatatypeFactory XSD_FACTORY;
+
+    static {
+        DatatypeFactory factory = null;
+
+        try {
+            factory = DatatypeFactory.newInstance();
+        } catch (DatatypeConfigurationException e) {
+            LOGGER.error("Failed to create xsdFactory", e);
+        }
+
+        XSD_FACTORY = factory;
+    }
+
+    public GmdConverter() {
+
+        XStream xstream = new XStream(new Xpp3Driver(new NoNameCoder()));
+
+        xstream.setClassLoader(xstream.getClass()
+                .getClassLoader());
+
+        xstream.registerConverter(this);
+        xstream.alias(GmdMetacardType.GMD_LOCAL_NAME, Metacard.class);
+        xstream.alias(GmdMetacardType.GMD_METACARD_TYPE_NAME, Metacard.class);
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return Metacard.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter inWriter,
+            MarshallingContext context) {
+        if (source == null || !(source instanceof Metacard)) {
+            LOGGER.warn("Failed to marshal Metacard: {}", source);
+            return;
+        }
+        MetacardImpl metacard = new MetacardImpl((Metacard) source);
+
+        PathTracker tracker = new PathTracker();
+        PathTrackingWriter trackingWriter = new PathTrackingWriter(inWriter, tracker);
+
+        XstreamPathValueTracker pathValueTracker = buildPaths(metacard);
+        XmlTree tree = buildTree(pathValueTracker.getPaths());
+
+        tree.accept(new XstreamTreeWriter(trackingWriter, tracker, pathValueTracker));
+
+    }
+
+    protected XmlTree buildTree(Set<Path> paths) {
+
+        XmlTree gmdTree = new XmlTree(GmdMetacardType.GMD_LOCAL_NAME);
+
+        XmlTree current = gmdTree;
+
+        for (Path path : paths) {
+            String tree = path.toString();
+            XmlTree root = current;
+
+            tree = StringUtils.substringAfter(tree, GmdMetacardType.GMD_LOCAL_NAME);
+            for (String data : tree.split("/")) {
+                if (StringUtils.isNotBlank(data)) {
+                    current = current.addChild(data);
+                }
+            }
+
+            current = root;
+        }
+        return gmdTree;
+    }
+
+    /**
+     * Builds up the xml paths and values to write.
+     * Order matters!  Paths should be added in the order they must be written.
+     *
+     * @param metacard
+     * @return XstreamPathValueTracker containing XML paths and values to write
+     */
+    protected XstreamPathValueTracker buildPaths(MetacardImpl metacard) {
+
+        XstreamPathValueTracker pathValueTracker = new XstreamPathValueTracker();
+
+        pathValueTracker.add(new Path("/MD_Metadata/@xmlns"), GmdMetacardType.GMD_NAMESPACE);
+
+        pathValueTracker.add(new Path("/MD_Metadata/@xmlns:" + GmdMetacardType.GCO_PREFIX),
+                GmdMetacardType.GCO_NAMESPACE);
+        pathValueTracker.add(new Path(GmdMetacardType.FILE_IDENTIFIER_PATH), metacard.getId());
+
+        pathValueTracker.add(new Path(GmdMetacardType.CODE_LIST_VALUE_PATH),
+                StringUtils.defaultIfEmpty(metacard.getContentTypeName(), "dataset"));
+        pathValueTracker.add(new Path(GmdMetacardType.CODE_LIST_PATH),
+                GmdMetacardType.METACARD_URI);
+
+        pathValueTracker.add(new Path(GmdMetacardType.CONTACT_PATH), (String) null);
+
+        GregorianCalendar modifiedCal = new GregorianCalendar();
+        if (metacard.getModifiedDate() != null) {
+
+            modifiedCal.setTime(metacard.getModifiedDate());
+        }
+        pathValueTracker.add(new Path(GmdMetacardType.DATE_TIME_STAMP_PATH),
+                XSD_FACTORY.newXMLGregorianCalendar(modifiedCal)
+                        .toXMLFormat());
+
+        addIdentificationInfo(metacard, pathValueTracker);
+
+        addDistributionInfo(metacard, pathValueTracker);
+
+        return pathValueTracker;
+
+    }
+
+    protected void addDistributionInfo(MetacardImpl metacard,
+            XstreamPathValueTracker pathValueTracker) {
+
+        if (metacard.getResourceURI() != null) {
+            pathValueTracker.add(new Path(GmdMetacardType.LINKAGE_URI_PATH),
+                    metacard.getResourceURI()
+                            .toASCIIString());
+        }
+
+    }
+
+    protected void addIdentificationInfo(MetacardImpl metacard,
+            XstreamPathValueTracker pathValueTracker) {
+
+        pathValueTracker.add(new Path(GmdMetacardType.TITLE_PATH), StringUtils.defaultString(
+                metacard.getTitle()));
+
+        GregorianCalendar createdCal = new GregorianCalendar();
+
+        if (metacard.getCreatedDate() != null) {
+
+            createdCal.setTime(metacard.getCreatedDate());
+        }
+        pathValueTracker.add(new Path(GmdMetacardType.CREATED_DATE_PATH),
+                XSD_FACTORY.newXMLGregorianCalendar(createdCal)
+                        .toXMLFormat());
+
+        pathValueTracker.add(new Path(GmdMetacardType.CREATED_DATE_TYPE_CODE_PATH),
+                GmdMetacardType.METACARD_URI);
+        pathValueTracker.add(new Path(GmdMetacardType.CREATED_DATE_TYPE_CODE_VALUE_PATH),
+                Metacard.CREATED);
+
+        pathValueTracker.add(new Path(GmdMetacardType.ABSTRACT_PATH), StringUtils.defaultString(
+                metacard.getDescription()));
+        pathValueTracker.add(new Path(GmdMetacardType.POINT_OF_CONTACT_PATH),
+                StringUtils.defaultString(metacard.getPointOfContact()));
+
+        pathValueTracker.add(new Path(GmdMetacardType.POINT_OF_CONTACT_ROLE_PATH), (String) null);
+
+        pathValueTracker.add(new Path(GmdMetacardType.LANGUAGE_PATH), StringUtils.defaultIfEmpty(
+                Locale.getDefault()
+                        .getLanguage(),
+                Locale.ENGLISH.getLanguage()));
+        addExtent(metacard, pathValueTracker);
+
+    }
+
+    protected void addExtent(MetacardImpl metacard, XstreamPathValueTracker pathValueTracker) {
+
+        String wkt = metacard.getLocation();
+        if (StringUtils.isNotBlank(wkt)) {
+            WKTReader reader = new WKTReader();
+            Geometry geometry = null;
+
+            try {
+                geometry = reader.read(wkt);
+            } catch (ParseException e) {
+                LOGGER.warn("Unable to parse geometry {}", wkt, e);
+            }
+
+            if (geometry != null) {
+                Envelope bounds = geometry.getEnvelopeInternal();
+                String westLon = Double.toString(bounds.getMinX());
+                String eastLon = Double.toString(bounds.getMaxX());
+                String southLat = Double.toString(bounds.getMinY());
+                String northLat = Double.toString(bounds.getMaxY());
+                pathValueTracker.add(new Path(GmdMetacardType.BBOX_WEST_LON_PATH), westLon);
+                pathValueTracker.add(new Path(GmdMetacardType.BBOX_EAST_LON_PATH), eastLon);
+                pathValueTracker.add(new Path(GmdMetacardType.BBOX_SOUTH_LAT_PATH), southLat);
+                pathValueTracker.add(new Path(GmdMetacardType.BBOX_NORTH_LAT_PATH), northLat);
+
+            }
+
+        }
+    }
+
+}

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XmlTree.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XmlTree.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+class XmlTree {
+
+    private final Set<XmlTree> children = new LinkedHashSet<>();
+
+    private final String node;
+
+    XmlTree(String node) {
+        this.node = node;
+    }
+
+    void accept(XstreamTreeWriter visitor) {
+        visitor.startVisit(node);
+
+        for (XmlTree child : children) {
+            child.accept(visitor);
+        }
+        visitor.endVisit(node);
+
+    }
+
+    XmlTree addChild(String node) {
+        for (XmlTree child : children) {
+            if (child.node.equals(node)) {
+                return child;
+            }
+        }
+
+        return addChild(new XmlTree(node));
+    }
+
+    XmlTree addChild(XmlTree child) {
+        children.add(child);
+        return child;
+    }
+}

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamPathConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamPathConverter.java
@@ -13,7 +13,7 @@
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
-import java.util.List;
+import java.util.LinkedHashSet;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -47,7 +47,7 @@ public class XstreamPathConverter implements Converter {
             throws ConversionException {
 
         XstreamPathValueTracker pathValueTracker = new XstreamPathValueTracker();
-        pathValueTracker.buildPaths((List<Path>) context.get(PATH_KEY));
+        pathValueTracker.buildPaths((LinkedHashSet<Path>) context.get(PATH_KEY));
 
         if (pathValueTracker != null) {
 
@@ -77,7 +77,7 @@ public class XstreamPathConverter implements Converter {
      * </a>
      * <d></d>
      * {code}
-     *  @param reader
+     * @param reader
      * @param tracker
      * @param pathValueTracker
      */

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamPathValueTracker.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamPathValueTracker.java
@@ -13,24 +13,35 @@
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
+import org.apache.commons.collections.CollectionUtils;
 
 import com.thoughtworks.xstream.io.path.Path;
 
 public class XstreamPathValueTracker {
 
-    private MultivaluedMap<Path, String> pathMap = new MultivaluedHashMap<>();
+    private LinkedHashMap<Path, List<String>> pathMap = new LinkedHashMap<>();
 
-    public void buildPaths(List<Path> paths) {
-        paths.forEach(path -> pathMap.add(path, null));
+    public void buildPaths(LinkedHashSet<Path> paths) {
+        paths.forEach(path -> pathMap.put(path, null));
     }
 
-    public String getPathValue(Path key) {
-        return pathMap.getFirst(key);
+    public String getFirstValue(Path key) {
+
+        if (key != null) {
+            List<String> value = pathMap.get(key);
+            if (CollectionUtils.isNotEmpty(value)) {
+                return value.get(0);
+            }
+
+        }
+        return null;
     }
 
     public List<String> getAllValues(Path key) {
@@ -41,8 +52,23 @@ public class XstreamPathValueTracker {
         return pathMap.keySet();
     }
 
+    public void add(Path key, List<String> value) {
+
+        if (key != null) {
+            List<String> originalValue = pathMap.get(key);
+            if (originalValue == null) {
+                pathMap.put(key, value);
+            } else {
+                List<String> joinedList = new ArrayList<>(originalValue);
+                joinedList.addAll(value);
+                pathMap.put(key, joinedList);
+            }
+        }
+    }
+
     public void add(Path key, String value) {
-        pathMap.add(key, value);
+
+        this.add(key, Arrays.asList(value));
     }
 
 }

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamTreeWriter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamTreeWriter.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.thoughtworks.xstream.io.path.Path;
+import com.thoughtworks.xstream.io.path.PathTracker;
+import com.thoughtworks.xstream.io.path.PathTrackingWriter;
+
+public class XstreamTreeWriter {
+    private PathTrackingWriter writer = null;
+
+    private PathTracker tracker = null;
+
+    private XstreamPathValueTracker pathValues = null;
+
+    XstreamTreeWriter(PathTrackingWriter writer, PathTracker tracker,
+            XstreamPathValueTracker pathValues) {
+        this.writer = writer;
+        this.tracker = tracker;
+        this.pathValues = pathValues;
+    }
+
+    void startVisit(final String node) {
+        if (!isAttributeNode(node)) {
+            writer.startNode(node);
+        }
+
+        Path currentPath = tracker.getPath();
+
+        for (Path path : pathValues.getPaths()) {
+            String value = pathValues.getFirstValue(path);
+            Path searchPath = path;
+
+            if (value != null) {
+
+                if (currentPath.isAncestor(searchPath) && searchPath.toString()
+                        .endsWith(node)) {
+
+                    if (isAttributePath(searchPath) & isAttributeNode(node)) {
+
+                        writer.addAttribute(getAttributeNameFromPath(searchPath), value);
+                    } else if (!isAttributeNode(node) && !isAttributePath(searchPath)) {
+
+                        writer.setValue(value);
+                    }
+                }
+            }
+        }
+
+    }
+
+    void endVisit(final String node) {
+        if (!isAttributeNode(node)) {
+            writer.endNode();
+        }
+    }
+
+    private boolean isAttributeNode(final String node) {
+        return node.trim()
+                .startsWith("@");
+    }
+
+    public boolean isAttributePath(final Path path) {
+        return path.toString()
+                .contains("@");
+    }
+
+    public String getAttributeNameFromPath(final Path path) {
+        return StringUtils.substringAfterLast(path.toString(), "@");
+    }
+
+}

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -76,6 +76,14 @@
         </service-properties>
         <bean class="org.codice.ddf.spatial.ogc.csw.catalog.transformer.GmdTransformer"/>
     </service>
+    <service interface="ddf.catalog.transform.MetacardTransformer">
+        <service-properties>
+            <entry key="id" value="gmd:MD_Metadata"/>
+            <entry key="mime-type" value="text/xml"/>
+            <entry key="schema" value="http://www.isotc211.org/2005/gmd"/>
+        </service-properties>
+        <bean class="org.codice.ddf.spatial.ogc.csw.catalog.transformer.GmdTransformer"/>
+    </service>
 
     <bean id="getRecordsResponseConverter"
           class="org.codice.ddf.spatial.ogc.csw.catalog.converter.GetRecordsResponseConverter">

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGmdConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGmdConverter.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.core.Is.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.GregorianCalendar;
+
+import org.apache.commons.io.IOUtils;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.core.TreeMarshaller;
+import com.thoughtworks.xstream.io.naming.NoNameCoder;
+import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestGmdConverter {
+
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(TestGmdConverter.class);
+
+    private static final GregorianCalendar CREATED_DATE = new GregorianCalendar(2014, 10, 1);
+
+    private static final GregorianCalendar MODIFIED_DATE = new GregorianCalendar(2016, 10, 1);
+
+    private static final GregorianCalendar EFFECTIVE_DATE = new GregorianCalendar(2015, 10, 1);
+
+    private static final String ACTION_URL = "http://example.com/source/id?transform=resource";
+
+    private static final String POLYGON_LOCATION =
+            "POLYGON ((117.6552810668945 -30.92013931274414, 117.661361694336 -30.92383384704589, 117.6666412353516 -30.93005561828613, "
+                    + "117.6663589477539 -30.93280601501464, 117.6594467163086 -30.93186187744141, 117.6541137695312 -30.93780517578125, "
+                    + "117.6519470214844 -30.94397163391114, 117.6455535888672 -30.94255638122559, 117.6336364746094 -30.93402862548828, "
+                    + "117.6355285644531 -30.92874908447266, 117.6326370239258 -30.92138862609864, 117.6395568847656 -30.92236137390137, "
+                    + "117.6433029174805 -30.91708374023438, 117.6454467773437 -30.91711044311523, 117.6484985351563 -30.92061042785645, "
+                    + "117.6504135131836 -30.92061042785645, 117.6504440307617 -30.91638946533203, 117.6552810668945 -30.92013931274414))";
+
+    @BeforeClass
+    public static void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+    }
+
+    private String convert(Object object, boolean writeNamespaces) {
+        GmdConverter converter = new GmdConverter();
+        StringWriter stringWriter = new StringWriter();
+
+        PrettyPrintWriter writer = new PrettyPrintWriter(stringWriter, new NoNameCoder());
+        MarshallingContext context = new TreeMarshaller(writer, null, null);
+
+        context.put(CswConstants.WRITE_NAMESPACES, writeNamespaces);
+
+        converter.marshal(object, writer, context);
+
+        return stringWriter.toString();
+    }
+
+    @Test
+    public void testConvertNullMetacard() {
+        String xml = convert(null, true);
+
+        assertThat(xml, isEmptyString());
+    }
+
+    @Test
+    public void testConvertNonMetacard() {
+        String xml = convert(new String(), true);
+
+        assertThat(xml, isEmptyString());
+    }
+
+    @Test
+    public void testMarshal() throws IOException, SAXException {
+        String compareString = null;
+        try (InputStream input = getClass().getResourceAsStream("/gmd/metacard-as-GMD.xml")) {
+
+            compareString = IOUtils.toString(input);
+        }
+        Metacard metacard = getTestMetacard(POLYGON_LOCATION);
+
+        String xml = convert(metacard, true);
+        Diff diff = new Diff(compareString, xml);
+
+        assertThat(diff.identical(), is(true));
+    }
+
+    @Test
+    public void testMarshalSparseMetacard() throws IOException, SAXException {
+        String compareString = null;
+        try (InputStream input = getClass().getResourceAsStream("/gmd/metacard-as-GMD-sparse.xml")) {
+
+            compareString = IOUtils.toString(input);
+        }
+        Metacard metacard = getSparseMetacard();
+
+        String xml = convert(metacard, true);
+        Diff diff = new Diff(compareString, xml);
+
+        assertThat(diff.identical(), is(true));
+
+    }
+
+    private MetacardImpl getSparseMetacard() {
+
+        MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+        metacard.setId("ID");
+        metacard.setCreatedDate(CREATED_DATE.getTime());
+        metacard.setModifiedDate(MODIFIED_DATE.getTime());
+
+        return metacard;
+    }
+
+    private MetacardImpl getTestMetacard(String wkt) {
+
+        MetacardImpl metacard = getSparseMetacard();
+
+        metacard.setContentTypeName("jpeg");
+        metacard.setContentTypeVersion("1.0.0");
+        metacard.setCreatedDate(CREATED_DATE.getTime());
+        metacard.setEffectiveDate(EFFECTIVE_DATE.getTime());
+        metacard.setPointOfContact("John Doe");
+        metacard.setDescription("example description");
+        metacard.setLocation((wkt));
+        metacard.setMetadata("</xml>");
+        metacard.setResourceSize("123TB");
+        metacard.setSourceId("sourceID");
+        metacard.setTitle("example title");
+
+        try {
+            metacard.setResourceURI(new URI(ACTION_URL));
+        } catch (URISyntaxException e) {
+            LOGGER.debug("URISyntaxException", e);
+        }
+
+        return metacard;
+    }
+
+}

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -20,7 +20,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 
 import java.io.StringReader;
 import java.util.Arrays;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -50,17 +51,11 @@ public class TestXstreamPathConverter {
                     + "        </gml:LinearRing>\n" + "    " + "</gml:exterior>\n"
                     + "</gml:Polygon>" + "";
 
-    private XstreamPathConverter converter;
-
     private static final Path POLYGON_POS_PATH = new Path("/Polygon/exterior/LinearRing/pos");
 
     private static final Path BAD_PATH = new Path("/Polygon/a/b/c");
 
     private static final Path POLYGON_GML_ID_PATH = new Path("/Polygon/@id");
-
-    private static final List<Path> PATHS = Arrays.asList(POLYGON_POS_PATH,
-            BAD_PATH,
-            POLYGON_GML_ID_PATH);
 
     private static final String GML_NAMESPACE = "";
 
@@ -83,7 +78,10 @@ public class TestXstreamPathConverter {
         xstream.registerConverter(converter);
         xstream.alias("Polygon", XstreamPathValueTracker.class);
         argumentHolder = xstream.newDataHolder();
-        argumentHolder.put(XstreamPathConverter.PATH_KEY, PATHS);
+
+        Set<Path> paths = new LinkedHashSet<>();
+        paths.addAll(Arrays.asList(POLYGON_POS_PATH, BAD_PATH, POLYGON_GML_ID_PATH));
+        argumentHolder.put(XstreamPathConverter.PATH_KEY, paths);
 
     }
 
@@ -97,7 +95,7 @@ public class TestXstreamPathConverter {
                 null,
                 argumentHolder);
 
-        assertThat(pathValueTracker.getPathValue(POLYGON_GML_ID_PATH), is("p1"));
+        assertThat(pathValueTracker.getFirstValue(POLYGON_GML_ID_PATH), is("p1"));
 
     }
 
@@ -110,7 +108,7 @@ public class TestXstreamPathConverter {
                 reader,
                 null,
                 argumentHolder);
-        assertThat(pathValueTracker.getPathValue(POLYGON_POS_PATH), is("-180.000000 90.000000"));
+        assertThat(pathValueTracker.getFirstValue(POLYGON_POS_PATH), is("-180.000000 90.000000"));
 
     }
 
@@ -123,7 +121,7 @@ public class TestXstreamPathConverter {
                 reader,
                 null,
                 argumentHolder);
-        assertThat(pathValueTracker.getPathValue(BAD_PATH), nullValue());
+        assertThat(pathValueTracker.getFirstValue(BAD_PATH), nullValue());
 
     }
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/dataset.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/dataset.xml
@@ -476,7 +476,7 @@
 					<onLine>
 						<CI_OnlineResource>
 							<linkage>
-								<URL>http://...</URL>
+								<URL>http:/example.com/linkage</URL>
 							</linkage>
 						</CI_OnlineResource>
 					</onLine>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/metacard-as-GMD-sparse.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/metacard-as-GMD-sparse.xml
@@ -1,0 +1,47 @@
+<MD_Metadata xmlns="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+    <fileIdentifier>
+        <gco:CharacterString>ID</gco:CharacterString>
+    </fileIdentifier>
+    <hierarchyLevel>
+        <MD_ScopeCode codeListValue="dataset" codeList="urn:catalog:metacard"/>
+    </hierarchyLevel>
+    <contact/>
+    <dateStamp>
+        <gco:DateTime>2016-11-01T00:00:00.000-06:00</gco:DateTime>
+    </dateStamp>
+    <identificationInfo>
+        <MD_DataIdentification>
+            <citation>
+                <CI_Citation>
+                    <title>
+                        <gco:CharacterString></gco:CharacterString>
+                    </title>
+                    <date>
+                        <CI_Date>
+                            <date>
+                                <gco:DateTime>2014-11-01T00:00:00.000-06:00</gco:DateTime>
+                            </date>
+                            <dateType>
+                                <CI_DateTypeCode codeList="urn:catalog:metacard" codeListValue="created"/>
+                            </dateType>
+                        </CI_Date>
+                    </date>
+                </CI_Citation>
+            </citation>
+            <abstract>
+                <gco:CharacterString></gco:CharacterString>
+            </abstract>
+            <pointOfContact>
+                <CI_ResponsibleParty>
+                    <organisationName>
+                        <gco:CharacterString></gco:CharacterString>
+                    </organisationName>
+                    <role/>
+                </CI_ResponsibleParty>
+            </pointOfContact>
+            <language>
+                <gco:CharacterString>en</gco:CharacterString>
+            </language>
+        </MD_DataIdentification>
+    </identificationInfo>
+</MD_Metadata>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/metacard-as-GMD.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/gmd/metacard-as-GMD.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MD_Metadata xmlns="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+    <fileIdentifier>
+        <gco:CharacterString>ID</gco:CharacterString>
+    </fileIdentifier>
+    <hierarchyLevel>
+        <MD_ScopeCode codeListValue="jpeg" codeList="urn:catalog:metacard"/>
+    </hierarchyLevel>
+    <contact/>
+    <dateStamp>
+        <gco:DateTime>2016-11-01T00:00:00.000-06:00</gco:DateTime>
+    </dateStamp>
+    <identificationInfo>
+        <MD_DataIdentification>
+            <citation>
+                <CI_Citation>
+                    <title>
+                        <gco:CharacterString>example title</gco:CharacterString>
+                    </title>
+                    <date>
+                        <CI_Date>
+                            <date>
+                                <gco:DateTime>2014-11-01T00:00:00.000-06:00</gco:DateTime>
+                            </date>
+                            <dateType>
+                                <CI_DateTypeCode codeList="urn:catalog:metacard" codeListValue="created"/>
+                            </dateType>
+                        </CI_Date>
+                    </date>
+                </CI_Citation>
+            </citation>
+            <abstract>
+                <gco:CharacterString>example description</gco:CharacterString>
+            </abstract>
+            <pointOfContact>
+                <CI_ResponsibleParty>
+                    <organisationName>
+                        <gco:CharacterString>John Doe</gco:CharacterString>
+                    </organisationName>
+                    <role/>
+                </CI_ResponsibleParty>
+            </pointOfContact>
+            <language>
+                <gco:CharacterString>en</gco:CharacterString>
+            </language>
+            <extent>
+                <EX_Extent>
+                    <geographicElement>
+                        <EX_GeographicBoundingBox>
+                            <westBoundLongitude>
+                                <gco:Decimal>117.6326370239258</gco:Decimal>
+                            </westBoundLongitude>
+                            <eastBoundLongitude>
+                                <gco:Decimal>117.6666412353516</gco:Decimal>
+                            </eastBoundLongitude>
+                            <southBoundLatitude>
+                                <gco:Decimal>-30.94397163391114</gco:Decimal>
+                            </southBoundLatitude>
+                            <northBoundLatitude>
+                                <gco:Decimal>-30.91638946533203</gco:Decimal>
+                            </northBoundLatitude>
+                        </EX_GeographicBoundingBox>
+                    </geographicElement>
+                </EX_Extent>
+            </extent>
+        </MD_DataIdentification>
+    </identificationInfo>
+    <distributionInfo>
+        <MD_Distribution>
+            <transferOptions>
+                <MD_DigitalTransferOptions>
+                    <onLine>
+                        <CI_OnlineResource>
+                            <linkage>
+                                <URL>http://example.com/source/id?transform=resource</URL>
+                            </linkage>
+                        </CI_OnlineResource>
+                    </onLine>
+                </MD_DigitalTransferOptions>
+            </transferOptions>
+        </MD_Distribution>
+    </distributionInfo>
+</MD_Metadata>


### PR DESCRIPTION
#### What does this PR do?
Adds a a transformer to convert from metacard to the Geographic MetaData (GMD) format.
#### Who is reviewing it?
@kcwire @bdeining 
#### How should this be tested?
Metacards can be exported to the GMD format.  For example:
`dump -t gmd:MD_Metadata <dump dir>`
#### Any background context you want to provide?
GMD is one of  the metadata formats required by the CSW ISO profile. See: http://www.isotc211.org/schemas/2005/gmd/
#### What are the relevant tickets?
DDF-1976
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
