### PR TITLE
DDF-2062: added unit test for docs

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -21,13 +21,16 @@
     </parent>
     <artifactId>docs</artifactId>
     <name>DDF DOCS</name>
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>${skipTests}</skip>
                 </configuration>
             </plugin>
 
@@ -56,6 +59,7 @@
                     <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
                     <packaging>pom</packaging>
                     <module>docs</module>
+                    <skipTests>false</skipTests>
                 </properties>
                 <repositories>
                     <repository>

--- a/distribution/docs/src/main/resources/_contents/securing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/securing-contents.adoc
@@ -75,8 +75,6 @@ The IdP client that interacts with the specified Identity Provider.
 
 ===== IdP SSO Configuration
 
-===== Configuring
-
 . Navigate to ${admin-console} -> ${ddf-security} -> Configuration -> IdP Client
 . Populate IdP Metadata field through one of the following:
 .. An HTTPS URL (https://)
@@ -1010,7 +1008,7 @@ Resources for changing truststore values can be found in the ${branding} Certifi
 ====== Certificate Configuration Management
 
 Configuration management includes configuring ${branding} to use existing certificates and defining configuration options for the system.
-This includes configuration certificate revocation and keystores.
+This includes configuring certificate revocation and keystores.
 
 ====== Certificate Revocation Configuration
 
@@ -1286,7 +1284,6 @@ Self signed certificates should never be used outside of development/testing are
 SSL/TLS is enabled out of the box for ${branding}.
 ====
 
-// Still an issue?
 [IMPORTANT]
 ====
 Do not use the ${admin-console} to SSL enable the ${branding} services.

--- a/distribution/docs/src/test/java/ddf/docs/DocumentationTest.java
+++ b/distribution/docs/src/test/java/ddf/docs/DocumentationTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.docs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class DocumentationTest {
+
+    private static final String UNRESOLVED_DIRECTORY_MSG = "Unresolved directive";
+
+    private static final String DOCS_DIRECTORY = "docs";
+
+    private static final String HTML_DIRECTORY = "html";
+
+    @Test
+    public void testDocumentationIncludes() throws IOException, URISyntaxException {
+
+        Path testPath = Paths.get(this.getClass().getResource("").toURI());
+        Path targetDirectory = testPath.getParent().getParent().getParent();
+        Path docPath = Paths.get(targetDirectory.toString()).resolve(DOCS_DIRECTORY).resolve(
+                HTML_DIRECTORY);
+
+
+        assertThat("Unresolved directive found.",
+                Files.list(docPath).filter(f -> f.toString().endsWith(".html")).noneMatch(f -> {
+                    try {
+                        return Files.lines(f).anyMatch(s -> s.toString().contains(UNRESOLVED_DIRECTORY_MSG));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+}
+


### PR DESCRIPTION
#### What does this PR do?

This PR adds a unit test to check the completeness of finished documentation. This will also fix the incremental builds for documentation PRs.

#### Who is reviewing it?
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested?
full build with documentation profile on should pass all tests,
full build without documentation profile should also pass

#### Any background context you want to provide?
This replaces a manual check of documentation and enables incremental builds to pass.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2062

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
