### PR TITLE
Improve the RNG seed for the HashSessionIdManager:

### DIFF
--- a/platform/security/platform-security-session/pom.xml
+++ b/platform/security/platform-security-session/pom.xml
@@ -27,6 +27,11 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>${bouncy.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -35,16 +40,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Fragment-Host>org.ops4j.pax.web.pax-web-jetty;bundle-version="[4,5)"
-                        </Fragment-Host>
+                        <Fragment-Host>org.ops4j.pax.web.pax-web-jetty;bundle-version="[4,5)"</Fragment-Host>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Import-Package>
-                            org.eclipse.jetty.server.session,
-                            javax.servlet.http,
-                            *
-                        </Import-Package>
-                        <Import-Package/>
-                        <Export-Package/>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
#### What does this PR do?
Provides a seed to the random number generator in the HashSessionIdManager 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @bcwaters @coyotesqrl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison
#### How should this be tested?
Startup ddf and ensure you get unique session ids with multiple logins
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

 - Used bouncycastle random bit generator to provide the random number generator with a good seed