### PR TITLE
DDF-1987 Added property to update/delete requests that contains the original metacards before the operation is performed.

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/OperationTransaction.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/OperationTransaction.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.operation.impl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * Class for storing operation information. This is primarily for capturing the state before an
+ * operation is performed so it can be referenced later if needed.
+ */
+public class OperationTransaction implements Serializable {
+
+    private OperationType type;
+
+    private List<Metacard> previousStateMetacards;
+
+    public OperationTransaction(OperationType type, Collection<Metacard> previousStateMetacards) {
+        this.type = type;
+        this.previousStateMetacards = Collections.unmodifiableList(new ArrayList(
+                previousStateMetacards));
+    }
+
+    public List<Metacard> getPreviousStateMetacards() {
+        return previousStateMetacards;
+    }
+
+    public OperationType getType() {
+        return type;
+    }
+
+    public enum OperationType {
+        CREATE,
+        UPDATE,
+        DELETE
+    }
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
@@ -142,4 +142,6 @@ public final class Constants {
     public static final String REMOTE_DESTINATION_KEY = "remote-destination";
 
     public static final String LOCAL_DESTINATION_KEY = "local-destination";
+
+    public static final String OPERATION_TRANSACTION_KEY = "operation-transaction";
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -110,6 +110,7 @@ import ddf.catalog.operation.UpdateResponse;
 import ddf.catalog.operation.impl.CreateRequestImpl;
 import ddf.catalog.operation.impl.CreateResponseImpl;
 import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.operation.impl.OperationTransaction;
 import ddf.catalog.operation.impl.ProcessingDetailsImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
@@ -998,6 +999,11 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                 createReq = plugin.processPreCreate(createReq);
             }
 
+            createReq.getProperties()
+                    .put(Constants.OPERATION_TRANSACTION_KEY,
+                            new OperationTransaction(OperationTransaction.OperationType.CREATE,
+                                    new ArrayList<>()));
+
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
                 try {
                     createReq = plugin.process(createReq);
@@ -1314,6 +1320,11 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                 updateReq = plugin.processPreUpdate(updateReq, metacardMap);
             }
 
+            updateReq.getProperties()
+                    .put(Constants.OPERATION_TRANSACTION_KEY,
+                            new OperationTransaction(OperationTransaction.OperationType.UPDATE,
+                                    metacardMap.values()));
+
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
                 try {
                     updateReq = plugin.process(updateReq);
@@ -1446,6 +1457,11 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
                 deleteRequest = plugin.processPreDelete(deleteRequest);
             }
+
+            deleteRequest.getProperties()
+                    .put(Constants.OPERATION_TRANSACTION_KEY,
+                            new OperationTransaction(OperationTransaction.OperationType.DELETE,
+                                    metacards));
 
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
                 try {


### PR DESCRIPTION
#### What does this PR do?
Adds the an OperationTransaction to update and delete requests
#### Who is reviewing it?
@pklinef 
#### How should this be tested?
Successful bamboo build
#### Any background context you want to provide?
This is being added to support CatalogStores and Registry to prevent repeat queries. This could also be used in the future to support operation rollbacks 
#### What are the relevant tickets?
DDF-1987
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests



- Added OperationTransaction to hold metacards and operation type.