### PR TITLE
DDF-2094 Add support for decrypting encrypted passwords in sources

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
@@ -87,6 +87,7 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
+import ddf.security.encryption.EncryptionService;
 
 /**
  * Federated site that talks via OpenSearch to the DDF platform. Communication is usually performed
@@ -116,6 +117,8 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     private static final String LOCAL_SEARCH_PARAMETER = "local";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchSource.class);
+
+    private final EncryptionService encryptionService;
 
     private boolean isInitialized = false;
 
@@ -156,8 +159,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
      *
      * @throws ddf.catalog.source.UnsupportedQueryException
      */
-    public OpenSearchSource(FilterAdapter filterAdapter) {
+    public OpenSearchSource(FilterAdapter filterAdapter, EncryptionService encryptionService) {
         this.filterAdapter = filterAdapter;
+        this.encryptionService = encryptionService;
     }
 
     /**
@@ -753,7 +757,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     }
 
     public void setPassword(String password) {
-        this.password = password;
+        this.password = encryptionService.decryptValue(password);
     }
 
     private WebClient newRestClient(Query query, String metacardId, boolean retrieveResource,

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,6 +27,7 @@
     <reference id="resourceReader" interface="ddf.catalog.resource.ResourceReader"
         filter="(shortname=URLResourceReader)" />
 
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
     <cm:managed-service-factory id="DDFfederationPrototypeServiceFactory"
         factory-pid="OpenSearchSource" interface="ddf.catalog.source.FederatedSource">
@@ -67,7 +68,7 @@
                 </list>
             </property>
             <property name="resourceReader" ref="resourceReader" />
-
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id=""
                 update-strategy="container-managed" />
         </cm:managed-component>

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/TestOpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/TestOpenSearchSource.java
@@ -81,6 +81,7 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
+import ddf.security.encryption.EncryptionService;
 
 /**
  * Tests parts of the {@link OpenSearchSource}
@@ -97,6 +98,8 @@ public class TestOpenSearchSource {
     private static final String SAMPLE_SEARCH_PHRASE = "foobar";
 
     private static final String BYTES_TO_SKIP = "BytesToSkip";
+
+    private EncryptionService encryptionService = mock(EncryptionService.class);
 
     private static final List<String> DEFAULT_PARAMETERS = Arrays.asList("q",
             "src",
@@ -312,7 +315,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.init();
@@ -369,7 +373,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.init();
@@ -407,7 +412,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.init();
@@ -446,7 +452,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         InputTransformer inputTransformer = mock(InputTransformer.class);
 
         MetacardImpl generatedMetacard = new MetacardImpl();
@@ -495,7 +502,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         InputTransformer inputTransformer = mock(InputTransformer.class);
 
         MetacardImpl generatedMetacard = new MetacardImpl();
@@ -548,7 +556,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.init();
@@ -577,7 +586,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.init();
@@ -627,7 +637,8 @@ public class TestOpenSearchSource {
      */
     @Test
     public void testRetrieveNullProduct() throws ResourceNotSupportedException, IOException {
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         // when
         try {
             source.retrieveResource(null, null);
@@ -658,7 +669,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setLocalQueryOnly(true);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
@@ -704,7 +716,8 @@ public class TestOpenSearchSource {
 
         SecureCxfClientFactory factory = getMockFactory(client);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setLocalQueryOnly(true);
         source.setInputTransformer(getMockInputTransformer());
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
@@ -814,7 +827,8 @@ public class TestOpenSearchSource {
 
         when(clientResponse.getHeaders()).thenReturn(headers);
 
-        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER);
+        OverriddenOpenSearchSource source = new OverriddenOpenSearchSource(FILTER_ADAPTER,
+                encryptionService);
         source.setEndpointUrl("http://localhost:8181/services/catalog/query");
         source.setParameters(DEFAULT_PARAMETERS);
         source.init();
@@ -894,13 +908,14 @@ public class TestOpenSearchSource {
          * @param filterAdapter
          * @throws UnsupportedQueryException
          */
-        public OverriddenOpenSearchSource(FilterAdapter filterAdapter) {
-            super(filterAdapter);
+        public OverriddenOpenSearchSource(FilterAdapter filterAdapter,
+                EncryptionService encryptionService) {
+            super(filterAdapter, encryptionService);
         }
 
         public OverriddenOpenSearchSource(FilterAdapter filterAdapter,
-                SecureCxfClientFactory factory) {
-            super(filterAdapter);
+                SecureCxfClientFactory factory, EncryptionService encryptionService) {
+            super(filterAdapter, encryptionService);
             this.factory = factory;
         }
 

--- a/catalog/spatial/csw/spatial-csw-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-common/pom.xml
@@ -173,5 +173,9 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-urlresourcereader</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.encryption</groupId>
+            <artifactId>security-encryption-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import ddf.security.encryption.EncryptionService;
 import ddf.security.permission.Permissions;
 
 /**
@@ -61,7 +62,17 @@ public class CswSourceConfiguration {
 
     private boolean registerForEvents;
 
+    private EncryptionService encryptionService;
+
     private Map<String, Set<String>> securityAttributes = new HashMap<>();
+
+    public CswSourceConfiguration(EncryptionService encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
+    @Deprecated
+    public CswSourceConfiguration() {
+    }
 
     public String getCswUrl() {
         return cswUrl;
@@ -92,7 +103,11 @@ public class CswSourceConfiguration {
     }
 
     public void setPassword(String password) {
-        this.password = password;
+        String updatedPassword = password;
+        if (encryptionService != null) {
+            updatedPassword = encryptionService.decryptValue(password);
+        }
+        this.password = updatedPassword;
     }
 
     public void setMetacardCswMappings(Map<String, String> mapping) {

--- a/catalog/spatial/csw/spatial-csw-source-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/pom.xml
@@ -150,6 +150,10 @@
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.encryption</groupId>
+            <artifactId>security-encryption-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswStore.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswStore.java
@@ -69,6 +69,7 @@ import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
+import ddf.security.encryption.EncryptionService;
 import net.opengis.cat.csw.v_2_0_2.BriefRecordType;
 import net.opengis.cat.csw.v_2_0_2.DeleteType;
 import net.opengis.cat.csw.v_2_0_2.InsertResultType;
@@ -92,15 +93,15 @@ public abstract class AbstractCswStore extends AbstractCswSource implements Cata
      * @param factory                client factory already configured for this source
      */
     public AbstractCswStore(BundleContext context, CswSourceConfiguration cswSourceConfiguration,
-            Converter provider, SecureCxfClientFactory factory) {
-        super(context, cswSourceConfiguration, provider, factory);
+            Converter provider, SecureCxfClientFactory factory, EncryptionService encryptionService) {
+        super(context, cswSourceConfiguration, provider, factory, encryptionService);
     }
 
     /**
      * Instantiates a CswStore.
      */
-    public AbstractCswStore() {
-        super();
+    public AbstractCswStore(EncryptionService encryptionService) {
+        super(encryptionService);
     }
 
     @Override

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswSourceStub.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswSourceStub.java
@@ -27,14 +27,16 @@ import org.osgi.framework.BundleContext;
 import com.thoughtworks.xstream.converters.Converter;
 
 import ddf.security.Subject;
+import ddf.security.encryption.EncryptionService;
 
 public class CswSourceStub extends AbstractCswSource {
 
     Subject subject = mock(Subject.class);
 
     public CswSourceStub(BundleContext mockContext, CswSourceConfiguration cswSourceConfiguration,
-            Converter mockProvider, SecureCxfClientFactory mockFactory) {
-        super(mockContext, cswSourceConfiguration, mockProvider, mockFactory);
+            Converter mockProvider, SecureCxfClientFactory mockFactory,
+            EncryptionService encryptionService) {
+        super(mockContext, cswSourceConfiguration, mockProvider, mockFactory, encryptionService);
         super.subscribeClientFactory = mock(SecureCxfClientFactory.class);
     }
 

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
@@ -101,6 +101,7 @@ import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.resource.ResourceReader;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.security.encryption.EncryptionService;
 import ddf.security.service.SecurityServiceException;
 import net.opengis.cat.csw.v_2_0_2.AcknowledgementType;
 import net.opengis.cat.csw.v_2_0_2.CapabilitiesType;
@@ -113,6 +114,8 @@ public class TestCswSource extends TestCswSourceBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCswSource.class);
 
     private Converter mockProvider = mock(Converter.class);
+
+    private EncryptionService encryptionService = mock(EncryptionService.class);
 
     @Test
     public void testParseCapabilities() throws CswException, SecurityServiceException {
@@ -901,11 +904,17 @@ public class TestCswSource extends TestCswSourceBase {
 
     @Test
     public void testRefreshWithNullConfiguration() throws SecurityServiceException {
-        AbstractCswSource cswSource = getCswSource(null, null, "type", null, null);
+        AbstractCswSource cswSource = getCswSource(null,
+                null,
+                "type",
+                null,
+                null,
+                encryptionService);
         CswSourceConfiguration defaultCswSourceConfiguration = getStandardCswSourceConfiguration(
                 null,
                 null,
-                null);
+                null,
+                encryptionService);
 
         // Assert that the default configuration is set
         assertDefaultCswSourceConfiguration(cswSource.cswSourceConfiguration,
@@ -920,11 +929,17 @@ public class TestCswSource extends TestCswSourceBase {
 
     @Test
     public void testRefreshWithEmptyConfiguration() throws SecurityServiceException {
-        AbstractCswSource cswSource = getCswSource(null, null, "type", null, null);
+        AbstractCswSource cswSource = getCswSource(null,
+                null,
+                "type",
+                null,
+                null,
+                encryptionService);
         CswSourceConfiguration defaultCswSourceConfiguration = getStandardCswSourceConfiguration(
                 null,
                 null,
-                null);
+                null,
+                encryptionService);
 
         Map<String, Object> configuration = new HashMap<>();
 
@@ -945,7 +960,8 @@ public class TestCswSource extends TestCswSourceBase {
         CswSourceConfiguration defaultCswSourceConfiguration = getStandardCswSourceConfiguration(
                 "contentType",
                 "qname",
-                "queryprefix");
+                "queryprefix",
+                encryptionService);
 
         // Assert Defaults
         assertDefaultCswSourceConfiguration(cswSource.cswSourceConfiguration,
@@ -953,6 +969,7 @@ public class TestCswSource extends TestCswSourceBase {
 
         // Set Configuration Map
         Map<String, Object> configuration = getConfigurationMap(cswSource);
+        when(encryptionService.decryptValue(PASSWORD)).thenReturn(PASSWORD);
 
         // Call Refresh
         cswSource.refresh(configuration);
@@ -962,6 +979,56 @@ public class TestCswSource extends TestCswSourceBase {
 
         // Assert Refresh Changes
         assertConfigurationAfterRefresh(cswSourceConfiguration);
+    }
+
+    @Test
+    public void testSetPassword() {
+        AbstractCswSource cswSource = getCswSource(null,
+                null,
+                "type",
+                null,
+                null,
+                encryptionService);
+        when(encryptionService.decryptValue("secret")).thenReturn("secret");
+
+        cswSource.setPassword("secret");
+
+        // The password is first initialized to "pass" on creation of the AbstractCswSource.
+        // Verify the encryption service was called with "secret".
+        // Assert the password is equal to "secret".
+        verify(encryptionService, times(2)).decryptValue("secret");
+        assertThat(cswSource.cswSourceConfiguration.getPassword(), is(equalTo("secret")));
+    }
+
+    @Test
+    public void testSetPasswordWithEmptyPassword() {
+        AbstractCswSource cswSource = getCswSource(null,
+                null,
+                "type",
+                null,
+                null,
+                encryptionService);
+        when(encryptionService.decryptValue("")).thenReturn("");
+
+        cswSource.setPassword("");
+
+        // The password is first initialized to "pass" on creation of the AbstractCswSource.
+        // Verify the encryption service was called with an empty password.
+        // Assert the password is equal to "".
+        verify(encryptionService, times(2)).decryptValue("");
+        assertThat(cswSource.cswSourceConfiguration.getPassword(), is(equalTo("")));
+    }
+
+    @Test
+    public void testSetPasswordWithNullEncryptionService() {
+        AbstractCswSource cswSource = getCswSource(null, null, "type", null, null, null);
+
+        cswSource.setPassword("secret");
+
+        // Verify the encryption service was not called.
+        // Assert the password is equal to the value it was set to.
+        verify(encryptionService, times(0)).decryptValue("secret");
+        assertThat(cswSource.cswSourceConfiguration.getPassword(), is(equalTo("secret")));
     }
 
     @Test
@@ -1103,7 +1170,8 @@ public class TestCswSource extends TestCswSourceBase {
                 mockContext,
                 null,
                 expectedQname.getPrefix() + ":" + expectedQname.getLocalPart(),
-                expectedQname.getNamespaceURI());
+                expectedQname.getNamespaceURI(),
+                null);
 
         cswSource.setCswUrl(URL);
         cswSource.setId(ID);
@@ -1154,7 +1222,7 @@ public class TestCswSource extends TestCswSourceBase {
         query.setPageSize(pageSize);
 
         // Verify passing a null config for qname/prefix falls back to CSW Record
-        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null);
+        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null, null);
         cswSource.setCswUrl(URL);
         cswSource.setId(ID);
 
@@ -1181,7 +1249,12 @@ public class TestCswSource extends TestCswSourceBase {
 
     @Test
     public void testCreateResults() throws SecurityServiceException {
-        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null);
+        AbstractCswSource cswSource = getCswSource(mockCsw,
+                mockContext,
+                null,
+                null,
+                null,
+                encryptionService);
         CswRecordCollection recordCollection = new CswRecordCollection();
         final int total = 2;
         List<Metacard> metacards = new ArrayList<>(total);
@@ -1227,7 +1300,7 @@ public class TestCswSource extends TestCswSourceBase {
             throws URISyntaxException, ResourceNotFoundException, IOException,
             ResourceNotSupportedException, CswException {
         configureMockCsw();
-        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null);
+        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null, null);
         ResourceReader reader = mock(ResourceReader.class);
         when(reader.retrieveResource(any(URI.class), any(Map.class))).thenReturn(mock(
                 ResourceResponse.class));
@@ -1250,7 +1323,7 @@ public class TestCswSource extends TestCswSourceBase {
         when(collection.getResource()).thenReturn(resource);
         when(csw.getRecordById(any(GetRecordByIdRequest.class),
                 anyString())).thenReturn(collection);
-        AbstractCswSource cswSource = getCswSource(csw, mockContext, null, null, null);
+        AbstractCswSource cswSource = getCswSource(csw, mockContext, null, null, null, null);
         ResourceReader reader = mock(ResourceReader.class);
         when(reader.retrieveResource(any(URI.class), any(Map.class))).thenReturn(mock(
                 ResourceResponse.class));
@@ -1274,7 +1347,7 @@ public class TestCswSource extends TestCswSourceBase {
         when(collection.getResource()).thenReturn(resource);
         when(csw.getRecordById(any(GetRecordByIdRequest.class),
                 anyString())).thenReturn(collection);
-        AbstractCswSource cswSource = getCswSource(csw, mockContext, null, null, null);
+        AbstractCswSource cswSource = getCswSource(csw, mockContext, null, null, null, null);
         ResourceReader reader = mock(ResourceReader.class);
         when(reader.retrieveResource(any(URI.class), any(Map.class))).thenReturn(mock(
                 ResourceResponse.class));
@@ -1285,8 +1358,12 @@ public class TestCswSource extends TestCswSourceBase {
     }
 
     private CswSourceConfiguration getStandardCswSourceConfiguration(String contentTypeMapping,
-            String queryTypeQName, String queryTypePrefix) {
-        CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
+            String queryTypeQName, String queryTypePrefix, EncryptionService encryptionService) {
+        CswSourceConfiguration cswSourceConfiguration =
+                new CswSourceConfiguration(encryptionService);
+        if (encryptionService != null) {
+            when(encryptionService.decryptValue("pass")).thenReturn("pass");
+        }
         if (contentTypeMapping == null) {
             cswSourceConfiguration.putMetacardCswMapping(Metacard.CONTENT_TYPE,
                     CswRecordMetacardType.CSW_TYPE);
@@ -1316,16 +1393,18 @@ public class TestCswSource extends TestCswSourceBase {
                 context,
                 contentMapping,
                 CswConstants.CSW_RECORD,
-                CswConstants.CSW_OUTPUT_SCHEMA);
+                CswConstants.CSW_OUTPUT_SCHEMA,
+                encryptionService);
     }
 
     private AbstractCswSource getCswSource(Csw csw, BundleContext context, String contentMapping,
-            String queryTypeQName, String queryTypePrefix) {
+            String queryTypeQName, String queryTypePrefix, EncryptionService encryptionService) {
 
         CswSourceConfiguration cswSourceConfiguration = getStandardCswSourceConfiguration(
                 contentMapping,
                 queryTypeQName,
-                queryTypePrefix);
+                queryTypePrefix,
+                encryptionService);
         cswSourceConfiguration.putMetacardCswMapping(Metacard.CONTENT_TYPE, contentMapping);
 
         SecureCxfClientFactory mockFactory = mock(SecureCxfClientFactory.class);
@@ -1337,7 +1416,8 @@ public class TestCswSource extends TestCswSourceBase {
         CswSourceStub cswSource = new CswSourceStub(mockContext,
                 cswSourceConfiguration,
                 mockProvider,
-                mockFactory);
+                mockFactory,
+                encryptionService);
         cswSource.setFilterAdapter(new GeotoolsFilterAdapterImpl());
         cswSource.setFilterBuilder(builder);
         cswSource.setContext(context);

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/TestGetRecordsMessageBodyReader.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/TestGetRecordsMessageBodyReader.java
@@ -62,10 +62,13 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.resource.Resource;
+import ddf.security.encryption.EncryptionService;
 
 public class TestGetRecordsMessageBodyReader {
 
     private Converter mockProvider = mock(Converter.class);
+
+    private EncryptionService encryptionService = mock(EncryptionService.class);
 
     @Before
     public void setUp() {
@@ -75,7 +78,7 @@ public class TestGetRecordsMessageBodyReader {
     @Test
     public void testConfigurationArguments() throws Exception {
 
-        CswSourceConfiguration config = new CswSourceConfiguration();
+        CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
         config.setMetacardCswMappings(DefaultCswRecordMap.getCswToMetacardAttributeNames());
         config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
         config.setCswAxisOrder(CswAxisOrder.LAT_LON);
@@ -131,7 +134,7 @@ public class TestGetRecordsMessageBodyReader {
         collection.setCswRecords(inputMetacards);
         when(mockProvider.unmarshal(any(), any())).thenReturn(collection);
 
-        CswSourceConfiguration config = new CswSourceConfiguration();
+        CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
         Map<String, String> mappings = new HashMap<>();
         mappings.put(Metacard.CREATED, "dateSubmitted");
         mappings.put(Metacard.EFFECTIVE, "created");
@@ -169,7 +172,7 @@ public class TestGetRecordsMessageBodyReader {
         CswRecordCollection collection = new CswRecordCollection();
         collection.setCswRecords(inputMetacards);
         when(mockProvider.unmarshal(any(), any())).thenReturn(collection);
-        CswSourceConfiguration config = new CswSourceConfiguration();
+        CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
         config.setMetacardCswMappings(DefaultCswRecordMap.getCswToMetacardAttributeNames());
         config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
         GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(mockProvider, config);
@@ -189,7 +192,7 @@ public class TestGetRecordsMessageBodyReader {
 
     @Test
     public void testReadProductData() throws Exception {
-        CswSourceConfiguration config = new CswSourceConfiguration();
+        CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
         config.setMetacardCswMappings(DefaultCswRecordMap.getCswToMetacardAttributeNames());
         config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
         GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(mockProvider, config);

--- a/catalog/spatial/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSourceImpl.java
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSourceImpl.java
@@ -24,14 +24,17 @@ import org.osgi.framework.BundleContext;
 
 import com.thoughtworks.xstream.converters.Converter;
 
+import ddf.security.encryption.EncryptionService;
+
 public class CswSourceImpl extends AbstractCswSource {
     public CswSourceImpl(BundleContext context, CswSourceConfiguration cswSourceConfiguration,
-            Converter provider, SecureCxfClientFactory factory) {
-        super(context, cswSourceConfiguration, provider, factory);
+            Converter provider, SecureCxfClientFactory factory,
+            EncryptionService encryptionService) {
+        super(context, cswSourceConfiguration, provider, factory, encryptionService);
     }
 
-    public CswSourceImpl() {
-        super();
+    public CswSourceImpl(EncryptionService encryptionService) {
+        super(encryptionService);
     }
 
     @Override

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,6 +28,7 @@
                filter="(shortname=URLResourceReader)"/>
     <reference id="cswTransformProvider" interface="com.thoughtworks.xstream.converters.Converter"/>
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
     <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
@@ -72,6 +73,7 @@
             <property name="metacardTypes" ref="metacardTypes"/>
             <property name="eventServiceAddress" value=""/>
             <property name="registerForEvents" value="false"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>
@@ -113,6 +115,7 @@
             <property name="eventServiceAddress" value=""/>
             <property name="registerForEvents" value="false"/>
             <property name="metacardTypes" ref="metacardTypes"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>
@@ -155,6 +158,7 @@
             <property name="metacardTypes" ref="metacardTypes"/>
             <property name="eventServiceAddress" value=""/>
             <property name="registerForEvents" value="false"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/pom.xml
+++ b/catalog/spatial/pom.xml
@@ -56,6 +56,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>ddf.security.encryption</groupId>
+                <artifactId>security-encryption-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codice.ddf.spatial</groupId>
                 <artifactId>spatial-wfs-common</artifactId>
                 <version>${project.version}</version>

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
@@ -54,6 +54,7 @@ import ddf.catalog.operation.UpdateResponse;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.security.encryption.EncryptionService;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
 
@@ -74,12 +75,13 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
     private ParserConfigurator unmarshalConfigurator;
 
     public RegistryStoreImpl(BundleContext context, CswSourceConfiguration cswSourceConfiguration,
-            Converter provider, SecureCxfClientFactory factory) {
-        super(context, cswSourceConfiguration, provider, factory);
+            Converter provider, SecureCxfClientFactory factory,
+            EncryptionService encryptionService) {
+        super(context, cswSourceConfiguration, provider, factory, encryptionService);
     }
 
-    public RegistryStoreImpl() {
-        super();
+    public RegistryStoreImpl(EncryptionService encryptionService) {
+        super(encryptionService);
     }
 
     @Override

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,6 +38,8 @@
                             unbind-method="unbindPlugin"/>
     </reference-list>
 
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
+
     <!-- MetacardTransformer Manager -->
     <bean id="metacardTransformerManager"
           class="org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager">
@@ -101,6 +103,7 @@
             <property name="parser" ref="xmlParser"/>
             <property name="pullAllowed" value="true"/>
             <property name="pushAllowed" value="true"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/TestRegistryStore.java
@@ -55,6 +55,7 @@ import ddf.catalog.operation.impl.OperationTransactionImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.security.encryption.EncryptionService;
 import net.opengis.cat.csw.v_2_0_2.TransactionResponseType;
 import net.opengis.cat.csw.v_2_0_2.TransactionSummaryType;
 
@@ -74,6 +75,8 @@ public class TestRegistryStore {
 
     private TransformerManager transformer;
 
+    private EncryptionService encryptionService;
+
     @Before
     public void setup() {
         parser = new XmlParser();
@@ -82,7 +85,12 @@ public class TestRegistryStore {
         configuration = mock(CswSourceConfiguration.class);
         factory = mock(SecureCxfClientFactory.class);
         transformer = mock(TransformerManager.class);
-        registryStore = new RegistryStoreImpl(context, configuration, provider, factory);
+        encryptionService = mock(EncryptionService.class);
+        registryStore = new RegistryStoreImpl(context,
+                configuration,
+                provider,
+                factory,
+                encryptionService);
         registryStore.setParser(parser);
         registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
         registryStore.setSchemaTransformerManager(transformer);
@@ -91,8 +99,11 @@ public class TestRegistryStore {
 
     @Test
     public void testUpdate() throws Exception {
-
-        registryStore = new RegistryStoreImpl(context, configuration, provider, factory) {
+        registryStore = new RegistryStoreImpl(context,
+                configuration,
+                provider,
+                factory,
+                encryptionService) {
             @Override
             public SourceResponse query(QueryRequest queryRequest)
                     throws UnsupportedQueryException {

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
@@ -119,6 +119,10 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.encryption</groupId>
+            <artifactId>security-encryption-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,6 +27,8 @@
                     interface="org.codice.ddf.spatial.ogc.wfs.v1_0_0.catalog.converter.FeatureConverterFactory"
                     availability="optional"/>
 
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
+
     <cm:managed-service-factory
             id="org.codice.ddf.spatial.ogc.wfs.v1_0_0.catalog.source.WfsFederatedSource.id"
             factory-pid="Wfs_v1_0_0_Federated_Source"
@@ -48,6 +50,7 @@
             <property name="forceSpatialFilter" value=""/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>
@@ -74,6 +77,7 @@
             <property name="forceSpatialFilter" value=""/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/TestWfsSource.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/TestWfsSource.java
@@ -68,6 +68,7 @@ import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.security.encryption.EncryptionService;
 import ddf.security.service.SecurityServiceException;
 import ogc.schema.opengis.filter.v_1_0_0.BinaryLogicOpType;
 import ogc.schema.opengis.filter.v_1_0_0.LogicOpsType;
@@ -187,6 +188,8 @@ public class TestWfsSource {
 
     private AvailabilityTask mockAvailabilityTask = mock(AvailabilityTask.class);
 
+    private EncryptionService encryptionService = mock(EncryptionService.class);
+
     public void setUp(final String schema, final List<Object> supportedGeos, final String srsName,
             final Integer numFeatures, final Integer numResults)
             throws WfsException, SecurityServiceException {
@@ -275,7 +278,8 @@ public class TestWfsSource {
         source = new WfsSource(new GeotoolsFilterAdapterImpl(),
                 mockContext,
                 mockAvailabilityTask,
-                mockFactory);
+                mockFactory,
+                encryptionService);
 
     }
 

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
@@ -144,6 +144,10 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.encryption</groupId>
+            <artifactId>security-encryption-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,6 +33,8 @@
                     interface="org.codice.ddf.spatial.ogc.wfs.v2_0_0.catalog.converter.FeatureConverterFactory"
                     availability="optional"/>
 
+    <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
+
     <cm:managed-service-factory
             id="org.codice.ddf.spatial.ogc.wfs.v2_0_0.catalog.source.WfsFederatedSource.id"
             factory-pid="Wfs_v2_0_0_Federated_Source"
@@ -57,6 +59,7 @@
             <property name="disableSorting" value="false"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>
@@ -86,6 +89,7 @@
             <property name="disableSorting" value="false"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
@@ -72,6 +72,7 @@ import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.security.encryption.EncryptionService;
 import ddf.security.service.SecurityServiceException;
 import net.opengis.filter.v_2_0_0.ConformanceType;
 import net.opengis.filter.v_2_0_0.FilterCapabilities;
@@ -117,6 +118,8 @@ public class TestWfsSource {
     private Wfs20FeatureCollection mockFeatureCollection = mock(Wfs20FeatureCollection.class);
 
     private SecureCxfClientFactory mockFactory = mock(SecureCxfClientFactory.class);
+
+    private EncryptionService encryptionService = mock(EncryptionService.class);
 
     public WfsSource getWfsSource(final String schema, final FilterCapabilities filterCapabilities,
             final String srsName, final int numFeatures)
@@ -203,7 +206,8 @@ public class TestWfsSource {
         WfsSource source = new WfsSource(new GeotoolsFilterAdapterImpl(),
                 mockContext,
                 mockAvailabilityTask,
-                mockFactory);
+                mockFactory,
+                encryptionService);
 
         source.setMetacardToFeatureMapper(mappers);
         return source;
@@ -286,7 +290,8 @@ public class TestWfsSource {
         WfsSource wfsSource = new WfsSource(new GeotoolsFilterAdapterImpl(),
                 mockContext,
                 mockAvailabilityTask,
-                mockFactory);
+                mockFactory,
+                encryptionService);
 
         wfsSource.setFeatureCollectionReader(mockReader);
 

--- a/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
@@ -104,9 +104,12 @@ public class EncryptionServiceImpl implements EncryptionService {
         String decryptedValue = null;
         String encryptedValue = unwrapEncryptedValue(wrappedEncryptedValue);
 
-        if (wrappedEncryptedValue == null || wrappedEncryptedValue.isEmpty()) {
-            LOGGER.error("A blank password was provided in the configuration.");
+        if (wrappedEncryptedValue == null) {
+            LOGGER.error("A null password was provided.");
             decryptedValue = null;
+        } else if (wrappedEncryptedValue.isEmpty()) {
+            LOGGER.warn("A blank password was provided in the configuration.");
+            decryptedValue = "";
         } else if (!wrappedEncryptedValue.equals(encryptedValue)) {
             LOGGER.debug("Unwrapped encrypted password is now being decrypted");
             decryptedValue = decrypt(encryptedValue);

--- a/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
@@ -122,7 +122,7 @@ public class EncryptionServiceImplTest {
 
         final String decryptedValue = encryptionService.decryptValue(wrappedEncryptedValue);
 
-        assertNull(decryptedValue);
+        assertEquals(decryptedValue, "");
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
The following sources now support decrypting encrypted passwords:
catalog-opensearch-source
spatial-csw-source
spatial-wfs-v2_0_0-source
spatial-wfs-v1_0_0-source
catalog-registry-api-impl
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @coyotesqrl @tbatie @jckilmer @bcwaters @kcwire 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison 
#### How should this be tested?
Enter an unencrypted password in a password field of a source configuration. Check the logs and verify it says a clear text password has been passed in. If possible, encrypt the password and pass it in a source configuration and verify the source works.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2094
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

