### PR TITLE
DDF-1978 Create and implement a new metacard validation API

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -476,6 +476,16 @@
         <dependency>
             <groupId>ddf.catalog.plugin</groupId>
             <artifactId>catalog-plugin-versioning</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attribute-registry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-validator</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -350,6 +350,14 @@
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacard-validation/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-core-validator" install="manual" version="${project.version}"
+             description="DDF Metacard and attribute validation services">
+        <feature prerequisite="true">catalog-app</feature>
+        <bundle>mvn:ddf.catalog.core/catalog-core-validator/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-attribute-registry/${project.version}</bundle>
+        <feature>catalog-plugin-metacard-validation</feature>
+    </feature>
+
     <feature name="catalog-transformer-pdf" install="auto" version="${project.version}"
              description="DDF PDF Input Transformer">
         <feature prerequisite="true">catalog-app</feature>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -15,7 +15,10 @@ package ddf.catalog.data.impl;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -29,14 +32,13 @@ import ddf.catalog.data.MetacardType;
  * @author ddf.isgs@lmco.com
  */
 public class BasicTypes {
-
     /**
      * A Constant for a {@link MetacardType} with the required {@link AttributeType}s.
      */
     public static final MetacardType BASIC_METACARD;
 
     /**
-     * A Constant for an {@link AttributeType} with {@link AttributeFormat#DATE} .
+     * A Constant for an {@link AttributeType} with {@link AttributeFormat#DATE}.
      */
     public static final AttributeType<Date> DATE_TYPE;
 
@@ -51,7 +53,7 @@ public class BasicTypes {
     public static final AttributeType<String> XML_TYPE;
 
     /**
-     * A Constant for an {@link AttributeType} with {@link AttributeFormat#LONG} .
+     * A Constant for an {@link AttributeType} with {@link AttributeFormat#LONG}.
      */
     public static final AttributeType<Long> LONG_TYPE;
 
@@ -99,190 +101,60 @@ public class BasicTypes {
 
     public static final String VALIDATION_ERRORS = "validation-errors";
 
+    private static final Map<String, AttributeType> ATTRIBUTE_TYPE_MAP = new HashMap<>();
+
     static {
+        DATE_TYPE = addAttributeType("DATE_TYPE", AttributeFormat.DATE, Date.class);
 
-        AttributeType<Boolean> booleanType = new AttributeType<Boolean>() {
+        STRING_TYPE = addAttributeType("STRING_TYPE", AttributeFormat.STRING, String.class);
+
+        XML_TYPE = addAttributeType("XML_TYPE", AttributeFormat.XML, String.class);
+
+        LONG_TYPE = addAttributeType("LONG_TYPE", AttributeFormat.LONG, Long.class);
+
+        BINARY_TYPE = addAttributeType("BINARY_TYPE", AttributeFormat.BINARY, byte[].class);
+
+        GEO_TYPE = addAttributeType("GEO_TYPE", AttributeFormat.GEOMETRY, String.class);
+
+        BOOLEAN_TYPE = addAttributeType("BOOLEAN_TYPE", AttributeFormat.BOOLEAN, Boolean.class);
+
+        DOUBLE_TYPE = addAttributeType("DOUBLE_TYPE", AttributeFormat.DOUBLE, Double.class);
+
+        FLOAT_TYPE = addAttributeType("FLOAT_TYPE", AttributeFormat.FLOAT, Float.class);
+
+        INTEGER_TYPE = addAttributeType("INTEGER_TYPE", AttributeFormat.INTEGER, Integer.class);
+
+        OBJECT_TYPE = addAttributeType("OBJECT_TYPE", AttributeFormat.OBJECT, Serializable.class);
+
+        SHORT_TYPE = addAttributeType("SHORT_TYPE", AttributeFormat.SHORT, Short.class);
+
+        BASIC_METACARD = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME,
+                getBasicAttributeDescriptors());
+    }
+
+    private static <T extends Serializable> AttributeType<T> addAttributeType(final String typeName,
+            final AttributeFormat format, final Class<T> bindingClass) {
+        final AttributeType<T> attributeType = new AttributeType<T>() {
             private static final long serialVersionUID = 1L;
 
             @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.BOOLEAN;
+            public Class<T> getBinding() {
+                return bindingClass;
             }
-
-            @Override
-            public Class<Boolean> getBinding() {
-                return Boolean.class;
-            }
-        };
-        BOOLEAN_TYPE = booleanType;
-
-        AttributeType<Double> doubleType = new AttributeType<Double>() {
-            private static final long serialVersionUID = 1L;
 
             @Override
             public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.DOUBLE;
-            }
-
-            @Override
-            public Class<Double> getBinding() {
-                return Double.class;
+                return format;
             }
         };
-        DOUBLE_TYPE = doubleType;
 
-        AttributeType<Float> floatType = new AttributeType<Float>() {
-            private static final long serialVersionUID = 1L;
+        ATTRIBUTE_TYPE_MAP.put(typeName, attributeType);
 
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.FLOAT;
-            }
+        return attributeType;
+    }
 
-            @Override
-            public Class<Float> getBinding() {
-                return Float.class;
-            }
-        };
-        FLOAT_TYPE = floatType;
-
-        AttributeType<Integer> integerType = new AttributeType<Integer>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.INTEGER;
-            }
-
-            @Override
-            public Class<Integer> getBinding() {
-                return Integer.class;
-            }
-        };
-        INTEGER_TYPE = integerType;
-
-        AttributeType<Serializable> objectType = new AttributeType<Serializable>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.OBJECT;
-            }
-
-            @Override
-            public Class<Serializable> getBinding() {
-                return Serializable.class;
-            }
-        };
-        OBJECT_TYPE = objectType;
-
-        AttributeType<Short> shortType = new AttributeType<Short>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.SHORT;
-            }
-
-            @Override
-            public Class<Short> getBinding() {
-                return Short.class;
-            }
-        };
-        SHORT_TYPE = shortType;
-
-        AttributeType<Date> dateType = new AttributeType<Date>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.DATE;
-            }
-
-            @Override
-            public Class<Date> getBinding() {
-                return Date.class;
-            }
-        };
-        DATE_TYPE = dateType;
-
-        AttributeType<String> stringType = new AttributeType<String>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.STRING;
-            }
-
-            @Override
-            public Class<String> getBinding() {
-                return String.class;
-            }
-        };
-        STRING_TYPE = stringType;
-
-        AttributeType<String> xmlType = new AttributeType<String>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.XML;
-            }
-
-            @Override
-            public Class<String> getBinding() {
-                return String.class;
-            }
-        };
-        XML_TYPE = xmlType;
-
-        AttributeType<Long> longType = new AttributeType<Long>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.LONG;
-            }
-
-            @Override
-            public Class<Long> getBinding() {
-                return Long.class;
-            }
-        };
-        LONG_TYPE = longType;
-
-        AttributeType<byte[]> binaryType = new AttributeType<byte[]>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.BINARY;
-            }
-
-            @Override
-            public Class<byte[]> getBinding() {
-                return byte[].class;
-            }
-        };
-        BINARY_TYPE = binaryType;
-
-        AttributeType<String> geoType = new AttributeType<String>() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return AttributeFormat.GEOMETRY;
-            }
-
-            @Override
-            public Class<String> getBinding() {
-                return String.class;
-            }
-        };
-        GEO_TYPE = geoType;
-
-        MetacardType basic = null;
-        HashSet<AttributeDescriptor> descriptors = new HashSet<AttributeDescriptor>();
+    private static Set<AttributeDescriptor> getBasicAttributeDescriptors() {
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
         descriptors.add(new AttributeDescriptorImpl(Metacard.MODIFIED,
                 true /* indexed */,
                 true /* stored */,
@@ -403,15 +275,10 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
-
-        basic = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME, descriptors);
-
-        BASIC_METACARD = basic;
+        return descriptors;
     }
 
-    /**
-     * Constructor - does nothing
-     */
-    public BasicTypes() {
+    public static AttributeType getAttributeType(String type) {
+        return ATTRIBUTE_TYPE_MAP.get(type);
     }
 }

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.report;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class AttributeValidationReportImpl implements AttributeValidationReport {
+    private final Set<ValidationViolation> attributeValidationViolations = new HashSet<>();
+
+    private final Set<String> suggestedValues = new HashSet<>();
+
+    /**
+     * Adds a {@link ValidationViolation} to the report.
+     *
+     * @param violation the violation to add to the report, cannot be null
+     * @throws IllegalArgumentException if {@code violation} is null
+     */
+    public void addViolation(final ValidationViolation violation) {
+        Preconditions.checkArgument(violation != null, "The violation cannot be null.");
+
+        attributeValidationViolations.add(violation);
+    }
+
+    /**
+     * Adds a suggested attribute value to the report.
+     *
+     * @param value a suggested attribute value to add to the report
+     * @throws IllegalArgumentException if {@code value} is null
+     */
+    public void addSuggestedValue(final String value) {
+        Preconditions.checkArgument(value != null, "The suggested value cannot be null.");
+
+        suggestedValues.add(value);
+    }
+
+    @Override
+    public Set<ValidationViolation> getAttributeValidationViolations() {
+        return Collections.unmodifiableSet(attributeValidationViolations);
+    }
+
+    @Override
+    public Set<String> getSuggestedValues() {
+        return Collections.unmodifiableSet(suggestedValues);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/MetacardValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/MetacardValidationReportImpl.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.report;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class MetacardValidationReportImpl implements MetacardValidationReport {
+    private final Set<ValidationViolation> attributeValidationViolations = new HashSet<>();
+
+    private final Set<ValidationViolation> metacardValidationViolations = new HashSet<>();
+
+    /**
+     * Adds an attribute-level {@link ValidationViolation} to the report.
+     *
+     * @param violation the attribute-level violation to add to the report, cannot be null
+     * @throws IllegalArgumentException if {@code violation} is null
+     */
+    public void addAttributeViolation(final ValidationViolation violation) {
+        Preconditions.checkArgument(violation != null, "The violation cannot be null.");
+
+        attributeValidationViolations.add(violation);
+    }
+
+    /**
+     * Adds a metacard-level {@link ValidationViolation} to the report.
+     *
+     * @param violation the metacard-level violation to add to the report, cannot be null
+     * @throws IllegalArgumentException if {@code violation} is null
+     */
+    public void addMetacardViolation(final ValidationViolation violation) {
+        Preconditions.checkArgument(violation != null, "The violation cannot be null.");
+
+        metacardValidationViolations.add(violation);
+    }
+
+    @Override
+    public Set<ValidationViolation> getAttributeValidationViolations() {
+        return Collections.unmodifiableSet(attributeValidationViolations);
+    }
+
+    @Override
+    public Set<ValidationViolation> getMetacardValidationViolations() {
+        return Collections.unmodifiableSet(metacardValidationViolations);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/AbstractDateValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/AbstractDateValidator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import java.util.function.Function;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Provides support for {@link ddf.catalog.validation.AttributeValidator}s that validate
+ * {@link Date}s.
+ */
+public abstract class AbstractDateValidator {
+    /**
+     * Validates the values of {@code attribute} that are {@link Date}s.
+     * <p>
+     * If {@code validator} returns false for a value, this method will return an {@link Optional}
+     * containing an {@link AttributeValidationReport} with a message of
+     * {@code attribute.getName() + " " + message} and a severity of {@link Severity#ERROR}.
+     * Otherwise, an empty {@link Optional} is returned.
+     *
+     * @param attribute the {@link Attribute} to validate
+     * @param validator the test to apply to the values of {@code attribute}
+     * @param message   the message to include in the report in the case of a validation violation
+     * @return an {@link Optional} containing an {@link AttributeValidationReport} if there are
+     * violations, or an empty {@link Optional} if there are no violations
+     */
+    protected final Optional<AttributeValidationReport> validate(final Attribute attribute,
+            final Function<Date, Boolean> validator, final String message) {
+        final String name = attribute.getName();
+
+        for (final Serializable value : attribute.getValues()) {
+            if (value instanceof Date && !validator.apply((Date) value)) {
+                final AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+                report.addViolation(new ValidationViolationImpl(Collections.singleton(name),
+                        name + " " + message,
+                        Severity.ERROR));
+                return Optional.of(report);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/EnumerationValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/EnumerationValidator.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Validates an attribute's value(s) against a set of acceptable values.
+ */
+public class EnumerationValidator implements AttributeValidator {
+    private final Set<String> values;
+
+    /**
+     * Constructs an {@code EnumerationValidator} with a given set of acceptable values.
+     *
+     * @param values the values accepted by this validator
+     * @throws IllegalArgumentException if {@code values} is null or empty
+     */
+    public EnumerationValidator(final Set<String> values) {
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(values),
+                "Must specify at least one possible enumeration value.");
+
+        this.values = values.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Validates each of {@code attribute}'s values against the set of acceptable values by calling
+     * {@link String#valueOf(Object)} on each value and checking whether that string is in the set.
+     * <p>
+     * Note: comparisons are <strong>case-sensitive</strong>.
+     */
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final String name = attribute.getName();
+        for (final Serializable value : attribute.getValues()) {
+            final String stringValue = String.valueOf(value);
+            if (!values.contains(stringValue)) {
+                final AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+                // TODO (jrnorth) - escape the value.
+                report.addViolation(new ValidationViolationImpl(Collections.singleton(name),
+                        name + " has an invalid value: [" + stringValue + "]",
+                        Severity.ERROR));
+                values.forEach(report::addSuggestedValue);
+                return Optional.of(report);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EnumerationValidator that = (EnumerationValidator) o;
+
+        return new EqualsBuilder().append(values, that.values)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(23, 37).append(values)
+                .toHashCode();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/FutureDateValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/FutureDateValidator.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+/**
+ * Validates an attribute's value(s) against the current date and time, validating that they are
+ * in the future.
+ * <p>
+ * Is capable of validating {@link Date}s.
+ */
+public class FutureDateValidator extends AbstractDateValidator implements AttributeValidator {
+    private static final FutureDateValidator INSTANCE = new FutureDateValidator();
+
+    private FutureDateValidator() {
+    }
+
+    public static FutureDateValidator getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Validates only the values of {@code attribute} that are {@link Date}s.
+     */
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final Date now = Date.from(Instant.now());
+        return validate(attribute, (date) -> date.after(now), "must be in the future");
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/PastDateValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/PastDateValidator.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+/**
+ * Validates an attribute's value(s) against the current date and time, validating that they are in
+ * the past.
+ * <p>
+ * Is capable of validating {@link Date}s.
+ */
+public class PastDateValidator extends AbstractDateValidator implements AttributeValidator {
+    private static final PastDateValidator INSTANCE = new PastDateValidator();
+
+    private PastDateValidator() {
+    }
+
+    public static PastDateValidator getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Validates only the values of {@code attribute} that are {@link Date}s.
+     */
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final Date now = Date.from(Instant.now());
+        return validate(attribute, (date) -> date.before(now), "must be in the past");
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/PatternValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/PatternValidator.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Validates an attribute's value(s) against a regular expression.
+ * <p>
+ * Is capable of validating {@link CharSequence}s.
+ */
+public class PatternValidator implements AttributeValidator {
+    private final Pattern pattern;
+
+    /**
+     * Constructs a {@code PatternValidator} with the given regular expression.
+     *
+     * @param regex the regular expression
+     * @throws IllegalArgumentException               if {@code regex} is null
+     * @throws java.util.regex.PatternSyntaxException if {@code regex} is not a valid regular
+     *                                                expression
+     */
+    public PatternValidator(final String regex) {
+        Preconditions.checkArgument(regex != null, "The regular expression cannot be null.");
+
+        pattern = Pattern.compile(regex);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Validates only the values of {@code attribute} that are {@link CharSequence}s.
+     */
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final String name = attribute.getName();
+        for (final Serializable value : attribute.getValues()) {
+            if (value instanceof CharSequence
+                    && !(pattern.matcher((CharSequence) value)).matches()) {
+                final AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+                report.addViolation(new ValidationViolationImpl(Collections.singleton(name),
+                        name + " does not follow the pattern " + pattern.pattern(),
+                        Severity.ERROR));
+                return Optional.of(report);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PatternValidator validator = (PatternValidator) o;
+
+        return new EqualsBuilder().append(pattern.pattern(), validator.pattern.pattern())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 29).append(pattern.pattern())
+                .toHashCode();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/RangeValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/RangeValidator.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Validates an attribute's value(s) against an <strong>inclusive</strong> numeric range.
+ * <p>
+ * Is capable of validating {@link Number}s.
+ */
+public class RangeValidator implements AttributeValidator {
+    private static final BigDecimal DEFAULT_EPSILON = new BigDecimal("1E-6");
+
+    private final BigDecimal min;
+
+    private final BigDecimal max;
+
+    /**
+     * Creates a {@code RangeValidator} with an <strong>inclusive</strong> range.
+     * <p>
+     * Uses an epsilon of 1e-6 on both sides of the range to account for floating point
+     * representation inaccuracies, so the range is really [min - epsilon, max + epsilon].
+     *
+     * @param min the minimum allowable value (inclusive), cannot be null
+     * @param max the maximum allowable value (inclusive), cannot be null and must be greater than
+     *            {@code min}
+     * @throws IllegalArgumentException if {@code max} is not greater than {@code min} or either is
+     *                                  null
+     */
+    public RangeValidator(final BigDecimal min, final BigDecimal max) {
+        this(min, max, DEFAULT_EPSILON);
+    }
+
+    /**
+     * Creates a {@code RangeValidator} with an <strong>inclusive</strong> range and the provided
+     * epsilon.
+     * <p>
+     * Uses the provided epsilon on both sides of the range to account for floating point
+     * representation inaccuracies, so the range is really [min - epsilon, max + epsilon].
+     *
+     * @param min     the minimum allowable value (inclusive), cannot be null
+     * @param max     the maximum allowable value (inclusive), cannot be null and must be greater
+     *                than {@code min}
+     * @param epsilon the epsilon value, cannot be null and must be positive
+     * @throws IllegalArgumentException if {@code max} is not greater than {@code min},
+     *                                  {@code epsilon} is not positive, or if any argument is null
+     */
+    public RangeValidator(final BigDecimal min, final BigDecimal max, final BigDecimal epsilon) {
+        Preconditions.checkArgument(min != null, "The minimum cannot be null.");
+        Preconditions.checkArgument(max != null, "The maximum cannot be null.");
+        Preconditions.checkArgument(epsilon != null, "The epsilon cannot be null.");
+        Preconditions.checkArgument(min.compareTo(max) == -1,
+                "The maximum must be greater than the minimum.");
+        Preconditions.checkArgument(epsilon.compareTo(BigDecimal.ZERO) == 1,
+                "The epsilon must be greater than 0.");
+
+        this.min = min.subtract(epsilon);
+        this.max = max.add(epsilon);
+    }
+
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final String name = attribute.getName();
+
+        for (final Serializable value : attribute.getValues()) {
+            final BigDecimal bdValue;
+            if (value instanceof Number) {
+                bdValue = new BigDecimal(value.toString());
+            } else {
+                continue;
+            }
+
+            if (!checkRange(bdValue)) {
+                final String violationMessage = String.format("%s must be between %s and %s",
+                        name,
+                        min.toPlainString(),
+                        max.toPlainString());
+                final AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+                report.addViolation(new ValidationViolationImpl(Collections.singleton(name),
+                        violationMessage,
+                        Severity.ERROR));
+                return Optional.of(report);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean checkRange(final BigDecimal value) {
+        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RangeValidator that = (RangeValidator) o;
+
+        return new EqualsBuilder().append(min, that.min)
+                .append(max, that.max)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 41).append(min)
+                .append(max)
+                .toHashCode();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/RequiredAttributesMetacardValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/RequiredAttributesMetacardValidator.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ReportingMetacardValidator;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.ValidationExceptionImpl;
+import ddf.catalog.validation.impl.report.MetacardValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Validates that a {@link Metacard} contains certain {@link Attribute}s.
+ */
+public class RequiredAttributesMetacardValidator
+        implements MetacardValidator, ReportingMetacardValidator {
+    private final String metacardTypeName;
+
+    private final Set<String> requiredAttributes;
+
+    /**
+     * Creates a {@code RequiredAttributesMetacardValidator} with the given metacard type name and
+     * set of attribute names representing the required attributes.
+     * <p>
+     * This validator will only validate {@link Metacard}s that have the type name specified by
+     * {@code metacardTypeName} (case-sensitive).
+     * <p>
+     * Any missing required attributes will be flagged as metacard-level validation errors.
+     *
+     * @param metacardTypeName   the name of the metacard type this validator can validate, cannot
+     *                           be null
+     * @param requiredAttributes the names of the attributes this validator will check for, cannot
+     *                           be null or empty
+     * @throws IllegalArgumentException if {@code metacardTypeName} is null or if
+     *                                  {@code requiredAttributes} is null or empty
+     */
+    public RequiredAttributesMetacardValidator(final String metacardTypeName,
+            final Set<String> requiredAttributes) {
+        Preconditions.checkArgument(metacardTypeName != null,
+                "The metacard type name cannot be null.");
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(requiredAttributes),
+                "Must specify at least one required attribute.");
+
+        this.metacardTypeName = metacardTypeName;
+        this.requiredAttributes = requiredAttributes.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public void validate(final Metacard metacard) throws ValidationException {
+        final Optional<MetacardValidationReport> reportOptional = validateMetacard(metacard);
+
+        if (reportOptional.isPresent()) {
+            final List<String> errors = reportOptional.get()
+                    .getMetacardValidationViolations()
+                    .stream()
+                    .map(ValidationViolation::getMessage)
+                    .collect(Collectors.toList());
+
+            final ValidationExceptionImpl exception = new ValidationExceptionImpl();
+            exception.setErrors(errors);
+            throw exception;
+        }
+    }
+
+    @Override
+    public Optional<MetacardValidationReport> validateMetacard(final Metacard metacard) {
+        Preconditions.checkArgument(metacard != null, "The metacard cannot be null.");
+
+        final MetacardType metacardType = metacard.getMetacardType();
+
+        if (metacardTypeName.equals(metacardType.getName())) {
+            final Set<ValidationViolation> violations = new HashSet<>();
+
+            for (final String attributeName : requiredAttributes) {
+                final Attribute attribute = metacard.getAttribute(attributeName);
+                if (attribute != null) {
+                    final AttributeDescriptor descriptor = metacardType.getAttributeDescriptor(
+                            attributeName);
+                    if (descriptor.isMultiValued()) {
+                        if (attribute.getValues()
+                                .size() == 0) {
+                            addRequiredAttributeViolation(attributeName, violations);
+                        }
+                    } else if (attribute.getValue() == null) {
+                        addRequiredAttributeViolation(attributeName, violations);
+                    }
+                } else {
+                    addRequiredAttributeViolation(attributeName, violations);
+                }
+            }
+
+            if (violations.size() > 0) {
+                return getReport(violations);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private void addRequiredAttributeViolation(final String attributeName,
+            final Set<ValidationViolation> violations) {
+        violations.add(new ValidationViolationImpl(Collections.singleton(attributeName),
+                attributeName + " is required",
+                Severity.ERROR));
+    }
+
+    private Optional<MetacardValidationReport> getReport(
+            final Set<ValidationViolation> violations) {
+        final MetacardValidationReportImpl report = new MetacardValidationReportImpl();
+        violations.forEach(report::addMetacardViolation);
+        return Optional.of(report);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/SizeValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/SizeValidator.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Validates the size of an attribute's value(s).
+ * <p>
+ * Is capable of validating the sizes of {@link CharSequence}s, {@link Collection}s, {@link Map}s,
+ * and arrays.
+ */
+public class SizeValidator implements AttributeValidator {
+    private final long min;
+
+    private final long max;
+
+    /**
+     * Creates a {@code SizeValidator} with an <strong>inclusive</strong> range (i.e., [min, max]).
+     * <p>
+     * The minimum must be non-negative and the maximum must be greater than the minimum.
+     *
+     * @param min the minimum allowable size (inclusive), must be non-negative
+     * @param max the maximum allowable size (inclusive), must be greater than {@code min}
+     * @throws IllegalArgumentException if 0 <= min < max does not hold
+     */
+    public SizeValidator(final long min, final long max) {
+        Preconditions.checkArgument(0 <= min && min < max,
+                "The minimum must be non-negative and the maximum must be greater than the minimum.");
+
+        this.min = min;
+        this.max = max;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Validates only the values of {@code attribute} that are {@link CharSequence}s,
+     * {@link Collection}s, {@link Map}s, or arrays.
+     */
+    @Override
+    public Optional<AttributeValidationReport> validate(final Attribute attribute) {
+        Preconditions.checkArgument(attribute != null, "The attribute cannot be null.");
+
+        final String name = attribute.getName();
+        for (final Serializable value : attribute.getValues()) {
+            int size;
+            if (value instanceof CharSequence) {
+                size = ((CharSequence) value).length();
+            } else if (value instanceof Collection) {
+                size = ((Collection) value).size();
+            } else if (value instanceof Map) {
+                size = ((Map) value).size();
+            } else if (value != null && value.getClass()
+                    .isArray()) {
+                size = Array.getLength(value);
+            } else {
+                continue;
+            }
+
+            if (!checkSize(size)) {
+                final String violationMessage = String.format("%s size must be between %d and %d",
+                        name,
+                        min,
+                        max);
+                final AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+                report.addViolation(new ValidationViolationImpl(Collections.singleton(name),
+                        violationMessage,
+                        Severity.ERROR));
+                return Optional.of(report);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean checkSize(final int size) {
+        return min <= size && size <= max;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SizeValidator validator = (SizeValidator) o;
+
+        return new EqualsBuilder().append(min, validator.min)
+                .append(max, validator.max)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(29, 37).append(min)
+                .append(max)
+                .toHashCode();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/violation/ValidationViolationImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/violation/ValidationViolationImpl.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.violation;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class ValidationViolationImpl implements ValidationViolation {
+    private final Set<String> attributes;
+
+    private final String message;
+
+    private final Severity severity;
+
+    /**
+     * Creates a {@code ValidationViolationImpl} with the specified attribute(s), message, and
+     * severity.
+     *
+     * @param attributes the attribute(s) involved in the violation, cannot be null or empty
+     * @param message    the message describing the violation, cannot be null, empty, or blank
+     * @param severity   the severity of the violation, cannot be null
+     * @throws IllegalArgumentException if any of the parameters are null, empty, or blank
+     */
+    public ValidationViolationImpl(final Set<String> attributes, final String message,
+            final Severity severity) {
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(attributes),
+                "Must specify at least one attribute.");
+        Preconditions.checkArgument(StringUtils.isNotBlank(message),
+                "The message cannot be null, empty, or blank.");
+        Preconditions.checkArgument(severity != null, "The severity cannot be null.");
+
+        this.attributes = Collections.unmodifiableSet(attributes);
+        this.message = message;
+        this.severity = severity;
+    }
+
+    @Override
+    public Set<String> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Severity getSeverity() {
+        return severity;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ValidationViolationImpl that = (ValidationViolationImpl) o;
+
+        return new EqualsBuilder().append(attributes, that.attributes)
+                .append(message, that.message)
+                .append(severity, that.severity)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(attributes)
+                .append(message)
+                .append(severity)
+                .toHashCode();
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/EnumerationValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/EnumerationValidatorTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.EnumerationValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class EnumerationValidatorTest {
+    private static final String[] ENUMERATED_VALUES = {"hearts", "spades", "diamonds", "clubs"};
+
+    @Test
+    public void testValidValue() {
+        validateNoErrors(new AttributeImpl("test", "spades"));
+    }
+
+    @Test
+    public void testInvalidValue() {
+        validateWithErrors(new AttributeImpl("test", "other"), 1);
+    }
+
+    @Test
+    public void testSuggestedValues() {
+        final Optional<AttributeValidationReport> reportOptional = getReport(new AttributeImpl(
+                "test",
+                "something"));
+        assertThat(reportOptional.get()
+                .getSuggestedValues(), containsInAnyOrder(ENUMERATED_VALUES));
+    }
+
+    private Optional<AttributeValidationReport> getReport(final Attribute attribute) {
+        final Set<String> enumeratedValuesSet = Arrays.stream(ENUMERATED_VALUES)
+                .collect(Collectors.toSet());
+        final EnumerationValidator validator = new EnumerationValidator(enumeratedValuesSet);
+        return validator.validate(attribute);
+    }
+
+    private void validateNoErrors(final Attribute attribute) {
+        final Optional<AttributeValidationReport> reportOptional = getReport(attribute);
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final Attribute attribute, final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional = getReport(attribute);
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttribute() {
+        new EnumerationValidator(Sets.newHashSet("first")).validate(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullEnumerationValues() {
+        new EnumerationValidator(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyEnumerationValues() {
+        new EnumerationValidator(new HashSet<>());
+    }
+
+    @Test
+    public void testEquals() {
+        final EnumerationValidator validator1 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        final EnumerationValidator validator2 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        assertThat(validator1.equals(validator2), is(true));
+        assertThat(validator2.equals(validator1), is(true));
+    }
+
+    @Test
+    public void testEqualsSelf() {
+        final EnumerationValidator validator = new EnumerationValidator(Sets.newHashSet("first"));
+        assertThat(validator.equals(validator), is(true));
+    }
+
+    @Test
+    public void testEqualsNull() {
+        final EnumerationValidator validator1 = new EnumerationValidator(Sets.newHashSet("first"));
+        assertThat(validator1.equals(null), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentEnumerationValues() {
+        final EnumerationValidator validator1 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        final EnumerationValidator validator2 = new EnumerationValidator(Sets.newHashSet("first",
+                "third"));
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testHashCode() {
+        final EnumerationValidator validator1 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        final EnumerationValidator validator2 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        assertThat(validator1.hashCode(), is(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentEnumerationValues() {
+        final EnumerationValidator validator1 = new EnumerationValidator(Sets.newHashSet("first",
+                "second"));
+        final EnumerationValidator validator2 = new EnumerationValidator(Sets.newHashSet("first",
+                "third"));
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/FutureDateValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/FutureDateValidatorTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.FutureDateValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class FutureDateValidatorTest {
+    private static final FutureDateValidator VALIDATOR = FutureDateValidator.getInstance();
+
+    @Test
+    public void testValidValue() {
+        final Instant futureInstant = Instant.now()
+                .plus(5, MINUTES);
+        validateNoErrors(futureInstant);
+    }
+
+    @Test
+    public void testInvalidValue() {
+        final Instant pastInstant = Instant.now()
+                .minus(5, MINUTES);
+        validateWithErrors(pastInstant, 1);
+    }
+
+    private void validateNoErrors(final Instant instant) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", Date.from(instant)));
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final Instant instant, final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", Date.from(instant)));
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttribute() {
+        VALIDATOR.validate(null);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/PastDateValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/PastDateValidatorTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.PastDateValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class PastDateValidatorTest {
+    private static final PastDateValidator VALIDATOR = PastDateValidator.getInstance();
+
+    @Test
+    public void testValidValue() {
+        final Instant pastInstant = Instant.now()
+                .minus(5, MINUTES);
+        validateNoErrors(pastInstant);
+    }
+
+    @Test
+    public void testInvalidValue() {
+        final Instant futureInstant = Instant.now()
+                .plus(5, MINUTES);
+        validateWithErrors(futureInstant, 1);
+    }
+
+    private void validateNoErrors(final Instant instant) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", Date.from(instant)));
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final Instant instant, final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", Date.from(instant)));
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttribute() {
+        VALIDATOR.validate(null);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/PatternValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/PatternValidatorTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+import java.util.regex.PatternSyntaxException;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.PatternValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class PatternValidatorTest {
+    private static final PatternValidator VALIDATOR = new PatternValidator(
+            "(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$");
+
+    @Test
+    public void testValidValue() {
+        validateNoErrors("12test34@test-789.org");
+    }
+
+    @Test
+    public void testInvalidValue() {
+        validateWithErrors("12test34@test-789", 1);
+    }
+
+    private void validateNoErrors(final String value) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", value));
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final String value, final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional =
+                VALIDATOR.validate(new AttributeImpl("test", value));
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullRegex() {
+        new PatternValidator(null);
+    }
+
+    @Test(expected = PatternSyntaxException.class)
+    public void testInvalidRegex() {
+        new PatternValidator("[");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttribute() {
+        VALIDATOR.validate(null);
+    }
+
+    @Test
+    public void testEquals() {
+        final PatternValidator validator1 = new PatternValidator("test");
+        final PatternValidator validator2 = new PatternValidator("test");
+        assertThat(validator1.equals(validator2), is(true));
+        assertThat(validator2.equals(validator1), is(true));
+    }
+
+    @Test
+    public void testEqualsSelf() {
+        final PatternValidator validator = new PatternValidator("test");
+        assertThat(validator.equals(validator), is(true));
+    }
+
+    @Test
+    public void testEqualsNull() {
+        final PatternValidator validator = new PatternValidator("test");
+        assertThat(validator.equals(null), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentPattern() {
+        final PatternValidator validator1 = new PatternValidator("test1");
+        final PatternValidator validator2 = new PatternValidator("test2");
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testHashCode() {
+        final PatternValidator validator1 = new PatternValidator("test");
+        final PatternValidator validator2 = new PatternValidator("test");
+        assertThat(validator1.hashCode(), is(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentPattern() {
+        final PatternValidator validator1 = new PatternValidator("test1");
+        final PatternValidator validator2 = new PatternValidator("test2");
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/RangeValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/RangeValidatorTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.RangeValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class RangeValidatorTest {
+    @Test
+    public void testWithinIntegerRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("-123456789123456"),
+                new BigDecimal("987654321987654"));
+        validateNoErrors(new AttributeImpl("", -123456789123456L), validator);
+        validateNoErrors(new AttributeImpl("", 987654321987654L), validator);
+        validateNoErrors(new AttributeImpl("", 0), validator);
+
+        validateNoErrors(new AttributeImpl("", -123456789123455.9), validator);
+        validateNoErrors(new AttributeImpl("", 987654321987653.9), validator);
+    }
+
+    @Test
+    public void testOutsideIntegerRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("-123456789123456"),
+                new BigDecimal("987654321987654"));
+        validateWithErrors(new AttributeImpl("", -123456789123457L), validator, 1);
+        validateWithErrors(new AttributeImpl("", 987654321987655L), validator, 1);
+
+        validateWithErrors(new AttributeImpl("", -123456789123456.1), validator, 1);
+        validateWithErrors(new AttributeImpl("", 987654321987654.1), validator, 1);
+    }
+
+    @Test
+    public void testWithinLargeDecimalRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("-123456789123456.857"),
+                new BigDecimal("987654321987654.923"),
+                new BigDecimal("0.01"));
+        validateNoErrors(new AttributeImpl("", -123456789123456.857), validator);
+        validateNoErrors(new AttributeImpl("", 987654321987654.923), validator);
+        validateNoErrors(new AttributeImpl("", 0), validator);
+
+        validateNoErrors(new AttributeImpl("", -123456789123456L), validator);
+        validateNoErrors(new AttributeImpl("", 987654321987654L), validator);
+    }
+
+    @Test
+    public void testOutsideLargeDecimalRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("-123456789123456.857"),
+                new BigDecimal("987654321987654.923"),
+                new BigDecimal("0.01"));
+        validateWithErrors(new AttributeImpl("", -123456789123456.87), validator, 1);
+        validateWithErrors(new AttributeImpl("", 987654321987654.94), validator, 1);
+
+        validateWithErrors(new AttributeImpl("", -123456789123457L), validator, 1);
+        validateWithErrors(new AttributeImpl("", 987654321987655L), validator, 1);
+    }
+
+    @Test
+    public void testWithinSmallDecimalRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("1.2457515"),
+                new BigDecimal("1.2487595"),
+                new BigDecimal("1E-7"));
+        validateNoErrors(new AttributeImpl("", 1.2457515), validator);
+        validateNoErrors(new AttributeImpl("", 1.2487595), validator);
+        validateNoErrors(new AttributeImpl("", 1.246), validator);
+    }
+
+    @Test
+    public void testOutsideSmallDecimalRange() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("1.2457515"),
+                new BigDecimal("1.2487595"),
+                new BigDecimal("1E-7"));
+        validateWithErrors(new AttributeImpl("", 1.24575135), validator, 1);
+        validateWithErrors(new AttributeImpl("", 1.24875965), validator, 1);
+
+        validateWithErrors(new AttributeImpl("", 1), validator, 1);
+        validateWithErrors(new AttributeImpl("", 2), validator, 1);
+    }
+
+    private void validateNoErrors(final Attribute attribute, final RangeValidator validator) {
+        final Optional<AttributeValidationReport> reportOptional = validator.validate(attribute);
+        assertThat(
+                "Expected no validation violations but a report was returned (which indicates that there are violations).",
+                reportOptional.isPresent(),
+                is(false));
+    }
+
+    private void validateWithErrors(final Attribute attribute, final RangeValidator validator,
+            final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional = validator.validate(attribute);
+        assertThat(
+                "Expected some validation violations but no report was returned (which indicates that there are no violations).",
+                reportOptional.isPresent(),
+                is(true));
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullMin() {
+        new RangeValidator(null, BigDecimal.ONE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullMax() {
+        new RangeValidator(BigDecimal.ONE, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullEpsilon() {
+        new RangeValidator(BigDecimal.ONE, BigDecimal.TEN, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRange() {
+        new RangeValidator(BigDecimal.TEN, BigDecimal.ONE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeEpsilon() {
+        new RangeValidator(BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(-1));
+    }
+
+    @Test
+    public void testEquals() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        assertThat(validator1.equals(validator2), is(true));
+        assertThat(validator2.equals(validator1), is(true));
+    }
+
+    @Test
+    public void testEqualsSelf() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        assertThat(validator.equals(validator), is(true));
+    }
+
+    @Test
+    public void testEqualsNull() {
+        final RangeValidator validator = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        assertThat(validator.equals(null), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentMin() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.1"),
+                new BigDecimal("2.5"));
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentMax() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.1"));
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testHashCode() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        assertThat(validator1.hashCode(), is(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentMin() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.1"),
+                new BigDecimal("2.5"));
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentMax() {
+        final RangeValidator validator1 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.5"));
+        final RangeValidator validator2 = new RangeValidator(new BigDecimal("1.5"),
+                new BigDecimal("2.1"));
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/RequiredAttributesMetacardValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/RequiredAttributesMetacardValidatorTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.validation.impl.validator.RequiredAttributesMetacardValidator;
+import ddf.catalog.validation.report.MetacardValidationReport;
+
+public class RequiredAttributesMetacardValidatorTest {
+    @Test
+    public void testValidMetacard() {
+        final Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl("title", "test"));
+        metacard.setAttribute(new AttributeImpl("created", new Date()));
+        metacard.setAttribute(new AttributeImpl("thumbnail", new byte[] {1, 2, 3, 4}));
+        validateNoErrors(metacard, Sets.newHashSet("title", "created", "thumbnail"));
+    }
+
+    @Test
+    public void testInvalidMetacard() {
+        final Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl("title", "test"));
+        metacard.setAttribute(new AttributeImpl("created", new Date()));
+        metacard.setAttribute(new AttributeImpl("thumbnail", new byte[] {1, 2, 3, 4}));
+        validateWithErrors(metacard,
+                Sets.newHashSet("title", "created", "thumbnail", "effective", "metadata"),
+                2);
+    }
+
+    private void validateNoErrors(final Metacard metacard, final Set<String> requiredAttributes) {
+        final Optional<MetacardValidationReport> reportOptional = getReportOptional(metacard,
+                requiredAttributes);
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final Metacard metacard, final Set<String> requiredAttributes,
+            final int expectedErrors) {
+        final Optional<MetacardValidationReport> reportOptional = getReportOptional(metacard,
+                requiredAttributes);
+        assertThat(reportOptional.get()
+                .getMetacardValidationViolations(), hasSize(expectedErrors));
+    }
+
+    private Optional<MetacardValidationReport> getReportOptional(final Metacard metacard,
+            final Set<String> requiredAttributes) {
+        final RequiredAttributesMetacardValidator validator =
+                new RequiredAttributesMetacardValidator(metacard.getMetacardType()
+                        .getName(), requiredAttributes);
+        return validator.validateMetacard(metacard);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullMetacardTypeName() {
+        new RequiredAttributesMetacardValidator(null, Sets.newHashSet("title"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullRequiredAttributes() {
+        new RequiredAttributesMetacardValidator("test", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyRequiredAttributes() {
+        new RequiredAttributesMetacardValidator("test", new HashSet<>());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullMetacard() {
+        new RequiredAttributesMetacardValidator("test", Sets.newHashSet("title")).validateMetacard(
+                null);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/SizeValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/SizeValidatorTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.validation.impl.validator.SizeValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class SizeValidatorTest {
+    @Test
+    public void testValidStringValue() {
+        validateNoErrors(new AttributeImpl("test", StringUtils.repeat("a", 33)), 0, 36);
+    }
+
+    @Test
+    public void testValidArrayValue() {
+        validateNoErrors(new AttributeImpl("test", new byte[15]), 10, 15);
+    }
+
+    @Test
+    public void testValidCollectionValue() {
+        validateNoErrors(new AttributeImpl("test", Sets.newHashSet(1, 2, 3, 4, 5)), 4, 6);
+    }
+
+    @Test
+    public void testValidMapValue() {
+        final HashMap<Integer, Integer> map = new HashMap<>();
+        map.put(1, 2);
+        validateNoErrors(new AttributeImpl("test", map), 0, 5);
+    }
+
+    @Test
+    public void testInvalidStringValue() {
+        validateWithErrors(new AttributeImpl("test", StringUtils.repeat("a", 33)), 40, 50, 1);
+    }
+
+    @Test
+    public void testInvalidArrayValue() {
+        validateWithErrors(new AttributeImpl("test", new byte[15]), 20, 25, 1);
+    }
+
+    @Test
+    public void testInvalidCollectionValue() {
+        validateWithErrors(new AttributeImpl("test", Sets.newHashSet(1, 2, 3, 4, 5)), 6, 8, 1);
+    }
+
+    @Test
+    public void testInvalidMapValue() {
+        validateWithErrors(new AttributeImpl("test", new HashMap<>()), 5, 10, 1);
+    }
+
+    private void validateNoErrors(final Attribute attribute, final long min, final long max) {
+        final Optional<AttributeValidationReport> reportOptional = getReportOptional(attribute,
+                min,
+                max);
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    private void validateWithErrors(final Attribute attribute, final long min, final long max,
+            final int expectedErrors) {
+        final Optional<AttributeValidationReport> reportOptional = getReportOptional(attribute,
+                min,
+                max);
+        assertThat(reportOptional.get()
+                .getAttributeValidationViolations(), hasSize(expectedErrors));
+    }
+
+    private Optional<AttributeValidationReport> getReportOptional(final Attribute attribute,
+            final long min, final long max) {
+        final SizeValidator validator = new SizeValidator(min, max);
+        return validator.validate(attribute);
+    }
+
+    @Test
+    public void testEquals() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(13, 1799);
+        assertThat(validator1.equals(validator1), is(true));
+        assertThat(validator1.equals(validator2), is(true));
+        assertThat(validator2.equals(validator1), is(true));
+    }
+
+    @Test
+    public void testEqualsSelf() {
+        final SizeValidator validator = new SizeValidator(13, 1799);
+        assertThat(validator.equals(validator), is(true));
+    }
+
+    @Test
+    public void testEqualsNull() {
+        final SizeValidator validator = new SizeValidator(13, 1799);
+        assertThat(validator.equals(null), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentMin() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(0, 1799);
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testEqualsDifferentMax() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(13, 2000);
+        assertThat(validator1.equals(validator2), is(false));
+        assertThat(validator2.equals(validator1), is(false));
+    }
+
+    @Test
+    public void testHashCode() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(13, 1799);
+        assertThat(validator1.hashCode(), is(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentMin() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(0, 1799);
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+
+    @Test
+    public void testHashCodeDifferentMax() {
+        final SizeValidator validator1 = new SizeValidator(13, 1799);
+        final SizeValidator validator2 = new SizeValidator(13, 2000);
+        assertThat(validator1.hashCode(), not(validator2.hashCode()));
+    }
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeRegistry.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeRegistry.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.data;
+
+import java.util.Optional;
+
+/**
+ * Manages registered attribute types.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface AttributeRegistry {
+    /**
+     * Registers a new attribute. Returns false if an attribute with the same name already exists
+     * (in which case the attribute is not registered) and true otherwise.
+     *
+     * @param attributeDescriptor the {@link AttributeDescriptor} describing the attribute
+     * @return whether the attribute was registered
+     * @throws IllegalArgumentException if {@code attributeDescriptor} or
+     *                                  {@link AttributeDescriptor#getName()} is null
+     */
+    boolean registerAttribute(AttributeDescriptor attributeDescriptor);
+
+    /**
+     * Removes an attribute from the registry.
+     * <p>
+     * Does nothing if no attribute by the name {@code name} exists in the registry.
+     *
+     * @param name the name of the attribute to remove
+     * @throws IllegalArgumentException if {@code name} is null
+     */
+    void deregisterAttribute(String name);
+
+    /**
+     * Gets the {@link AttributeDescriptor} for the attribute with the given name.
+     * <p>
+     * Returns an empty {@link Optional} if no attribute by the name {@code name} exists in the
+     * registry.
+     *
+     * @param name the name of the attribute
+     * @return an {@link Optional} containing the registered {@link AttributeDescriptor}
+     * @throws IllegalArgumentException if {@code name} is null
+     */
+    Optional<AttributeDescriptor> getAttributeDescriptor(String name);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/AttributeValidator.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/AttributeValidator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation;
+
+import java.util.Optional;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+/**
+ * A service that validates a single {@link ddf.catalog.data.Metacard} attribute and provides
+ * information if problems exist with the attribute's value.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface AttributeValidator {
+    /**
+     * Validates a single {@link Attribute}.
+     *
+     * @param attribute the {@link Attribute} to validate, cannot be null
+     * @return an {@link Optional} containing an {@link AttributeValidationReport} if there are
+     * violations, or an empty {@link Optional} if there are no violations
+     * @throws IllegalArgumentException if {@code attribute} is null
+     */
+    Optional<AttributeValidationReport> validate(Attribute attribute);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/AttributeValidatorRegistry.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/AttributeValidatorRegistry.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation;
+
+import java.util.Set;
+
+/**
+ * Manages registered attribute validators.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface AttributeValidatorRegistry {
+    /**
+     * Registers the given {@link AttributeValidator}(s) to the given attribute name.
+     * <p>
+     * This method doesn't care whether an attribute with the given name actually exists; it is only
+     * responsible for managing the validators associated with a given attribute name.
+     * <p>
+     * Note that the {@link AttributeValidator} implementations registered should implement
+     * {@link Object#hashCode()} and {@link Object#equals(Object)} so that duplicate validators
+     * aren't registered for an attribute.
+     *
+     * @param attributeName the name of the attribute that the given validators will validate
+     * @param validators    the {@link AttributeValidator}s to apply to the attribute
+     * @throws IllegalArgumentException if {@code attributeName} is null, or if no
+     *                                  {@link AttributeValidator}s were passed
+     */
+    void registerValidators(String attributeName, Set<? extends AttributeValidator> validators);
+
+    /**
+     * Deregisters all {@link AttributeValidator}s associated with the given attribute name.
+     * <p>
+     * Does nothing if there are no validators registered to the given attribute name.
+     *
+     * @param attributeName the name of the attribute whose validators will be deregistered, cannot
+     *                      be null
+     * @throws IllegalArgumentException if {@code attributeName} is null
+     */
+    void deregisterValidators(String attributeName);
+
+    /**
+     * Gets all the {@link AttributeValidator}s associated with the given attribute name.
+     *
+     * @param attributeName the name of the attribute, cannot be null
+     * @return the set of {@link AttributeValidator}s registered to the attribute, or an empty set
+     * if no attribute by that name exists.
+     * @throws IllegalArgumentException if {@code attributeName} is null
+     */
+    Set<AttributeValidator> getValidators(String attributeName);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/ReportingMetacardValidator.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/ReportingMetacardValidator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation;
+
+import java.util.Optional;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.validation.report.MetacardValidationReport;
+
+/**
+ * Validates a {@link Metacard} and provides information via a report if problems exist with the
+ * {@link Metacard}'s data.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface ReportingMetacardValidator {
+    /**
+     * Validates a {@link Metacard}.
+     *
+     * @param metacard the {@link Metacard} to validate, cannot be null
+     * @return an {@link Optional} containing a {@link MetacardValidationReport} if there are
+     * violations, or an empty {@link Optional} if there are no violations
+     * @throws IllegalArgumentException if {@code metacard} is null
+     */
+    Optional<MetacardValidationReport> validateMetacard(Metacard metacard);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/AttributeValidationReport.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/AttributeValidationReport.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.report;
+
+import java.util.Set;
+
+import ddf.catalog.validation.violation.ValidationViolation;
+
+/**
+ * Describes the outcome of validating a single metacard attribute.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface AttributeValidationReport {
+    /**
+     * Returns the set of {@link ValidationViolation}s for the validated attribute.
+     * <p>
+     * If there are no violations, this method just returns an empty set.
+     *
+     * @return the set of violations or an empty set if there are none
+     */
+    Set<ValidationViolation> getAttributeValidationViolations();
+
+    /**
+     * Returns a set of suggested values for the attribute.
+     * <p>
+     * If there are no suggested values, this method just returns an empty set.
+     *
+     * @return the set of suggested values or an empty set if there are none
+     */
+    Set<String> getSuggestedValues();
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/MetacardValidationReport.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/MetacardValidationReport.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.report;
+
+import java.util.Set;
+
+import ddf.catalog.validation.violation.ValidationViolation;
+
+/**
+ * Describes the outcome of validating a single {@link ddf.catalog.data.Metacard}.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface MetacardValidationReport {
+    /**
+     * Returns the set of {@link ValidationViolation}s representing the attribute-level
+     * violations on the validated {@link ddf.catalog.data.Metacard}.
+     * <p>
+     * If there are no attribute-level violations, this method just returns an empty set.
+     *
+     * @return the set of attribute-level violations or an empty set if there are none
+     */
+    Set<ValidationViolation> getAttributeValidationViolations();
+
+    /**
+     * Returns the set of {@link ValidationViolation}s representing the metacard-level
+     * violations on the validated {@link ddf.catalog.data.Metacard}.
+     * <p>
+     * If there are no metacard-level violations, this method just returns an empty set.
+     *
+     * @return the set of metacard-level violations or an empty set if there are none
+     */
+    Set<ValidationViolation> getMetacardValidationViolations();
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/violation/ValidationViolation.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/violation/ValidationViolation.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.violation;
+
+import java.util.Set;
+
+/**
+ * Describes a violation of a constraint on an attribute or metacard.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface ValidationViolation {
+    /**
+     * Describes the severity of a validation violation. An error is a violation severe enough to
+     * cause validation to fail, and a warning is a less severe violation unrelated to validation
+     * failure.
+     */
+    enum Severity {
+        WARNING,
+        ERROR
+    }
+
+    /**
+     * Returns the severity of the violation. Cannot return null.
+     *
+     * @return the severity
+     */
+    Severity getSeverity();
+
+    /**
+     * Returns a message describing the violation. Cannot return null.
+     *
+     * @return the message
+     */
+    String getMessage();
+
+    /**
+     * Returns the name(s) of the attribute(s) associated with the violation. Cannot return null.
+     *
+     * @return the set of names
+     */
+    Set<String> getAttributes();
+}

--- a/catalog/core/catalog-core-attribute-registry/pom.xml
+++ b/catalog/core/catalog-core-attribute-registry/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -11,73 +11,50 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
--->
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
+        <groupId>ddf.catalog.core</groupId>
         <version>2.9.0-SNAPSHOT</version>
     </parent>
-    <artifactId>catalog-core-api-impl</artifactId>
-    <name>DDF :: Catalog :: Core :: API :: Impl</name>
-    <description>Implementations of the DDF Catalog Core API</description>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-core-attribute-registry</artifactId>
+    <name>DDF :: Catalog :: Core :: Attribute Registry</name>
+    <packaging>bundle</packaging>
+
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-main</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>0.9.24</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
     </dependencies>
+
     <build>
         <plugins>
-            <!-- Export mock objects in test JAR for use by other projects -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
-                    <!-- Turns off the generation of txt file reports, change to true for
-                        debugging. -->
-                    <useFile>false</useFile>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                    </instructions>
                 </configuration>
             </plugin>
             <plugin>
@@ -98,22 +75,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.97</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.33</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>1.00</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -122,13 +99,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Generate Javadocs for this project -->
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
 </project>

--- a/catalog/core/catalog-core-attribute-registry/src/main/java/ddf/catalog/data/impl/AttributeRegistryImpl.java
+++ b/catalog/core/catalog-core-attribute-registry/src/main/java/ddf/catalog/data/impl/AttributeRegistryImpl.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.data.impl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
+
+public class AttributeRegistryImpl implements AttributeRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttributeRegistryImpl.class);
+
+    private final Map<String, AttributeDescriptor> attributeMap = new ConcurrentHashMap<>();
+
+    public AttributeRegistryImpl() {
+        BasicTypes.BASIC_METACARD.getAttributeDescriptors()
+                .stream()
+                .forEach(this::registerAttribute);
+    }
+
+    @Override
+    public boolean registerAttribute(final AttributeDescriptor attributeDescriptor) {
+        Preconditions.checkArgument(attributeDescriptor != null,
+                "The attribute descriptor cannot be null.");
+        Preconditions.checkArgument(attributeDescriptor.getName() != null,
+                "The attribute name cannot be null.");
+
+        final String name = attributeDescriptor.getName();
+
+        if (attributeMap.putIfAbsent(name, attributeDescriptor) == null) {
+            return true;
+        }
+
+        LOGGER.debug(
+                "Attempted to register an attribute with name '{}', but an attribute with that name already exists.",
+                name);
+        return false;
+    }
+
+    @Override
+    public void deregisterAttribute(final String name) {
+        Preconditions.checkArgument(name != null, "The attribute name cannot be null.");
+
+        attributeMap.remove(name);
+    }
+
+    @Override
+    public Optional<AttributeDescriptor> getAttributeDescriptor(final String name) {
+        Preconditions.checkArgument(name != null, "The attribute name cannot be null.");
+
+        return Optional.ofNullable(attributeMap.get(name));
+    }
+}

--- a/catalog/core/catalog-core-attribute-registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-attribute-registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="attributeRegistry" class="ddf.catalog.data.impl.AttributeRegistryImpl"/>
+
+    <service ref="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+
+</blueprint>

--- a/catalog/core/catalog-core-attribute-registry/src/test/java/ddf/catalog/data/impl/AttributeRegistryImplTest.java
+++ b/catalog/core/catalog-core-attribute-registry/src/test/java/ddf/catalog/data/impl/AttributeRegistryImplTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.data.impl;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
+
+public class AttributeRegistryImplTest {
+    private AttributeRegistry registry;
+
+    @Before
+    public void setup() {
+        registry = new AttributeRegistryImpl();
+    }
+
+    @Test
+    public void testAddAttribute() {
+        final AttributeDescriptor descriptor = new AttributeDescriptorImpl("test",
+                true,
+                false,
+                true,
+                false,
+                BasicTypes.STRING_TYPE);
+        assertThat(registry.registerAttribute(descriptor), is(true));
+
+        final Optional<AttributeDescriptor> descriptorOptional = registry.getAttributeDescriptor(
+                "test");
+        assertThat(descriptorOptional.isPresent(), is(true));
+        assertThat(descriptorOptional.get(), is(descriptor));
+    }
+
+    @Test
+    public void testRemoveAttribute() {
+        final AttributeDescriptor descriptor = new AttributeDescriptorImpl("test",
+                true,
+                false,
+                true,
+                false,
+                BasicTypes.STRING_TYPE);
+        assertThat(registry.registerAttribute(descriptor), is(true));
+
+        Optional<AttributeDescriptor> descriptorOptional = registry.getAttributeDescriptor("test");
+        assertThat(descriptorOptional.isPresent(), is(true));
+
+        registry.deregisterAttribute("test");
+        descriptorOptional = registry.getAttributeDescriptor("test");
+        assertThat(descriptorOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testAddAttributeWithSameName() {
+        final AttributeDescriptor descriptor1 = new AttributeDescriptorImpl("test",
+                true,
+                true,
+                true,
+                true,
+                BasicTypes.STRING_TYPE);
+        assertThat(registry.registerAttribute(descriptor1), is(true));
+
+        final AttributeDescriptor descriptor2 = new AttributeDescriptorImpl("test",
+                false,
+                false,
+                false,
+                false,
+                BasicTypes.BINARY_TYPE);
+        assertThat(registry.registerAttribute(descriptor2), is(false));
+
+        final Optional<AttributeDescriptor> descriptorOptional = registry.getAttributeDescriptor(
+                "test");
+        assertThat(descriptorOptional.isPresent(), is(true));
+        assertThat(descriptorOptional.get(), is(descriptor1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttributeDescriptor() {
+        registry.registerAttribute(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttributeDescriptorName() {
+        final AttributeDescriptor descriptor = new AttributeDescriptorImpl(null,
+                true,
+                false,
+                true,
+                false,
+                BasicTypes.STRING_TYPE);
+        registry.registerAttribute(descriptor);
+    }
+}

--- a/catalog/core/catalog-core-validator/pom.xml
+++ b/catalog/core/catalog-core-validator/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -11,117 +11,115 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
--->
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
         <version>2.9.0-SNAPSHOT</version>
     </parent>
-    <artifactId>catalog-core-api</artifactId>
-    <name>DDF :: Catalog :: Core :: API</name>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-core-validator</artifactId>
     <packaging>bundle</packaging>
+    <name>DDF :: Catalog :: Core :: Validator</name>
+
     <dependencies>
         <dependency>
-            <groupId>ddf.mime.core</groupId>
-            <artifactId>mime-core-api</artifactId>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-opengis</artifactId>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-ext</artifactId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <groupId>io.fastjson</groupId>
+            <artifactId>boon</artifactId>
+            <version>0.33</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.fileinstall</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-bundle</artifactId>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attribute-registry</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
+
+        <!-- groovy dependencies -->
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-main</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>0.9.24</version>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>common-system</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.platform.api</groupId>
-            <artifactId>platform-api</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>1.0-groovy-2.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>findbugs</artifactId>
-            <scope>compile</scope>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system</Embed-Dependency>
-                        <Export-Package>
-                            ddf.catalog*
-                        </Export-Package>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util,
+
+                            <!--external-->
+                            boon,
+                            commons-lang3
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !com.sun.management,
+                            *
+                        </Import-Package>
                     </instructions>
-                </configuration>
-            </plugin>
-            <!-- Export mock objects in test JAR for use by other projects -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Turns off the generation of txt file reports, change to true for
-                        debugging. -->
-                    <useFile>false</useFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -142,22 +140,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -166,12 +164,18 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Generate Javadocs for this project -->
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/AttributeValidatorRegistryImpl.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/AttributeValidatorRegistryImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.AttributeValidatorRegistry;
+
+public class AttributeValidatorRegistryImpl implements AttributeValidatorRegistry {
+    private final Map<String, Set<AttributeValidator>> attributeValidatorMap =
+            new ConcurrentHashMap<>();
+
+    @Override
+    public void registerValidators(final String attributeName,
+            final Set<? extends AttributeValidator> validators) {
+        Preconditions.checkArgument(attributeName != null, "The attribute name cannot be null.");
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(validators),
+                "Must register at least one validator.");
+
+        attributeValidatorMap.compute(attributeName, (name, registeredValidators) -> {
+            if (registeredValidators == null) {
+                return new HashSet<>(validators);
+            } else {
+                registeredValidators.addAll(validators);
+                return registeredValidators;
+            }
+        });
+    }
+
+    @Override
+    public void deregisterValidators(final String attributeName) {
+        Preconditions.checkArgument(attributeName != null, "The attribute name cannot be null.");
+
+        attributeValidatorMap.remove(attributeName);
+    }
+
+    @Override
+    public Set<AttributeValidator> getValidators(final String attributeName) {
+        Preconditions.checkArgument(attributeName != null, "The attribute name cannot be null.");
+
+        return Collections.unmodifiableSet(attributeValidatorMap.getOrDefault(attributeName,
+                Collections.emptySet()));
+    }
+}

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImpl.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImpl.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.AttributeValidatorRegistry;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ReportingMetacardValidator;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.report.MetacardValidationReportImpl;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+import ddf.catalog.validation.violation.ValidationViolation.Severity;
+
+/**
+ * Default {@link Metacard} validator that validates all of a {@link Metacard}'s attributes using
+ * the {@link AttributeValidator}s registered in the attribute validator registry.
+ */
+public class ReportingMetacardValidatorImpl
+        implements MetacardValidator, ReportingMetacardValidator {
+    private final AttributeValidatorRegistry validatorRegistry;
+
+    public ReportingMetacardValidatorImpl(final AttributeValidatorRegistry validatorRegistry) {
+        this.validatorRegistry = validatorRegistry;
+    }
+
+    private void getMessages(final Set<ValidationViolation> violations, final List<String> warnings,
+            final List<String> errors) {
+        for (final ValidationViolation violation : violations) {
+            if (violation.getSeverity() == Severity.WARNING) {
+                warnings.add(violation.getMessage());
+            } else {
+                errors.add(violation.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void validate(final Metacard metacard) throws ValidationException {
+        final Optional<MetacardValidationReport> reportOptional = validateMetacard(metacard);
+
+        if (reportOptional.isPresent()) {
+            final MetacardValidationReport report = reportOptional.get();
+            final List<String> warnings = new ArrayList<>();
+            final List<String> errors = new ArrayList<>();
+
+            getMessages(report.getAttributeValidationViolations(), warnings, errors);
+            getMessages(report.getMetacardValidationViolations(), warnings, errors);
+
+            final ValidationExceptionImpl exception = new ValidationExceptionImpl();
+            exception.setWarnings(warnings);
+            exception.setErrors(errors);
+
+            throw exception;
+        }
+    }
+
+    @Override
+    public Optional<MetacardValidationReport> validateMetacard(final Metacard metacard) {
+        Preconditions.checkArgument(metacard != null, "The metacard cannot be null.");
+
+        final Set<ValidationViolation> violations = new HashSet<>();
+
+        for (final AttributeDescriptor descriptor : metacard.getMetacardType()
+                .getAttributeDescriptors()) {
+            final String attributeName = descriptor.getName();
+            final Attribute attribute = metacard.getAttribute(attributeName);
+            if (attribute != null) {
+                for (final AttributeValidator validator : validatorRegistry.getValidators(
+                        attributeName)) {
+                    validator.validate(attribute)
+                            .ifPresent(report -> violations.addAll(report.getAttributeValidationViolations()));
+                }
+            }
+        }
+
+        if (violations.size() > 0) {
+            return getReport(violations);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<MetacardValidationReport> getReport(
+            final Set<ValidationViolation> violations) {
+        final MetacardValidationReportImpl report = new MetacardValidationReportImpl();
+        violations.forEach(report::addAttributeViolation);
+        return Optional.of(report);
+    }
+}

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.fileinstall.ArtifactInstaller;
+import org.boon.json.JsonFactory;
+import org.boon.json.annotations.JsonIgnore;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.AttributeValidatorRegistry;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.impl.validator.EnumerationValidator;
+import ddf.catalog.validation.impl.validator.FutureDateValidator;
+import ddf.catalog.validation.impl.validator.PastDateValidator;
+import ddf.catalog.validation.impl.validator.PatternValidator;
+import ddf.catalog.validation.impl.validator.RangeValidator;
+import ddf.catalog.validation.impl.validator.RequiredAttributesMetacardValidator;
+import ddf.catalog.validation.impl.validator.SizeValidator;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings
+public class ValidationParser implements ArtifactInstaller {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationParser.class);
+
+    private AttributeRegistry attributeRegistry;
+
+    private AttributeValidatorRegistry attributeValidatorRegistry;
+
+    private static Map<String, Outer> sourceMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void install(File file) throws Exception {
+        String data;
+        try (InputStream input = new FileInputStream(file)) {
+            data = IOUtils.toString(input, StandardCharsets.UTF_8.name());
+            LOGGER.debug("Installing file [{}}. Contents:\n{}", file.getAbsolutePath(), data);
+        }
+        if (StringUtils.isEmpty(data)) {
+            LOGGER.warn("File is empty [{}]", file.getAbsolutePath());
+            return; /* nothing to install */
+        }
+
+        Outer outer;
+        try {
+            outer = JsonFactory.create()
+                    .readValue(data, Outer.class);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("Cannot parse json [" + file.getAbsolutePath() + "]",
+                    e);
+        }
+
+        /* Must manually parse validators */
+        Map<String, Object> root = JsonFactory.create()
+                .parser()
+                .parseMap(data);
+        parseValidators(root, outer);
+
+        sourceMap.put(file.getName(), outer);
+        List<Callable<Boolean>> stagedAdds = new ArrayList<>();
+
+        try {
+            if (outer.attributeTypes != null) {
+                stagedAdds.addAll(parseAttributeTypes(outer.attributeTypes));
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Could not parse Attribute Types section of [" + file.getAbsolutePath() + "]",
+                    e);
+        }
+        LOGGER.debug("Committing staged attribute type definitions.");
+        commitStaged(stagedAdds);
+
+        try {
+            if (outer.metacardTypes != null) {
+                stagedAdds.addAll(parseMetacardTypes(outer.metacardTypes));
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Could not parse Metacard Types section of [" + file.getAbsolutePath() + "]",
+                    e);
+        }
+        LOGGER.debug("Committing staged metacard type definitions.");
+        commitStaged(stagedAdds);
+
+        try {
+            if (outer.validators != null) {
+                stagedAdds.addAll(parseValidators(outer.validators));
+
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Could not parse Validators section of [" + file.getAbsolutePath() + "]", e);
+        }
+        LOGGER.debug("Committing staged validator definitions.");
+        commitStaged(stagedAdds);
+    }
+
+    private void commitStaged(Collection<Callable<Boolean>> stagedAdds) throws Exception {
+        for (Callable<Boolean> staged : stagedAdds) {
+            try {
+                staged.call();
+            } catch (RuntimeException e) {
+                LOGGER.warn("Error adding staged item {}", staged, e);
+            }
+        }
+        stagedAdds.clear();
+    }
+
+    @Override
+    public void update(File file) throws Exception {
+    }
+
+    @Override
+    public void uninstall(File file) throws Exception {
+    }
+
+    @Override
+    public boolean canHandle(File file) {
+        return file.getName()
+                .endsWith(".json");
+    }
+
+    public void setAttributeRegistry(AttributeRegistry attributeRegistry) {
+        this.attributeRegistry = attributeRegistry;
+    }
+
+    public void setAttributeValidatorRegistry(
+            AttributeValidatorRegistry attributeValidatorRegistry) {
+        this.attributeValidatorRegistry = attributeValidatorRegistry;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void parseValidators(Map<String, Object> root, Outer outer) {
+        if (root == null || root.get("validators") == null) {
+            return;
+        }
+
+        Map<String, List<Outer.Validator>> validators = new HashMap<>();
+        for (Map.Entry<String, Object> entry : ((Map<String, Object>) root.get("validators")).entrySet()) {
+            String rejson = JsonFactory.create()
+                    .toJson(entry.getValue());
+            List<Outer.Validator> lv = JsonFactory.create()
+                    .readValue(rejson, List.class, Outer.Validator.class);
+            validators.put(entry.getKey(), lv);
+        }
+        outer.validators = validators;
+    }
+
+    private List<Callable<Boolean>> parseAttributeTypes(
+            Map<String, Outer.AttributeType> attributeTypes) {
+        List<Callable<Boolean>> staged = new ArrayList<>();
+        for (Map.Entry<String, Outer.AttributeType> entry : attributeTypes.entrySet()) {
+            final AttributeDescriptor descriptor = new AttributeDescriptorImpl(entry.getKey(),
+                    entry.getValue().indexed,
+                    entry.getValue().stored,
+                    entry.getValue().tokenized,
+                    entry.getValue().multivalued,
+                    BasicTypes.getAttributeType(entry.getValue().type));
+
+            staged.add(() -> attributeRegistry.registerAttribute(descriptor));
+        }
+        return staged;
+    }
+
+    private List<Callable<Boolean>> parseMetacardTypes(List<Outer.MetacardType> metacardTypes) {
+        List<Callable<Boolean>> staged = new ArrayList<>();
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle == null) {
+            LOGGER.warn(String.format(
+                    "Unable to get bundle for [%s], Metacard Types will not be registered",
+                    this.getClass()
+                            .getName()));
+            return new ArrayList<>();
+        }
+        BundleContext context = bundle.getBundleContext();
+        for (Outer.MetacardType metacardType : metacardTypes) {
+            Set<AttributeDescriptor> attributeDescriptors =
+                    new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+            Set<String> requiredAttributes = new HashSet<>();
+
+            for (Map.Entry<String, Outer.MetacardAttribute> entry : metacardType.attributes.entrySet()) {
+                String attributeName = entry.getKey();
+                AttributeDescriptor descriptor = attributeRegistry.getAttributeDescriptor(
+                        attributeName)
+                        .orElseThrow(() -> new IllegalStateException(String.format(
+                                "Metacard type [%s] includes the attribute [%s], but that attribute is not in the attribute registry.",
+                                metacardType.type,
+                                attributeName)));
+                attributeDescriptors.add(descriptor);
+                if (entry.getValue().required) {
+                    requiredAttributes.add(attributeName);
+                }
+            }
+            if (!requiredAttributes.isEmpty()) {
+                final MetacardValidator validator = new RequiredAttributesMetacardValidator(
+                        metacardType.type,
+                        requiredAttributes);
+                staged.add(() -> context.registerService(MetacardValidator.class, validator, null)
+                        != null);
+            }
+            Dictionary<String, Object> properties = new Hashtable<>();
+            properties.put("name", metacardType.type);
+            MetacardType type = new MetacardTypeImpl(metacardType.type, attributeDescriptors);
+            staged.add(() -> context.registerService(MetacardType.class, type, properties) != null);
+        }
+        return staged;
+    }
+
+    private List<Callable<Boolean>> parseValidators(Map<String, List<Outer.Validator>> validators) {
+        List<Callable<Boolean>> staged = new ArrayList<>();
+        for (Map.Entry<String, List<Outer.Validator>> entry : validators.entrySet()) {
+            Set<AttributeValidator> attributeValidators = validatorFactory(entry.getValue());
+            staged.add(() -> {
+                attributeValidatorRegistry.registerValidators(entry.getKey(), attributeValidators);
+                return true;
+            });
+        }
+        return staged;
+    }
+
+    private Set<AttributeValidator> validatorFactory(List<Outer.Validator> validators) {
+        return validators.stream()
+                .filter(Objects::nonNull)
+                .filter(v -> StringUtils.isNotBlank(v.validator))
+                .map(this::getValidator)
+                .collect(Collectors.toSet());
+    }
+
+    private AttributeValidator getValidator(Outer.Validator validator) {
+        switch (validator.validator) {
+        case "size": {
+            long lmin = Long.parseLong(validator.arguments.get(0));
+            long lmax = Long.parseLong(validator.arguments.get(1));
+            return new SizeValidator(lmin, lmax);
+        }
+        case "pattern": {
+            String regex = validator.arguments.get(0);
+            return new PatternValidator(regex);
+        }
+        case "pastdate": {
+            return PastDateValidator.getInstance();
+        }
+        case "futuredate": {
+            return FutureDateValidator.getInstance();
+        }
+        case "enumeration": {
+            Set<String> values = new HashSet<>(validator.arguments);
+            return new EnumerationValidator(values);
+        }
+        case "range": {
+            BigDecimal min = new BigDecimal(validator.arguments.get(0));
+            BigDecimal max = new BigDecimal(validator.arguments.get(1));
+            if (validator.arguments.size() > 2) {
+                BigDecimal epsilon = new BigDecimal(validator.arguments.get(2));
+                return new RangeValidator(min, max, epsilon);
+            }
+            return new RangeValidator(min, max);
+        }
+        default:
+            throw new IllegalStateException(
+                    "Validator does not exist. (" + validator.validator + ")");
+        }
+    }
+
+    private class Outer {
+        List<MetacardType> metacardTypes;
+
+        Map<String, AttributeType> attributeTypes;
+
+        @JsonIgnore
+        Map<String, List<Validator>> validators;
+
+        class MetacardType {
+            String type;
+
+            Map<String, MetacardAttribute> attributes;
+        }
+
+        class MetacardAttribute {
+            boolean required;
+        }
+
+        class AttributeType {
+            String type;
+
+            boolean tokenized;
+
+            boolean stored;
+
+            boolean indexed;
+
+            boolean multivalued;
+        }
+
+        class Validator {
+            String validator;
+
+            List<String> arguments;
+        }
+    }
+
+}

--- a/catalog/core/catalog-core-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="metacardValidator" class="ddf.catalog.validation.impl.ReportingMetacardValidatorImpl">
+        <argument ref="attributeValidatorRegistry"/>
+    </bean>
+
+    <service ref="metacardValidator">
+        <interfaces>
+            <value>ddf.catalog.validation.MetacardValidator</value>
+            <value>ddf.catalog.validation.ReportingMetacardValidator</value>
+        </interfaces>
+    </service>
+
+    <bean id="attributeValidatorRegistry"
+          class="ddf.catalog.validation.impl.AttributeValidatorRegistryImpl"/>
+
+    <service ref="attributeValidatorRegistry"
+             interface="ddf.catalog.validation.AttributeValidatorRegistry"/>
+
+    <bean id="validationDeployer" class="ddf.catalog.validation.impl.ValidationParser">
+        <property name="attributeRegistry">
+            <reference interface="ddf.catalog.data.AttributeRegistry"/>
+        </property>
+        <property name="attributeValidatorRegistry" ref="attributeValidatorRegistry"/>
+    </bean>
+
+    <service ref="validationDeployer" interface="org.apache.felix.fileinstall.ArtifactInstaller"/>
+
+</blueprint>

--- a/catalog/core/catalog-core-validator/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpecTest.groovy
+++ b/catalog/core/catalog-core-validator/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpecTest.groovy
@@ -1,0 +1,172 @@
+package ddf.catalog.validation.impl
+
+import ddf.catalog.data.AttributeRegistry
+import ddf.catalog.data.impl.AttributeRegistryImpl
+import ddf.catalog.validation.AttributeValidatorRegistry
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ValidationParserSpecTest extends Specification {
+    @Rule
+    TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    ValidationParser validationParser = new ValidationParser();
+
+    AttributeRegistry attributeRegistry
+
+    AttributeValidatorRegistry attributeValidatorRegistry
+
+    File file
+
+    void setup() {
+        attributeRegistry = new AttributeRegistryImpl()
+        validationParser.attributeRegistry = attributeRegistry
+
+        attributeValidatorRegistry = new AttributeValidatorRegistryImpl()
+        validationParser.attributeValidatorRegistry = attributeValidatorRegistry
+        file = temporaryFolder.newFile("temp.json")
+    }
+
+    void cleanup() {
+
+    }
+
+    def "Test Blank File"() {
+        when: "Blank file installed should be noop"
+        validationParser.install(file)
+
+        then:
+        notThrown(Exception)
+    }
+
+    def "test empty object"() {
+        setup:
+        file.withPrintWriter { it.write('{}') }
+
+        when:
+        validationParser.install(file)
+
+        then:
+        notThrown(Exception)
+    }
+
+    def "test garbage file"() {
+        setup:
+        file.withPrintWriter { it.write('lk124!%^(#)zjlksdf@#%!@%spacecats243623ZCBV\\|') }
+
+        when:
+        validationParser.install(file)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "test valid file"() {
+        setup:
+        file.withPrintWriter { it.write(valid) }
+
+        when:
+        validationParser.install(file)
+
+        then:
+        attributeRegistry.getAttributeDescriptor("cool-attribute").isPresent()
+        attributeRegistry.getAttributeDescriptor("geospatial-goodness").isPresent()
+
+        def validators = attributeValidatorRegistry.getValidators("cool-attribute")
+        validators.size() == 2
+    }
+
+    def "test invalid validators"() {
+        setup:
+        file.withPrintWriter { it.write(invalidValidator) }
+
+        when:
+        validationParser.install(file)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "ensure transaction component completely fails if one part fails"() {
+        setup: "break the validators section, so no validators should get in"
+        file.withPrintWriter { it.write(valid.replace("pattern", "spacecats")) }
+
+        when:
+        validationParser.install(file)
+
+        then:
+        thrown(IllegalArgumentException)
+        attributeRegistry.getAttributeDescriptor("cool-attribute").isPresent()
+        attributeValidatorRegistry.getValidators("cool-attribute").size() == 0
+    }
+
+    String valid = '''
+{
+    "metacardTypes": [
+        {
+            "type": "my-metacard-type",
+            "attributes": {
+                "cool-attribute": {
+                    "required": true
+                },
+                "geospatial-goodness": {
+                    "required": false
+                }
+            }
+        },
+        {
+            "type": "another-useful-type",
+            "attributes": {
+                "cool-attribute": {
+                    "required": false
+                },
+                "useful-attribute": {
+                    "required": false
+                }
+            }
+        }
+    ],
+    "attributeTypes": {
+        "cool-attribute": {
+            "type": "STRING_TYPE",
+            "stored": true,
+            "indexed": true,
+            "tokenized": false,
+            "multivalued": false
+        },
+        "geospatial-goodness": {
+            "type": "XML_TYPE",
+            "stored": true,
+            "indexed": true,
+            "tokenized": false,
+            "multivalued": true
+        }
+    },
+    "validators": {
+        "cool-attribute": [
+            {
+                "validator": "size",
+                "arguments": ["0", "128"]
+            },
+            {
+                "validator": "pattern",
+                "arguments": ["(hi)+\\d"]
+            }
+        ]
+    }
+}
+'''
+    def invalidValidator = '''
+{
+    "validators": {
+        "cool-attribute": [
+            {
+                "validator": "spacecats",
+                "arguments": ["(hi)+\\d"]
+            }
+        ]
+    }
+}'''
+
+}

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/AttributeValidatorRegistryImplTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/AttributeValidatorRegistryImplTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import ddf.catalog.validation.AttributeValidatorRegistry;
+import ddf.catalog.validation.impl.validator.PastDateValidator;
+import ddf.catalog.validation.impl.validator.PatternValidator;
+import ddf.catalog.validation.impl.validator.SizeValidator;
+
+public class AttributeValidatorRegistryImplTest {
+    private AttributeValidatorRegistry registry;
+
+    @Before
+    public void setup() {
+        registry = new AttributeValidatorRegistryImpl();
+    }
+
+    @Test
+    public void testRegisterValidators() {
+        registry.registerValidators("title",
+                Sets.newHashSet(new SizeValidator(1, 10), new PatternValidator("\\d+")));
+        assertThat(registry.getValidators("title"), hasSize(2));
+
+        registry.registerValidators("title", Sets.newHashSet(PastDateValidator.getInstance()));
+        assertThat(registry.getValidators("title"), hasSize(3));
+    }
+
+    @Test
+    public void testDeregisterValidators() {
+        registry.registerValidators("title",
+                Sets.newHashSet(new SizeValidator(1, 10), new PatternValidator("\\d+")));
+        assertThat(registry.getValidators("title"), hasSize(2));
+
+        registry.deregisterValidators("title");
+        assertThat(registry.getValidators("title"), empty());
+    }
+
+    @Test
+    public void testRegisterValidatorsForMultipleAttributes() {
+        registry.registerValidators("title",
+                Sets.newHashSet(new SizeValidator(1, 10), new PatternValidator("\\d+")));
+        registry.registerValidators("modified", Sets.newHashSet(PastDateValidator.getInstance()));
+        assertThat(registry.getValidators("title"), hasSize(2));
+        assertThat(registry.getValidators("modified"), hasSize(1));
+    }
+
+    @Test
+    public void testRegisterDuplicateValidator() {
+        registry.registerValidators("title", Sets.newHashSet(new SizeValidator(1, 10)));
+        assertThat(registry.getValidators("title"), hasSize(1));
+
+        registry.registerValidators("title", Sets.newHashSet(new SizeValidator(1, 10)));
+        assertThat(registry.getValidators("title"), hasSize(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullAttributeName() {
+        registry.registerValidators(null, Sets.newHashSet(PastDateValidator.getInstance()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterNoValidators() {
+        registry.registerValidators("title", Collections.emptySet());
+    }
+}

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImplTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImplTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.validation.AttributeValidatorRegistry;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.validator.EnumerationValidator;
+import ddf.catalog.validation.impl.validator.FutureDateValidator;
+import ddf.catalog.validation.impl.validator.PastDateValidator;
+import ddf.catalog.validation.impl.validator.PatternValidator;
+import ddf.catalog.validation.impl.validator.SizeValidator;
+import ddf.catalog.validation.report.MetacardValidationReport;
+
+public class ReportingMetacardValidatorImplTest {
+    private AttributeValidatorRegistry registry;
+
+    private ReportingMetacardValidatorImpl validator;
+
+    private static final Date PAST_DATE = Date.from(Instant.now()
+            .minus(5, DAYS));
+
+    private static final Date FUTURE_DATE = Date.from(Instant.now()
+            .plus(5, DAYS));
+
+    @Before
+    public void setup() {
+        registry = new AttributeValidatorRegistryImpl();
+        validator = new ReportingMetacardValidatorImpl(registry);
+        registerValidators();
+    }
+
+    private void registerValidators() {
+        registry.registerValidators(Metacard.TITLE,
+                Sets.newHashSet(new SizeValidator(1, 20), new PatternValidator("[A-Z]+")));
+        registry.registerValidators(Metacard.MODIFIED,
+                Sets.newHashSet(PastDateValidator.getInstance()));
+        registry.registerValidators(Metacard.EFFECTIVE,
+                Sets.newHashSet(FutureDateValidator.getInstance()));
+        final EnumerationValidator enumerationValidator = new EnumerationValidator(Sets.newHashSet(
+                "application/xml",
+                "text/xml"));
+        registry.registerValidators(Metacard.CONTENT_TYPE, Sets.newHashSet(enumerationValidator));
+    }
+
+    private Metacard getValidMetacard() {
+        final MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("VALIDTITLE");
+        metacard.setModifiedDate(PAST_DATE);
+        metacard.setEffectiveDate(FUTURE_DATE);
+        metacard.setContentTypeName("application/xml");
+        return metacard;
+    }
+
+    private Metacard getInvalidMetacard() {
+        final MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("title is too long and doesn't match the pattern");
+        metacard.setModifiedDate(FUTURE_DATE);
+        metacard.setEffectiveDate(PAST_DATE);
+        metacard.setContentTypeName("application/json");
+        return metacard;
+    }
+
+    @Test
+    public void testValidateValidMetacardByReport() {
+        final Optional<MetacardValidationReport> reportOptional = validator.validateMetacard(
+                getValidMetacard());
+        assertThat(reportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testValidateInvalidMetacardByReport() {
+        final Optional<MetacardValidationReport> reportOptional = validator.validateMetacard(
+                getInvalidMetacard());
+        assertThat(
+                "Expected some validation violations but no report was returned (which indicates that there are no violations).",
+                reportOptional.isPresent(),
+                is(true));
+
+        final MetacardValidationReport report = reportOptional.get();
+        // 2 title violations and 1 violation each for modified, effective, and content type
+        assertThat(report.getAttributeValidationViolations(), hasSize(5));
+        assertThat(report.getMetacardValidationViolations(), empty());
+
+        final List<String> violatedAttributes = report.getAttributeValidationViolations()
+                .stream()
+                .flatMap(violation -> violation.getAttributes()
+                        .stream())
+                .collect(Collectors.toList());
+        assertThat(violatedAttributes,
+                containsInAnyOrder(Metacard.TITLE,
+                        Metacard.TITLE,
+                        Metacard.MODIFIED,
+                        Metacard.EFFECTIVE,
+                        Metacard.CONTENT_TYPE));
+    }
+
+    @Test
+    public void testValidateValidMetacardByException() {
+        try {
+            validator.validate(getValidMetacard());
+        } catch (ValidationException e) {
+            assertThat(e.getErrors(), nullValue());
+            assertThat(e.getWarnings(), nullValue());
+        }
+    }
+
+    @Test
+    public void testValidateInvalidMetacardByException() {
+        try {
+            validator.validate(getInvalidMetacard());
+        } catch (ValidationException e) {
+            // 2 title violations and 1 violation each for modified, effective, and content type
+            assertThat(e.getErrors(), hasSize(5));
+            assertThat(e.getWarnings(), nullValue());
+        }
+    }
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -112,5 +112,7 @@
         <module>catalog-core-camelcontext</module>
         <module>catalog-core-directorymonitor</module>
         <module>catalog-core-versioning</module>
+        <module>catalog-core-validator</module>
+        <module>catalog-core-attribute-registry</module>
     </modules>
 </project>

--- a/catalog/docs/src/main/resources/_contents/integrating-contents.adoc
+++ b/catalog/docs/src/main/resources/_contents/integrating-contents.adoc
@@ -1394,9 +1394,294 @@ Schematron files may reference other schematron files using an include statement
 However, when using the document function within a schematron ruleset to reference another file, the path must be absolute or relative to the ${ddf-branding} installation home directory.
 ====
 
-===== Configuring
+==== Configuring
 
 Schematron validation services are configured with a namespace and one or more schematron rule sets.
 Additionally, warnings may be suppressed so that only errors are reported.
 To create a new service, ensure that catalog-schematron-plugin is started and then click Schematron Validation Services.
 
+=== Adding New Attribute Types, Metacard Types, and Validators Using JSON Files
+
+[WARNING]
+====
+This section concerns capabilities that are considered experimental. The features described in this section may change or be removed in a future version of the application.
+====
+
+==== Definition File Format
+
+Metacard Types, Attribute Types, and global Attribute Validators can be defined within a definition file. A definition file follows the JSON format as specified in ECMA-404. All definition files must be valid JSON in order to be parsed. There are three main types that can be defined in a definition file.
+
+- Metacard Types
+- Attribute Types
+- Global Attribute Validators
+
+Within a definition file you may define as many of the three types as you wish. This means that types can be defined across multiple files for grouping or clarity. 
+
+==== Deploying 
+The file must have a `.json` extension in order to be picked up by the deployer. Once the definition file is ready to be deployed, put the definition file `<filename>.json` into the `etc/definitions` folder.
+
+* * *
+==== Attribute Type Definition
+
+To define Attribute Types, your definition file must have an `attributeTypes` key in the root object.
+
+[source,json]
+----
+{
+    "attributeTypes": {...}
+}
+----
+
+The value of `attributeTypes` must be a map where each key is the attribute type's name and each value is a map that includes the data type and whether the attribute type is stored, indexed, tokenized, or multi-valued.
+
+[source,json]
+----
+{
+    "attributeTypes": {
+        "temperature": {
+            "type": "DOUBLE_TYPE",
+            "stored": true,
+            "indexed": true,
+            "tokenized": false,
+            "multivalued": false
+        }
+    }
+}
+----
+
+The attributes `stored`, `indexed`, `tokenized`, and `multivalued` must be included and must have a boolean value. The `type` attribute must also be included and must have one of the following values:
+
+ - `DATE_TYPE`
+ - `STRING_TYPE`
+ - `XML_TYPE`
+ - `LONG_TYPE`
+ - `BINARY_TYPE`
+ - `GEO_TYPE`
+ - `BOOLEAN_TYPE`
+ - `DOUBLE_TYPE`
+ - `FLOAT_TYPE`
+ - `INTEGER_TYPE`
+ - `OBJECT_TYPE`
+ - `SHORT_TYPE`
+
+An example with multiple attributes defined:
+
+[source,json]
+----
+{
+    "attributeTypes": {
+        "resolution": {
+            "type": "STRING_TYPE",
+            "stored": true,
+            "indexed": true,
+            "tokenized": false,
+            "multivalued": false
+        },
+        "target-areas": {
+            "type": "GEO_TYPE",
+            "stored": true,
+            "indexed": true,
+            "tokenized": false,
+            "multivalued": true
+        }
+    }
+}
+----
+
+* * *
+
+==== Metacard Type Definition
+
+To define Metacard Types, your definition file must have a `metacardTypes` key in the root object.
+
+[source,javascript]
+----
+{
+    "metacardTypes": [...]
+}
+----
+
+The value of `metacardTypes` must be an array of Metacard Type Objects, which are composed of the `type` and `attributes` keys. 
+
+[source,json]
+----
+{
+    "metacardTypes": [
+        {
+            "type": "my-metacard-type",
+            "attributes": {...}
+        }
+    ]
+}
+----
+
+The value of the `type` key is the name of the metacard type being defined.
+
+The value of the `attributes` key is a map where each key is the name of an attribute type to include in this metacard type and each value is a map with a single key named `required` and a boolean value. Required attributes are used for metacard validation - metacards that lack required attributes will be flagged with validation errors.
+
+[source,json]
+----
+{
+    "metacardTypes": [
+        {
+            "type": "my-metacard-type",
+            "attributes": {
+                "resolution": {
+                    "required": true
+                },
+                "target-areas": {
+                    "required": false
+                },
+                "point-of-contact": {
+                    "required": true
+                }
+            }
+        }
+    ]
+}
+----
+
+[NOTE]
+====
+The DDF basic metacard attribute types are added to custom metacard types by default. If you wish to make any of them required by your metacard type, just include them in your `attributes` map and set `required` to `true`, as shown in the above example with `point-of-contact`.
+====
+
+You can define multiple metacard types in a single file:
+[source,json]
+----
+{
+    "metacardTypes": [
+        {
+            "type": "my-metacard-type",
+            "attributes": {
+                "resolution": {
+                    "required": true
+                },
+                "target-areas": {
+                    "required": false
+                }
+            }
+        },
+        {
+            "type": "another-metacard-type",
+            "attributes": {
+                "effective": {
+                    "required": true
+                },
+                "resolution": {
+                    "required": false
+                }
+            }
+        }
+    ]
+}
+----
+
+==== Validator Definition
+
+To define Validators, your definition file must have a `validators` key in the root object.
+
+[source,json]
+----
+{
+    "validators": {...}
+}
+----
+
+The value of `validators` is a map of the attribute name to a list of validators for that attribute.
+
+[source,json]
+----
+{
+    "validators": {
+        "point-of-contact": [...]
+    }
+}
+----
+
+Each object in the list of validators is the validator name and list of arguments for that validator.
+
+[source,json]
+----
+{
+    "validators": {
+        "point-of-contact": [
+            {
+                "validator": "pattern",
+                "arguments": [".*regex.+\\s"]
+            }
+        ]
+    }
+}
+----
+
+[WARNING]
+====
+The value of the `arguments` key must always be an array of strings, even for numeric arguments, e.g. `["1", "10"]`
+====
+
+The `validator` key must have a value of one of the following:
+
+ - `size` (validates the size of Strings, Arrays, Collections, and Maps)
+ * `arguments`: (2) [integer: lower bound (inclusive), integer: upper bound (inclusive)]
+ - `pattern`
+ * `arguments`: (1) [regular expression]
+ - `pastdate`
+ * `arguments`: (0) [NO ARGUMENTS]
+ - `futuredate`
+ * `arguments`: (0) [NO ARGUMENTS]
+ - `range`
+ ** (2) [number (decimal or integer): inclusive lower bound, number (decimal or integer): inclusive upper bound]
+ *** uses a default epsilon of 1E-6 on either side of the range to account for floating point representation inaccuracies
+ ** (3) [number (decimal or integer): inclusive lower bound, number (decimal or integer): inclusive upper bound, decimal number: epsilon (the maximum tolerable error on either side of the range)]
+ - `enumeration`
+ * `arguments`: (unlimited) [list of strings: each argument is one case-sensitive, valid enumeration value]
+
+Examples:
+[source, json]
+----
+{
+    "validators": {
+        "title": [
+            {
+                "validator": "size",
+                "arguments": ["1", "50"]
+            },
+            {
+                "validator": "pattern",
+                "arguments": ["\\D+"]
+            }
+        ],
+        "created": [
+            {
+                "validator": "pastdate",
+                "arguments": []
+            }
+        ],
+        "expiration": [
+            {
+                "validator": "futuredate",
+                "arguments": []
+            }
+        ],
+        "page-count": [
+            {
+                "validator": "range",
+                "arguments": ["1", "500"]
+            }
+        ],
+        "temperature": [
+            {
+                "validator": "range",
+                "arguments": ["12.2", "19.8", "0.01"]
+            }
+        ],
+        "resolution": [
+            {
+                "validator": "enumeration",
+                "arguments": ["1080p", "1080i", "720p"]
+            }
+        ]
+    }
+}
+----

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.felix.fileinstall-definitions.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.felix.fileinstall-definitions.cfg
@@ -1,9 +1,9 @@
- 
+
 #/*
 # * Copyright (c) Codice Foundation
 # *
 # * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
-# * version 3 of the License, or any later version. 
+# * version 3 of the License, or any later version.
 # *
 # * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -11,13 +11,13 @@
 # *
 # */
 
-felix.fileinstall.dir = ${karaf.base}/etc/ddf
-felix.fileinstall.tmpdir  = ${karaf.data}/generated-bundles
-felix.fileinstall.poll    = 1000
-felix.fileinstall.bundles.new.start = true
-felix.fileinstall.filter = 
-felix.fileinstall.bundles.startTransient = false
-felix.fileinstall.bundles.startActivationPolicy = true
+felix.fileinstall.dir = ${karaf.base}/etc/definitions
+felix.fileinstall.tmpdir  = ${karaf.data}/generated-bundles #do we need
+felix.fileinstall.poll    = 997
+felix.fileinstall.bundles.new.start = true              #do we need
+felix.fileinstall.filter = .*\\.json
+felix.fileinstall.bundles.startTransient = false        #do we need
+felix.fileinstall.bundles.startActivationPolicy = true  #do we need
 felix.fileinstall.log.level = 0
 felix.fileinstall.noInitialDelay = false
 felix.fileinstall.start.level = 0

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -13,6 +13,7 @@
  */
 package ddf.test.itests.catalog;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -37,9 +38,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,6 +81,7 @@ import com.google.common.collect.Maps;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 
+import ddf.catalog.data.MetacardType;
 import ddf.common.test.BeforeExam;
 import ddf.test.itests.AbstractIntegrationTest;
 import ddf.test.itests.common.CswQueryBuilder;
@@ -294,7 +296,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .newXPath();
         String idPath = "//*[local-name()='identifier']/text()";
         InputSource xml = new InputSource(IOUtils.toInputStream(response.getBody()
-                .asString(), StandardCharsets.UTF_8.name()));
+                .asString(), UTF_8.name()));
         return xPath.compile(idPath)
                 .evaluate(xml);
     }
@@ -309,8 +311,8 @@ public class TestCatalog extends AbstractIntegrationTest {
         Response response = ingestCswRecord();
         ValidatableResponse validatableResponse = response.then();
 
-        validatableResponse.body(
-                hasXPath("//TransactionResponse/TransactionSummary/totalInserted", is("1")),
+        validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalInserted",
+                is("1")),
                 hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is("0")),
                 hasXPath("//TransactionResponse/TransactionSummary/totalDeleted", is("0")),
                 hasXPath("//TransactionResponse/InsertResult/BriefRecord/title",
@@ -348,7 +350,8 @@ public class TestCatalog extends AbstractIntegrationTest {
     public void testCswDeleteOneWithFilter() {
         ingestCswRecord();
 
-        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
                 .body(Library.getCswFilterDelete())
                 .post(CSW_PATH.getUrl())
                 .then();
@@ -361,7 +364,8 @@ public class TestCatalog extends AbstractIntegrationTest {
     public void testCswDeleteOneWithCQL() {
         ingestCswRecord();
 
-        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
                 .body(Library.getCswCqlDelete())
                 .post(CSW_PATH.getUrl())
                 .then();
@@ -419,7 +423,8 @@ public class TestCatalog extends AbstractIntegrationTest {
         ingestCswRecord();
         ingestCswRecord();
 
-        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
                 .body(Library.getCswFilterDelete())
                 .post(CSW_PATH.getUrl())
                 .then();
@@ -450,8 +455,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .body(requestXml)
                 .post(CSW_PATH.getUrl())
                 .then();
-        validatableResponse.body(
-                hasXPath("//TransactionResponse/TransactionSummary/totalDeleted", is("0")),
+        validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalDeleted",
+                is("0")),
                 hasXPath("//TransactionResponse/TransactionSummary/totalInserted", is("0")),
                 hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is("1")));
 
@@ -570,7 +575,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Test
     public void testCswUpdateByFilterConstraintNoExistingMetacards() {
-        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
                 .body(Library.getCswUpdateByFilterConstraint())
                 .post(CSW_PATH.getUrl())
                 .then();
@@ -754,8 +760,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
         String productDirectory = new File(fileName).getAbsoluteFile()
                 .getParent();
-        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
-                new String[] {DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
+        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
+                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
 
         given().get(url)
                 .then()
@@ -988,7 +994,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     fileBytes,
                     "video/mp4")
                     .post(REST_PATH.getUrl())
-                    .then().statusCode(201);
+                    .then()
+                    .statusCode(201);
         }
     }
 
@@ -1003,7 +1010,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .deleteOnExit();
         Files.copy(this.getClass()
                         .getClassLoader()
-                        .getResourceAsStream("metacard5.xml"), tmpFile,
+                        .getResourceAsStream("metacard5.xml"),
+                tmpFile,
                 StandardCopyOption.REPLACE_EXISTING);
 
         Map<String, Object> cdmProperties = new HashMap<>();
@@ -1061,7 +1069,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "AnyText",
                     "*")
                     .getQuery();
-            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                    MediaType.APPLICATION_XML)
                     .body(query)
                     .post(CSW_PATH.getUrl())
                     .then();
@@ -1158,7 +1167,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "AnyText",
                     "*")
                     .getQuery();
-            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                    MediaType.APPLICATION_XML)
                     .body(query)
                     .post(CSW_PATH.getUrl())
                     .then();
@@ -1204,12 +1214,13 @@ public class TestCatalog extends AbstractIntegrationTest {
             response.body(hasXPath(String.format(
                     "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
                     id1)));
-            response.body(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id2)));
+            response.body(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id2)));
 
             // Search for all entries that are invalid
-            query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_LIKE, VALIDATION_WARNINGS,
+            query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_LIKE,
+                    VALIDATION_WARNINGS,
                     "*")
                     .getQuery();
 
@@ -1234,9 +1245,9 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .post(CSW_PATH.getUrl())
                     .then();
             // Assert Metacard2 is in results AND not Metacard1
-            response.body(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id2)));
+            response.body(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id2)));
             response.body(not(hasXPath(String.format(
                     "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
                     id1))));
@@ -1313,7 +1324,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
             // Configure invalid filtering
             config = configAdmin.getConfiguration(
-                    "ddf.catalog.metacard.validation.MetacardValidityFilterPlugin", null);
+                    "ddf.catalog.metacard.validation.MetacardValidityFilterPlugin",
+                    null);
             properties = new Hashtable<>();
             property = new ArrayList<>();
             property.add("invalid-state=system-admin,guest");
@@ -1328,9 +1340,9 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .post(CSW_PATH.getUrl())
                     .then();
             // Assert Metacard2 is in results AND Metacard1
-            response.body(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id1)));
+            response.body(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id1)));
             response.body(hasXPath(String.format(
                     "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
                     id2)));
@@ -1384,9 +1396,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin",
                     null);
             properties = new Hashtable<>();
-            property = new ArrayList<>();
-            property.add("false");
-            properties.put("showInvalidMetacards", property);
+            properties.put("showInvalidMetacards", "false");
             config.update(properties);
 
             String id1 = ingestXmlFromResource("/metacard1.xml");
@@ -1398,7 +1408,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "AnyText",
                     "*")
                     .getQuery();
-            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                    MediaType.APPLICATION_XML)
                     .body(query)
                     .post(CSW_PATH.getUrl())
                     .then();
@@ -1421,9 +1432,9 @@ public class TestCatalog extends AbstractIntegrationTest {
             response.body(hasXPath(String.format(
                     "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
                     id1)));
-            response.body(not(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id2))));
+            response.body(not(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id2))));
 
             //Search for all entries that have validation-warnings from sample-validator or no validation warnings
             //Only search that will actually return all entries
@@ -1443,9 +1454,9 @@ public class TestCatalog extends AbstractIntegrationTest {
             response.body(hasXPath(String.format(
                     "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
                     id1)));
-            response.body(not(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id2))));
+            response.body(not(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id2))));
 
             // Search for all metacards that have validation-warnings
             query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_EQUAL_TO,
@@ -1458,17 +1469,74 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .post(CSW_PATH.getUrl())
                     .then();
             // Assert Metacard1 and metacard2 are NOT in results
-            response.body(not(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id1))));
-            response.body(not(hasXPath(
-                    String.format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
-                            id2))));
+            response.body(not(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id1))));
+            response.body(not(hasXPath(String.format(
+                    "/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]",
+                    id2))));
 
             deleteMetacard(id1);
             deleteMetacard(id2);
         } finally {
             getServiceManager().stopFeature(true, "catalog-plugin-metacard-validation");
+        }
+    }
+
+    @Test
+    public void testMetacardDefinitionJsonFile() throws Exception {
+        getServiceManager().startFeature(true, "catalog-core-validator");
+        try {
+            Path definitionsDir = Paths.get(System.getProperty("ddf.home"), "etc/definitions");
+            definitionsDir = Files.createDirectories(definitionsDir);
+            definitionsDir.toFile()
+                    .deleteOnExit();
+            Path tmpFile = definitionsDir.resolve("definitions.json");
+            tmpFile.toFile()
+                    .deleteOnExit();
+            Files.copy(getClass().getClassLoader()
+                    .getResourceAsStream("definitions.json"), tmpFile);
+
+            expect("Service to be available: " + MetacardType.class.getName()).within(10,
+                    TimeUnit.SECONDS)
+                    .until(() -> getServiceManager().getServiceReferences(MetacardType.class,
+                            "(name=new.metacard.type)"), not(empty()));
+
+            String ddfMetacardXml = IOUtils.toString(getClass().getClassLoader()
+                    .getResourceAsStream("metacard1.xml"), UTF_8.name());
+
+            String modifiedMetacardXml = ddfMetacardXml.replaceFirst("ddf\\.metacard",
+                    "new.metacard.type")
+                    .replaceFirst("resource-uri", "new-attribute-required-2");
+            String id = ingest(modifiedMetacardXml, "text/xml");
+
+            Configuration config = configAdmin.getConfiguration(
+                    "ddf.catalog.metacard.validation.MetacardValidityCheckerPlugin",
+                    null);
+            Dictionary<String, Object> properties = new Hashtable<>();
+            properties.put("showInvalidMetacards", "true");
+            config.update(properties);
+
+            String newMetacardXpath = String.format("/metacards/metacard[@id=\"%s\"]", id);
+
+            executeOpenSearch("xml", "q=*").log()
+                    .all()
+                    .assertThat()
+                    .body(hasXPath(newMetacardXpath))
+                    .body(hasXPath(newMetacardXpath + "/type", is("new.metacard.type")))
+                    .body(hasXPath("count(" + newMetacardXpath + "/string[@name=\"validation-errors\"]/value)",
+                            is("2")))
+                    .body(hasXPath(newMetacardXpath
+                            + "/string[@name=\"validation-errors\"]/value[text()=\"point-of-contact is required\"]"))
+                    .body(hasXPath(newMetacardXpath
+                            + "/string[@name=\"validation-errors\"]/value[text()=\"new-attribute-required-1 is required\"]"))
+                    .body(hasXPath(
+                            newMetacardXpath + "/string[@name=\"new-attribute-required-2\"]/value",
+                            is("\" + uri + \"")));
+
+            deleteMetacard(id);
+        } finally {
+            getServiceManager().stopFeature(true, "catalog-core-validator");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/definitions.json
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/definitions.json
@@ -1,0 +1,47 @@
+{
+  "metacardTypes": [
+    {
+      "type": "new.metacard.type",
+      "attributes": {
+        "title": {
+          "required": true
+        },
+        "point-of-contact": {
+          "required": true
+        },
+        "new-attribute-notrequired": {
+          "required": false
+        },
+        "new-attribute-required-1": {
+          "required": true
+        },
+        "new-attribute-required-2": {
+          "required": true
+        }
+      }
+    }
+  ],
+  "attributeTypes": {
+    "new-attribute-notrequired": {
+      "type": "STRING_TYPE",
+      "indexed": true,
+      "stored": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "new-attribute-required-1": {
+      "type": "STRING_TYPE",
+      "indexed": true,
+      "stored": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "new-attribute-required-2": {
+      "type": "STRING_TYPE",
+      "indexed": true,
+      "stored": true,
+      "tokenized": false,
+      "multivalued": false
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Create a new metacard validation API and provide an implementation.

Provides the ability to create new validators, attribute types, and metacard types by dropping JSON files into a directory.

#### Who is reviewing it?
@rzwiefel @pklinef @jlcsmith @kcwire 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1978

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### ==== Notes ====
The new APIs added in this PR are marked as **experimental**. The existing APIs are **not** being deprecated.