### PR TITLE
DDF-1971 Clean up federated source error log messages

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -491,7 +491,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             response = new SourceInfoResponseImpl(sourceInfoRequest, null, sourceDescriptors);
 
         } catch (RuntimeException re) {
-            LOGGER.warn("Exception during runtime while performing getSourceInfo", re);
+            LOGGER.warn(
+                    "Exception during runtime while performing getSourceInfo: {}",
+                    re.getMessage());
+            LOGGER.debug("Exception during runtime while performing getSourceInfo", re);
             throw new SourceUnavailableException(
                     "Exception during runtime while performing getSourceInfo");
 

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -389,7 +389,8 @@ public class RESTEndpoint implements RESTService {
                 resultsList.add(sourceObj);
             }
         } catch (SourceUnavailableException e) {
-            LOGGER.warn("Unable to retrieve Sources", e);
+            LOGGER.warn("Unable to retrieve Sources. {}", e.getMessage());
+            LOGGER.debug("Unable to retrieve Sources", e);
         }
 
         sourcesString = JSONValue.toJSONString(resultsList);

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswResponseExceptionMapper.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswResponseExceptionMapper.java
@@ -87,7 +87,8 @@ public class CswResponseExceptionMapper implements ResponseExceptionMapper<CswEx
                             "Error received from remote Csw server" + (msg != null ?
                                     ": " + msg :
                                     ""));
-                    LOGGER.warn("Unable to parse exception report: {}", e);
+                    LOGGER.warn("Unable to parse exception report: {}", e.getMessage());
+                    LOGGER.debug("Unable to parse exception report: {}", e);
                 }
                 if (msg != null) {
                     try {
@@ -102,7 +103,8 @@ public class CswResponseExceptionMapper implements ResponseExceptionMapper<CswEx
                     } catch (JAXBException e) {
                         cswException = new CswException(
                                 "Error received from remote Csw server: " + msg, e);
-                        LOGGER.warn("Error parsing the exception report: {}", e);
+                        LOGGER.warn("Error parsing the exception report: {}", e.getMessage());
+                        LOGGER.debug("Error parsing the exception report", e);
                     }
                 }
             } else {

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/search/QueryRunnable.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/search/QueryRunnable.java
@@ -250,18 +250,26 @@ public abstract class QueryRunnable implements Runnable {
                         .query(request);
             }
         } catch (UnsupportedQueryException | FederationException e) {
-            LOGGER.warn("Error executing query", e);
+            LOGGER.warn("Error executing query. {}. Set log level to DEBUG for more information",
+                    e.getMessage());
+            LOGGER.debug("Error executing query", e);
             response.getProcessingDetails()
                     .add(new ProcessingDetailsImpl(sourceId, e));
         } catch (SourceUnavailableException e) {
-            LOGGER.warn("Error executing query because the underlying source was unavailable.", e);
+            LOGGER.warn(
+                    "Error executing query because the underlying source was unavailable. {}. Set log level to DEBUG for more information",
+                    e.getMessage());
+            LOGGER.debug("Error executing query because the underlying source was unavailable.", e);
             response.getProcessingDetails()
                     .add(new ProcessingDetailsImpl(sourceId, e));
         } catch (RuntimeException e) {
             // Account for any runtime exceptions and send back a server error
             // this prevents full stacktraces returning to the client
             // this allows for a graceful server error to be returned
-            LOGGER.warn("RuntimeException on executing query", e);
+            LOGGER.warn(
+                    "RuntimeException on executing query. {}. Set log level to DEBUG for more information",
+                    e.getMessage());
+            LOGGER.debug("RuntimeException on executing query", e);
             response.getProcessingDetails()
                     .add(new ProcessingDetailsImpl(sourceId, e));
         }

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -86,3 +86,4 @@ log4j.logger.org.apache.solr = WARN
 log4j.logger.lux.solr = WARN
 log4j.logger.org.ops4j.pax.web.jsp = WARN
 log4j.logger.org.apache.aries.spifly = WARN
+log4j.logger.org.apache.cxf.phase.PhaseInterceptorChain = ERROR


### PR DESCRIPTION
#### What does this PR do?
Cleans up log stack traces for unavailable federated sources.
- Move unavailable source stack traces to DEBUG level
- Add checks for more specific exceptions
- Change CXF PhaseInterceptorChain default log level to ERROR to remove unwanted stack traces, can be set back to WARN using log:set command

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jaymcnallie @bdeining @kcwire @troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire 
#### How should this be tested?
Build and start and instance of DDF and add federated sources with bologna information. 

Some WFS sources:
http://www.pyxisinnovation.com/pyxwiki/index.php?title=WFS_Servers
https://github.com/DamonOehlman/geofilter/issues/1
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
[DDF-1971](https://codice.atlassian.net/projects/DDF/issues/DDF-1971?filter=allissues)
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests