### PR TITLE
DDF-2076: Use a RNG for the generation fo SessionIndex in the SAML element AuthnStatement

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -189,10 +189,10 @@
                         <plugin>
                             <groupId>de.saumya.mojo</groupId>
                             <artifactId>gem-maven-plugin</artifactId>
-                            <version>1.0.5</version>
+                            <version>1.1.5</version>
                             <configuration>
                                 <!-- align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-                                <jrubyVersion>1.7.9</jrubyVersion>
+                                <jrubyVersion>1.7.25</jrubyVersion>
                                 <gemHome>${project.build.directory}/gems</gemHome>
                                 <gemPath>${project.build.directory}/gems-provided</gemPath>
                             </configuration>

--- a/platform/security/platform-security-session/pom.xml
+++ b/platform/security/platform-security-session/pom.xml
@@ -28,9 +28,8 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bouncy.version}</version>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -42,6 +41,9 @@
                     <instructions>
                         <Fragment-Host>org.ops4j.pax.web.pax-web-jetty;bundle-version="[4,5)"</Fragment-Host>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            platform-util
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/security/platform-security-session/src/main/java/org/codice/ddf/security/session/HashSessionIdManager.java
+++ b/platform/security/platform-security-session/src/main/java/org/codice/ddf/security/session/HashSessionIdManager.java
@@ -31,7 +31,6 @@
 package org.codice.ddf.security.session;
 
 import java.lang.ref.WeakReference;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,10 +45,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import org.bouncycastle.crypto.digests.SHA256Digest;
-import org.bouncycastle.crypto.prng.BasicEntropySourceProvider;
-import org.bouncycastle.crypto.prng.EntropySourceProvider;
-import org.bouncycastle.crypto.prng.drbg.DualECSP800DRBG;
+import org.codice.ddf.platform.util.RandomNumberGenerator;
 import org.eclipse.jetty.server.session.AbstractSession;
 import org.eclipse.jetty.server.session.AbstractSessionIdManager;
 
@@ -63,11 +59,11 @@ public class HashSessionIdManager extends AbstractSessionIdManager {
             new HashMap<String, Set<WeakReference<HttpSession>>>();
 
     public HashSessionIdManager() {
-        super(new SecureRandom(getBcRbgSeed()));
+        super(RandomNumberGenerator.getRNG());
     }
 
     public HashSessionIdManager(Random random) {
-        super(new SecureRandom(getBcRbgSeed()));
+        super(RandomNumberGenerator.getRNG());
     }
 
     /**
@@ -269,20 +265,5 @@ public class HashSessionIdManager extends AbstractSessionIdManager {
                 this.sessions.put(newClusterId, sessions);
             }
         }
-    }
-
-    public static byte[] getBcRbgSeed() {
-        EntropySourceProvider esp = new BasicEntropySourceProvider(new SecureRandom(), true);
-        byte[] nonce = new byte[256];
-        new SecureRandom().nextBytes(nonce);
-
-        DualECSP800DRBG bcRbg = new DualECSP800DRBG(new SHA256Digest(),
-                256,
-                esp.get(256),
-                null,
-                nonce);
-        byte[] seed = new byte[256];
-        bcRbg.generate(seed, null, true);
-        return seed;
     }
 }

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/AuthNStatementProvider.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/AuthNStatementProvider.java
@@ -25,10 +25,11 @@ import org.apache.cxf.sts.token.provider.TokenProviderParameters;
 import org.apache.wss4j.common.principal.UsernameTokenPrincipal;
 import org.apache.wss4j.common.saml.bean.AuthenticationStatementBean;
 import org.apache.wss4j.common.saml.builder.SAML2Constants;
+import org.codice.ddf.platform.util.RandomNumberGenerator;
+
 
 /**
  * This class will always return the unspecified string to the SAML Token Provider
- *
  */
 public class AuthNStatementProvider implements AuthenticationStatementProvider {
 
@@ -46,6 +47,7 @@ public class AuthNStatementProvider implements AuthenticationStatementProvider {
     @Override
     public AuthenticationStatementBean getStatement(TokenProviderParameters providerParameters) {
         AuthenticationStatementBean authBean = new AuthenticationStatementBean();
+        authBean.setSessionIndex(Integer.toString(RandomNumberGenerator.getRNG().nextInt()));
 
         TokenRequirements tokenRequirements = providerParameters.getTokenRequirements();
         ReceivedToken receivedToken = null;

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>org.apache.felix.configadmin</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>${bouncy.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/RandomNumberGenerator.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/RandomNumberGenerator.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.prng.BasicEntropySourceProvider;
+import org.bouncycastle.crypto.prng.EntropySourceProvider;
+import org.bouncycastle.crypto.prng.drbg.DualECSP800DRBG;
+
+public class RandomNumberGenerator {
+
+    public static SecureRandom getRNG() {
+        return new SecureRandom(getBcRbgSeed());
+    }
+
+    public static byte[] getBcRbgSeed() {
+        EntropySourceProvider esp = new BasicEntropySourceProvider(new SecureRandom(), true);
+        byte[] nonce = new byte[256];
+        new SecureRandom().nextBytes(nonce);
+
+        DualECSP800DRBG bcRbg = new DualECSP800DRBG(new SHA256Digest(),
+                256,
+                esp.get(256),
+                null,
+                nonce);
+        byte[] seed = new byte[256];
+        bcRbg.generate(seed, null, true);
+        return seed;
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Sets the SessionIndex in the AuthenticationStatementBean to a uid
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats 
@coyotesqrl 
@roelens8 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison
#### How should this be tested?
Ensure the sessionIndex varies in randomness
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
