### PR TITLE
DDF-2021 add outgoing and incoming audit logging interceptors.

### DIFF
--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -277,6 +277,11 @@
             <artifactId>platform-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.interceptor</groupId>
+            <artifactId>security-interceptor-logger</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in used in platform-app's features.xml

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -689,6 +689,12 @@
         <bundle>mvn:ddf.platform/platform-scheduler/${project.version}</bundle>
     </feature>
 
+    <feature name="security-logger" install="manual" version="${project.version}"
+             description="Logs incoming and outgoing requests">
+        <feature prerequisite="true">security-core-api</feature>
+        <bundle>mvn:ddf.security.interceptor/security-interceptor-logger/${project.version}</bundle>
+    </feature>
+
     <feature name="platform-commands" install="manual" version="${project.version}"
              description="Platform Command line tools">
         <feature prerequisite="true">platform-configuration</feature>
@@ -994,6 +1000,7 @@
         <feature>security-core-api</feature>
         <feature>metrics-reporting</feature>
         <feature>metrics-services</feature>
+        <feature>security-logger</feature>
         <feature>solr</feature>
         <feature>persistence-core</feature>
         <feature>error</feature>

--- a/platform/security/interceptor/pom.xml
+++ b/platform/security/interceptor/pom.xml
@@ -27,5 +27,6 @@
     <modules>
         <module>security-interceptor-guest</module>
         <module>security-interceptor-guest-wrapper</module>
+        <module>security-interceptor-logger</module>
     </modules>
 </project>

--- a/platform/security/interceptor/security-interceptor-logger/pom.xml
+++ b/platform/security/interceptor/security-interceptor-logger/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>interceptor</artifactId>
+        <groupId>ddf.security.interceptor</groupId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>security-interceptor-logger</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>DDF :: Security :: Interceptor :: Logger</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+            <version>${shiro.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            ddf.security.interceptor*;version=${project.version}
+                        </Export-Package>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityInterceptorFeature.java
+++ b/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityInterceptorFeature.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.interceptor;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
+
+public class SecurityInterceptorFeature extends AbstractFeature {
+
+    private static final SecurityLoggerInInterceptor SECURITY_LOGGER_IN = new SecurityLoggerInInterceptor();
+
+    private static final SecurityLoggerOutInterceptor SECURITY_LOGGER_OUT = new SecurityLoggerOutInterceptor();
+
+
+    @Override
+    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
+        provider.getInInterceptors()
+                .add(SECURITY_LOGGER_IN);
+        provider.getOutInterceptors()
+                .add(SECURITY_LOGGER_OUT);
+    }
+
+
+}

--- a/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityLoggerInInterceptor.java
+++ b/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityLoggerInInterceptor.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.interceptor;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+
+import ddf.security.SubjectUtils;
+import ddf.security.common.audit.SecurityLogger;
+
+public class SecurityLoggerInInterceptor extends AbstractPhaseInterceptor<Message> {
+    public SecurityLoggerInInterceptor() {
+        super(Phase.INVOKE);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        if(!MessageUtils.isRequestor(message)) {
+            Subject subject = ThreadContext.getSubject();
+            if (subject != null) {
+                String username = SubjectUtils.getName(subject);
+                SecurityLogger.logInfo(username + " is making an inbound request to "+message.get(Message.REQUEST_URL)+".");
+            } else {
+                SecurityLogger.logInfo("No subject associated with inbound request to "+message.get(Message.REQUEST_URL)+".");
+            }
+        }
+    }
+}

--- a/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityLoggerOutInterceptor.java
+++ b/platform/security/interceptor/security-interceptor-logger/src/main/java/ddf/security/interceptor/SecurityLoggerOutInterceptor.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.interceptor;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+
+import ddf.security.SubjectUtils;
+import ddf.security.common.audit.SecurityLogger;
+
+public class SecurityLoggerOutInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    public SecurityLoggerOutInterceptor() {
+        super(Phase.WRITE);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        if (MessageUtils.isRequestor(message)) {
+            Subject subject = ThreadContext.getSubject();
+            if (subject != null) {
+                String username = SubjectUtils.getName(subject);
+                SecurityLogger.logInfo(username + " is making an outbound request.");
+            } else {
+                SecurityLogger.logInfo("No subject associated with outbound request.");
+            }
+
+        }
+    }
+}

--- a/platform/security/interceptor/security-interceptor-logger/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/interceptor/security-interceptor-logger/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" default-activation="lazy">
+
+    <bean id="serviceBean" class="ddf.security.interceptor.SecurityInterceptorFeature"/>
+
+    <service ref="serviceBean" interface="org.apache.cxf.feature.Feature"/>
+
+</blueprint>


### PR DESCRIPTION
#### What does this PR do?
Adds interceptors that log all incoming and outgoing requests 
#### Who is reviewing it?
@codice/security @roelens8 @bcwaters @coyotesqrl @tbatie @jckilmer 
#### How should this be tested?
do a loopback federation verify that their are security logs for queries that are going out to the endpoint and coming in to the endpoint specified in the loopback configuration .
#### What are the relevant tickets?
DDF-2021
#### Screenshots (if appropriate)
```Admin is making an outbound request. Outbound endpoint: https://localhost:8993/services/csw
No subject associated with outbound request. Outbound endpoint: https://localhost:8993/services/csw
Admin is making an inbound request to  https://localhost:8993/services/csw. Request IP: 127.0.0.1, Port: 8080
No subject associated with inbound request to https://localhost:8993/services/csw. Request IP: 127.0.0.1, Port: 8080```
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
