### PR TITLE
DDF-2043 Guards against NPEs caused by null Principals being passed to ClaimsHandlers

### DIFF
--- a/platform/security/sts/security-sts-attributequerycommon/src/main/java/org/codice/ddf/security/claims/attributequery/common/AttributeQueryClaimsHandler.java
+++ b/platform/security/sts/security-sts-attributequerycommon/src/main/java/org/codice/ddf/security/claims/attributequery/common/AttributeQueryClaimsHandler.java
@@ -112,11 +112,14 @@ public class AttributeQueryClaimsHandler implements ClaimsHandler {
     @Override
     public ProcessedClaimCollection retrieveClaimValues(ClaimCollection claims,
             ClaimsParameters parameters) {
+        ProcessedClaimCollection claimCollection = new ProcessedClaimCollection();
         Principal principal = parameters.getPrincipal();
+        if (principal == null) {
+            return claimCollection;
+        }
 
         String nameId = getNameId(principal);
 
-        ProcessedClaimCollection claimCollection = new ProcessedClaimCollection();
         try {
             if (!StringUtils.isEmpty(nameId)) {
                 ProcessedClaimCollection securityClaimCollection = getAttributes(nameId);

--- a/platform/security/sts/security-sts-attributequerycommon/src/test/java/org/codice/ddf/security/claims/attributequery/common/TestAttributeQueryClaimsHandler.java
+++ b/platform/security/sts/security-sts-attributequerycommon/src/test/java/org/codice/ddf/security/claims/attributequery/common/TestAttributeQueryClaimsHandler.java
@@ -241,6 +241,19 @@ public class TestAttributeQueryClaimsHandler {
     }
 
     @Test
+    public void testRetrieveClaimsValuesNullPrincipal() {
+        ClaimsParameters claimsParameters = mock(ClaimsParameters.class);
+        when(claimsParameters.getPrincipal()).thenReturn(null);
+
+        ClaimCollection claimCollection = new ClaimCollection();
+        ProcessedClaimCollection processedClaims =
+                spyAttributeQueryClaimsHandler.retrieveClaimValues(claimCollection,
+                        claimsParameters);
+
+        assertThat(processedClaims.size(), is(equalTo(0)));
+    }
+
+    @Test
     public void testSupportedClaimsTypes() {
         List<URI> supportedClaimTypes = spyAttributeQueryClaimsHandler.getSupportedClaimTypes();
 

--- a/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
@@ -163,22 +163,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.37</minimum>
+                                            <minimum>0.43</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.15</minimum>
+                                            <minimum>0.24</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.25</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -14,6 +14,7 @@
 
 package ddf.security.sts.claimsHandler;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -28,6 +29,8 @@ import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.responses.BindResult;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -66,4 +69,14 @@ public class LdapClaimsHandlerTest {
         assertThat(testClaimCollection.isEmpty(), is(true));
     }
 
+    @Test
+    public void testRetrieveClaimsValuesNullPrincipal() {
+        LdapClaimsHandler claimsHandler = new LdapClaimsHandler();
+        ClaimsParameters claimsParameters = new ClaimsParameters();
+        ClaimCollection claimCollection = new ClaimCollection();
+        ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(
+                claimCollection, claimsParameters);
+
+        Assert.assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
+    }
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.sts.claimsHandler;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.apache.cxf.rt.security.claims.ClaimCollection;
+import org.apache.cxf.sts.claims.ClaimsParameters;
+import org.apache.cxf.sts.claims.ProcessedClaimCollection;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RoleClaimsHandlerTest {
+    @Test
+    public void testRetrieveClaimsValuesNullPrincipal() {
+        RoleClaimsHandler claimsHandler = new RoleClaimsHandler();
+        ClaimsParameters claimsParameters = new ClaimsParameters();
+        ClaimCollection claimCollection = new ClaimCollection();
+        ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(
+                claimCollection, claimsParameters);
+
+        Assert.assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
+    }
+}

--- a/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
@@ -133,12 +133,12 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.49</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/AttributeFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/AttributeFileClaimsHandler.java
@@ -103,6 +103,10 @@ public class AttributeFileClaimsHandler implements ClaimsHandler, RealmSupport {
             ClaimsParameters claimsParameters) {
         ProcessedClaimCollection claimsColl = new ProcessedClaimCollection();
         Principal principal = claimsParameters.getPrincipal();
+        if (principal == null) {
+            return claimsColl;
+        }
+
         String name;
         if (principal instanceof X500Principal) {
             name = SubjectUtils.getCommonName((X500Principal) principal);

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestAttributeFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestAttributeFileClaimsHandler.java
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.security.sts.claims.property;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +34,8 @@ import org.apache.cxf.rt.security.claims.ClaimCollection;
 import org.apache.cxf.sts.claims.ClaimsParameters;
 import org.apache.cxf.sts.claims.ProcessedClaim;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -162,5 +165,15 @@ public class TestAttributeFileClaimsHandler {
         ProcessedClaimCollection processedClaims = attributeFileClaimsHandler.retrieveClaimValues(
                 claimCollection, unknownClaimsParameters);
         assertThat(processedClaims.size(), is(0));
+    }
+
+    @Test
+    public void testRetrieveClaimsValuesNullPrincipal() {
+        ClaimsParameters claimsParameters = new ClaimsParameters();
+        ClaimCollection claimCollection = new ClaimCollection();
+        ProcessedClaimCollection processedClaims = attributeFileClaimsHandler.retrieveClaimValues(
+                claimCollection, claimsParameters);
+
+        Assert.assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
     }
 }

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestPropertyFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestPropertyFileClaimsHandler.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.security.sts.claims.property;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -29,6 +30,8 @@ import org.apache.cxf.rt.security.claims.Claim;
 import org.apache.cxf.rt.security.claims.ClaimCollection;
 import org.apache.cxf.sts.claims.ClaimsParameters;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPropertyFileClaimsHandler {
@@ -77,5 +80,16 @@ public class TestPropertyFileClaimsHandler {
         principal = new KerberosPrincipal("mykman@SOMEDOMAIN.COM");
         user = propertyFileClaimsHandler.getUser(principal);
         assertEquals("mykman", user);
+    }
+
+    @Test
+    public void testRetrieveClaimsValuesNullPrincipal() {
+        PropertyFileClaimsHandler claimsHandler = new PropertyFileClaimsHandler();
+        ClaimsParameters claimsParameters = new ClaimsParameters();
+        ClaimCollection claimCollection = new ClaimCollection();
+        ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(
+                claimCollection, claimsParameters);
+
+        Assert.assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Some of the DDF ClaimsHandlers failed to guard against null Principals. Under rare conditions, the Principal passed has been seen to be null; this will protect against NPEs and return empty claims.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jckilmer 
@bcwaters 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
Full build with unit and integration tests is sufficient to test.

#### Any background context you want to provide?
In testing the possibility of emptying or removing the `users.properties` file and using an LDAP server as the sole realm provider, we found that there were some conditions at startup that could result in a null Principal. While this is a rare case, it is nonetheless a code path that needs to be protected.

#### What are the relevant tickets?
DDF-2043

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests