### PR TITLE
DDF-1945 Remove karaf 3 import and duplicate dependency

### DIFF
--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -119,11 +119,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${org.slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.karaf.bundle</groupId>
             <artifactId>org.apache.karaf.bundle.core</artifactId>
             <version>${karaf.version}</version>

--- a/platform/admin/admin-app/pom.xml
+++ b/platform/admin/admin-app/pom.xml
@@ -108,11 +108,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codice</groupId>
-            <artifactId>org.apache.karaf.bundle.core</artifactId>
-            <version>3.0.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.admin.core</groupId>
             <artifactId>admin-core-appservice</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
#### What does this PR do?
This is a Spring cleaning PR. It is intended to remove a POM dependency which pulls in the wrong version of Karaf; additionally, it deletes a duplicate dependency.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @spearskw @tbatie @torvalds
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison 
#### How should this be tested?
You can open up `ddf/platform/admin/admin-app/pom.xml` and then look at the effective POM to ensure that the karaf 4 version is imported like this:
```xml
<dependency>
<groupId>org.apache.karaf.bundle</groupId>
<artifactId>org.apache.karaf.bundle.core</artifactId>
<version>4.0.4</version>
</dependency>
```
And the karaf 3 version *does not* exist:
```xml 
<dependency>
<groupId>org.codice</groupId>
<artifactId>org.apache.karaf.bundle.core</artifactId>
<version>3.0.0.1</version>
<scope>compile</scope>
</dependency>
```
#### Any background context you want to provide?
This change was uncovered when trying to call the getBundle() method of the BundleService class and receiving the `org.apache.karaf.bundle.3.0.0.1` version instead of the latest.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1945
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
