### PR TITLE
DDF-2038 Added NSF and NSIF to NITF Mime Type Configuration

### DIFF
--- a/platform/platform-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
+++ b/platform/platform-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
@@ -1,4 +1,4 @@
-customMimeTypes=["nitf\=image/nitf","ntf\=image/nitf"]
+customMimeTypes=["nitf\=image/nitf","ntf\=image/nitf","nsf\=image/nitf","nsif\=image/nitf"]
 name="NITF\ Content\ Resolver"
 priority=I"10"
 service.factoryPid="DDF_Custom_Mime_Type_Resolver"


### PR DESCRIPTION
#### What does this PR do?
This PR adds NSIF and NSF to the NITF Custom Mime Types in DDF
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver
@glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build DDF and observe that the NITF Custom Mime Type has NSF and NSIF.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-30
https://codice.atlassian.net/browse/DDF-2038
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
