### PR TITLE
DDF-1999: Fixed download URL in GmdMetacardTransformer

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverter.java
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
+import java.net.URI;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Set;
@@ -43,6 +44,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
 
@@ -51,7 +53,7 @@ public class GmdConverter implements Converter {
     private static final Logger LOGGER = LoggerFactory.getLogger(GmdConverter.class);
 
     static final DatatypeFactory XSD_FACTORY;
-    
+
     private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
 
     static {
@@ -175,10 +177,21 @@ public class GmdConverter implements Converter {
     protected void addDistributionInfo(MetacardImpl metacard,
             XstreamPathValueTracker pathValueTracker) {
 
-        if (metacard.getResourceURI() != null) {
-            pathValueTracker.add(new Path(GmdMetacardType.LINKAGE_URI_PATH),
-                    metacard.getResourceURI()
-                            .toASCIIString());
+        String resourceUrl = null;
+        Attribute downloadUrlAttr = metacard.getAttribute(Metacard.RESOURCE_DOWNLOAD_URL);
+        if (downloadUrlAttr != null) {
+            resourceUrl = (String) downloadUrlAttr.getValue();
+        }
+
+        if (StringUtils.isNotBlank(resourceUrl)) {
+            pathValueTracker.add(new Path(GmdMetacardType.LINKAGE_URI_PATH), resourceUrl);
+        } else {
+            URI resourceUri = metacard.getResourceURI();
+            if (resourceUri != null) {
+
+                pathValueTracker.add(new Path(GmdMetacardType.LINKAGE_URI_PATH),
+                        resourceUri.toASCIIString());
+            }
         }
 
     }

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGmdConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGmdConverter.java
@@ -54,7 +54,10 @@ public class TestGmdConverter {
 
     private static GregorianCalendar effectiveDate;
 
-    private static final String ACTION_URL = "http://example.com/source/id?transform=resource";
+    private static final String RESOURCE_DOWNLOAD_URL =
+            "http://example.com/source/id?transform=resource";
+
+    private static final String RESOURCE_URI = "content:123";
 
     private static final String POLYGON_LOCATION =
             "POLYGON ((117.6552810668945 -30.92013931274414, 117.661361694336 -30.92383384704589, 117.6666412353516 -30.93005561828613, "
@@ -119,7 +122,7 @@ public class TestGmdConverter {
         String xml = convert(metacard, true);
         Diff diff = new Diff(compareString, xml);
 
-        LOGGER.info("diff:\n" + diff);
+        LOGGER.info("diff:\n" + diff.toString());
         assertThat(diff.identical(), is(true));
     }
 
@@ -134,8 +137,8 @@ public class TestGmdConverter {
 
         String xml = convert(metacard, true);
         Diff diff = new Diff(compareString, xml);
-        LOGGER.info("diff:\n" + diff);
 
+        LOGGER.info("diff:\n" + diff.toString());
         assertThat(diff.identical(), is(true));
 
     }
@@ -166,8 +169,10 @@ public class TestGmdConverter {
         metacard.setSourceId("sourceID");
         metacard.setTitle("example title");
 
+        metacard.setAttribute(Metacard.RESOURCE_DOWNLOAD_URL, RESOURCE_DOWNLOAD_URL);
+
         try {
-            metacard.setResourceURI(new URI(ACTION_URL));
+            metacard.setResourceURI(new URI(RESOURCE_URI));
         } catch (URISyntaxException e) {
             LOGGER.debug("URISyntaxException", e);
         }


### PR DESCRIPTION
#### What does this PR do?
GmdMetacardTransformer was mapping the metacard resource URI to the
resource in the produced Gmd metadata.  This URI is not always resolvable
by externals.  Updated the transformer to instead use the metacard
resource-download-url.

#### Who is reviewing it?
@kcwire @bdeining 
#### How should this be tested?
1) ingest data into the catalog (pdf for example) 
2) catalog:dump -t gmd:MD_Metadata 
3) verify the linkage URL in the GMD metadata is a valid link to the data.

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

