### PR TITLE
DDF-2018 Added content-length header for cached products

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -513,6 +513,11 @@ public class RESTEndpoint implements RESTService {
                             "inline; filename=\"" + filename + "\"");
                 }
 
+                long size = content.getSize();
+                if (size > 0) {
+                    responseBuilder.header(HEADER_CONTENT_LENGTH, size);
+                }
+
                 response = responseBuilder.build();
             } catch (FederationException e) {
                 String exceptionMessage = "READ failed due to unexpected exception: ";


### PR DESCRIPTION
#### What does this PR do?
Adds content length header for cached product returns. 
#### Who is reviewing it?
@jaymcnallie @kcwire @bdeining 
#### How should this be tested?
Run the following ITest: 
mvn clean  test -nsu  -Dtest=TestCatalog#testCachedContentLengthHeader
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2018
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests