### PR TITLE
DDF-1631 Fix the GeoNames web service's getNearbyCity implementation

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
@@ -84,22 +84,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.25</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.27</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/src/main/java/org/codice/ddf/spatial/geocoder/geonames/GeoNamesWebService.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/src/main/java/org/codice/ddf/spatial/geocoder/geonames/GeoNamesWebService.java
@@ -45,11 +45,23 @@ public class GeoNamesWebService implements GeoCoder {
     private static final Logger LOGGER = LoggerFactory.getLogger(GeoNamesWebService.class);
 
     //geonames requires an application username, this is the default name for DDF
-    protected String username = "ddf_ui";
+    private static final String USERNAME = "ddf_ui";
 
-    protected String geoNamesApiServer = "api.geonames.org";
+    private static final String GEONAMES_API_ADDRESS = "api.geonames.org";
 
-    protected String geoNamesProtocol = "http";
+    private static final String GEONAMES_PROTOCOL = "http";
+
+    private static final String GEONAMES_KEY = "geonames";
+
+    private static final String LAT_KEY = "lat";
+
+    private static final String LON_KEY = "lng";
+
+    private static final String POPULATION_KEY = "population";
+
+    private static final String ADMIN_CODE_KEY = "fcode";
+
+    private static final String PLACENAME_KEY = "name";
 
     @Override
     public GeoResult getLocation(String location) {
@@ -57,31 +69,28 @@ public class GeoNamesWebService implements GeoCoder {
         location = getUrlEncodedLocation(location);
 
         String urlStr = String.format("%s://%s/searchJSON?q=%s&username=%s",
-                geoNamesProtocol,
-                geoNamesApiServer,
+                GEONAMES_PROTOCOL,
+                GEONAMES_API_ADDRESS,
                 location,
-                username);
+                USERNAME);
 
         Object result = query(urlStr);
 
         if (result != null) {
             if (result instanceof JSONObject) {
                 JSONObject jsonResult = (JSONObject) result;
-                JSONArray geonames = (JSONArray) jsonResult.get("geonames");
+                JSONArray geonames = (JSONArray) jsonResult.get(GEONAMES_KEY);
                 if (geonames != null && geonames.size() > 0) {
                     JSONObject firstResult = (JSONObject) geonames.get(0);
                     if (firstResult != null) {
-                        double lat = Double.valueOf((String) firstResult.get("lat"));
-                        double lon = Double.valueOf((String) firstResult.get("lng"));
+                        double lat = Double.valueOf((String) firstResult.get(LAT_KEY));
+                        double lon = Double.valueOf((String) firstResult.get(LON_KEY));
 
-                        Long population = (Long) firstResult.get("population");
-                        String adminCode = (String) firstResult.get("fcode");
+                        Long population = (Long) firstResult.get(POPULATION_KEY);
+                        String adminCode = (String) firstResult.get(ADMIN_CODE_KEY);
 
-                        return GeoResultCreator.createGeoResult((String) firstResult.get("name"),
-                                lat,
-                                lon,
-                                adminCode,
-                                population);
+                        return GeoResultCreator.createGeoResult((String) firstResult.get(
+                                PLACENAME_KEY), lat, lon, adminCode, population);
                     }
                 }
             }
@@ -130,6 +139,7 @@ public class GeoNamesWebService implements GeoCoder {
         return location;
     }
 
+    @Override
     public NearbyLocation getNearbyCity(String locationWkt) {
         if (locationWkt == null) {
             throw new IllegalArgumentException("argument 'locationWkt' may not be null.");
@@ -138,24 +148,24 @@ public class GeoNamesWebService implements GeoCoder {
         Point wktCenterPoint = createPointFromWkt(locationWkt);
 
         String urlStr = String.format(
-                "%s://%s/findNearbyPlaceNameJSON?lat=%f&lng=%f&maxRows=1&username=%s",
-                geoNamesProtocol,
-                geoNamesApiServer,
+                "%s://%s/findNearbyPlaceNameJSON?lat=%f&lng=%f&maxRows=1&username=%s&cities=cities5000",
+                GEONAMES_PROTOCOL,
+                GEONAMES_API_ADDRESS,
                 wktCenterPoint.getY(),
                 wktCenterPoint.getX(),
-                username);
+                USERNAME);
 
         Object result = query(urlStr);
 
         if (result instanceof JSONObject) {
             JSONObject jsonResult = (JSONObject) result;
-            JSONArray geonames = (JSONArray) jsonResult.get("geonames");
+            JSONArray geonames = (JSONArray) jsonResult.get(GEONAMES_KEY);
             if (geonames != null && geonames.size() > 0) {
                 JSONObject firstResult = (JSONObject) geonames.get(0);
                 if (firstResult != null) {
-                    double lat = Double.valueOf((String) firstResult.get("lat"));
-                    double lon = Double.valueOf((String) firstResult.get("lng"));
-                    String cityName = (String) firstResult.get("adminName1");
+                    double lat = Double.valueOf((String) firstResult.get(LAT_KEY));
+                    double lon = Double.valueOf((String) firstResult.get(LON_KEY));
+                    String cityName = (String) firstResult.get(PLACENAME_KEY);
                     Point cityPoint = new PointImpl(lon, lat, SpatialContext.GEO);
 
                     return new NearbyLocationImpl(wktCenterPoint, cityPoint, cityName);

--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/src/test/java/org/codice/ddf/spatial/geocoder/geonames/TestGeoNamesWebService.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/src/test/java/org/codice/ddf/spatial/geocoder/geonames/TestGeoNamesWebService.java
@@ -87,7 +87,7 @@ public class TestGeoNamesWebService {
     }
 
     @Test
-    public void testQuery() {
+    public void testGetNearbyCity() {
         WebClient webClientMock = mock(WebClient.class);
         when(webClientMock.acceptEncoding(anyString())).thenReturn(webClientMock);
         when(webClientMock.accept(anyString())).thenReturn(webClientMock);
@@ -99,6 +99,6 @@ public class TestGeoNamesWebService {
         assertThat(nearbyLocation.getCardinalDirection(), equalTo("W"));
         assertThat(nearbyLocation.getDistance(), greaterThan(14.0));
         assertThat(nearbyLocation.getDistance(), lessThan(15.0));
-        assertThat(nearbyLocation.getName(), equalTo("Aswān"));
+        assertThat(nearbyLocation.getName(), equalTo("Qaryat Wādī ‘Abbādī 2"));
     }
 }


### PR DESCRIPTION
#### What does this PR do?
- Previously, the GeoNames web service implementation was returning the name of the administrative division in which the nearby city resides rather than the name of the city. This PR fixes `GeoNamesWebService` so that it returns the name of the city.
- Filter nearby cities results to cities with a population of at least 5000
- Refactor JSON keys into string constants
- Fix `spatial-geocoding-websearch` test directory structure to match the Maven standard

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire 

#### How should this be tested?
- Search using the web service gazetteer and verify the results are correct
- Create metacards with location data and verify that the spatial context information in the metacard summary pane includes the name of a nearby city

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1631

#### Screenshots (if appropriate)
See ticket

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests