### PR TITLE
DDF-1910: added a config to generate a sitemap for indexing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 bin/
 atlassian-ide-plugin.xml
 *.sonar-ide.properties
+_site/

--- a/Documentation-versions.html
+++ b/Documentation-versions.html
@@ -51,7 +51,7 @@
                     <h2>Managing DDF</h2>
                     <p>How to install and configure DDF, targeted for system administrators</p>
                     <div class="doc-buttons">
-                        <a class="btn btn-primary" href="managing.html" target="_blank">    html &raquo;</a>
+                        <a class="btn btn-primary" href="managing.html">html &raquo;</a>
                         <a class="btn btn-primary" href="managing.pdf" target="_blank">pdf &raquo;</a>   
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                     <h2>Integrating DDF</h2>
                     <p>How to connect to and from DDF using service interfaces, targeted for system integrators</p>
                     <div class="doc-buttons">
-                        <a class="btn btn-primary" href="integrating.html" target="_blank">html &raquo;</a>                        
+                        <a class="btn btn-primary" href="integrating.html">html &raquo;</a>                        
                         <a class="btn btn-primary" href="integrating.pdf" target="_blank">pdf &raquo;</a>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
                     <h2>Extending DDF</h2>
                     <p>How to add and modify system behaviors, targeted for developers</p>
                     <div class="doc-buttons">
-                        <a class="btn btn-primary" href="extending.html" target="_blank">html &raquo; </a>
+                        <a class="btn btn-primary" href="extending.html">html &raquo; </a>
                         <a class="btn btn-primary" href="extending.pdf" target="_blank">pdf &raquo;</a>
                     </div>
                 </div>
@@ -80,7 +80,7 @@
                     <h2>Complete DDF Documentation</h2>
                     <p>Convenient compilation of all DDF documentation</p>
                     <div class="doc-buttons">
-                        <a class="btn btn-primary" href="documentation.html" target="_blank">html &raquo;</a>
+                        <a class="btn btn-primary" href="documentation.html">html &raquo;</a>
                         <a class="btn btn-primary" href="documentation.pdf" target="_blank">pdf &raquo;</a>
                     </div>
                 </div>

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+gems:
+  - jekyll-sitemap


### PR DESCRIPTION
#### What does this PR do?

Adds a configuration to generate a sitemap per github recommendation to include documentation files into search engine indexing.

#### Who is reviewing it?

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@michaelmenousek
@shaundmorris

#### How should this be tested?
check links on static html pages

#### Any background context you want to provide?

https://help.github.com/articles/sitemaps-for-github-pages/

#### What are the relevant tickets?
DDF-1915, 

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
