### PR TITLE
DDF-2093: Fixed DeleteRequestImpl to correctly use generics

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
@@ -76,7 +76,7 @@ public class AttributeImpl implements Attribute {
      * @param values - the value of this {@link Attribute}
      */
 
-    public AttributeImpl(String name, List<Serializable> values) {
+    public AttributeImpl(String name, List<? extends Serializable> values) {
         /*
          * If any defensive logic is added to this constructor, then that logic should be reflected
          * in the deserialization (readObject()) of this object so that the integrity of a

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/DeleteRequestImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/DeleteRequestImpl.java
@@ -37,7 +37,7 @@ public class DeleteRequestImpl extends OperationImpl implements DeleteRequest {
     /**
      * Ids or URIs
      */
-    protected List<Serializable> values;
+    protected List<? extends Serializable> values;
 
     /**
      * Set of destination ids this request should be sent to
@@ -110,14 +110,14 @@ public class DeleteRequestImpl extends OperationImpl implements DeleteRequest {
      * @param attributeName - the attribute name associated with the values
      * @param properties    the properties
      */
-    public DeleteRequestImpl(List<Serializable> values, String attributeName,
+    public DeleteRequestImpl(List<? extends Serializable> values, String attributeName,
             Map<String, Serializable> properties) {
         this(values, attributeName, properties, new HashSet<>());
         this.name = attributeName;
         this.values = values;
     }
 
-    public DeleteRequestImpl(List<Serializable> values, String attributeName,
+    public DeleteRequestImpl(List<? extends Serializable> values, String attributeName,
             Map<String, Serializable> properties, Set<String> destinations) {
         super(properties);
         this.name = attributeName;
@@ -134,7 +134,7 @@ public class DeleteRequestImpl extends OperationImpl implements DeleteRequest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ddf.catalog.operation.DeleteRequest#getAttributeName()
      */
     @Override
@@ -145,11 +145,11 @@ public class DeleteRequestImpl extends OperationImpl implements DeleteRequest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ddf.catalog.operation.DeleteRequest#getAttributeValues()
      */
     @Override
-    public List<Serializable> getAttributeValues() {
+    public List<? extends Serializable> getAttributeValues() {
         return values;
     }
 

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/UpdateRequestImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/UpdateRequestImpl.java
@@ -34,7 +34,7 @@ public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
 
     protected String name;
 
-    protected List<Entry<Serializable, Metacard>> updates;
+    protected List<Entry<? extends Serializable, Metacard>> updates;
 
     protected Set<String> destinations = new HashSet<>();
 
@@ -46,7 +46,7 @@ public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
      * @param properties    the properties associated with the operation
      * @param destinations  the destination ids this request should be sent to
      */
-    public UpdateRequestImpl(List<Entry<Serializable, Metacard>> updateList, String attributeName,
+    public UpdateRequestImpl(List<Entry<? extends Serializable, Metacard>> updateList, String attributeName,
             Map<String, Serializable> properties, Set<String> destinations) {
         super(properties);
         this.name = attributeName;
@@ -64,7 +64,7 @@ public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
      * @param attributeName the attribute name (e.g. Metacard.ID, Metacard.PRODUCT_URI)
      * @param properties    the properties associated with the operation
      */
-    public UpdateRequestImpl(List<Entry<Serializable, Metacard>> updateList, String attributeName,
+    public UpdateRequestImpl(List<Entry<? extends Serializable, Metacard>> updateList, String attributeName,
             Map<String, Serializable> properties) {
         this(updateList, attributeName, properties, new HashSet<>());
     }
@@ -112,10 +112,9 @@ public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
      * @param metacards the metacards to format
      * @return the list of {@link Entry}
      */
-    private static List<Entry<Serializable, Metacard>> formatEntryList(Serializable[] values,
+    private static List<Entry<? extends Serializable, Metacard>> formatEntryList(Serializable[] values,
             List<Metacard> metacards) {
-        List<Entry<Serializable, Metacard>> updateList =
-                new ArrayList<Entry<Serializable, Metacard>>();
+        List<Entry<? extends Serializable, Metacard>> updateList = new ArrayList<>();
         if (values.length != metacards.size()) {
             throw new IllegalArgumentException("Id List and Metacard List must be the same size.");
         } else {
@@ -148,7 +147,7 @@ public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
      * @see ddf.catalog.operation.UpdateRequest#getUpdates()
      */
     @Override
-    public List<Entry<Serializable, Metacard>> getUpdates() {
+    public List<Entry<? extends Serializable, Metacard>> getUpdates() {
         return updates;
     }
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/operation/UpdateRequest.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/operation/UpdateRequest.java
@@ -67,5 +67,5 @@ public interface UpdateRequest extends Request {
      * @return List - pairs of {@link ddf.catalog.data.Attribute} values and associated new {@link Metacard}s to
      *         update if a match is found.
      */
-    public List<Entry<Serializable, Metacard>> getUpdates();
+    public List<Entry<? extends Serializable, Metacard>> getUpdates();
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes DeleteRequestImpl's bad generics
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 
@pklinef


 - Now is `? extends Serializable` so that we can use anything that extends it instead of having to cast everything to serializable