### PR TITLE
DDF-2083 Fix password values within configurations to not be visible when inspected via chrome/developer console.

### DIFF
--- a/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
+++ b/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
@@ -14,6 +14,7 @@
 
 package org.codice.ddf.catalog.admin.poller;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.empty;
@@ -41,6 +42,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.metatype.AttributeDefinition;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
@@ -146,6 +148,13 @@ public class AdminPollerTest {
 
         assertThat(sources.get(0), not(hasKey("configurations")));
         assertThat(sources.get(1), hasKey("configurations"));
+
+        // Assert that the password value was changed from "secret" to "password".
+        String password =
+                (String) ((Map<String, Object>) ((List<Map<String, Object>>) sources.get(1)
+                        .get("configurations")).get(0)
+                        .get("properties")).get("password");
+        assertThat(password, is(equalTo("password")));
     }
 
     @Test
@@ -242,6 +251,8 @@ public class AdminPollerTest {
                 Dictionary<String, Object> dict = new Hashtable<>();
                 dict.put("service.pid", CONFIG_PID);
                 dict.put("service.factoryPid", FPID);
+                // Add a password property with the value of "secret".
+                dict.put("password", "secret");
                 when(config.getProperties()).thenReturn(dict);
                 when(helper.getConfigurations(anyMap())).thenReturn(CollectionUtils.asList(config),
                         null);
@@ -262,8 +273,14 @@ public class AdminPollerTest {
 
                 // Mock out the metatypes
                 Map<String, Object> metatype = new HashMap<>();
+                // Add a password property to the metatype.
+                List<Map<String, Object>> metatypeProperties = new ArrayList<>();
+                Map<String, Object> metatypeProperty = new HashMap<>();
+                metatypeProperty.put("id", "password");
+                metatypeProperty.put("type", AttributeDefinition.PASSWORD);
+                metatypeProperties.add(metatypeProperty);
                 metatype.put("id", "OpenSearchSource");
-                metatype.put("metatype", new ArrayList<Map<String, Object>>());
+                metatype.put("metatype", metatypeProperties);
 
                 Map<String, Object> noConfigMetaType = new HashMap<>();
                 noConfigMetaType.put("id", "No Configurations");

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExt.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExt.java
@@ -121,8 +121,7 @@ public class ConfigurationAdminExt {
 
     /**
      * @param configurationAdmin
-     * @throws ClassCastException
-     *             if {@code service} is not a MetaTypeService instances
+     * @throws ClassCastException if {@code service} is not a MetaTypeService instances
      */
     public ConfigurationAdminExt(final Object configurationAdmin) {
         this.configurationAdmin = (ConfigurationAdmin) configurationAdmin;
@@ -316,6 +315,18 @@ public class ConfigurationAdminExt {
                 }
             }
 
+            // If the configuration property is a password, set its value to "password" so that
+            // the real password value will be hidden.
+            List<HashMap<String, Object>> metatypeList =
+                    (List<HashMap<String, Object>>) service.get("metatype");
+            metatypeList.stream()
+                    .filter(metatype -> AttributeDefinition.PASSWORD == (Integer) metatype.get(
+                            "type"))
+                    .forEach(metatype -> {
+                        String passwordProperty = (String) metatype.get("id");
+                        propertiesTable.put(passwordProperty, "password");
+                    });
+
             configData.put(MAP_ENTRY_PROPERTIES, propertiesTable);
 
             Map<String, Object> pluginDataMap = getConfigurationPluginData(configData.get(
@@ -368,8 +379,7 @@ public class ConfigurationAdminExt {
      * <li>Finally, as a last resort, the bundles id is returned</li>
      * </ol>
      *
-     * @param bundle
-     *            the bundle which name to retrieve
+     * @param bundle the bundle which name to retrieve
      * @return the bundle name - see the description of the method for more details.
      */
     public String getName(Bundle bundle) {
@@ -424,11 +434,10 @@ public class ConfigurationAdminExt {
      * <code>idGetter</code>. Depending on the <code>idGetter</code> implementation this will be for
      * factory PIDs or plain PIDs.
      *
-     * @param idGetter
-     *            The {@link IdGetter} used to get the list of factory PIDs or PIDs from
-     *            <code>MetaTypeInformation</code> objects.
+     * @param idGetter The {@link IdGetter} used to get the list of factory PIDs or PIDs from
+     *                 <code>MetaTypeInformation</code> objects.
      * @return Map of <code>ObjectClassDefinition</code> objects indexed by the PID (or factory PID)
-     *         to which they pertain
+     * to which they pertain
      */
     private Map getObjectClassDefinitions(final IdGetter idGetter) {
         Locale locale = Locale.getDefault();
@@ -522,8 +531,7 @@ public class ConfigurationAdminExt {
      * Gets the service with the specified class name. Will create a new {@link ServiceTracker} if
      * the service is not already retrieved.
      *
-     * @param serviceName
-     *            the service name to obtain
+     * @param serviceName the service name to obtain
      * @return the service or <code>null</code> if missing.
      */
     final Object getService(String serviceName) {

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExtTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminExtTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.ui.admin.api;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertNotNull;
@@ -333,6 +334,36 @@ public class ConfigurationAdminExtTest {
                 (String) result.get(0)
                         .get("id"),
                 is(TEST_PID));
+    }
+
+    /**
+     * Tests the {@link ConfigurationAdminExt#listServices(String, String)} method and connected
+     * methods for the case where the Configuration contains a password property and that its value
+     * is properly changed to "password".
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testListServicesPasswordType() throws Exception {
+        setUpTestConfig();
+        setUpListServices();
+
+        // Create a password property with a value of "secret".
+        Dictionary<String, Object> testProp = new Hashtable<>();
+        testProp.put("password", "secret");
+        when(testAttDef.getID()).thenReturn("password");
+        when(testAttDef.getType()).thenReturn(AttributeDefinition.PASSWORD);
+        when(testConfig.getProperties()).thenReturn(testProp);
+
+        List<Map<String, Object>> result = configurationAdminExt.listServices(TEST_FACT_FILTER,
+                TEST_FILTER);
+
+        // Assert that the password value was changed from "secret" to "password".
+        String password = (String) ((Map<String, Object>) ((List<Map<String, Object>>) result.get(0)
+                .get("configurations")).get(0)
+                .get("properties")).get("password");
+
+        assertThat(password, is(equalTo("password")));
     }
 
     /**

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/ConfigurationAdminTest.java
@@ -798,6 +798,64 @@ public class ConfigurationAdminTest {
                 .get(arrayInteger)).length, equalTo(0));
     }
 
+    /**
+     * Tests the {@link ConfigurationAdmin#update(String, Map)} and
+     * {@link ConfigurationAdmin#updateForLocation(String, String, Map)} methods and
+     * verifies when updating a password with a value other than "password", it will update
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testUpdatePassword() throws Exception {
+        ConfigurationAdmin configAdmin = getConfigAdmin();
+
+        // Initialize password to "secret".
+        Dictionary<String, Object> currentProps = new Hashtable<>();
+        currentProps.put("TestKey_0_12", "secret");
+        when(testConfig.getProperties()).thenReturn(currentProps);
+
+        // Update the password with "newPassword".
+        Hashtable<String, Object> values = new Hashtable<>();
+        values.put("TestKey_0_12", "newPassword");
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        configAdmin.update(TEST_PID, values);
+        verify(testConfig, times(1)).update(captor.capture());
+
+        // Assert the password updated to "newPassword".
+        assertThat(captor.getValue()
+                .get("TestKey_0_12"), equalTo("newPassword"));
+    }
+
+    /**
+     * Tests the {@link ConfigurationAdmin#update(String, Map)} and
+     * {@link ConfigurationAdmin#updateForLocation(String, String, Map)} methods and
+     * verifies when attempting to update a password with "password", it will not update it.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testUpdatePasswordWithPassword() throws Exception {
+        ConfigurationAdmin configAdmin = getConfigAdmin();
+
+        // Initialize password to "secret".
+        Dictionary<String, Object> currentProps = new Hashtable<>();
+        currentProps.put("TestKey_0_12", "secret");
+        when(testConfig.getProperties()).thenReturn(currentProps);
+
+        // Attempt updating the password with "password", the password should not actually update.
+        Hashtable<String, Object> values = new Hashtable<>();
+        values.put("TestKey_0_12", "password");
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        configAdmin.update(TEST_PID, values);
+        verify(testConfig, times(1)).update(captor.capture());
+
+        // Assert the password did not update to "password".
+        assertThat(captor.getValue()
+                .get("TestKey_0_12"), equalTo("secret"));
+    }
+
     private Object getValue(int cardinality, TYPE type) {
         Object value = null;
         switch (type) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -105,8 +105,7 @@ public class ClaimsHandlerManager {
             return;
         }
         LOGGER.debug("Received an updated set of configurations for the LDAP/Role Claims Handlers.");
-        String url = props.get(ClaimsHandlerManager.URL)
-                .toString();
+        String url = new PropertyResolver((String) props.get(ClaimsHandlerManager.URL)).toString();
         Boolean startTls;
         if (props.get(ClaimsHandlerManager.START_TLS) instanceof String) {
             startTls = Boolean.valueOf((String) props.get(ClaimsHandlerManager.START_TLS));
@@ -292,7 +291,7 @@ public class ClaimsHandlerManager {
 
     public void setUrl(String url) {
         LOGGER.trace("Setting url: {}", url);
-        ldapProperties.put(URL, new PropertyResolver(url));
+        ldapProperties.put(URL, url);
     }
 
     public void setStartTls(boolean startTls) {

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -38,8 +38,6 @@ public class LdapLoginConfig {
 
     public static final String GROUP_BASE_DN = "groupBaseDn";
 
-    public static final String KEY_ALIAS = "keyAlias";
-
     public static final String START_TLS = "startTls";
 
     private static final String SUFFICIENT_FLAG = "sufficient";
@@ -83,8 +81,8 @@ public class LdapLoginConfig {
         Properties props = new Properties();
         props.put("connection.username", properties.get(LDAP_BIND_USER_DN));
         props.put("connection.password", properties.get(LDAP_BIND_USER_PASS));
-        props.put("connection.url", properties.get(LDAP_URL)
-                        .toString());
+        props.put("connection.url",
+                new PropertyResolver((String) properties.get(LDAP_URL)).toString());
         props.put("user.base.dn", properties.get(USER_BASE_DN));
         props.put("user.filter", "(uid=%u)");
         props.put("user.search.subtree", "true");
@@ -117,7 +115,7 @@ public class LdapLoginConfig {
 
     public void setLdapUrl(String ldapUrl) {
         LOGGER.trace("setLdapUrl called: {}", ldapUrl);
-        ldapProperties.put(LDAP_URL, new PropertyResolver(ldapUrl));
+        ldapProperties.put(LDAP_URL, ldapUrl);
     }
 
     public void setUserBaseDn(String userBaseDn) {

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -17,8 +17,7 @@
     <type-converters>
         <bean class="ddf.security.sts.PropertiesConverter"/>
     </type-converters>
-
-
+    
     <cm:managed-service-factory
             id="ddf.ldap.ldaplogin.LdapLoginConfig.id"
             factory-pid="Ldap_Login_Config"
@@ -41,7 +40,5 @@
     <bean id="ldapService" class="ddf.ldap.ldaplogin.LdapService">
         <argument ref="blueprintBundleContext"/>
     </bean>
-
-    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
 </blueprint>

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
@@ -132,7 +132,6 @@ public class LdapLoginConfigTest {
         ldapProps.put(LdapLoginConfig.LDAP_URL, "ldaps://test-ldap:1636");
         ldapProps.put(LdapLoginConfig.USER_BASE_DN, "ou=users,dc=example,dc=com");
         ldapProps.put(LdapLoginConfig.GROUP_BASE_DN, "ou=groups,dc=example,dc=com");
-        ldapProps.put(LdapLoginConfig.KEY_ALIAS, "server");
         ldapProps.put(LdapLoginConfig.START_TLS, "false");
         return ldapProps;
     }


### PR DESCRIPTION
#### What does this PR do?
Passwords values within any configuration will not be visible when inspecting its HTML input element via the chrome/developer console.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @coyotesqrl @tbatie @bcwaters @jckilmer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
-Verify that when changing a password to its correct value within some configuration, the password value is shown as "password" when inspecting its input element via the chrome/developer console. Then verify the password is still correct by testing the feature containing that password property, still works. 
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2083
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests