### PR TITLE
DDF-1910: fix for javadoc dependencies

### DIFF
--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -164,6 +164,38 @@
         </profile>
         <profile>
             <id>javadoc-unpack</id>
+            <dependencies>
+                <dependency>
+                    <groupId>ddf.catalog.core</groupId>
+                    <artifactId>catalog-core-api</artifactId>
+                    <version>${project.version}</version>
+                    <type>javadoc</type>
+                </dependency>
+                <dependency>
+                    <groupId>ddf.mime.core</groupId>
+                    <artifactId>mime-core-api</artifactId>
+                    <version>${project.version}</version>
+                    <type>javadoc</type>
+                </dependency>
+                <dependency>
+                    <groupId>ddf.action.core</groupId>
+                    <artifactId>action-core-api</artifactId>
+                    <version>${project.version}</version>
+                    <type>javadoc</type>
+                </dependency>
+                <dependency>
+                    <groupId>ddf.security.core</groupId>
+                    <artifactId>security-core-api</artifactId>
+                    <version>${project.version}</version>
+                    <type>javadoc</type>
+                </dependency>
+                <dependency>
+                    <groupId>ddf.security.encryption</groupId>
+                    <artifactId>security-encryption-api</artifactId>
+                    <version>${project.version}</version>
+                    <type>javadoc</type>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -229,36 +261,7 @@
         </profile>
     </profiles>
     <dependencies>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
-            <type>javadoc</type>
-        </dependency>
-        <dependency>
-            <groupId>ddf.mime.core</groupId>
-            <artifactId>mime-core-api</artifactId>
-            <version>${project.version}</version>
-            <type>javadoc</type>
-        </dependency>
-        <dependency>
-            <groupId>ddf.action.core</groupId>
-            <artifactId>action-core-api</artifactId>
-            <version>${project.version}</version>
-            <type>javadoc</type>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security.core</groupId>
-            <artifactId>security-core-api</artifactId>
-            <version>${project.version}</version>
-            <type>javadoc</type>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security.encryption</groupId>
-            <artifactId>security-encryption-api</artifactId>
-            <version>${project.version}</version>
-            <type>javadoc</type>
-        </dependency>
+
         <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>kernel</artifactId>

--- a/libs/libs-pomfix/bin/pom-fix
+++ b/libs/libs-pomfix/bin/pom-fix
@@ -61,7 +61,8 @@ var options = {
     group: [/^org\.codice/, /^ddf/].concat(program.include || [])
   },
   exclude: {
-    artifact: ['docs', /^sample-/]
+    artifact: ['docs', /^sample-/],
+    type: ['javadoc']
   }
 }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes build errors on non-existent javadoc artifacts
#### Who is reviewing it?
@shaundmorris @djblue @clockard @pklinef 
#### How should this be tested?
Bamboo build should pass

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-1910](https://codice.atlassian.net/browse/DDF-1910)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
