### PR TITLE
DDF-2088 updated DDF to use Arbitro

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/pdp/policies/access-policy.xml
+++ b/distribution/ddf-common/src/main/resources/etc/pdp/policies/access-policy.xml
@@ -12,7 +12,6 @@
  *
  **/
 -->
-<!-- WARNING: DO NOT FORMAT THIS FILE - BALANA DOES NOT PROPERLY PARSE THE ELEMENTS IF THE ARE ON MULTIPLE LINES -->
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="AccessPolicy"
         RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides"
         Version="1.0">

--- a/platform/security/pdp/security-pdp-authzrealm/pom.xml
+++ b/platform/security/pdp/security-pdp-authzrealm/pom.xml
@@ -34,9 +34,9 @@
             <artifactId>cxf-rt-ws-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.balana</groupId>
-            <artifactId>org.wso2.balana</artifactId>
-            <version>1.0.2</version>
+            <groupId>com.connexta.arbitro</groupId>
+            <artifactId>arbitro-core</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -111,8 +111,8 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            org.wso2.balana,
-                            commons-io
+                            arbitro-core,
+                            commons-io,
                             httpclient,
                             httpcore,
                             platform-util-unavailableurls,

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/AuthzRealm.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/AuthzRealm.java
@@ -65,11 +65,13 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
 
     private HashMap<String, String> matchOneMap = new HashMap<>();
 
+    private List<String> environmentAttributes = new ArrayList<>();
+
     private XacmlPdp xacmlPdp;
 
     public AuthzRealm(String dirPath, Parser parser) throws PdpException {
         super();
-        xacmlPdp = new XacmlPdp(dirPath, parser);
+        xacmlPdp = new XacmlPdp(dirPath, parser, environmentAttributes);
     }
 
     // this realm is for authorization only
@@ -84,17 +86,17 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
      * or {@code null} if no account could be found. The resulting {@code AuthorizationInfo} object
      * is used by the other method implementations in this class to automatically perform access
      * control checks for the corresponding {@code Subject}.
-     * <p>
+     * <p/>
      * This implementation obtains the actual {@code AuthorizationInfo} object from the subclass's
      * implementation of
      * {@link #doGetAuthorizationInfo(org.apache.shiro.subject.PrincipalCollection)
      * doGetAuthorizationInfo}, and then caches it for efficient reuse if caching is enabled (see
      * below).
-     * <p>
+     * <p/>
      * Invocations of this method should be thought of as completely orthogonal to acquiring
      * {@link #getAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken) authenticationInfo}
      * , since either could occur in any order.
-     * <p>
+     * <p/>
      * For example, in &quot;Remember Me&quot; scenarios, the user identity is remembered (and
      * assumed) for their current session and an authentication attempt during that session might
      * never occur. But because their identity would be remembered, that is sufficient enough
@@ -107,7 +109,7 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
      * {@link #setAuthorizationCache authorizationCache} instance has been explicitly configured, or
      * if a {@link #setCacheManager cacheManager} has been configured, which will be used to lazily
      * create the {@code authorizationCache} as needed.
-     * <p>
+     * <p/>
      * If caching is enabled, the authorization cache will be checked first and if found, will
      * return the cached {@code AuthorizationInfo} immediately. If caching is disabled, or there is
      * a cache miss, the authorization info will be looked up from the underlying data store via the
@@ -136,8 +138,8 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
     /**
      * Returns <tt>true</tt> if the corresponding subject/user is permitted to perform an action or
      * access a resource summarized by the specified permission.
-     * <p>
-     * <p>
+     * <p/>
+     * <p/>
      * More specifically, this method determines if any <tt>Permission</tt>s associated with the
      * subject {@link Permission#implies(Permission) imply} the specified permission.
      *
@@ -153,13 +155,13 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
     /**
      * Checks if the corresponding Subject/user implies the given Permissions and returns a boolean
      * array indicating which permissions are implied.
-     * <p>
-     * <p>
+     * <p/>
+     * <p/>
      * More specifically, this method should determine if each <tt>Permission</tt> in the array is
      * {@link Permission#implies(Permission) implied} by permissions already associated with the
      * subject.
-     * <p>
-     * <p>
+     * <p/>
+     * <p/>
      * This is primarily a performance-enhancing method to help reduce the number of
      * {@link #isPermitted} invocations over the wire in client/server systems.
      *
@@ -442,7 +444,7 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
     /**
      * Sets the mappings used by the "match all" evaluation to determine if this user should be
      * authorized to access requested data.
-     * <p>
+     * <p/>
      * Each string is of the format: <code>subjectAttrName=metacardAttrName</code><br/>
      * where <code>metacardAttrName</code> is the name of an attribute in the metacard and
      * <code>subjectAttrName</code> is the name of the corresponding attribute in the user
@@ -475,7 +477,7 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
     /**
      * Sets the mappings used by the "match one" evaluation to determine if this user should be
      * authorized to access requested data.
-     * <p>
+     * <p/>
      * Each string is of the format: <code>subjectAttrName=metacardAttrName</code><br/>
      * where <code>metacardAttrName</code> is the name of an attribute in the metacard and
      * <code>subjectAttrName</code> is the name of the corresponding attribute in the user
@@ -503,5 +505,10 @@ public class AuthzRealm extends AbstractAuthorizingRealm {
                 }
             }
         }
+    }
+
+    public void setEnvironmentAttributes(List<String> environmentAttributes) {
+        this.environmentAttributes.clear();
+        this.environmentAttributes.addAll(environmentAttributes);
     }
 }

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/XACMLConstants.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/XACMLConstants.java
@@ -20,6 +20,8 @@ public class XACMLConstants {
 
     public static final String STRING_DATA_TYPE = "http://www.w3.org/2001/XMLSchema#string";
 
+    public static final String BOOLEAN_DATA_TYPE = "http://www.w3.org/2001/XMLSchema#boolean";
+
     public static final String TIME_DATA_TYPE = "http://www.w3.org/2001/XMLSchema#time";
 
     public static final String DATE_DATA_TYPE = "http://www.w3.org/2001/XMLSchema#date";

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/XacmlPdp.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/XacmlPdp.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.security.common.audit.SecurityLogger;
-import ddf.security.pdp.realm.xacml.processor.BalanaClient;
 import ddf.security.pdp.realm.xacml.processor.PdpException;
+import ddf.security.pdp.realm.xacml.processor.XacmlClient;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.permission.KeyValueCollectionPermission;
 import ddf.security.permission.KeyValuePermission;
@@ -43,38 +43,39 @@ public class XacmlPdp {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XacmlPdp.class);
 
-    private BalanaClient pdp;
+    private XacmlClient pdp;
+
+    private List<String> environmentAttributes;
 
     /**
      * Creates a general
      */
-    public XacmlPdp(String dirPath, Parser parser) throws PdpException {
+    public XacmlPdp(String dirPath, Parser parser, List<String> environmentAttributes)
+            throws PdpException {
         super();
-        pdp = new BalanaClient(dirPath, parser);
+        pdp = new XacmlClient(dirPath, parser);
+        this.environmentAttributes = environmentAttributes;
         LOGGER.debug("Creating new PDP-backed Authorizing Realm");
     }
 
     public boolean isPermitted(String primaryPrincipal, AuthorizationInfo info,
             KeyValueCollectionPermission curPermission) {
         boolean curResponse;
-        LOGGER.debug("Checking if {} has access for action {}",
-                primaryPrincipal,
+        LOGGER.debug("Checking if {} has access for action {}", primaryPrincipal,
                 curPermission.getAction());
 
         SecurityLogger.audit("Checking if [" + primaryPrincipal + "] has access for action "
                 + curPermission.getAction());
 
-        if (CollectionUtils.isEmpty(info.getObjectPermissions())
-                && CollectionUtils.isEmpty(info.getStringPermissions()) && CollectionUtils.isEmpty(
-                info.getRoles())
+        if (CollectionUtils.isEmpty(info.getObjectPermissions()) && CollectionUtils.isEmpty(
+                info.getStringPermissions()) && CollectionUtils.isEmpty(info.getRoles())
                 && !CollectionUtils.isEmpty(curPermission.getKeyValuePermissionList())) {
             return false;
         }
 
-        if ((!CollectionUtils.isEmpty(info.getObjectPermissions())
-                || !CollectionUtils.isEmpty(info.getStringPermissions())
-                || !CollectionUtils.isEmpty(info.getRoles())) && CollectionUtils.isEmpty(
-                curPermission.getKeyValuePermissionList())) {
+        if ((!CollectionUtils.isEmpty(info.getObjectPermissions()) || !CollectionUtils.isEmpty(
+                info.getStringPermissions()) || !CollectionUtils.isEmpty(info.getRoles()))
+                && CollectionUtils.isEmpty(curPermission.getKeyValuePermissionList())) {
             return true;
         }
 
@@ -88,8 +89,7 @@ public class XacmlPdp {
 
     protected RequestType createXACMLRequest(String subject, AuthorizationInfo info,
             CollectionPermission permission) {
-        LOGGER.debug("Creating XACML request for subject: {} and metacard permissions {}",
-                subject,
+        LOGGER.debug("Creating XACML request for subject: {} and metacard permissions {}", subject,
                 permission);
 
         RequestType xacmlRequestType = new RequestType();
@@ -124,30 +124,63 @@ public class XacmlPdp {
         AttributesType metadataAttributes = new AttributesType();
         metadataAttributes.setCategory(XACMLConstants.RESOURCE_CATEGORY);
 
+        AttributesType environmentAttributesType = new AttributesType();
+        environmentAttributesType.setCategory(XACMLConstants.ENVIRONMENT_CATEGORY);
+        if (!CollectionUtils.isEmpty(environmentAttributes)) {
+            for (String envAttr : environmentAttributes) {
+                String[] attr = envAttr.split("=");
+                if (attr.length == 2) {
+                    AttributeType attributeType = new AttributeType();
+                    attributeType.setAttributeId(attr[0].trim());
+                    String[] attrVals = attr[1].split(",");
+                    for (String attrVal : attrVals) {
+                        AttributeValueType attributeValueType = new AttributeValueType();
+                        attributeValueType.setDataType(XACMLConstants.STRING_DATA_TYPE);
+                        attributeValueType.getContent()
+                                .add(attrVal.trim());
+                        attributeType.getAttributeValue()
+                                .add(attributeValueType);
+                    }
+                    environmentAttributesType.getAttribute()
+                            .add(attributeType);
+                }
+            }
+        }
+
         if (permission instanceof KeyValueCollectionPermission) {
-            List<KeyValuePermission> tmpList =
-                    ((KeyValueCollectionPermission) permission).getKeyValuePermissionList();
+            List<KeyValuePermission> tmpList = ((KeyValueCollectionPermission) permission).getKeyValuePermissionList();
             for (KeyValuePermission curPermission : tmpList) {
-                for (String curPermValue : curPermission.getValues()) {
-                    AttributeType resourceAttribute = new AttributeType();
-                    AttributeValueType resourceAttributeValue = new AttributeValueType();
-                    resourceAttribute.setAttributeId(curPermission.getKey());
-                    resourceAttribute.setIncludeInResult(false);
-                    resourceAttributeValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
-                    LOGGER.trace("Adding permission: {}:{} for incoming resource",
-                            new Object[] {curPermission.getKey(), curPermValue});
-                    resourceAttributeValue.getContent()
-                            .add(curPermValue);
-                    resourceAttribute.getAttributeValue()
-                            .add(resourceAttributeValue);
+                AttributeType resourceAttribute = new AttributeType();
+                resourceAttribute.setAttributeId(curPermission.getKey());
+                resourceAttribute.setIncludeInResult(false);
+                if (curPermission.getValues()
+                        .size() > 0) {
+                    for (String curPermValue : curPermission.getValues()) {
+                        AttributeValueType resourceAttributeValue = new AttributeValueType();
+                        if ("false".equalsIgnoreCase(curPermValue) || "true".equalsIgnoreCase(
+                                curPermValue)) {
+                            resourceAttributeValue.setDataType(XACMLConstants.BOOLEAN_DATA_TYPE);
+                        } else {
+                            resourceAttributeValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
+                        }
+                        LOGGER.trace("Adding permission: {}:{} for incoming resource",
+                                new Object[] {curPermission.getKey(), curPermValue});
+                        resourceAttributeValue.getContent()
+                                .add(curPermValue);
+                        resourceAttribute.getAttributeValue()
+                                .add(resourceAttributeValue);
+                    }
                     metadataAttributes.getAttribute()
                             .add(resourceAttribute);
                 }
-
             }
 
             xacmlRequestType.getAttributes()
                     .add(metadataAttributes);
+            if (!CollectionUtils.isEmpty(environmentAttributes)) {
+                xacmlRequestType.getAttributes()
+                        .add(environmentAttributesType);
+            }
         } else {
             LOGGER.warn(
                     "Permission on the resource need to be of type KeyValueCollectionPermission, cannot process this resource.");
@@ -192,37 +225,47 @@ public class XacmlPdp {
         subjectAttributes.getAttribute()
                 .add(subjectAttribute);
 
-        for (String curRole : info.getRoles()) {
-            AttributeType roleAttribute = new AttributeType();
-            roleAttribute.setAttributeId(XACMLConstants.ROLE_CLAIM);
-            roleAttribute.setIncludeInResult(false);
-            AttributeValueType roleValue = new AttributeValueType();
-            roleValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
-            LOGGER.trace("Adding role: {} for subject: {}", curRole, subject);
-            roleValue.getContent()
-                    .add(curRole);
-            roleAttribute.getAttributeValue()
-                    .add(roleValue);
+        AttributeType roleAttribute = new AttributeType();
+        roleAttribute.setAttributeId(XACMLConstants.ROLE_CLAIM);
+        roleAttribute.setIncludeInResult(false);
+        if (info.getRoles()
+                .size() > 0) {
+            for (String curRole : info.getRoles()) {
+                AttributeValueType roleValue = new AttributeValueType();
+                roleValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
+                LOGGER.trace("Adding role: {} for subject: {}", curRole, subject);
+                roleValue.getContent()
+                        .add(curRole);
+                roleAttribute.getAttributeValue()
+                        .add(roleValue);
+            }
             subjectAttributes.getAttribute()
                     .add(roleAttribute);
         }
 
         for (Permission curPermission : info.getObjectPermissions()) {
             if (curPermission instanceof KeyValuePermission) {
-                for (String curPermValue : ((KeyValuePermission) curPermission).getValues()) {
-                    AttributeType subjAttr = new AttributeType();
-                    AttributeValueType subjAttrValue = new AttributeValueType();
-                    subjAttr.setAttributeId(((KeyValuePermission) curPermission).getKey());
-                    subjAttr.setIncludeInResult(false);
-                    subjAttrValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
-                    LOGGER.trace("Adding permission: {}:{} for subject: {}",
-                            ((KeyValuePermission) curPermission).getKey(),
-                            curPermValue,
-                            subject);
-                    subjAttrValue.getContent()
-                            .add(curPermValue);
-                    subjAttr.getAttributeValue()
-                            .add(subjAttrValue);
+                AttributeType subjAttr = new AttributeType();
+                subjAttr.setAttributeId(((KeyValuePermission) curPermission).getKey());
+                subjAttr.setIncludeInResult(false);
+                if (((KeyValuePermission) curPermission).getValues()
+                        .size() > 0) {
+                    for (String curPermValue : ((KeyValuePermission) curPermission).getValues()) {
+                        AttributeValueType subjAttrValue = new AttributeValueType();
+                        if ("false".equalsIgnoreCase(curPermValue) || "true".equalsIgnoreCase(
+                                curPermValue)) {
+                            subjAttrValue.setDataType(XACMLConstants.BOOLEAN_DATA_TYPE);
+                        } else {
+                            subjAttrValue.setDataType(XACMLConstants.STRING_DATA_TYPE);
+                        }
+                        LOGGER.trace("Adding permission: {}:{} for subject: {}",
+                                ((KeyValuePermission) curPermission).getKey(), curPermValue,
+                                subject);
+                        subjAttrValue.getContent()
+                                .add(curPermValue);
+                        subjAttr.getAttributeValue()
+                                .add(subjAttrValue);
+                    }
                     subjectAttributes.getAttribute()
                             .add(subjAttr);
                 }

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PdpException.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PdpException.java
@@ -14,7 +14,7 @@
 package ddf.security.pdp.realm.xacml.processor;
 
 /**
- * Exception thrown by the DDF implementation of the Balana PDP.
+ * Exception thrown by the DDF implementation of the XACML PDP.
  */
 public class PdpException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
@@ -23,7 +23,8 @@ import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.balana.finder.impl.FileBasedPolicyFinderModule;
+
+import com.connexta.arbitro.finder.impl.FileBasedPolicyFinderModule;
 
 /**
  *

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/XacmlClient.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/XacmlClient.java
@@ -39,14 +39,6 @@ import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.balana.PDP;
-import org.wso2.balana.PDPConfig;
-import org.wso2.balana.finder.AttributeFinder;
-import org.wso2.balana.finder.AttributeFinderModule;
-import org.wso2.balana.finder.PolicyFinder;
-import org.wso2.balana.finder.PolicyFinderModule;
-import org.wso2.balana.finder.impl.CurrentEnvModule;
-import org.wso2.balana.finder.impl.SelectorModule;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -54,6 +46,14 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import com.connexta.arbitro.PDP;
+import com.connexta.arbitro.PDPConfig;
+import com.connexta.arbitro.finder.AttributeFinder;
+import com.connexta.arbitro.finder.AttributeFinderModule;
+import com.connexta.arbitro.finder.PolicyFinder;
+import com.connexta.arbitro.finder.PolicyFinderModule;
+import com.connexta.arbitro.finder.impl.CurrentEnvModule;
+import com.connexta.arbitro.finder.impl.SelectorModule;
 import com.google.common.collect.ImmutableList;
 
 import oasis.names.tc.xacml._3_0.core.schema.wd_17.ObjectFactory;
@@ -61,11 +61,11 @@ import oasis.names.tc.xacml._3_0.core.schema.wd_17.RequestType;
 import oasis.names.tc.xacml._3_0.core.schema.wd_17.ResponseType;
 
 /**
- * Balana implementation of a XACML Policy Decision Point (PDP). This class acts as a proxy to the
- * real Balana PDP.
+ * Implementation of a XACML Policy Decision Point (PDP). This class acts as a proxy to the
+ * real XACML PDP.
  */
-public class BalanaClient {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BalanaClient.class);
+public class XacmlClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XacmlClient.class);
 
     private static final String XACML30_NAMESPACE =
             "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17";
@@ -88,13 +88,13 @@ public class BalanaClient {
     private final Parser parser;
 
     /**
-     * Creates the proxy to the real Balana PDP.
+     * Creates the proxy to the real XACML PDP.
      *
      * @param relativeXacmlPoliciesDirectoryPath Relative directory path to the root of the DDF installation.
      * @param parser                             for marshal and unmarshal
      * @throws PdpException
      */
-    public BalanaClient(String relativeXacmlPoliciesDirectoryPath, Parser parser)
+    public XacmlClient(String relativeXacmlPoliciesDirectoryPath, Parser parser)
             throws PdpException {
         this.parser = parser;
         if (StringUtils.isEmpty(relativeXacmlPoliciesDirectoryPath)) {
@@ -146,7 +146,7 @@ public class BalanaClient {
 
         String xacmlResponse = this.callPdp(xacmlRequest);
 
-        LOGGER.debug("\nXACML 3.0 Response from Balana PDP:\n {}", xacmlResponse);
+        LOGGER.debug("\nXACML 3.0 Response from XACML PDP:\n {}", xacmlResponse);
 
         DOMResult domResult = addNamespaceAndPrefixes(xacmlResponse);
 
@@ -154,7 +154,7 @@ public class BalanaClient {
     }
 
     /**
-     * Creates the Balana PDP.
+     * Creates the XACML PDP.
      */
     private void createPdp(PDPConfig pdpConfig) {
         LOGGER.debug("Creating PDP of type: {}", PDP.class.getName());
@@ -163,7 +163,7 @@ public class BalanaClient {
     }
 
     /**
-     * Creates the Balana PDP configuration.
+     * Creates the XACML PDP configuration.
      *
      * @return PDPConfig
      */
@@ -229,7 +229,7 @@ public class BalanaClient {
     }
 
     /**
-     * Calls the real Balana PDP to evaluate the XACML request.
+     * Calls the real XACML PDP to evaluate the XACML request.
      *
      * @param xacmlRequest The XACML request as a string.
      * @return The XACML response as a string.
@@ -240,8 +240,8 @@ public class BalanaClient {
     }
 
     /**
-     * Adds namespaces and namespace prefixes to the XACML response returned by the Balana PDP. The
-     * Balana PDP returns a response with no namespaces, so we need to add them to unmarshal the
+     * Adds namespaces and namespace prefixes to the XACML response returned by the XACML PDP. The
+     * XACML PDP returns a response with no namespaces, so we need to add them to unmarshal the
      * response.
      *
      * @param xacmlResponse The XACML response as a string.
@@ -278,7 +278,7 @@ public class BalanaClient {
         ClassLoader tccl = Thread.currentThread()
                 .getContextClassLoader();
         Thread.currentThread()
-                .setContextClassLoader(BalanaClient.class.getClassLoader());
+                .setContextClassLoader(XacmlClient.class.getClassLoader());
         try {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
 
@@ -315,7 +315,7 @@ public class BalanaClient {
             ctxPath.add(ResponseType.class.getPackage()
                     .getName());
             ParserConfigurator configurator = parser.configureParser(ctxPath,
-                    BalanaClient.class.getClassLoader());
+                    XacmlClient.class.getClassLoader());
             configurator.addProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             ObjectFactory objectFactory = new ObjectFactory();
@@ -349,7 +349,7 @@ public class BalanaClient {
         }
 
         ParserConfigurator configurator = parser.configureParser(ctxPath,
-                BalanaClient.class.getClassLoader());
+                XacmlClient.class.getClassLoader());
 
         try {
             JAXBElement<ResponseType> xacmlResponseTypeElement = parser.unmarshal(configurator,

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -28,6 +28,12 @@
             cardinality="100"
             type="String"
             default=""/>
+
+        <AD description="List of environment attributes to pass to the XACML engine. Format is attributeId=attributeValue1,attributeValue2."
+            name="Environment Attributes" id="environmentAttributes" required="false"
+            cardinality="100"
+            type="String"
+            default=""/>
     </OCD>
 
     <Designate pid="ddf.security.pdp.realm.AuthzRealm">

--- a/platform/security/pdp/security-pdp-authzrealm/src/test/java/ddf/security/pdp/realm/xacml/XacmlPdpTest.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/test/java/ddf/security/pdp/realm/xacml/XacmlPdpTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,26 +13,39 @@
  */
 package ddf.security.pdp.realm.xacml;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.codice.ddf.parser.xml.XmlParser;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import ddf.security.pdp.realm.xacml.processor.PdpException;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.permission.KeyValueCollectionPermission;
 import ddf.security.permission.KeyValuePermission;
+import oasis.names.tc.xacml._3_0.core.schema.wd_17.AttributesType;
 import oasis.names.tc.xacml._3_0.core.schema.wd_17.RequestType;
 
 public class XacmlPdpTest {
@@ -55,44 +68,55 @@ public class XacmlPdpTest {
     // Subject info
     private static final String TEST_COUNTRY = "ATA";
 
-    private static final String NAME_IDENTIFIER =
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
+    private static final String NAME_IDENTIFIER = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
 
-    private static final String GIVEN_NAME =
-            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname";
+    private static final String GIVEN_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname";
 
     private static final String COUNTRY = "http://www.opm.gov/feddata/CountryOfCitizenship";
 
     private static XacmlPdp testRealm;
 
-    @BeforeClass()
-    public static void setupLogging() throws PdpException {
-        testRealm = new XacmlPdp("src/test/resources/policies", new XmlParser());
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before()
+    public void setup() throws PdpException, IOException {
+        temporaryFolder.create();
+        File policy = temporaryFolder.newFile("policy.xml");
+        FileOutputStream policyOutStream = new FileOutputStream(policy);
+        InputStream policyStream = XacmlPdp.class.getResourceAsStream("/policies/test-policy.xml");
+        IOUtils.copy(policyStream, policyOutStream);
+        testRealm = new XacmlPdp(new File(policy.getParent()).getAbsolutePath(), new XmlParser(),
+                Arrays.asList("item0=item0Val1", "item1=item1Val1,item1Val2",
+                        "item2=item2Val1,item2Val2,item2Val3"));
+    }
+
+    @After
+    public void destroy() {
+        temporaryFolder.delete();
     }
 
     @Test(expected = PdpException.class)
     public void testBadSetupNull() throws PdpException {
-        XacmlPdp xacmlPdp = new XacmlPdp(null, new XmlParser());
+        XacmlPdp xacmlPdp = new XacmlPdp(null, new XmlParser(), new ArrayList<>());
     }
 
     @Test(expected = PdpException.class)
     public void testBadSetupEmpty() throws PdpException {
-        XacmlPdp xacmlPdp = new XacmlPdp("", new XmlParser());
+        XacmlPdp xacmlPdp = new XacmlPdp("", new XmlParser(), new ArrayList<>());
     }
 
     @Test
     public void testActionGoodCountry() {
         RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo(TEST_COUNTRY),
-                new KeyValueCollectionPermission(QUERY_ACTION));
+                generateSubjectInfo(TEST_COUNTRY), new KeyValueCollectionPermission(QUERY_ACTION));
 
         assertTrue(testRealm.isPermitted(request));
     }
 
     @Test
     public void testActionBadCountry() {
-        RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo("CAN"),
+        RequestType request = testRealm.createXACMLRequest(USER_NAME, generateSubjectInfo("CAN"),
                 new KeyValueCollectionPermission(QUERY_ACTION));
 
         assertFalse(testRealm.isPermitted(request));
@@ -102,8 +126,7 @@ public class XacmlPdpTest {
     public void testActionGoodSiteName() {
         SimpleAuthorizationInfo blankUserInfo = new SimpleAuthorizationInfo(new HashSet<String>());
         blankUserInfo.setObjectPermissions(new HashSet<Permission>());
-        RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                blankUserInfo,
+        RequestType request = testRealm.createXACMLRequest(USER_NAME, blankUserInfo,
                 new KeyValueCollectionPermission(SITE_NAME_ACTION));
 
         assertTrue(testRealm.isPermitted(request));
@@ -113,8 +136,7 @@ public class XacmlPdpTest {
     public void testActionBadAction() {
 
         RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo(TEST_COUNTRY),
-                new KeyValueCollectionPermission("bad"));
+                generateSubjectInfo(TEST_COUNTRY), new KeyValueCollectionPermission("bad"));
 
         assertFalse(testRealm.isPermitted(request));
     }
@@ -126,12 +148,10 @@ public class XacmlPdpTest {
         security.put(RESOURCE_ACCESS, Arrays.asList(ACCESS_TYPE_A, ACCESS_TYPE_B));
 
         KeyValueCollectionPermission resourcePermissions = new KeyValueCollectionPermission(
-                CollectionPermission.READ_ACTION,
-                security);
+                CollectionPermission.READ_ACTION, security);
 
         RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo(TEST_COUNTRY),
-                resourcePermissions);
+                generateSubjectInfo(TEST_COUNTRY), resourcePermissions);
 
         assertTrue(testRealm.isPermitted(request));
 
@@ -144,11 +164,9 @@ public class XacmlPdpTest {
         security.put(RESOURCE_ACCESS, Arrays.asList(ACCESS_TYPE_A));
 
         KeyValueCollectionPermission resourcePermissions = new KeyValueCollectionPermission(
-                CollectionPermission.READ_ACTION,
-                security);
+                CollectionPermission.READ_ACTION, security);
         RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo(TEST_COUNTRY),
-                resourcePermissions);
+                generateSubjectInfo(TEST_COUNTRY), resourcePermissions);
 
         assertTrue(testRealm.isPermitted(request));
 
@@ -161,14 +179,52 @@ public class XacmlPdpTest {
         security.put(RESOURCE_ACCESS, Arrays.asList(ACCESS_TYPE_A, ACCESS_TYPE_B, ACCESS_TYPE_C));
 
         KeyValueCollectionPermission resourcePermissions = new KeyValueCollectionPermission(
-                CollectionPermission.READ_ACTION,
-                security);
+                CollectionPermission.READ_ACTION, security);
         RequestType request = testRealm.createXACMLRequest(USER_NAME,
-                generateSubjectInfo(TEST_COUNTRY),
-                resourcePermissions);
+                generateSubjectInfo(TEST_COUNTRY), resourcePermissions);
 
         assertFalse(testRealm.isPermitted(request));
 
+    }
+
+    @Test
+    public void testEnvironmentVariables() {
+        RequestType request = testRealm.createXACMLRequest(USER_NAME,
+                generateSubjectInfo(TEST_COUNTRY), new KeyValueCollectionPermission(QUERY_ACTION));
+
+        List<AttributesType> attributes = request.getAttributes();
+
+        AttributesType environmentAttributes = null;
+        for (AttributesType attribute : attributes) {
+            if (attribute.getCategory()
+                    .equals(XACMLConstants.ENVIRONMENT_CATEGORY)) {
+                environmentAttributes = attribute;
+            }
+        }
+
+        assertNotNull(environmentAttributes);
+
+        assertThat(environmentAttributes.getAttribute()
+                .get(0)
+                .getAttributeId(), is("item0"));
+        assertThat(environmentAttributes.getAttribute()
+                .get(0)
+                .getAttributeValue()
+                .size(), is(1));
+        assertThat(environmentAttributes.getAttribute()
+                .get(1)
+                .getAttributeId(), is("item1"));
+        assertThat(environmentAttributes.getAttribute()
+                .get(1)
+                .getAttributeValue()
+                .size(), is(2));
+        assertThat(environmentAttributes.getAttribute()
+                .get(2)
+                .getAttributeId(), is("item2"));
+        assertThat(environmentAttributes.getAttribute()
+                .get(2)
+                .getAttributeValue()
+                .size(), is(3));
     }
 
     private AuthorizationInfo generateSubjectInfo(String country) {

--- a/platform/security/pdp/security-pdp-authzrealm/src/test/java/ddf/security/pdp/realm/xacml/processor/XacmlClientTest.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/test/java/ddf/security/pdp/realm/xacml/processor/XacmlClientTest.java
@@ -43,8 +43,8 @@ import oasis.names.tc.xacml._3_0.core.schema.wd_17.ObjectFactory;
 import oasis.names.tc.xacml._3_0.core.schema.wd_17.RequestType;
 import oasis.names.tc.xacml._3_0.core.schema.wd_17.ResponseType;
 
-public class BalanaClientTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BalanaClientTest.class);
+public class XacmlClientTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XacmlClientTest.class);
 
     private static final String ROLE_CLAIM =
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
@@ -180,7 +180,7 @@ public class BalanaClientTest {
             xacmlRequestType.getAttributes()
                     .add(categoryAttributes);
 
-            BalanaClient pdp = new BalanaClient(destDir.getCanonicalPath(), new XmlParser());
+            XacmlClient pdp = new XacmlClient(destDir.getCanonicalPath(), new XmlParser());
 
             // Perform Test
             ResponseType xacmlResponse = pdp.evaluate(xacmlRequestType);
@@ -277,7 +277,7 @@ public class BalanaClientTest {
         xacmlRequestType.getAttributes()
                 .add(categoryAttributes);
 
-        BalanaClient pdp = new BalanaClient(tempDir.getCanonicalPath(), new XmlParser());
+        XacmlClient pdp = new XacmlClient(tempDir.getCanonicalPath(), new XmlParser());
 
         // Perform Test
         ResponseType xacmlResponse = pdp.evaluate(xacmlRequestType);
@@ -296,12 +296,12 @@ public class BalanaClientTest {
     }
 
     @Test
-    public void testBalanaWrapperpoliciesdirectorydoesnotexist() throws PdpException, IOException {
-        LOGGER.debug("\n\n\n##### testBalanaWrapper_policies_directory_does_not_exist");
+    public void testWrapperpoliciesdirectorydoesnotexist() throws PdpException, IOException {
+        LOGGER.debug("\n\n\n##### testXACMLWrapper_policies_directory_does_not_exist");
 
         // Perform Test on new directory
         // Expect directory to be created
-        new BalanaClient(TEST_CREATION_DIR, new XmlParser());
+        new XacmlClient(TEST_CREATION_DIR, new XmlParser());
 
         // Delete the directory that was just created
         FileUtils.forceDelete(new File(TEST_CREATION_DIR));
@@ -310,8 +310,8 @@ public class BalanaClientTest {
     @Test
     /**
      * No longer expect an exception thrown here since we can start with an empty directory
-     */ public void testBalanaWrapperpoliciesdirectoryexistsandisempty() throws Exception {
-        LOGGER.debug("\n\n\n##### testBalanaWrapper_policies_directory_exists_and_is_empty");
+     */ public void testWrapperpoliciesdirectoryexistsandisempty() throws Exception {
+        LOGGER.debug("\n\n\n##### testXACMLWrapper_policies_directory_exists_and_is_empty");
 
         // Setup
         File dir = folder.newFolder(TEMP_DIR_NAME);
@@ -321,7 +321,7 @@ public class BalanaClientTest {
             assertTrue(isDirEmpty(dir));
 
             // Perform Test
-            new BalanaClient(dir.getCanonicalPath(), new XmlParser());
+            new XacmlClient(dir.getCanonicalPath(), new XmlParser());
 
             // Cleanup
             LOGGER.debug("Deleting directory: {}", dir.getPath());
@@ -332,14 +332,14 @@ public class BalanaClientTest {
     }
 
     @Test
-    public void testBalanaWrapperpoliciesdirectorypolicyadded() throws Exception {
-        LOGGER.debug("\n\n\n##### testBalanaWrapper_policies_directory_policy_added");
+    public void testWrapperpoliciesdirectorypolicyadded() throws Exception {
+        LOGGER.debug("\n\n\n##### testXACMLWrapper_policies_directory_policy_added");
 
         File policyDir = folder.newFolder("tempDir");
 
-        BalanaClient.defaultPollingIntervalInSeconds = 1;
+        XacmlClient.defaultPollingIntervalInSeconds = 1;
         // Perform Test
-        BalanaClient pdp = new BalanaClient(policyDir.getCanonicalPath(), new XmlParser());
+        XacmlClient pdp = new XacmlClient(policyDir.getCanonicalPath(), new XmlParser());
 
         File srcFile = new File(
                 projectHome + File.separator + RELATIVE_POLICIES_DIR + File.separator
@@ -437,7 +437,7 @@ public class BalanaClientTest {
         File policyDir = folder.newFolder("tempDir");
 
         // Perform Test
-        BalanaClient pdp = new BalanaClient(policyDir.getCanonicalPath(), null);
+        XacmlClient pdp = new XacmlClient(policyDir.getCanonicalPath(), null);
 
         File srcFile = new File(
                 projectHome + File.separator + RELATIVE_POLICIES_DIR + File.separator


### PR DESCRIPTION
#### What does this PR do?
Moves DDF to Arbitro instead of balana.
Adds support for XACML environment variables.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@coyotesqrl @bcwaters @ryeats 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb 
@stustison
#### How should this be tested?
unit/itests
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

