### PR TITLE
DDF-2033 Add support for connecting to multiple LDAP servers at the s…

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_security-contents/integrating-security-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_security-contents/integrating-security-contents.adoc
@@ -505,9 +505,11 @@ Complete the following procedure to provide your own keystore information for th
 
 . The embedded LDAP server is not recommended for production use as it has hardcoded keystores and truststores with localhost certificates. These cannot be changed unless the embedded server bundle is re-built with new stores.
 
-==== Connect to a Standalone LDAP Server
+==== Connect to Standalone LDAP Servers
 
-${branding} instances can connect to an external LDAP server by installing and configuring the `security-sts-ldaplogin` and `security-sts-ldapclaimshandler` features detailed here.
+${branding} instances can connect to external LDAP servers by installing and configuring the `security-sts-ldaplogin` and `security-sts-ldapclaimshandler` features detailed here.
+
+In order to connect to more than one LDAP server, configure these features for each LDAP server.
 
 ==== Embedded LDAP Configuration
 

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,30 +33,33 @@
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
-		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-        http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-        http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
-
+      http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
-    <bean id="claimsHandlerManager" class="ddf.security.sts.claimsHandler.ClaimsHandlerManager"
-          init-method="configure" destroy-method="destroy">
-        <cm:managed-properties persistent-id="ddf.security.sts.claimsHandler"
-                               update-strategy="component-managed" update-method="update"/>
-        <argument ref="encryptionService"/>
-        <!-- Default properties -->
-        <property name="url" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
-        <property name="startTls" value="false"/>
-        <property name="ldapBindUserDn" value="cn=admin"/>
-        <property name="password" value="secret"/>
-        <property name="userNameAttribute" value="uid"/>
-        <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
-        <property name="objectClass" value="groupOfNames"/>
-        <property name="memberNameAttribute" value="member"/>
-        <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
-        <property name="propertyFileLocation" value="etc/ws-security/attributeMap.properties"/>
-    </bean>
+    <cm:managed-service-factory
+            id="ddf.security.sts.claimsHandler.ClaimsHandlerManager.id"
+            factory-pid="Claims_Handler_Manager"
+            interface="ddf.security.sts.claimsHandler.ClaimsHandlerManager">
+        <cm:managed-component class="ddf.security.sts.claimsHandler.ClaimsHandlerManager"
+                              init-method="configure" destroy-method="destroy">
+            <argument ref="encryptionService"/>
+            <!-- Default properties -->
+            <property name="url" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="startTls" value="false"/>
+            <property name="ldapBindUserDn" value="cn=admin"/>
+            <property name="password" value="secret"/>
+            <property name="userNameAttribute" value="uid"/>
+            <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
+            <property name="objectClass" value="groupOfNames"/>
+            <property name="memberNameAttribute" value="member"/>
+            <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
+            <property name="propertyFileLocation" value="etc/ws-security/attributeMap.properties"/>
+            <cm:managed-properties persistent-id=""
+                                   update-strategy="component-managed" update-method="update"/>
+        </cm:managed-component>
+    </cm:managed-service-factory>
 
 </blueprint>
+
 

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -16,7 +16,7 @@
                    xsi:schemaLocation="http://www.osgi.org/xmlns/metatype/v1.2.0 http://www.osgi.org/xmlns/metatype/v1.2.0">
 
 	<OCD description="STS Ldap and Roles Claims Handler Configuration. WARNING: The server must be restarted for these updates to take affect."
-         name="Security STS LDAP and Roles Claims Handler" id="ddf.security.sts.claimsHandler">
+         name="Security STS LDAP and Roles Claims Handler" id="Claims_Handler_Manager">
 
 	    <AD name="LDAP URL:" id="url" required="true" type="String"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
@@ -70,8 +70,8 @@
 
 	</OCD>
 
-	<Designate pid="ddf.security.sts.claimsHandler">
-	    <Object ocdref="ddf.security.sts.claimsHandler"/>
+	<Designate factoryPid="Claims_Handler_Manager">
+	    <Object ocdref="Claims_Handler_Manager"/>
   	</Designate>
 
 </metatype:MetaData>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapService.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapService.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.ldap.ldaplogin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.jaas.config.JaasRealm;
+import org.apache.karaf.jaas.config.impl.Config;
+import org.apache.karaf.jaas.config.impl.Module;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LdapService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapService.class);
+
+    private static final String CONFIG_NAME = "ldap";
+
+    private Config config;
+
+    private List<Module> modules;
+
+    public LdapService(final BundleContext context) {
+        config = new Config();
+        modules = new ArrayList<>();
+        config.setBundleContext(context);
+        config.setName(CONFIG_NAME);
+        config.setRank(2);
+        config.setModules(new Module[] {});
+
+        LOGGER.debug("Registering new service as a JaasRealm.");
+        context.registerService(JaasRealm.class, config, null);
+    }
+
+    /**
+     * Updates an existing ldap module with a new one or adds a
+     * new module to the list of existing modules.
+     *
+     * @param newModule that will replace a module or be added to the list of modules.
+     */
+    public synchronized void update(Module newModule) {
+        modules = modules.stream()
+                .filter(m -> !m.getName()
+                        .equals(newModule.getName()))
+                .collect(Collectors.toList());
+        modules.add(newModule);
+        config.setModules(modules.toArray(new Module[modules.size()]));
+    }
+
+    /**
+     * Delete an ldap module given its id.
+     *
+     * @param id of the module.
+     * @return true, if the delete was successful, false otherwise.
+     */
+    public synchronized boolean delete(String id) {
+        int initSize = modules.size();
+        modules = modules.stream()
+                .filter(m -> !m.getName()
+                        .equals(id))
+                .collect(Collectors.toList());
+        config.setModules(modules.toArray(new Module[modules.size()]));
+        return initSize > modules.size();
+    }
+
+    /**
+     * Return the list of created ldap modules.
+     *
+     * @return list of modules.
+     */
+    List<Module> getModules() {
+        return Collections.unmodifiableList(this.modules);
+    }
+}

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -18,24 +18,35 @@
         <bean class="ddf.security.sts.PropertiesConverter"/>
     </type-converters>
 
-    <bean id="LdapConfig" class="ddf.ldap.ldaplogin.LdapLoginConfig" init-method="configure">
-        <cm:managed-properties persistent-id="ddf.security.sts.ldap"
-                               update-strategy="component-managed"
-                               update-method="update"/>
-        <!-- Default properties -->
-        <property name="ldapBindUserDn" value="cn=admin"/>
-        <property name="ldapBindUserPass" value="secret"/>
-        <property name="ldapUrl" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
-        <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
-        <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
-        <property name="keyAlias" value="${org.codice.ddf.system.hostname}"/>
-        <property name="startTls" value="false"/>
+
+    <cm:managed-service-factory
+            id="ddf.ldap.ldaplogin.LdapLoginConfig.id"
+            factory-pid="Ldap_Login_Config"
+            interface="ddf.ldap.ldaplogin.LdapLoginConfig">
+        <cm:managed-component class="ddf.ldap.ldaplogin.LdapLoginConfig"
+                              init-method="configure" destroy-method="destroy">
+            <!-- Default properties -->
+            <property name="ldapBindUserDn" value="cn=admin"/>
+            <property name="ldapBindUserPass" value="secret"/>
+            <property name="ldapUrl" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
+            <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
+            <property name="keyAlias" value="${org.codice.ddf.system.hostname}"/>
+            <property name="startTls" value="false"/>
+            <property name="ldapService" ref="ldapService"/>
+            <cm:managed-properties persistent-id=""
+                                   update-strategy="component-managed" update-method="update"/>
+        </cm:managed-component>
+    </cm:managed-service-factory>
+
+    <bean id="ldapService" class="ddf.ldap.ldaplogin.LdapService">
+        <argument ref="blueprintBundleContext"/>
     </bean>
 
     <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
     <bean id="keystoreManager" class="ddf.ldap.ldaplogin.KeystoreManager">
-        <cm:managed-properties persistent-id="ddf.security.sts.ldap"
+        <cm:managed-properties persistent-id="Ldap_Login_Config"
                                update-strategy="container-managed"/>
         <argument ref="encryptionService"/>
         <argument value="${org.codice.ddf.system.hostname}"/>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -16,7 +16,7 @@
                    xsi:schemaLocation="http://www.osgi.org/xmlns/metatype/v1.2.0 http://www.osgi.org/xmlns/metatype/v1.2.0">
 
 	<OCD description="STS Ldap Login Configuration" name="Security STS LDAP Login"
-         id="ddf.security.sts.ldap">
+         id="Ldap_Login_Config">
 	    
 	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
@@ -60,8 +60,8 @@
 	    
 	</OCD>
 	
-	<Designate pid="ddf.security.sts.ldap">
-	    <Object ocdref="ddf.security.sts.ldap"/>
+	<Designate factoryPid="Ldap_Login_Config" pid="ddf.Ldap_Login_Config">
+	    <Object ocdref="Ldap_Login_Config"/>
   	</Designate>
   	
 </metatype:MetaData>


### PR DESCRIPTION
#### What does this PR do?
Adds support for connecting to multiple LDAP servers at the same time so that users from different LDAPs can login to DDF.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @tbatie @jckilmer @bcwaters @coyotesqrl @kcwire 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest)
@pklinef 
@stustison
#### How should this be tested?
In order to fully test this PR, connecting at least two LDAP Servers to a single DDF is required.

Instructions for connecting to LDAP server(s):
1. Install 'OpenDj Embedded'
2. Configure 'LDAP Server' with desired port numbers
3. Install 'security-sts-ldaplogin' and 'security-sts-ldapclaimshandler'
4. Configure 'Security STS LDAP Login' and 'Security STS LDAP and Roles Claims Handler' with the LDAP information of the LDAP you want to connect to. Connecting to multiple LDAPs will require creating a  set of these configurations for each  #LDAP.  (Note: the SSL Keystore Alias needs to be set to the DDF server's keystore alias even when connecting to an LDAP located on another server).
5. Configure the Web Context Policy
    Add the following to the Context Realms: '/search=ldap'', /services=ldap', '/cometd=ldap'
6. Login the Search UI with a different user from each connected LDAP. (Note: Make sure the user you login as does not exist in any other LDAPs.)

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2033
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…ame time