### PR TITLE
DDF-2064: Investigate and fix DDF itest Windows CI failures

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -382,7 +382,6 @@ public abstract class AbstractIntegrationTest {
                 .versionAsInProject()
                 .getURL(), "ddf", KARAF_VERSION).unpackDirectory(new File("target/exam"))
                 .useDeployFolder(false));
-
     }
 
     protected Option[] configurePaxExam() {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -124,6 +124,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             // Start the services needed for testing.
             // We need to start the Search UI to test that it redirects properly
             getServiceManager().startFeature(true, "security-idp", "search-ui-app");
+            getServiceManager().waitForAllBundles();
 
             // Get all of the metadata
             String metadata = get(SERVICE_ROOT + "/idp/login/metadata").asString();


### PR DESCRIPTION
#### What does this PR do?
Fixes DDF itest Windows CI failures
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@garrettfreibott @Lambeaux @oconnormi @bantillo 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested?

#### Any background context you want to provide?

#### What are the relevant tickets?
DDF-2064
#### Screenshots (if appropriate)

#### Checklist:

- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

 - Changed code to make Karaf unpack directory configurable
 - Added waitForAllBundles() after search UI feature is started in TestSingleSignOn.java