### PR TITLE
DDF-2010 IDP path uses the root context from system.properties

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -116,7 +116,7 @@ import net.shibboleth.utilities.java.support.logic.ConstraintViolationException;
 @Path("/")
 public class IdpEndpoint implements Idp {
 
-    public static final String SERVICES_IDP_PATH = "/services/idp";
+    public static final String SERVICES_IDP_PATH = SystemBaseUrl.getRootContext() + "/idp";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IdpEndpoint.class);
 


### PR DESCRIPTION
#### What does this PR do?
The IDP path replaces the hardcoded "/services" with the root context from the system.properties.
#### Who is reviewing it?
@ryeats @rzwiefel @coyotesqrl @tbatie 
#### How should this be tested?
PRBS
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
DDF-2010
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests

