### PR TITLE
DDF-1957: Create backend for Log Service

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/jmx.acl.whitelist.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/jmx.acl.whitelist.cfg
@@ -9,3 +9,4 @@ org.apache.karaf.features=bypass
 org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean=bypass
 org.codice.ddf.catalog.admin.plugin.AdminSourcePollerServiceBean=bypass
 org.codice.ddf.configuration.migration.ConfigurationMigrationManager=bypass
+org.codice.ddf.logging.platform.LoggingServiceBean=bypass

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -22,11 +22,11 @@ log4j.rootLogger=INFO, out, osgi:*
 log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
 
 # Security logger
-log4j.logger.securityLogger=INFO, security, syslog
+log4j.logger.securityLogger=INFO, security, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
 log4j.additivity.securityLogger=false
 
 # Ingest Logger
-log4j.logger.ingestLogger = INFO, ingestError, syslog
+log4j.logger.ingestLogger = INFO, ingestError, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
 log4j.additivity.ingestLogger=false
 
 # Syslog appender

--- a/distribution/docs/src/main/resources/_contents/configuring-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/configuring-contents.adoc
@@ -275,3 +275,8 @@ Integrators and developers can add more claims handlers that can handle other ty
 
 A claim is an additional piece of data about a principal that can be included in a token along with basic token data.
 A claims manager provides hooks for a developer to plug in claims handlers to ensure that the STS includes the specified claims in the issued token.
+
+==== Configuring ${branding} Logging Service
+
+The maximum number of log events to store can be configured in the Admin Console.
+

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -14,6 +14,9 @@
 
 package ddf.test.itests.platform;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.given;
 
@@ -30,11 +33,15 @@ import ddf.test.itests.AbstractIntegrationTest;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-public class TestBanana extends AbstractIntegrationTest {
+public class TestPlatform extends AbstractIntegrationTest {
 
-    private static final DynamicUrl BANANA_URL = new DynamicUrl(DynamicUrl.SECURE_ROOT,
-            HTTPS_PORT,
+    private static final DynamicUrl BANANA_URL = new DynamicUrl(DynamicUrl.SECURE_ROOT, HTTPS_PORT,
             "/solr/banana");
+
+    private static final DynamicUrl LOGGING_SERVICE_JOLOKIA_URL = new DynamicUrl(
+            DynamicUrl.SECURE_ROOT,
+            HTTPS_PORT,
+            "/jolokia/exec/org.codice.ddf.platform.logging.LoggingService:service=logging-service/retrieveLogEvents");
 
     @BeforeExam
     public void beforeTest() throws Exception {
@@ -61,5 +68,19 @@ public class TestBanana extends AbstractIntegrationTest {
                 .statusCode(200)
                 .when()
                 .get(BANANA_URL.getUrl());
+    }
+
+    @Test
+    public void testLoggingServiceEndpoint() throws Exception {
+
+        Response response = given().auth()
+                .preemptive()
+                .basic("admin", "admin")
+                .expect()
+                .statusCode(200)
+                .when()
+                .get(LOGGING_SERVICE_JOLOKIA_URL.getUrl());
+        
+        assertThat(response.getBody().asString(), not(isEmptyString()));
     }
 }

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -272,6 +272,11 @@
             <artifactId>platform-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-logging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in used in platform-app's features.xml

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -979,6 +979,7 @@
 
     <feature name="platform-all" install="manual" version="${project.version}" hidden="true">
         <feature prerequisite="true">platform-api</feature>
+        <bundle>mvn:ddf.platform/platform-logging/${project.version}</bundle>        
         <feature prerequisite="true">platform-security-session</feature>
         <feature prerequisite="true">platform-migrate-all</feature>
         <feature>platform-scheduler</feature>

--- a/platform/platform-logging/pom.xml
+++ b/platform/platform-logging/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>platform</artifactId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>platform-logging</artifactId>
+    <name>DDF :: Platform :: Logging</name>
+    <description>Logging Service</description>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.84</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.81</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.89</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LogEvent.java
+++ b/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LogEvent.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.logging;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.log4j.Priority;
+import org.ops4j.pax.logging.spi.PaxLoggingEvent;
+
+/**
+ * Describes a log event in the system
+ */
+class LogEvent {
+
+    private static final String BUNDLE_NAME_KEY = "bundle.name";
+
+    private static final String BUNDLE_VERSION_KEY = "bundle.version";
+
+    private final long timestamp;
+
+    private final Level level;
+
+    private final String message;
+
+    private final String bundleName;
+
+    private final String bundleVersion;
+
+    /**
+     * Constructor
+     * 
+     * @param paxLoggingEvent
+     *            the {@link org.ops4j.pax.logging.spi.PaxLoggingEvent} used to create this
+     *            {@link LogEvent}
+     */
+    LogEvent(PaxLoggingEvent paxLoggingEvent) {
+        this.timestamp = paxLoggingEvent.getTimeStamp();
+        this.level = getLevel(paxLoggingEvent.getLevel().toInt());
+        this.message = paxLoggingEvent.getMessage();
+        this.bundleName = getBundleName(paxLoggingEvent);
+        this.bundleVersion = getBundleVersion(paxLoggingEvent);
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Returns the log level
+     * 
+     * @return {@link Level} of this {@link LogEvent}
+     */
+    public Level getLevel() {
+        return level;
+    }
+
+    /**
+     * Returns the Message of this {@link LogEvent}
+     * 
+     * @return the message of this {@link LogEvent} (can be null)
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Returns the name of the bundle that created this {@link LogEvent}
+     * 
+     * @return the name of the bundle that created this {@link LogEvent} (can be null)
+     */
+    public String getBundleName() {
+        return bundleName;
+    }
+
+    /**
+     * Returns the version of the bundle that created this {@link LogEvent}
+     * 
+     * @return the version of the bundle that created this {@link LogEvent} (can be null)
+     */
+    public String getBundleVersion() {
+        return bundleVersion;
+    }
+
+    /**
+     * Compares this {@link LogEvent} with the specified {@link java.lang.Object}
+     */
+    @Override
+    public boolean equals(Object anotherLogEvent) {
+        if (!(anotherLogEvent instanceof LogEvent)) {
+            return false;
+        }
+        if (anotherLogEvent == this) {
+            return true;
+        }
+        LogEvent rhs = (LogEvent) anotherLogEvent;
+        return new EqualsBuilder().append(timestamp, rhs.getTimestamp())
+                .append(level.getLevel(), rhs.getLevel().getLevel())
+                .append(message, rhs.getMessage()).append(bundleName, rhs.getBundleName())
+                .append(bundleVersion, rhs.getBundleVersion()).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 31).append(timestamp).append(level).append(message)
+                .append(bundleName).append(bundleVersion).toHashCode();
+    }
+
+    private String getBundleName(PaxLoggingEvent paxLoggingEvent) {
+        return (String) paxLoggingEvent.getProperties().get(BUNDLE_NAME_KEY);
+    }
+
+    private String getBundleVersion(PaxLoggingEvent paxLoggingEvent) {
+        return (String) paxLoggingEvent.getProperties().get(BUNDLE_VERSION_KEY);
+    }
+
+    private Level getLevel(int level) {
+        switch (level) {
+        case Priority.ERROR_INT:
+            return Level.ERROR;
+        case Priority.WARN_INT:
+            return Level.WARN;
+        case Priority.INFO_INT:
+            return Level.INFO;
+        case Priority.DEBUG_INT:
+            return Level.DEBUG;
+        case org.apache.log4j.Level.TRACE_INT:
+            return Level.TRACE;
+        default:
+            return Level.UNKNOWN;
+        }
+    }
+
+    enum Level {
+        TRACE("TRACE"), 
+        DEBUG("DEBUG"), 
+        INFO("INFO"), 
+        WARN("WARN"), 
+        ERROR("ERROR"),
+        UNKNOWN("UNKNOWN");
+
+        private String level;
+
+        Level(String l) {
+            level = l;
+        }
+
+        String getLevel() {
+            return level;
+        }
+    }
+}

--- a/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LoggingService.java
+++ b/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LoggingService.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.logging;
+
+import java.util.List;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.ops4j.pax.logging.spi.PaxAppender;
+import org.ops4j.pax.logging.spi.PaxLoggingEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Lists;
+
+/**
+ * A custom {@link org.ops4j.pax.logging.spi.PaxAppender} which receives
+ * {@link org.ops4j.pax.logging.spi.PaxLoggingEvent}s and is the Jolokia endpoint for the Logging UI
+ * in the Admin Console.
+ */
+public class LoggingService implements PaxAppender, LoggingServiceMBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingService.class);
+
+    private static final String CLASS_NAME = LoggingService.class.getName();
+
+    private static final String MBEAN_OBJECT_NAME = CLASS_NAME + ":service=logging-service";
+
+    private static final int MAX_LOG_EVENTS_LIMIT = 5000;
+
+    private static final int DEFAULT_LOG_EVENTS_LIMIT = 500;
+
+    private final MBeanServer mBeanServer;
+
+    private ObjectName objectName;
+
+    private EvictingQueue<LogEvent> logEvents;
+
+    private int maxLogEvents = DEFAULT_LOG_EVENTS_LIMIT;
+
+    /**
+     * Constructor
+     * 
+     * @param mBeanServer
+     *            object used to register this object as an MBean
+     */
+    public LoggingService(MBeanServer mBeanServer) {
+        this.mBeanServer = mBeanServer;
+    }
+
+    public void init() throws Exception {
+        try {
+            if (logEvents == null) {
+                logEvents = EvictingQueue.create(DEFAULT_LOG_EVENTS_LIMIT);
+            }
+            objectName = new ObjectName(MBEAN_OBJECT_NAME);
+            mBeanServer.registerMBean(this, objectName);
+            LOGGER.info("Registered [{}] MBean under object name: [{}].", CLASS_NAME,
+                    objectName.toString());
+        } catch (InstanceAlreadyExistsException e) {
+            LOGGER.info("[{}] already registered as an MBean. Re-registering.", CLASS_NAME);
+
+            mBeanServer.unregisterMBean(objectName);
+            mBeanServer.registerMBean(this, objectName);
+
+            LOGGER.info("Successfully re-registered [{}] as an MBean.", CLASS_NAME);
+        }
+    }
+
+    public void destroy() {
+        try {
+            if (objectName != null && mBeanServer != null) {
+                mBeanServer.unregisterMBean(objectName);
+                LOGGER.info("Unregistered Logging Service MBean");
+            }
+        } catch (InstanceNotFoundException | MBeanRegistrationException e) {
+            LOGGER.error("Exception unregistering MBean [{}].", objectName.toString(), e);
+        }
+    }
+
+    /**
+     * Called each time a {@link org.ops4j.pax.logging.spi.PaxLoggingEvent} is created in the system
+     */
+    @Override
+    public void doAppend(PaxLoggingEvent paxLoggingEvent) {
+        add(new LogEvent(paxLoggingEvent));
+    }
+
+    @Override
+    public synchronized List<LogEvent> retrieveLogEvents() {
+        return Lists.newArrayList(logEvents);
+    }
+
+    /**
+     * Sets the maximum number of {@link LogEvent}s to store
+     * 
+     * @param newMaxLogEvents
+     *            This number cannot be less than 0 or greater than {@code MAX_LOG_EVENTS_LIMIT}. In
+     *            the event that this parameter is less than 0 or greater than
+     *            {@code MAX_LOG_EVENTS_LIMIT}, the maximum log events stored will set set to
+     *            {@code MAX_LOG_EVENTS_LIMIT}.
+     */
+    public synchronized void setMaxLogEvents(int newMaxLogEvents) {
+        if (newMaxLogEvents <= 0 || newMaxLogEvents > MAX_LOG_EVENTS_LIMIT) {
+            String message = String
+                    .format("An invalid value of [%d] was entered for maximum log events to store. This "
+                            + "value must be greater than 0 and must not exceed [%d]. Unable to reset maximum log"
+                            + " events to store.", newMaxLogEvents, MAX_LOG_EVENTS_LIMIT);
+            LOGGER.warn(message);
+            throw new IllegalArgumentException(message);
+        }
+
+        EvictingQueue<LogEvent> evictingQueue = createNewEvictingQueue(newMaxLogEvents);
+        this.maxLogEvents = newMaxLogEvents;
+        logEvents = evictingQueue;
+    }
+
+    public synchronized int getMaxLogEvents() {
+        return maxLogEvents;
+    }
+
+    private synchronized void add(LogEvent logEvent) {
+        logEvents.add(logEvent);
+    }
+
+    private EvictingQueue<LogEvent> createNewEvictingQueue(int newMaxLogEvents) {
+        EvictingQueue<LogEvent> evictingQueue = EvictingQueue.create(newMaxLogEvents);
+        evictingQueue.addAll(logEvents);
+        return evictingQueue;
+    }
+}

--- a/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LoggingServiceMBean.java
+++ b/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LoggingServiceMBean.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.logging;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * The {@link LoggingServiceMBean} interface is an MBean 
+ * interface that defines logging event operations.
+ *
+ */
+public interface LoggingServiceMBean {
+
+    /**
+     * Retrieves all of the stored {@link LogEvent}s
+     * 
+     * @return non-null list of {@link LogEvent}s in ascending order
+     */
+    @NotNull
+    List<LogEvent> retrieveLogEvents();
+}

--- a/platform/platform-logging/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-logging/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+    xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="logging" class="org.codice.ddf.platform.logging.LoggingService"
+        init-method="init" destroy-method="destroy">
+        <argument ref="mBeanServer" />
+        <cm:managed-properties
+            persistent-id="org.codice.ddf.platform.logging.LoggingService"
+            update-strategy="container-managed" />
+    </bean>
+
+    <bean id="mBeanServer" class="java.lang.management.ManagementFactory"
+        factory-method="getPlatformMBeanServer" />
+
+    <service id="loggingService" ref="logging"
+        interface="org.ops4j.pax.logging.spi.PaxAppender">
+        <service-properties>
+            <entry key="org.ops4j.pax.logging.appender.name"
+                value="org.codice.ddf.platform.logging.LoggingService" />
+        </service-properties>
+    </service>
+</blueprint>

--- a/platform/platform-logging/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/platform-logging/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Logging Service" id="org.codice.ddf.platform.logging.LoggingService">
+        <AD
+            description="The maximum number of log events stored for display in the Admin Console. This must be greater than 0 and must not exceed 5000."
+            name="Max Log Events" id="maxLogEvents" required="true"
+            type="Integer" default="500" />
+    </OCD>
+
+    <Designate pid="org.codice.ddf.platform.logging.LoggingService">
+        <Object ocdref="org.codice.ddf.platform.logging.LoggingService" />
+    </Designate>
+
+</metatype:MetaData>

--- a/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LogEventTest.java
+++ b/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LogEventTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.logging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.apache.log4j.Priority;
+import org.codice.ddf.platform.logging.LogEvent.Level;
+import org.junit.Test;
+import org.ops4j.pax.logging.spi.PaxLevel;
+import org.ops4j.pax.logging.spi.PaxLoggingEvent;
+
+public class LogEventTest {
+
+    private static final String ERROR_LEVEL = "ERROR";
+
+    private static final String WARN_LEVEL = "WARN";
+
+    private static final String INFO_LEVEL = "INFO";
+
+    private static final String DEBUG_LEVEL = "DEBUG";
+
+    private static final String TRACE_LEVEL = "TRACE";
+
+    private static final String BUNDLE_VERSION = "1.2.3";
+
+    private static final String MESSAGE_1 = "message 1";
+
+    private static final String MESSAGE_2 = "message 2";
+
+    private static final String BUNDLE_NAME_1 = "my-bundle-name-1";
+
+    private static final String BUNDLE_NAME_2 = "my-bundle-name-2";
+
+    private static final String BUNDLE_NAME_KEY = "bundle.name";
+
+    private static final String BUNDLE_VERSION_KEY = "bundle.version";
+
+    @Test
+    public void testEqualsLogEventsSameFieldValues() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, INFO_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        LogEvent anotherLogEvent = new LogEvent(getMockPaxLoggingEvent(1L, INFO_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        assertThat(logEvent, equalTo(anotherLogEvent));
+    }
+
+    @Test
+    public void testEqualsLogEventsDifferentReferences() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, INFO_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        LogEvent anotherLogEvent = new LogEvent(getMockPaxLoggingEvent(2L, ERROR_LEVEL, MESSAGE_2,
+                BUNDLE_NAME_2, BUNDLE_VERSION));
+        assertThat(logEvent, not(equalTo(anotherLogEvent)));
+    }
+
+    @Test
+    public void testEqualsLogEventsSameReference() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, TRACE_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        assertThat(logEvent, equalTo(logEvent));
+    }
+
+    @Test
+    public void testEqualsOtherLogEventNotInstanceOfLogEvent() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, DEBUG_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        String anotherLogEvent = "logEvent";
+        assertThat(logEvent, not(equalTo(anotherLogEvent)));
+    }
+
+    @Test
+    public void testHashCode() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, WARN_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        LogEvent anotherLogEvent = new LogEvent(getMockPaxLoggingEvent(1L, WARN_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        assertThat(logEvent, equalTo(anotherLogEvent));
+        assertThat(anotherLogEvent, equalTo(logEvent));
+        assertThat(logEvent.hashCode(), equalTo(anotherLogEvent.hashCode()));
+    }
+
+    @Test
+    public void testGetLogLevel() {
+        LogEvent logEvent = new LogEvent(getMockPaxLoggingEvent(1L, INFO_LEVEL, MESSAGE_1,
+                BUNDLE_NAME_1, BUNDLE_VERSION));
+        Level level = logEvent.getLevel();
+        assertThat(level, equalTo(Level.INFO));
+    }
+
+    private void addBundleNameProperty(Properties properties, String bundleName) {
+        properties.put(BUNDLE_NAME_KEY, bundleName);
+    }
+
+    private void addBundleVersionProperty(Properties properties, String bundleVersion) {
+        properties.put(BUNDLE_VERSION_KEY, bundleVersion);
+    }
+
+    private PaxLevel getMockPaxLevel(String level) {
+        PaxLevel mockPaxLevel = new PaxLevel() {
+            @Override
+            public String toString() {
+                return level;
+            }
+
+            @Override
+            public boolean isGreaterOrEqual(PaxLevel r) {
+                return false;
+            }
+
+            @Override
+            public int toInt() {
+                switch (level) {
+                case "ERROR":
+                    return Priority.ERROR_INT;
+                case "WARN":
+                    return Priority.WARN_INT;
+                case "INFO":
+                    return Priority.INFO_INT;
+                case "DEBUG":
+                    return Priority.DEBUG_INT;
+                case "TRACE":
+                    return org.apache.log4j.Level.TRACE_INT;
+                default:
+                    return -1;
+                }
+            }
+
+            @Override
+            public int getSyslogEquivalent() {
+                return 0;
+            }
+        };
+
+        return mockPaxLevel;
+    }
+
+    private Properties getLoggingProperties(String bundleName, String bundleVersion) {
+        Properties properties = new Properties();
+        addBundleNameProperty(properties, bundleName);
+        addBundleVersionProperty(properties, bundleVersion);
+        return properties;
+    }
+
+    private PaxLoggingEvent getMockPaxLoggingEvent(long timestamp, String level, String message,
+            String bundleName, String bundleVersion) {
+        PaxLoggingEvent mockPaxLoggingEvent = mock(PaxLoggingEvent.class);
+        when(mockPaxLoggingEvent.getTimeStamp()).thenReturn(timestamp);
+        when(mockPaxLoggingEvent.getLevel()).thenReturn(getMockPaxLevel(level));
+        when(mockPaxLoggingEvent.getMessage()).thenReturn(message);
+        when(mockPaxLoggingEvent.getProperties()).thenReturn(
+                getLoggingProperties(bundleName, bundleVersion));
+        return mockPaxLoggingEvent;
+    }
+}
+

--- a/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LoggingServiceTest.java
+++ b/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LoggingServiceTest.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.logging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import javax.management.MBeanServer;
+
+import org.apache.log4j.Priority;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ops4j.pax.logging.spi.PaxLevel;
+import org.ops4j.pax.logging.spi.PaxLoggingEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingServiceTest {
+
+    private static final String BUNDLE_NAME_KEY = "bundle.name";
+
+    private static final String BUNDLE_VERSION_KEY = "bundle.version";
+
+    private static final int MAX_LOG_EVENTS_LIMIT = 5000;
+
+    @Mock
+    private MBeanServer mockMBeanServer;
+
+    @Test
+    public void testRetrieveLogEvents() throws Exception {
+        // Setup
+        List<PaxLoggingEvent> mockPaxLoggingEvents = getMockPaxLoggingEventsTimestampOrderSmallestToLargest(3);
+        List<LogEvent> expectedLogEvents = getExpectedLogEvents(mockPaxLoggingEvents);
+        LoggingService loggingServiceBean = getLoggingService();
+        appendLogs(loggingServiceBean, mockPaxLoggingEvents);
+
+        // Perform Test
+        List<LogEvent> actualLogEvents = loggingServiceBean.retrieveLogEvents();
+
+        // Verify
+        assertThat(actualLogEvents,
+                contains(expectedLogEvents.toArray(new LogEvent[expectedLogEvents.size()])));
+    }
+
+    @Test
+    public void testResizeMaxLogEventsKeepsAppropriateLogEvents() throws Exception {
+        // Setup
+        List<PaxLoggingEvent> mockPaxLoggingEvents = getMockPaxLoggingEventsTimestampOrderSmallestToLargest(3);
+        LogEvent expectedLogEventAfterResize = getExpectedLogEvent(mockPaxLoggingEvents.get(2));
+        LoggingService loggingServiceBean = getLoggingService();
+        appendLogs(loggingServiceBean, mockPaxLoggingEvents);
+
+        // Perform Test
+        loggingServiceBean.setMaxLogEvents(1);
+
+        // Verify
+        List<LogEvent> actualLogEvents = loggingServiceBean.retrieveLogEvents();
+        assertThat(actualLogEvents, contains(expectedLogEventAfterResize));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetMaxLogEventsTo0() throws Exception {
+        // Setup
+        LoggingService loggingServiceBean = getLoggingService();
+
+        // Perform Test
+        loggingServiceBean.setMaxLogEvents(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetMaxLogEventsToExceedLimit() throws Exception {
+        // Setup
+        LoggingService loggingServiceBean = getLoggingService();
+
+        // Perform Test
+        loggingServiceBean.setMaxLogEvents(MAX_LOG_EVENTS_LIMIT + 1);
+    }
+
+    /**
+     * Verify oldest log events are evicted when queue is full.
+     */
+    @Test
+    public void testDoAppendWhenLoggingQueueIsFull() throws Exception {
+        // Setup
+        List<PaxLoggingEvent> mockPaxLoggingEvents = getMockPaxLoggingEventsTimestampOrderSmallestToLargest(6);
+        List<LogEvent> expectedLogEvents = getExpectedLogEvents(mockPaxLoggingEvents).subList(3,
+                mockPaxLoggingEvents.size());
+        LoggingService loggingServiceBean = getLoggingService();
+        loggingServiceBean.setMaxLogEvents(3);
+        appendLogs(loggingServiceBean, mockPaxLoggingEvents.subList(0, 3));
+
+        // Perform Test
+        appendLogs(loggingServiceBean, mockPaxLoggingEvents.subList(3, mockPaxLoggingEvents.size()));
+
+        // Verify
+        List<LogEvent> actualLogEvents = loggingServiceBean.retrieveLogEvents();
+        assertThat(actualLogEvents,
+                contains(expectedLogEvents.toArray(new LogEvent[expectedLogEvents.size()])));
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        LoggingService loggingServiceBean = getLoggingService();
+        loggingServiceBean.destroy();
+    }
+
+    private PaxLevel getMockPaxLevel(String level) {
+        PaxLevel mockPaxLevel = new PaxLevel() {
+            @Override
+            public String toString() {
+                return level;
+            }
+
+            @Override
+            public boolean isGreaterOrEqual(PaxLevel r) {
+                return false;
+            }
+
+            @Override
+            public int toInt() {
+                switch (level) {
+                case "ERROR":
+                    return Priority.ERROR_INT;
+                case "WARN":
+                    return Priority.WARN_INT;
+                case "INFO":
+                    return Priority.INFO_INT;
+                case "DEBUG":
+                    return Priority.DEBUG_INT;
+                case "TRACE":
+                    return org.apache.log4j.Level.TRACE_INT;
+                default:
+                    return -1;
+                }
+            }
+
+            @Override
+            public int getSyslogEquivalent() {
+                return 0;
+            }
+        };
+
+        return mockPaxLevel;
+    }
+
+    private List<PaxLoggingEvent> getMockPaxLoggingEventsTimestampOrderSmallestToLargest(
+            int numberOfLoggingEvents) {
+        String baseMessage = "message ";
+        String baseBundleName = "my-bundle-name-";
+
+        List<PaxLoggingEvent> mockPaxLoggingEvents = new ArrayList<>(3);
+
+        for (int i = 0; i < numberOfLoggingEvents; i++) {
+            PaxLoggingEvent mockPaxLoggingEvent = getMockPaxLoggingEvent(i, "INFO",
+                    baseMessage + i, baseBundleName + i, "1.2.3");
+            mockPaxLoggingEvents.add(mockPaxLoggingEvent);
+        }
+
+        return mockPaxLoggingEvents;
+    }
+
+    private List<LogEvent> getExpectedLogEvents(List<PaxLoggingEvent> mockPaxLoggingEvents) {
+        List<LogEvent> expectedLogEvents = new ArrayList<>(mockPaxLoggingEvents.size());
+
+        for (PaxLoggingEvent mockPaxLoggingEvent : mockPaxLoggingEvents) {
+            expectedLogEvents.add(getExpectedLogEvent(mockPaxLoggingEvent));
+        }
+
+        return expectedLogEvents;
+    }
+
+    private LogEvent getExpectedLogEvent(PaxLoggingEvent mockPaxLoggingEvent) {
+        return new LogEvent(mockPaxLoggingEvent);
+    }
+
+    private void addBundleNameProperty(Properties properties, String bundleName) {
+        properties.put(BUNDLE_NAME_KEY, bundleName);
+    }
+
+    private void addBundleVersionProperty(Properties properties, String bundleVersion) {
+        properties.put(BUNDLE_VERSION_KEY, bundleVersion);
+    }
+
+    private Properties getLoggingProperties(String bundleName, String bundleVersion) {
+        Properties properties = new Properties();
+        addBundleNameProperty(properties, bundleName);
+        addBundleVersionProperty(properties, bundleVersion);
+        return properties;
+    }
+
+    private PaxLoggingEvent getMockPaxLoggingEvent(long timestamp, String level, String message,
+            String bundleName, String bundleVersion) {
+        PaxLoggingEvent mockPaxLoggingEvent = mock(PaxLoggingEvent.class);
+        when(mockPaxLoggingEvent.getTimeStamp()).thenReturn(timestamp);
+        when(mockPaxLoggingEvent.getLevel()).thenReturn(getMockPaxLevel(level));
+        when(mockPaxLoggingEvent.getMessage()).thenReturn(message);
+        when(mockPaxLoggingEvent.getProperties()).thenReturn(
+                getLoggingProperties(bundleName, bundleVersion));
+        return mockPaxLoggingEvent;
+    }
+
+    private void appendLogs(LoggingService loggingServiceBean,
+            List<PaxLoggingEvent> mockPaxLoggingEvents) {
+        for (PaxLoggingEvent mockPaxLoggingEvent : mockPaxLoggingEvents) {
+            loggingServiceBean.doAppend(mockPaxLoggingEvent);
+        }
+    }
+
+    private LoggingService getLoggingService() throws Exception {
+        LoggingService loggingServiceBean = new LoggingService(mockMBeanServer);
+        loggingServiceBean.init();
+        return loggingServiceBean;
+    }
+}

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -346,6 +346,7 @@
     <modules>
         <module>platform-api</module>
         <module>util</module>
+        <module>platform-logging</module>
         <module>platform-configuration</module>
         <module>migration</module>
         <module>platform-migratable</module>


### PR DESCRIPTION
#### What does this PR do?
Provides a backend logging Jolokia endpoint
#### Who is reviewing it?
@garrettfreibott @lessarderic @Lambeaux @bantillo @oconnormi 
#### How should this be tested?
 1) Start DDF
 2) Run through the installer
 3) Verify logs show up when hitting endpoint: https://localhost:8993/jolokia/exec/org.codice.ddf.logging.platform.LoggingServiceBean:service=logging-service/retrieveLogEvents
5) Verify "number of logs to store" can be changed via the Admin Console: DDF Platform -> Configuration -> Logging Service
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-1957
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
