### PR TITLE
DDF-2096 Allow finer configuration of validation filtering

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -154,7 +154,9 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private ValidationQueryFactory validationQueryFactory;
 
-    private boolean showInvalidMetacards = false;
+    private boolean showErrors = false;
+
+    private boolean showWarnings = true;
 
     /**
      * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
@@ -403,7 +405,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private QueryRequest getQueryRequestWithAdditionalFilters(QueryRequest originalRequest) {
         return validationQueryFactory.getQueryRequestWithValidationFilter(getRequestWithTagsFilter(
-                originalRequest), showInvalidMetacards);
+                originalRequest), showErrors, showWarnings);
     }
 
     /**
@@ -658,12 +660,20 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         }
     }
 
-    public void setShowInvalidMetacards(boolean showInvalidMetacards) {
-        this.showInvalidMetacards = showInvalidMetacards;
+    public void setShowErrors(boolean showErrors) {
+        this.showErrors = showErrors;
     }
 
-    public boolean getShowInvalidMetacards() {
-        return showInvalidMetacards;
+    public boolean getShowErrors() {
+        return showErrors;
+    }
+
+    public void setShowWarnings(boolean showWarnings) {
+        this.showWarnings = showWarnings;
+    }
+
+    public boolean getShowWarnings() {
+        return showWarnings;
     }
 
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/ValidationQueryFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/ValidationQueryFactory.java
@@ -44,7 +44,7 @@ public class ValidationQueryFactory {
         builder = filterBuilder;
     }
 
-    public QueryRequest getQueryRequestWithValidationFilter(QueryRequest input, Boolean showErrors,
+    QueryRequest getQueryRequestWithValidationFilter(QueryRequest input, Boolean showErrors,
             Boolean showWarnings) {
         Query inputQuery = input.getQuery();
         try {
@@ -94,7 +94,7 @@ public class ValidationQueryFactory {
                         .empty());
     }
 
-    public QueryRequest getQueryRequestWithValidationFilter(QueryRequest input) {
+    QueryRequest getQueryRequestWithValidationFilter(QueryRequest input) {
         return getQueryRequestWithValidationFilter(input, false, true);
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/ValidationQueryFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/ValidationQueryFactory.java
@@ -13,6 +13,9 @@
  */
 package ddf.catalog.cache.solr.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,11 +44,11 @@ public class ValidationQueryFactory {
         builder = filterBuilder;
     }
 
-    public QueryRequest getQueryRequestWithValidationFilter(QueryRequest input,
-            boolean showInvalidMetacards) {
+    public QueryRequest getQueryRequestWithValidationFilter(QueryRequest input, Boolean showErrors,
+            Boolean showWarnings) {
         Query inputQuery = input.getQuery();
         try {
-            if (showInvalidMetacards || adapter.adapt(input.getQuery(),
+            if ((showErrors && showWarnings) || adapter.adapt(input.getQuery(),
                     new ValidationQueryDelegate())) {
                 return input;
             }
@@ -53,13 +56,18 @@ public class ValidationQueryFactory {
         } catch (UnsupportedQueryException e) {
             LOGGER.warn("This attribute filter is not supported by ValidationQueryDelegate.", e);
         }
-        QueryImpl query = new QueryImpl(builder.allOf(builder.allOf(
-                builder.attribute(BasicTypes.VALIDATION_ERRORS)
-                        .is()
-                        .empty(),
-                builder.attribute(BasicTypes.VALIDATION_WARNINGS)
-                        .is()
-                        .empty()), inputQuery),
+        List<Filter> filters = new ArrayList<>();
+        if (!showErrors) {
+            filters.add(builder.attribute(BasicTypes.VALIDATION_ERRORS)
+                    .is()
+                    .empty());
+        }
+        if (!showWarnings) {
+            filters.add(builder.attribute(BasicTypes.VALIDATION_WARNINGS)
+                    .is()
+                    .empty());
+        }
+        QueryImpl query = new QueryImpl(builder.allOf(builder.allOf(filters), inputQuery),
                 inputQuery.getStartIndex(),
                 inputQuery.getPageSize(),
                 inputQuery.getSortBy(),
@@ -87,7 +95,7 @@ public class ValidationQueryFactory {
     }
 
     public QueryRequest getQueryRequestWithValidationFilter(QueryRequest input) {
-        return getQueryRequestWithValidationFilter(input, false);
+        return getQueryRequestWithValidationFilter(input, false, true);
     }
 
 }

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
@@ -50,10 +50,16 @@
             id="cacheRemoteIngests" required="true" type="Boolean" default="false"/>
 
         <AD
-            description="Show invalid metacards in search results"
-            name="Show Invalid Metacards" id="showInvalidMetacards" required="true"
+            description="Show metacards with validation errors in search results"
+            name="Show Validation Errors" id="showErrors" required="true"
             type="Boolean"
             default="false"/>
+
+        <AD
+            description="Show metacards with validation warnings in search results"
+            name="Show Validation Warnings" id="showWarnings" required="true"
+            type="Boolean"
+            default="true"/>
     </OCD>
 
     <Designate pid="ddf.catalog.federation.impl.CachingFederationStrategy">

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/ValidationQueryFactoryTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/ValidationQueryFactoryTest.java
@@ -127,7 +127,7 @@ public class ValidationQueryFactoryTest {
     }
 
     @Test
-    public void testSearchNone()
+    public void testSearchWarningsAndNotErrors()
             throws StopProcessingException, PluginExecutionException, UnsupportedQueryException {
         QueryImpl query = new QueryImpl(filterBuilder.attribute(Metacard.MODIFIED)
                 .is()
@@ -151,6 +151,18 @@ public class ValidationQueryFactoryTest {
                         .equalTo()
                         .text("*")));
         QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(new QueryRequestImpl(query));
+
+        assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
+                is(true));
+    }
+
+    @Test
+    public void testSearchErrorsAndNotWarnings() throws UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(filterBuilder.attribute(Metacard.MODIFIED)
+                .is()
+                .equalTo()
+                .text("sample"));
+        QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(new QueryRequestImpl(query), true, false);
 
         assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
                 is(true));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/ValidationQueryFactoryTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/ValidationQueryFactoryTest.java
@@ -88,7 +88,7 @@ public class ValidationQueryFactoryTest {
                 .text("sample"));
         assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(false));
         QueryRequest sendQuery = new QueryRequestImpl(query);
-        QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(sendQuery, true);
+        QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(sendQuery, true, true);
         assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
                 is(false));
         assertThat(sendQuery, is(returnQuery));
@@ -103,7 +103,7 @@ public class ValidationQueryFactoryTest {
                 .text("sample"));
         assertThat(filterAdapter.adapt(query, testValidationQueryDelegate), is(true));
         QueryRequest sendQuery = new QueryRequestImpl(query);
-        QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(sendQuery, false);
+        QueryRequest returnQuery = validationQueryFactory.getQueryRequestWithValidationFilter(sendQuery, false, false);
         assertThat(filterAdapter.adapt(returnQuery.getQuery(), testValidationQueryDelegate),
                 is(true));
         assertThat(sendQuery, is(returnQuery));

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -559,13 +559,14 @@ public abstract class AbstractIntegrationTest {
         config.update(properties);
     }
 
-    protected void configureShowInvalidMetacards(String showInvalidMetacards) throws IOException {
+    protected void configureShowInvalidMetacards(String showErrors, String showWarnings) throws IOException {
         Configuration config = configAdmin.getConfiguration(
                 "ddf.catalog.federation.impl.CachingFederationStrategy",
                 null);
 
         Dictionary properties = new Hashtable<>();
-        properties.put("showInvalidMetacards", showInvalidMetacards);
+        properties.put("showErrors", showErrors);
+        properties.put("showWarnings", showWarnings);
         config.update(properties);
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -1422,7 +1422,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         // Configure invalid filtering
         configureMetacardValidityFilterPlugin(Arrays.asList(""));
 
-        configureShowInvalidMetacards("true");
+        configureShowInvalidMetacards("true", "true");
 
         String id1 = ingestXmlFromResource("/metacard1.xml");
         String id2 = ingestXmlFromResource("/metacard2.xml");
@@ -1505,7 +1505,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             deleteMetacard(id1);
             deleteMetacard(id2);
             getServiceManager().stopFeature(true, "catalog-plugin-metacard-validation");
-            configureShowInvalidMetacards("false");
+            configureShowInvalidMetacards("false", "true");
         }
     }
 
@@ -1534,7 +1534,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "new.metacard.type")
                 .replaceFirst("resource-uri", "new-attribute-required-2");
         String id = ingest(modifiedMetacardXml, "text/xml");
-        configureShowInvalidMetacards("true");
+        configureShowInvalidMetacards("true", "true");
         try {
 
             String newMetacardXpath = String.format("/metacards/metacard[@id=\"%s\"]", id);
@@ -1557,7 +1557,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         } finally {
             deleteMetacard(id);
             getServiceManager().stopFeature(true, "catalog-core-validator");
-            configureShowInvalidMetacards("false");
+            configureShowInvalidMetacards("false", "false");
         }
     }
 


### PR DESCRIPTION
#### What does this PR do?
CachingFederationStrategy has a flag "showInvalidMetacards". This allows an administrator to either show or filter invalid metacards (validation warnings or errors). Now, an administrator can show or filter either validation warnings or errors. This is no longer restricted to none or all.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@spearskw @brendan-hofmann @coyotesqrl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef 
#### How should this be tested?
Unit tests and integration tests should pass.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2096
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
