### PR TITLE
ddf-2095 ddf should prefer /dev/urandom on Linux

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -38,6 +38,14 @@ DDF_HOME=`cd $DIRNAME/..; pwd`
 # NOTE: export on separate line to support caveat of Solaris OS
 export DDF_HOME
 
+# Prefer /dev/urandom over /dev/random on Linux systems.
+OS="`uname`"
+
+if [[ $OS == Linux* ]]; then
+   if [ -e /dev/urandom ]; then
+      RANDOM_DEVICE_OPTION="-Djava.security.egd=file:/dev/./urandom"
+   fi
+fi
 
 #
 # The following section shows the possible configuration options for the default 
@@ -50,4 +58,4 @@ export JAVA_MAX_MEM=2048M
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder
 
-export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME"
+export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME $RANDOM_DEVICE_OPTION"


### PR DESCRIPTION
#### What does this PR do?
This PR adds logic to bin/setenv to set the random seed generator on Linux systems.  

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@kcwire

#### How should this be tested?
1) acquire access to a Linux host that demonstrates this problem.  
2) deploy the modified setenv script to $DDF_HOME/bin.
3) start DDF as usual.
4) verify that the web applications are now accessible.

#### Any background context you want to provide?
This is to solve an issue that prevented the security modules from being seeded and caused a timeout in the web applications.  The JVM delegates random number generation for the seed vales to the OS.  On Unix systems, it uses /dev/random.  On Linux systems, /dev/random will block until it has generated a truly random value.  This process can take tens of minutes, making the system unusable.  The /dev/urandom device provides slightly less randomness, but without blocking.  

#### What are the relevant tickets?
DDF-2095

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests