### PR TITLE
DDF-2071 Update CatalogFrameworkImpl so callers can supply a fully po…

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/CatalogFramework.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/CatalogFramework.java
@@ -80,6 +80,11 @@ public interface CatalogFramework extends Describable {
      * <b> This code is experimental. While this interface is functional and tested, it may change or be
      * removed in a future version of the library. </b>
      * </p>
+     * <p>
+     * If the ContentItems within the {@link CreateStorageRequest} contain a non-null Metacard, then the
+     * framework will not call the input transformers and the Metacard must contain the following attributes:
+     * {@link Metacard#ID}, {@link Metacard#TITLE} and {@link Metacard#POINT_OF_CONTACT}.
+     * </p>
      *
      * Creates {@link Metacard}s in the {@link ddf.catalog.source.CatalogProvider}.
      *

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -867,13 +867,31 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                 mimeTypeRaw = guessMimeType(mimeTypeRaw, contentItem.getFilename(), tmpPath);
 
                 String fileName = updateFileExtension(mimeTypeRaw, contentItem.getFilename());
-                Metacard metacard = generateMetacard(mimeTypeRaw,
-                        contentItem.getId(),
-                        fileName,
-                        size,
-                        (Subject) storageRequest.getProperties()
-                                .get(SecurityConstants.SECURITY_SUBJECT),
-                        tmpPath);
+
+                Metacard metacard;
+
+                if (contentItem.getMetacard() != null) {
+                    metacard = contentItem.getMetacard();
+                    if (StringUtils.isBlank(metacard.getId()) ||
+                            StringUtils.isBlank(metacard.getTitle()) ||
+                            metacard.getAttribute(Metacard.POINT_OF_CONTACT) == null ||
+                            StringUtils.isBlank((String) metacard.getAttribute(Metacard.POINT_OF_CONTACT)
+                                    .getValue())) {
+                        throw new MetacardCreationException(
+                                "caller supplied metacards must include an id, title and point of contact: id="
+                                        + metacard.getId() + ", title=" + metacard.getTitle()
+                                        + ", point-of-contact=" +
+                                        metacard.getAttribute(Metacard.POINT_OF_CONTACT));
+                    }
+                } else {
+                    metacard = generateMetacard(mimeTypeRaw,
+                            contentItem.getId(),
+                            fileName,
+                            size,
+                            (Subject) storageRequest.getProperties()
+                                    .get(SecurityConstants.SECURITY_SUBJECT),
+                            tmpPath);
+                }
                 metacardMap.put(metacard.getId(), metacard);
 
                 ContentItem generatedContentItem = new ContentItemImpl(metacard.getId(),

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -877,11 +877,11 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                             metacard.getAttribute(Metacard.POINT_OF_CONTACT) == null ||
                             StringUtils.isBlank((String) metacard.getAttribute(Metacard.POINT_OF_CONTACT)
                                     .getValue())) {
-                        throw new MetacardCreationException(
-                                "caller supplied metacards must include an id, title and point of contact: id="
-                                        + metacard.getId() + ", title=" + metacard.getTitle()
-                                        + ", point-of-contact=" +
-                                        metacard.getAttribute(Metacard.POINT_OF_CONTACT));
+                        throw new MetacardCreationException(String.format(
+                                "caller supplied metacards must include an id, title and point of contact: id=%s, title=%s, point-of-contact=%s",
+                                metacard.getId(),
+                                metacard.getTitle(),
+                                metacard.getAttribute(Metacard.POINT_OF_CONTACT)));
                     }
                 } else {
                     metacard = generateMetacard(mimeTypeRaw,

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -341,8 +341,6 @@ public class CatalogFrameworkImplTest {
     public void testCreateStorage() throws Exception {
         List<ContentItem> contentItems = new ArrayList<>();
 
-        MetacardImpl newCard = new MetacardImpl();
-        newCard.setId(null);
         ByteSource byteSource = new ByteSource() {
             @Override
             public InputStream openStream() throws IOException {
@@ -350,7 +348,7 @@ public class CatalogFrameworkImplTest {
             }
         };
         ContentItemImpl newItem = new ContentItemImpl(byteSource, "application/octet-stream",
-                "blah", newCard);
+                "blah", null);
         contentItems.add(newItem);
 
         CreateResponse response = framework.create(
@@ -423,7 +421,7 @@ public class CatalogFrameworkImplTest {
             }
         };
         ContentItemImpl newItem = new ContentItemImpl(byteSource, "application/octet-stream",
-                "blah", newCard);
+                "blah", null);
         contentItems.add(newItem);
 
         CreateResponse response = framework.create(
@@ -434,7 +432,7 @@ public class CatalogFrameworkImplTest {
         List<ContentItem> updatedContentItems = new ArrayList<>();
         updatedContentItems.add(
                 new ContentItemImpl(insertedCard.getId(), byteSource, "application/octet-stream",
-                        insertedCard));
+                        null));
         UpdateStorageRequest request = new UpdateStorageRequestImpl(updatedContentItems, null);
         // send update to framework
         List<Update> returnedCards = framework.update(request)


### PR DESCRIPTION
#### What does this PR do?
Add the ability for the caller of CatalogFramework.create() to pass in a fully defined metacard instead of letting the framework create a metacard with the input transformers.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@stustison 
@jlcsmith 
@jrnorth 
@kcwire 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Run standard maven tests. There is no UI support for testing this change.

#### Any background context you want to provide?
This change is being made because the new UDP MPEG-TS Stream Monitor can  supply a fully detailed metacard more efficiently.

#### What are the relevant tickets?
DDF-2071

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated (CatalogFramework javadoc)
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
