### PR TITLE
DDF-1910: updated javadocs profile to enable javadoc aggregation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
                         <execution>
                             <id>attach-javadocs</id>
                             <goals>
-                                <goal>jar</goal>
+                                <goal>aggregate</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -434,9 +434,8 @@
                         <bottom>
                             <![CDATA[This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License<a>.]]></bottom>
                         <failOnError>false</failOnError>
-                        <aggregate>true</aggregate>
                         <show>protected</show>
-                        <skip>true</skip>
+                        <skip>false</skip>
                         <additionalparam>
                             -Xdoclint:none
                         </additionalparam>


### PR DESCRIPTION
#### What does this PR do?

Enables javadoc aggregation with the command `javadoc:aggregate`
#### Who is reviewing it?
@jlcsmith @shaundmorris @Lambeaux @jrnorth @mcalcote @oscaritoro @vinamartin @lessarderic 

#### How should this be tested?
generate aggregated javadocs with the maven command `mvn javadoc:aggregate`; complete javadocs should be found in the `ddf/target directory.

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-1910
#### Screenshots (if appropriate)
n/a
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

