### PR TITLE
ddf-2039 Add the metacard to the properties of the ResourceResponse

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
@@ -24,6 +24,12 @@ import ddf.catalog.event.EventProcessor;
 public final class Constants {
 
     /**
+     * This constant is the name used to pass the metacard as part of a CatalogResponse.
+     *
+     */
+    public static final String METACARD_PROPERTY = "metacard";
+
+    /**
      * This constant should be used to pass the users credentials in the form of a Subject object
      * through any request/response property map.
      */

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -2407,6 +2407,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                             e);
                 }
             }
+
+            resourceResponse.getProperties().put(Constants.METACARD_PROPERTY, metacard);
         } catch(DataUsageLimitExceededException e) {
             LOGGER.error("RuntimeException caused by: ", e);
             throw e;
@@ -2416,12 +2418,6 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         } catch (StopProcessingException e) {
             LOGGER.error("Resource not supported", e);
             throw new ResourceNotSupportedException(FAILED_BY_GET_RESOURCE_PLUGIN + e.getMessage());
-        }
-
-        if (resourceResponse == null) {
-            throw new ResourceNotFoundException(
-                    "Resource could not be found for the given attribute value: "
-                            + resourceReq.getAttributeValue());
         }
 
         return resourceResponse;

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -1659,6 +1659,8 @@ public class CatalogFrameworkImplTest {
         ResourceResponse response = framework.getResource(request, federatedSite1Name);
 
         assertThat(response, is(ResourceResponse.class));
+        Metacard responseMetacard = (Metacard) response.getProperties().get("metacard");
+        assertThat(responseMetacard, is(Metacard.class));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
This PR makes it possible to retrieve a content item and its associated metacard in a single request.  

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@stustison 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire

#### How should this be tested?
Run CatalogFrameworkImplTest.testGetResourceFromCache().

#### Any background context you want to provide?

#### What are the relevant tickets?
DDF-2039

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

Modified the CatalogFrameworkImpl to add the metacard (which was already
being retrieved) to the properties of the ResourceResponse.