### PR TITLE
DDF-1910: corrected javadoc configuration.

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -394,6 +394,13 @@
                                 </execution>
                             </executions>
                         </plugin>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
                     </plugins>
                 </build>
             </profile>

--- a/javadoc-descriptor.xml
+++ b/javadoc-descriptor.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<assembly
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xsi:schemaLocation="
+      http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
+      http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>javadoc-aggregate</id>
+    <formats>
+          <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+             <fileMode>0644</fileMode>
+             <directoryMode>0755</directoryMode>
+             <directory>${project.build.directory}/site/project-info/api</directory>
+             <includes>
+                   <include>**</include>
+            </includes>
+            <outputDirectory>api</outputDirectory>
+        </fileSet>
+     </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,7 @@
                         <additionalparam>
                             -Xdoclint:none
                         </additionalparam>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -683,7 +684,9 @@
         <profile>
             <id>javadoc</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>javadoc-descriptor.xml</exists>
+                </file>
             </activation>
             <build>
                 <plugins>
@@ -706,6 +709,21 @@
                                     </reportOutputDirectory>
                                     <destDir>api</destDir>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <descriptor>javadoc-descriptor.xml</descriptor>
+                                </configuration>
+                                <id>package-javadoc</id>
+                                <phase>site</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
#### What does this PR do?

Enables Javadoc to be generated, aggregated and deployed during a `mvn site` build. Javadoc is deployed in a zip file that can be unzipped and installed locally or hosted publicly. 

#### Who is reviewing it?

@jlcsmith @shaundmorris @lessarderic @mcalcote @brianfelix @vinamartin @gordocanchola @clockard @oscaritoro 

#### Choose 2 committers to review/merge the PR.
@kcwire
@lessarderic

#### How should this be tested?
run `mvn clean site` to confirm javadoc aggregated
run `mvn clean install` to confirm no side effects to regular build process.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1910

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
