### PR TITLE
DDF-2023: Added Duplication PreIngest Plugin

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -453,5 +453,10 @@
             <artifactId>catalog-core-validator</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-duplication</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -363,6 +363,12 @@
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-pptx/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-duplication-plugin" install="manual" version="${project.version}"
+             description="DDF Metacard Duplication Plugin">
+        <feature prerequisite="true">catalog-core</feature>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-duplication/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-app" install="auto" version="${project.version}"
              description="The DDF Catalog provides a framework for storing, searching, processing, and transforming information.\nClients typically perform query, create, read, update, and delete (QCRUD) operations against the Catalog.\nAt the core of the Catalog functionality is the Catalog Framework, which routes all requests and responses through the system, invoking additional processing per the system configuration.::DDF Catalog">
         <feature prerequisite="true">security-services-app</feature>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -275,13 +275,13 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_CHECKSUM_ALGORITHM,
+        descriptors.add(new AttributeDescriptorImpl(Metacard.CHECKSUM_ALGORITHM,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_CHECKSUM,
+        descriptors.add(new AttributeDescriptorImpl(Metacard.CHECKSUM,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
@@ -202,14 +202,14 @@ public interface Metacard extends Serializable {
      *
      * @since DDF-2.9.0
      */
-    String RESOURCE_CHECKSUM_ALGORITHM = "resource-checksum-algorithm";
+    String CHECKSUM_ALGORITHM = "checksum-algorithm";
 
     /**
      * {@link Attribute} checksum value for the {@link Metacard#RESOURCE_URI}
      *
      * @since DDF-2.9.0
      */
-    String RESOURCE_CHECKSUM = "resource-checksum";
+    String CHECKSUM = "checksum";
 
     /**
      * {@link Attribute} that provides URIs for derived formats of the {@literal Metacard.RESOURCE_URI}

--- a/catalog/plugin/catalog-plugin-checksum/src/main/java/org/codice/ddf/catalog/content/plugin/checksum/Checksum.java
+++ b/catalog/plugin/catalog-plugin-checksum/src/main/java/org/codice/ddf/catalog/content/plugin/checksum/Checksum.java
@@ -84,8 +84,8 @@ public class Checksum implements PreCreateStoragePlugin, PreUpdateStoragePlugin 
 
     private void addChecksumAttributes(Metacard metacard, final String checksumAlgorithm,
             final String checksumValue) {
-        metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_CHECKSUM_ALGORITHM,
+        metacard.setAttribute(new AttributeImpl(Metacard.CHECKSUM_ALGORITHM,
                 checksumAlgorithm));
-        metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_CHECKSUM, checksumValue));
+        metacard.setAttribute(new AttributeImpl(Metacard.CHECKSUM, checksumValue));
     }
 }

--- a/catalog/plugin/catalog-plugin-checksum/src/test/java/org/codice/ddf/catalog/content/plugin/checksum/TestChecksum.java
+++ b/catalog/plugin/catalog-plugin-checksum/src/test/java/org/codice/ddf/catalog/content/plugin/checksum/TestChecksum.java
@@ -84,12 +84,12 @@ public class TestChecksum {
         String checksumResult = (String) request.getContentItems()
                 .get(0)
                 .getMetacard()
-                .getAttribute(Metacard.RESOURCE_CHECKSUM)
+                .getAttribute(Metacard.CHECKSUM)
                 .getValue();
         String checksumAlgorithm = (String) request.getContentItems()
                 .get(0)
                 .getMetacard()
-                .getAttribute(Metacard.RESOURCE_CHECKSUM_ALGORITHM)
+                .getAttribute(Metacard.CHECKSUM_ALGORITHM)
                 .getValue();
         assertThat(checksumResult, is(SAMPLE_CHECKSUM_VALUE));
         assertThat(checksumAlgorithm, is(SAMPLE_CHECKSUM_ALGORITHM));
@@ -102,12 +102,12 @@ public class TestChecksum {
         String checksumResult = (String) request.getContentItems()
                 .get(0)
                 .getMetacard()
-                .getAttribute(Metacard.RESOURCE_CHECKSUM)
+                .getAttribute(Metacard.CHECKSUM)
                 .getValue();
         String checksumAlgorithm = (String) request.getContentItems()
                 .get(0)
                 .getMetacard()
-                .getAttribute(Metacard.RESOURCE_CHECKSUM_ALGORITHM)
+                .getAttribute(Metacard.CHECKSUM_ALGORITHM)
                 .getValue();
         assertThat(checksumResult, is(SAMPLE_CHECKSUM_VALUE));
         assertThat(checksumAlgorithm, is(SAMPLE_CHECKSUM_ALGORITHM));

--- a/catalog/plugin/catalog-plugin-duplication/pom.xml
+++ b/catalog/plugin/catalog-plugin-duplication/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.catalog.plugin</groupId>
+        <artifactId>plugin</artifactId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <name>DDF :: Catalog :: Plugin :: Duplication</name>
+    <artifactId>catalog-plugin-duplication</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                        <Export-Package/>
+
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.62</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-duplication/src/main/java/ddf/catalog/metacard/duplication/DuplicationValidator.java
+++ b/catalog/plugin/catalog-plugin-duplication/src/main/java/ddf/catalog/metacard/duplication/DuplicationValidator.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * </p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.metacard.duplication;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.ArrayUtils;
+import org.opengis.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ReportingMetacardValidator;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.ValidationExceptionImpl;
+import ddf.catalog.validation.impl.report.MetacardValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class DuplicationValidator
+        implements MetacardValidator, ReportingMetacardValidator, ddf.catalog.util.Describable,
+        org.codice.ddf.platform.services.common.Describable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DuplicationValidator.class);
+
+    private final CatalogFramework catalogFramework;
+
+    private final FilterBuilder filterBuilder;
+
+    private String[] errorOnDuplicateAttributes;
+
+    private String[] warnOnDuplicateAttributes;
+
+    private static final String DESCRIBABLE_PROPERTIES_FILE = "/describable.properties";
+
+    private static Properties describableProperties = new Properties();
+
+    private static final String ORGANIZATION = "organization";
+
+    private static final String VERSION = "version";
+
+    static {
+        try (InputStream properties = DuplicationValidator.class.getResourceAsStream(
+                DESCRIBABLE_PROPERTIES_FILE)) {
+            describableProperties.load(properties);
+        } catch (IOException e) {
+            LOGGER.info("Failed to load properties", e);
+        }
+    }
+
+    public DuplicationValidator(CatalogFramework catalogFramework, FilterBuilder filterBuilder) {
+        this.catalogFramework = catalogFramework;
+        this.filterBuilder = filterBuilder;
+    }
+
+    /**
+     * Setter for the list of attributes to test for duplication in the local catalog.  Resulting
+     * attributes will cause the {@link ddf.catalog.data.impl.BasicTypes#VALIDATION_ERRORS} attribute
+     * to be set on the metacard.
+     *
+     * @param attributeStrings
+     */
+    public void setErrorOnDuplicateAttributes(String[] attributeStrings) {
+        if (attributeStrings != null) {
+            this.errorOnDuplicateAttributes = Arrays.copyOf(attributeStrings,
+                    attributeStrings.length);
+        }
+    }
+
+    /**
+     * Setter for the list of attributes to test for duplication in the local catalog.  Resulting
+     * attributes will cause the {@link ddf.catalog.data.impl.BasicTypes#VALIDATION_WARNINGS} attribute
+     * to be set on the metacard.
+     *
+     * @param attributeStrings
+     */
+    public void setWarnOnDuplicateAttributes(String[] attributeStrings) {
+        if (attributeStrings != null) {
+            this.warnOnDuplicateAttributes = Arrays.copyOf(attributeStrings,
+                    attributeStrings.length);
+        }
+    }
+
+    @Override
+    public Optional<MetacardValidationReport> validateMetacard(Metacard metacard) {
+        Preconditions.checkArgument(metacard != null, "The metacard cannot be null.");
+
+        return getReport(reportDuplicates(metacard));
+
+    }
+
+    @Override
+    public void validate(Metacard metacard) throws ValidationException {
+
+        final Optional<MetacardValidationReport> report = validateMetacard(metacard);
+
+        if (report.isPresent()) {
+            final List<String> errors = report.get()
+                    .getMetacardValidationViolations()
+                    .stream()
+                    .filter(validationViolation -> validationViolation.getSeverity()
+                            .equals(ValidationViolation.Severity.ERROR))
+                    .map(ValidationViolation::getMessage)
+                    .collect(Collectors.toList());
+            final List<String> warnings = report.get()
+                    .getMetacardValidationViolations()
+                    .stream()
+                    .filter(validationViolation -> validationViolation.getSeverity()
+                            .equals(ValidationViolation.Severity.WARNING))
+                    .map(ValidationViolation::getMessage)
+                    .collect(Collectors.toList());
+
+            String message = String.format("Duplicate data found in catalog for ID {%s}.",
+                    metacard.getId());
+            final ValidationExceptionImpl exception = new ValidationExceptionImpl(message);
+            exception.setErrors(errors);
+            exception.setWarnings(warnings);
+            throw exception;
+        }
+    }
+
+    private Set<ValidationViolation> reportDuplicates(final Metacard metacard) {
+
+        Set<ValidationViolation> violations = new HashSet<>();
+
+        if (ArrayUtils.isNotEmpty(warnOnDuplicateAttributes)) {
+            ValidationViolation warnValidation = reportDuplicates(metacard,
+                    warnOnDuplicateAttributes,
+                    ValidationViolation.Severity.WARNING);
+            if (warnValidation != null) {
+                violations.add(warnValidation);
+            }
+        }
+        if (ArrayUtils.isNotEmpty(errorOnDuplicateAttributes)) {
+            ValidationViolation errorViolation = reportDuplicates(metacard,
+                    errorOnDuplicateAttributes,
+                    ValidationViolation.Severity.ERROR);
+            if (errorViolation != null) {
+                violations.add(errorViolation);
+            }
+        }
+
+        return violations;
+
+    }
+
+    private ValidationViolation reportDuplicates(final Metacard metacard, String[] attributeNames,
+            ValidationViolation.Severity severity) {
+
+        Set<String> duplicates = new HashSet<>();
+        ValidationViolation violation = null;
+
+        final Set<String> uniqueAttributeNames = Stream.of(attributeNames)
+                .filter(attribute -> metacard.getAttribute(attribute) != null)
+                .collect(Collectors.toSet());
+        final Set<Attribute> uniqueAttributes = uniqueAttributeNames.stream()
+                .map(attribute -> metacard.getAttribute(attribute))
+                .collect(Collectors.toSet());
+        if (!uniqueAttributes.isEmpty()) {
+            LOGGER.debug("Checking for duplicates for id {} against attributes [{}]",
+                    metacard.getId(),
+                    collectionToString(uniqueAttributeNames));
+
+            SourceResponse response = query(uniqueAttributes);
+            if (response != null) {
+                response.getResults()
+                        .forEach(result -> duplicates.add(result.getMetacard()
+                                .getId()));
+            }
+            if (!duplicates.isEmpty()) {
+
+                violation = createViolation(uniqueAttributeNames, duplicates, severity);
+                LOGGER.debug(violation.getMessage());
+            }
+        }
+        return violation;
+    }
+
+    private Filter[] buildFilters(Set<Attribute> attributes) {
+
+        Filter[] filters = attributes.stream()
+                .flatMap(attribute -> {
+                    return attribute.getValues()
+                            .stream()
+                            .map(value -> filterBuilder.attribute(attribute.getName())
+                                    .equalTo()
+                                    .text(value.toString()
+                                            .trim()));
+                })
+                .toArray(Filter[]::new);
+
+        return filters;
+    }
+
+    private SourceResponse query(Set<Attribute> attributes) {
+
+        final Filter filter = filterBuilder.anyOf(buildFilters(attributes));
+
+        QueryImpl query = new QueryImpl(filter);
+        query.setRequestsTotalResultsCount(false);
+        QueryRequest request = new QueryRequestImpl(query);
+
+        SourceResponse response = null;
+        try {
+            response = catalogFramework.query(request);
+        } catch (FederationException | SourceUnavailableException | UnsupportedQueryException e) {
+            LOGGER.warn("Query failed ", e);
+        }
+        return response;
+    }
+
+    private ValidationViolation createViolation(final Set<String> attributes,
+            Set<String> duplicates, ValidationViolation.Severity severity) {
+
+        return new ValidationViolationImpl(attributes, String.format(
+                "Duplicate data found in catalog: {%s}, based on attributes: {%s}.",
+                collectionToString(duplicates),
+                collectionToString(attributes)), severity);
+    }
+
+    private String collectionToString(final Collection collection) {
+
+        return (String) collection.stream()
+                .map(Object::toString)
+                .sorted()
+                .collect(Collectors.joining(", "));
+    }
+
+    private Optional<MetacardValidationReport> getReport(
+            final Set<ValidationViolation> violations) {
+        if (CollectionUtils.isNotEmpty(violations)) {
+            final MetacardValidationReportImpl report = new MetacardValidationReportImpl();
+            violations.forEach(report::addMetacardViolation);
+            return Optional.of(report);
+        }
+
+        return Optional.empty();
+    }
+
+    // todo load from properties
+    @Override
+    public String getVersion() {
+        return describableProperties.getProperty(VERSION);
+    }
+
+    @Override
+    public String getId() {
+        return this.getClass()
+                .getSimpleName();
+    }
+
+    @Override
+    public String getTitle() {
+        return this.getClass()
+                .getSimpleName();
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks metacard against the local catalog for duplicates based on configurable attributes.";
+    }
+
+    @Override
+    public String getOrganization() {
+        return describableProperties.getProperty(ORGANIZATION);
+
+    }
+}

--- a/catalog/plugin/catalog-plugin-duplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-duplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+
+    <bean id="duplicateValidator" class="ddf.catalog.metacard.duplication.DuplicationValidator">
+        <cm:managed-properties persistent-id="ddf.catalog.metacard.duplication.DuplicationValidator"
+                               update-strategy="container-managed"/>
+        <argument ref="catalogFramework"/>
+        <argument ref="filterBuilder"/>
+        <property name="warnOnDuplicateAttributes">
+            <array>
+                <value>checksum</value>
+            </array>
+        </property>
+        <property name="errorOnDuplicateAttributes">
+            <array/>
+        </property>
+    </bean>
+
+    <service ref="duplicateValidator">
+        <interfaces>
+            <value>ddf.catalog.validation.MetacardValidator</value>
+            <value>ddf.catalog.validation.ReportingMetacardValidator</value>
+        </interfaces>
+    </service>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-duplication/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-duplication/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Catalog Duplicate Validator"
+         id="ddf.catalog.metacard.duplication.DuplicationValidator">
+        <AD
+                description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation ERROR, but the ingest will succeed."
+                name="Metacard attributes (duplicates cause a validation error)"
+                id="errorOnDuplicateAttributes" required="true" type="String" cardinality="1000"/>
+        <AD
+                description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation WARNING, but the ingest will succeed."
+                name="Metacard attributes (duplicates cause a validation warning)"
+                id="warnOnDuplicateAttributes" required="true" type="String" cardinality="1000"
+                default="checksum"/>
+    </OCD>
+
+    <Designate
+            pid="ddf.catalog.metacard.duplication.DuplicationValidator">
+        <Object
+                ocdref="ddf.catalog.metacard.duplication.DuplicationValidator"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-duplication/src/main/resources/describable.properties
+++ b/catalog/plugin/catalog-plugin-duplication/src/main/resources/describable.properties
@@ -1,0 +1,2 @@
+version=${version}
+organization=${organization.name}

--- a/catalog/plugin/catalog-plugin-duplication/src/test/java/ddf/catalog/metacard/duplication/TestDuplicationValidator.java
+++ b/catalog/plugin/catalog-plugin-duplication/src/test/java/ddf/catalog/metacard/duplication/TestDuplicationValidator.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * </p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.metacard.duplication;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opengis.filter.Filter;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestDuplicationValidator {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private FilterBuilder mockFilterBuilder;
+
+    @Mock
+    private CatalogFramework mockFramework;
+
+    private DuplicationValidator validator;
+
+    private MetacardImpl matchingMetacard;
+
+    private MetacardImpl testMetacard;
+
+    private static final String ID = "matching metacard id";
+
+    private static final String TAG1 = "1";
+
+    private static final String TAG2 = "2";
+
+    private Set tags = new HashSet<>(Arrays.asList(TAG1, TAG2));
+
+    @Before
+    public void setup()
+            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+
+        QueryResponse response = mock(QueryResponse.class);
+
+        when(mockFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        testMetacard = new MetacardImpl();
+        matchingMetacard = new MetacardImpl();
+        matchingMetacard.setId(ID);
+        testMetacard.setId("test metacard ID");
+        matchingMetacard.setAttribute(new AttributeImpl(Metacard.CHECKSUM, "checksum-value"));
+        testMetacard.setAttribute(new AttributeImpl(Metacard.CHECKSUM, "checksum-value"));
+        matchingMetacard.setTags(tags);
+        testMetacard.setTags(tags);
+
+        List<Result> results = Arrays.asList(new ResultImpl(matchingMetacard));
+
+        when(response.getResults()).thenReturn(results);
+        validator = new DuplicationValidator(mockFramework, mockFilterBuilder);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateMetacardNullInput() {
+        validator.validateMetacard(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateNullInput() throws ValidationException {
+        validator.validate(null);
+    }
+
+    @Test
+    public void testValidateMetacardNullConfiguration() throws ValidationException {
+
+        validator.setWarnOnDuplicateAttributes(null);
+        validator.setErrorOnDuplicateAttributes(null);
+
+        Optional<MetacardValidationReport> report = validator.validateMetacard(testMetacard);
+        assertThat(report.isPresent(), is(false));
+    }
+
+    @Test
+    public void testValidateNullConfiguration() throws ValidationException {
+
+        validator.setWarnOnDuplicateAttributes(null);
+        validator.setErrorOnDuplicateAttributes(null);
+
+        // verify no exception thrown
+        validator.validate(testMetacard);
+    }
+
+    @Test
+    public void testValidateMetacardBlankConfiguration() throws ValidationException {
+
+        validator.setWarnOnDuplicateAttributes(new String[0]);
+        validator.setErrorOnDuplicateAttributes(new String[0]);
+
+        Optional<MetacardValidationReport> report = validator.validateMetacard(testMetacard);
+        assertThat(report.isPresent(), is(false));
+    }
+
+    @Test
+    public void testValidateBlankConfiguration() throws ValidationException {
+
+        validator.setWarnOnDuplicateAttributes(new String[0]);
+        validator.setErrorOnDuplicateAttributes(new String[0]);
+
+        // verify no exception thrown
+        validator.validate(testMetacard);
+    }
+
+    @Test
+    public void testValidateMetacardWithValidationErrorAndWarning() {
+
+        String[] checksumAttribute = {Metacard.CHECKSUM};
+        String[] idAttribute = {Metacard.ID};
+
+        validator.setWarnOnDuplicateAttributes(checksumAttribute);
+        validator.setErrorOnDuplicateAttributes(idAttribute);
+
+        Optional<MetacardValidationReport> report = validator.validateMetacard(testMetacard);
+        assertThat(report.isPresent(), is(true));
+
+        assertThat(report.get()
+                .getMetacardValidationViolations(), hasSize(2));
+
+        Map<ValidationViolation.Severity, ValidationViolation> violations = report.get()
+                .getMetacardValidationViolations()
+                .stream()
+                .collect(Collectors.toMap(ValidationViolation::getSeverity, Function.identity()));
+
+        ValidationViolation warnViolation = violations.get(ValidationViolation.Severity.WARNING);
+        ValidationViolation errorViolation = violations.get(ValidationViolation.Severity.ERROR);
+
+        assertThat(warnViolation.getAttributes(),
+                is(new HashSet<>(Arrays.asList(checksumAttribute))));
+        assertThat(warnViolation.getMessage(), containsString(Metacard.CHECKSUM));
+        assertThat(errorViolation.getAttributes(), is(new HashSet<>(Arrays.asList(idAttribute))));
+        assertThat(errorViolation.getMessage(), containsString(Metacard.ID));
+    }
+
+    @Test
+    public void testValidateWithValidationErrorAndWarning() throws ValidationException {
+
+        String[] checksumAttribute = {Metacard.CHECKSUM};
+        String[] idAttribute = {Metacard.ID};
+        ValidationException expectedException = null;
+
+        validator.setWarnOnDuplicateAttributes(checksumAttribute);
+        validator.setErrorOnDuplicateAttributes(idAttribute);
+
+        try {
+            validator.validate(testMetacard);
+        } catch (ValidationException e) {
+            expectedException = e;
+        }
+
+        assertThat(expectedException, is(not(nullValue())));
+        assertThat(expectedException.getMessage(), is(not(nullValue())));
+        assertThat(expectedException.getErrors()
+                .size(), is(1));
+        assertThat(expectedException.getWarnings()
+                .size(), is(1));
+
+        expectedException.getWarnings()
+                .forEach(warning -> assertThat(warning, containsString(Metacard.CHECKSUM)));
+        expectedException.getErrors()
+                .forEach(error -> assertThat(error, containsString(Metacard.ID)));
+    }
+
+    @Test
+    public void testValidateMetacardWithMultiValuedAttribute()
+            throws StopProcessingException, PluginExecutionException, FederationException,
+            UnsupportedQueryException, SourceUnavailableException {
+        String[] tagAttributes = {Metacard.TAGS};
+
+        ArgumentCaptor<String> attributeValueCaptor = ArgumentCaptor.forClass(String.class);
+
+        ArgumentCaptor<QueryRequest> queryRequestCaptor =
+                ArgumentCaptor.forClass(QueryRequest.class);
+        when(mockFilterBuilder.attribute(anyString())
+                .equalTo()
+                .text(attributeValueCaptor.capture())).thenReturn(mock(Filter.class));
+
+
+        String[] attributes = {Metacard.TAGS};
+        validator.setWarnOnDuplicateAttributes(attributes);
+
+        Optional<MetacardValidationReport> report = validator.validateMetacard(testMetacard);
+        assertThat(report.isPresent(), is(true));
+
+        assertThat(report.get()
+                .getMetacardValidationViolations()
+                .size(), is(1));
+        verify(mockFramework).query(queryRequestCaptor.capture());
+        assertThat(attributeValueCaptor.getAllValues(), hasItems(TAG1, TAG2));
+        report.get()
+                .getMetacardValidationViolations()
+                .forEach(violation -> {
+                    assertThat(violation.getAttributes(), is(new HashSet<>(Arrays.asList(
+                            tagAttributes))));
+                    assertThat(violation.getMessage(), containsString(Metacard.TAGS));
+
+                });
+
+    }
+
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -30,5 +30,6 @@
         <module>catalog-plugin-checksum</module>
         <module>catalog-plugin-videothumbnail</module>
         <module>catalog-plugin-versioning</module>
+        <module>catalog-plugin-duplication</module>
     </modules>
 </project>

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/configuring-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/configuring-catalog-contents.adoc
@@ -39,6 +39,10 @@
 |${ddf-branding-lowercase}.catalog.transformer.xml.XmlResponseQueueTransformer
 |Set threshold for running marshalling in parallel
 
+|<<Catalog Duplicate Validator>>
+|${ddf-branding-lowercase}.catalog.metacard.duplication.DuplicationValidator
+|Configure rules to check for duplicate data
+
 |===
 
 .Backup Post-Ingest Plugin
@@ -149,7 +153,7 @@
 |createPermissions
 |String
 |Roles/attributes required for the create operations. Example: role=role1,role2
-|http://schemas.xmlsoap.org/ws/2005/05/ entity/claims/role=guest/>
+|http://schemasoap.org/ws/2005/05/ entity/claims/role=guest/>
 |Yes
 
 |Required Attributes
@@ -356,5 +360,32 @@ The X value will be the value that is placed within the security attribute on th
 |Response size threshold above which marshalling is run in parallel
 |50
 |true
+
+|===
+
+.Catalog Duplicate Validator
+[cols="1,1m,1,2,1,1" options="header"]
+|===
+|Name
+|Property
+|Type
+|Description
+|Default Value
+|Required
+
+
+|Metacard attributes (duplicates cause a validation error)
+|errorOnDuplicateAttributes
+|String  cardinality=1000
+|A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation ERROR, but the ingest will succeed.
+|
+|No
+
+|Metacard attributes (duplicates cause a validation warning)
+|warnOnDuplicateAttributes
+|String  cardinality=1000
+|A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation WARNING, but the ingest will succeed.
+|checksum
+|No
 
 |===


### PR DESCRIPTION
#### What does this PR do?
- checks for duplicates on ingested cards against configurable fields
- admin can configure a duplicate card to be marked with validation errors/warnings

#### Who is reviewing it?
@jrnorth 
@rzwiefel 
@bdeining 
@clockard 
@vinamartin 

#### Choose 2 committers to review/merge the PR:
@beyelerb 
@kcwire 

#### How should this be tested?
1) install the catalog-duplication-plugin feature
2) install the catalog-plugin-metacard-validation feature
3) Configure the duplication validator to check specific attributes for duplicates
4) Configure the metacard validity checker plugin to show invalid metacard on query
4) Ingest one or more items that may be duplicates (for instance, duplicate content)

#### Any background context you want to provide?
The default configuration of the plugin checks the checksum attribute on the metacard against any other checksum in the local catalog.  The checksum is calculated on ingest of a content item.  A validation warning is added to the metacard if a duplicate is found.  

The plugin can be configured to check for duplicates using any attribute.

#### What are the relevant tickets?
DDF-2023

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests