### PR TITLE
DDF-2015: Turned off itest logging and added a flag to enable

### DIFF
--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/AdminConfig.java
@@ -31,9 +31,9 @@ public class AdminConfig {
 
     public static final String LOGGER_PREFIX = "log4j.logger.";
 
-    public static final String DEFAULT_LOG_LEVEL = "TRACE";
+    public static final String DEFAULT_LOG_LEVEL = "WARN";
 
-    public static final String TEST_LOGLEVEL_PROPERTY = "org.codice.test.defaultLoglevel";
+    public static final String TEST_LOGLEVEL_PROPERTY = "itestLogLevel";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdminConfig.class);
 
@@ -119,11 +119,12 @@ public class AdminConfig {
 
         Configuration logConfig = configAdmin.getConfiguration(LOG_CONFIG_PID, null);
         Dictionary<String, Object> properties = logConfig.getProperties();
-        if (StringUtils.isEmpty(logLevel)) {
-            properties.put(LOGGER_PREFIX + "ddf", DEFAULT_LOG_LEVEL);
-            properties.put(LOGGER_PREFIX + "org.codice", DEFAULT_LOG_LEVEL);
-        } else {
-            properties.put(LOGGER_PREFIX + "*", logLevel);
+
+        properties.put(LOGGER_PREFIX + "*", DEFAULT_LOG_LEVEL);
+
+        if (!StringUtils.isEmpty(logLevel)) {
+            properties.put(LOGGER_PREFIX + "ddf", logLevel);
+            properties.put(LOGGER_PREFIX + "org.codice", logLevel);
         }
 
         logConfig.update(properties);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -78,15 +78,11 @@ import ddf.test.itests.common.UrlResourceReaderConfigurator;
  */
 public abstract class AbstractIntegrationTest {
 
-    public static final String TEST_LOGLEVEL_PROPERTY = "org.codice.test.defaultLoglevel";
-
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractIntegrationTest.class);
 
     protected static final String LOG_CONFIG_PID = AdminConfig.LOG_CONFIG_PID;
 
     protected static final String LOGGER_PREFIX = AdminConfig.LOGGER_PREFIX;
-
-    protected static final String DEFAULT_LOG_LEVEL = AdminConfig.DEFAULT_LOG_LEVEL;
 
     protected static final String KARAF_VERSION = "4.0.4";
 
@@ -387,7 +383,8 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configurePaxExam() {
-        return options(logLevel(LogLevelOption.LogLevel.INFO), useOwnExamBundlesStartLevel(100),
+        return options(logLevel(LogLevelOption.LogLevel.WARN),
+                useOwnExamBundlesStartLevel(100),
                 // increase timeout for CI environment
                 systemTimeout(TimeUnit.MINUTES.toMillis(10)), when(Boolean.getBoolean(
                         "keepRuntimeFolder")).useOptions(keepRuntimeFolder()), cleanCaches(true));
@@ -500,9 +497,9 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configureSystemSettings() {
-        return options(when(System.getProperty(TEST_LOGLEVEL_PROPERTY) != null).useOptions(
-                        systemProperty(TEST_LOGLEVEL_PROPERTY).value(System.getProperty(
-                                TEST_LOGLEVEL_PROPERTY,
+        return options(when(System.getProperty(AdminConfig.TEST_LOGLEVEL_PROPERTY) != null).useOptions(
+                systemProperty(AdminConfig.TEST_LOGLEVEL_PROPERTY).value(System.getProperty(
+                        AdminConfig.TEST_LOGLEVEL_PROPERTY,
                                 ""))),
                 when(Boolean.getBoolean("isDebugEnabled")).useOptions(vmOption(
                         "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")),

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -47,6 +47,7 @@ public class TestPlatform extends AbstractIntegrationTest {
     public void beforeTest() throws Exception {
         try {
             basePort = getBasePort();
+            getAdminConfig().setLogLevels();
             getServiceManager().waitForRequiredApps(getDefaultRequiredApps());
             getServiceManager().waitForAllBundles();
             // Start the services needed for testing.


### PR DESCRIPTION
#### What does this PR do?
Turns off itest logging and addes a flag to enable it
#### Who is reviewing it?
@coyotesqrl @ryeats @bcwaters @roelens8 @jckilmer 
#### How should this be tested?
Make sure all itests pass and that the flag `itestLogLevel `works properly
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

