### PR TITLE
DDF-2031 Adds a two-second delay on failed login to prevent automated password cracking

### DIFF
--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/FailedLoginDelayer.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/FailedLoginDelayer.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.common;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FailedLoginDelayer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedLoginDelayer.class);
+
+    private static final int TIMEOUT = 2;
+
+    public void delay(String username) {
+        try {
+            LOGGER.debug("Failed login for {}; sleeping for {} seconds\n", username, TIMEOUT);
+            TimeUnit.SECONDS.sleep(TIMEOUT);
+        } catch (InterruptedException e1) {
+            LOGGER.debug("Error sleeping for failed login attempt");
+        }
+    }
+}

--- a/platform/security/filter/security-filter-login/pom.xml
+++ b/platform/security/filter/security-filter-login/pom.xml
@@ -170,7 +170,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.36</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -185,7 +185,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.36</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/interceptor/security-interceptor-guest/src/main/java/org/codice/ddf/security/interceptor/GuestInterceptor.java
+++ b/platform/security/interceptor/security-interceptor-guest/src/main/java/org/codice/ddf/security/interceptor/GuestInterceptor.java
@@ -17,10 +17,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.namespace.QName;
@@ -137,7 +137,7 @@ public class GuestInterceptor extends AbstractWSS4JInterceptor {
 
     private boolean overrideEndpointPolicies = false;
 
-    private Map<String, Subject> cachedGuestSubjectMap = new HashMap<>();
+    private Map<String, Subject> cachedGuestSubjectMap = new ConcurrentHashMap<>();
 
     public GuestInterceptor(SecurityManager securityManager,
             ContextPolicyManager contextPolicyManager) {
@@ -453,7 +453,7 @@ public class GuestInterceptor extends AbstractWSS4JInterceptor {
         }
     }
 
-    private synchronized Subject getSubject(String ipAddress) {
+    private Subject getSubject(String ipAddress) {
         Subject subject = cachedGuestSubjectMap.get(ipAddress);
         if (Security.tokenAboutToExpire(subject)) {
             GuestAuthenticationToken token = new GuestAuthenticationToken(

--- a/platform/security/sts/security-sts-realm/src/test/java/ddf/security/realm/sts/TestStsRealm.java
+++ b/platform/security/sts/security-sts-realm/src/test/java/ddf/security/realm/sts/TestStsRealm.java
@@ -28,6 +28,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.cxf.ws.security.trust.STSClient;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.codice.ddf.security.handler.api.BSTAuthenticationToken;
@@ -110,7 +111,8 @@ public class TestStsRealm {
                 return securityToken;
             }
 
-            protected void configureStsClient() {
+            protected STSClient configureStsClient() {
+                return null;
             }
         };
         Element issuedAssertion = this.readDocument("/saml.xml")
@@ -140,7 +142,8 @@ public class TestStsRealm {
                 return token;
             }
 
-            protected void configureStsClient() {
+            protected STSClient configureStsClient() {
+                return null;
             }
         };
 

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -223,6 +223,12 @@
                     serviceName="ns1:SecurityTokenService"
                     endpointName="ns1:STS_Port"
                     depends-on="propertyWrapper">
+        <jaxws:executor>
+            <bean id="executor" class="java.util.concurrent.Executors"
+                  factory-method="newFixedThreadPool">
+                <argument value="16"/>
+            </bean>
+        </jaxws:executor>
         <jaxws:inInterceptors>
             <ref component-id="crlInterceptor"/>
             <ref component-id="SubjectDNConstraintsInterceptor"/>

--- a/platform/security/sts/security-sts-upbstvalidator/pom.xml
+++ b/platform/security/sts/security-sts-upbstvalidator/pom.xml
@@ -119,22 +119,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.22</minimum>
+                                            <minimum>0.31</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/sts/security-sts-upbstvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-upbstvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,8 +24,11 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
+    <bean id="failedLoginDelayer" class="org.codice.ddf.security.common.FailedLoginDelayer"/>
+
     <bean class="org.codice.ddf.security.validator.uname.UPBSTValidator" id="utValidator">
         <argument ref="xmlParser"/>
+        <argument ref="failedLoginDelayer"/>
     </bean>
 
     <reference-list id="jaasRealmList" interface="org.apache.karaf.jaas.config.JaasRealm">

--- a/platform/security/sts/security-sts-usernametokenvalidator/pom.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/pom.xml
@@ -112,22 +112,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.32</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.46</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,9 +41,12 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
+    <bean id="failedLoginDelayer" class="org.codice.ddf.security.common.FailedLoginDelayer"/>
+
     <bean class="org.codice.ddf.security.validator.username.UsernameTokenValidator"
           id="userValidator">
         <argument ref="xmlParser"/>
+        <argument ref="failedLoginDelayer"/>
     </bean>
 
     <reference-list interface="org.apache.karaf.jaas.config.JaasRealm">


### PR DESCRIPTION
#### What does this PR do?
Adds a delay mechanism on failed login attempts.

Also removes synchronization from `LoginFilter` and fixes `AbstractStsRealm` so it no longer shares an `STSClient` between threads.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie 
@roelens8 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison

#### How should this be tested?
A full build will exercise the unit tests. Further manual testing is probably best managed by attaching a remote debugger to a running DDF instance and confirming that the delay code is invoked. Additionally, any attempt to login through the STS with incorrect credentials will be timed out so scripting an attack-like scenario should demonstrate that the system slows down the operation of the script while still allowing correct logins to pass.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2031

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
