### PR TITLE
DDF-2049 Remove unnecessary synchronization in IDP Endpoint

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/cache/CookieCache.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/cache/CookieCache.java
@@ -72,7 +72,9 @@ public class CookieCache {
     public Element getSamlAssertion(String key) {
         DataWrapper dataWrapper = cache.getIfPresent(key);
         if (dataWrapper != null) {
-            return dataWrapper.element;
+            synchronized (dataWrapper) {
+                return dataWrapper.element;
+            }
         }
         return null;
     }
@@ -83,7 +85,9 @@ public class CookieCache {
             LOGGER.debug("Expiring Saml assertion due to LogoutRequest\n[{}:{}]",
                     key,
                     dataWrapper.element);
-            dataWrapper.element = null;
+            synchronized (dataWrapper) {
+                dataWrapper.element = null;
+            }
         }
     }
 
@@ -138,12 +142,12 @@ public class CookieCache {
         }
     }
 
+    /**
+     * Data access to each of the class variables should be synchronized
+     */
     private static class DataWrapper {
         private Element element;
 
-        /**
-         * Data access to this variable should be synchronized
-         */
         private final Set<String> activeSpSet;
 
         private DataWrapper(Element element) {

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -492,9 +492,8 @@ public class IdpEndpoint implements Idp {
                 .build();
     }
 
-    protected synchronized org.opensaml.saml.saml2.core.Response handleLogin(
-            AuthnRequest authnRequest, String authMethod, HttpServletRequest request,
-            boolean passive, boolean hasCookie)
+    protected org.opensaml.saml.saml2.core.Response handleLogin(AuthnRequest authnRequest,
+            String authMethod, HttpServletRequest request, boolean passive, boolean hasCookie)
             throws SecurityServiceException, WSSecurityException, SimpleSign.SignatureException,
             ConstraintViolationException {
         LOGGER.debug("Performing login for user. passive: {}, cookie: {}", passive, hasCookie);
@@ -571,12 +570,12 @@ public class IdpEndpoint implements Idp {
                 true)), SamlProtocol.createStatus(statusCode), authnRequest.getID(), samlToken);
     }
 
-    private synchronized Cookie getCookie(HttpServletRequest request) {
+    private Cookie getCookie(HttpServletRequest request) {
         Map<String, Cookie> cookies = HttpUtils.getCookieMap(request);
         return cookies.get(COOKIE);
     }
 
-    private synchronized Element getSamlAssertion(HttpServletRequest request) {
+    private Element getSamlAssertion(HttpServletRequest request) {
         Element samlToken = null;
         Cookie cookie = getCookie(request);
         if (cookie != null) {
@@ -590,7 +589,7 @@ public class IdpEndpoint implements Idp {
         return samlToken;
     }
 
-    private synchronized boolean hasValidCookie(HttpServletRequest request, boolean forceAuthn) {
+    private boolean hasValidCookie(HttpServletRequest request, boolean forceAuthn) {
         Cookie cookie = getCookie(request);
         if (cookie != null) {
             LOGGER.debug("Retrieving cookie {}:{} from cache.",
@@ -615,7 +614,7 @@ public class IdpEndpoint implements Idp {
         return false;
     }
 
-    private synchronized LogoutState getLogoutState(HttpServletRequest request) {
+    private LogoutState getLogoutState(HttpServletRequest request) {
         LogoutState logoutState = null;
         Cookie cookie = getCookie(request);
         if (cookie != null) {
@@ -624,7 +623,7 @@ public class IdpEndpoint implements Idp {
         return logoutState;
     }
 
-    private synchronized NewCookie createCookie(HttpServletRequest request,
+    private NewCookie createCookie(HttpServletRequest request,
             org.opensaml.saml.saml2.core.Response response) {
         LOGGER.debug("Creating cookie for user.");
         if (response.getAssertions() != null && response.getAssertions()
@@ -1030,11 +1029,11 @@ public class IdpEndpoint implements Idp {
                 .build();
     }
 
-    public synchronized void setSecurityManager(SecurityManager securityManager) {
+    public void setSecurityManager(SecurityManager securityManager) {
         this.securityManager = securityManager;
     }
 
-    public synchronized void setTokenFactory(PKIAuthenticationTokenFactory tokenFactory) {
+    public void setTokenFactory(PKIAuthenticationTokenFactory tokenFactory) {
         this.tokenFactory = tokenFactory;
     }
 


### PR DESCRIPTION
#### What does this PR do?
Removes synchronization on methods calling securityManager.getSubject() as instances of the StsClient are not being shared anymore. Also, removes synchronization from other methods that are already thread safe.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@coyotesqrl @ryeats @kcwire @rzwiefel @tbatie @jckilmer @bcwaters 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
Test IDP Login/Logout and verify it still works
Run Jmeter test with IDP active and verify no errors/exceptions occurs
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2049
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

