### PR TITLE
DDF-2097: Added logic to compare Sources based on attributes instead of hashcode

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePollerRunner.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePollerRunner.java
@@ -13,9 +13,11 @@
  */
 package ddf.catalog.util.impl;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,7 +46,18 @@ public class SourcePollerRunner implements Runnable {
 
     private List<Source> sources;
 
-    private Map<Source, CachedSource> cachedSources = new ConcurrentHashMap<Source, CachedSource>();
+    private Map<Source, CachedSource> cachedSources = new ConcurrentSkipListMap<>(
+            Comparator.comparing(Source::getId, Comparator
+                    .nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(Source::getTitle, Comparator
+                            .nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(Source::getVersion, Comparator
+                            .nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(Source::getDescription, Comparator
+                            .nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(Source::getOrganization, Comparator
+                            .nullsLast(Comparator.naturalOrder()))
+            );
 
     private ExecutorService pool;
 

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/SourcePollerRunnerTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/SourcePollerRunnerTest.java
@@ -14,6 +14,7 @@
 package ddf.catalog.util.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -25,15 +26,19 @@ import java.util.Set;
 
 import org.junit.Test;
 
+
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.impl.ContentTypeImpl;
 import ddf.catalog.source.Source;
 
 public class SourcePollerRunnerTest {
 
-    private Source createDefaultFederatedSource(boolean avail, Set<ContentType> types) {
+    private Source createDefaultFederatedSource(boolean avail, Set<ContentType> types,
+            String src, String version) {
         Source source = mock(Source.class);
 
+        when(source.getTitle()).thenReturn(src);
+        when(source.getVersion()).thenReturn(version);
         when(source.isAvailable()).thenReturn(avail);
         when(source.getContentTypes()).thenReturn(types);
 
@@ -52,7 +57,7 @@ public class SourcePollerRunnerTest {
     public void testDoesntUpdateUnexpiredCachedValuesOnAvailableSource() {
         SourcePollerRunner runner = new SourcePollerRunner();
         Set<ContentType> types = createContentTypes();
-        Source source = createDefaultFederatedSource(true, types);
+        Source source = createDefaultFederatedSource(true, types, "src", "1");
         CachedSource cached = null;
         runner.bind(source);
 
@@ -81,17 +86,13 @@ public class SourcePollerRunnerTest {
 
         verify(source, times(1)).isAvailable();
         verify(source, times(1)).getContentTypes();
-        verify(source, times(1)).getVersion();
-        verify(source, times(1)).getTitle();
-        verify(source, times(1)).getOrganization();
-        verify(source, times(1)).getDescription();
     }
 
     @Test
     public void testDoesntUpdateUnexpiredCachedValuesOnUnAvailableSource() {
         SourcePollerRunner runner = new SourcePollerRunner();
         Set<ContentType> types = createContentTypes();
-        Source source = createDefaultFederatedSource(false, types);
+        Source source = createDefaultFederatedSource(false, types, "src", "1");
         CachedSource cached;
         runner.bind(source);
 
@@ -119,10 +120,132 @@ public class SourcePollerRunnerTest {
 
         verify(source, times(1)).isAvailable();
         verify(source, never()).getContentTypes();
-        verify(source, never()).getVersion();
-        verify(source, never()).getTitle();
-        verify(source, never()).getOrganization();
-        verify(source, never()).getDescription();
     }
+
+    @Test
+    public void testCorrectSourceGetsIdentified() {
+        SourcePollerRunner runner = new SourcePollerRunner();
+        Set<ContentType> types = createContentTypes();
+        Source source = createDefaultFederatedSource(true, types, "src", "1");
+        Source source2 = createDefaultFederatedSource(true, types, "src2", "2");
+        CachedSource cached;
+        CachedSource cached2;
+        runner.bind(source);
+        runner.bind(source2);
+
+        SourceStatus status = null;
+        SourceStatus status2 = null;
+        do {
+            Thread.yield();
+            cached = runner.getCachedSource(source);
+            cached2 = runner.getCachedSource(source2);
+            if (cached != null) {
+                status = cached.getSourceStatus();
+            }
+            if (cached2 != null) {
+                status2 = cached2.getSourceStatus();
+            }
+        } while (status == null || status == SourceStatus.UNCHECKED ||
+                status2 == null || status2 == SourceStatus.UNCHECKED);
+
+        for (int i = 0; i < 10; i++) {
+            cached.isAvailable();
+            cached.getContentTypes();
+            cached2.isAvailable();
+            cached2.getContentTypes();
+        }
+        assertEquals(SourceStatus.AVAILABLE, cached.getSourceStatus());
+        assertEquals(true, cached.isAvailable());
+
+        assertEquals(SourceStatus.AVAILABLE, cached2.getSourceStatus());
+        assertEquals(true, cached2.isAvailable());
+
+        assertEquals(source.getTitle(), cached.getTitle());
+        assertEquals(source2.getTitle(), cached2.getTitle());
+
+        verify(source, times(1)).isAvailable();
+        verify(source, times(1)).getContentTypes();
+        verify(source2, times(1)).isAvailable();
+        verify(source2, times(1)).getContentTypes();
+    }
+
+    @Test
+    public void testKnownSourceRepresentedByDifferentObjectDiscovered() {
+        SourcePollerRunner runner = new SourcePollerRunner();
+        Set<ContentType> types = createContentTypes();
+        Source source = createDefaultFederatedSource(false, types, "src1", "1");
+        Source source2 = createDefaultFederatedSource(false, types, "src2", "1");
+        CachedSource cached;
+        runner.bind(source);
+
+        SourceStatus status = null;
+        do {
+            Thread.yield();
+            cached = runner.getCachedSource(source);
+            if (cached != null) {
+                status = cached.getSourceStatus();
+            }
+        } while (status == null || status == SourceStatus.UNCHECKED);
+
+        for (int i = 0; i < 10; i++) {
+            cached.isAvailable();
+            cached.getSourceStatus();
+            cached.getContentTypes();
+            cached.getVersion();
+            cached.getTitle();
+            cached.getOrganization();
+            cached.getId();
+            cached.getDescription();
+        }
+        assertEquals(SourceStatus.UNAVAILABLE, cached.getSourceStatus());
+        assertEquals(false, cached.isAvailable());
+
+        verify(source, times(1)).isAvailable();
+        verify(source, never()).getContentTypes();
+    }
+
+
+    @Test
+    public void testNonExistantWithUnknownTitleIsntFound() {
+        SourcePollerRunner runner = new SourcePollerRunner();
+        Set<ContentType> types = createContentTypes();
+        Source source = createDefaultFederatedSource(true, types, "src", "1");
+        Source source2 = createDefaultFederatedSource(true, types, "src2", "1");
+        CachedSource cached = null;
+        runner.bind(source);
+
+        SourceStatus status = null;
+        do {
+            Thread.yield();
+            cached = runner.getCachedSource(source);
+            if (cached != null) {
+                status = cached.getSourceStatus();
+            }
+        } while (status == null || status == SourceStatus.UNCHECKED);
+
+        assertNull(runner.getCachedSource(source2));
+    }
+
+    @Test
+    public void testNonExistantWithDuplicateTitleButWrongVersionIsntFound() {
+        SourcePollerRunner runner = new SourcePollerRunner();
+        Set<ContentType> types = createContentTypes();
+        Source source = createDefaultFederatedSource(true, types, "src", "1");
+        Source source2 = createDefaultFederatedSource(true, types, "src", "2");
+        CachedSource cached = null;
+        runner.bind(source);
+
+        SourceStatus status = null;
+        do {
+            Thread.yield();
+            cached = runner.getCachedSource(source);
+            if (cached != null) {
+                status = cached.getSourceStatus();
+            }
+        } while (status == null || status == SourceStatus.UNCHECKED);
+
+        assertNull(runner.getCachedSource(source2));
+    }
+
 
 }


### PR DESCRIPTION
#### Description
This adds Comparator Logic to the SourcePollerRunner so that it will recognize a source regardless if it is a ServiceProxy or not.   This resolves a bug where the framework was not finding cached values and calling isAvailable on all sources when the UI, splash page, or services/rest/sources was called.  

I screwed up the formatting of this pull request description

#### Reviewers: 
@kcwire, @pklinef, and @clockard 
#### 2 committers to review/merge the PR 
@kcwire
@pklinef

#### How should this be tested?
Run yourself some DDF, run the installer, add some federated sources (could be self-federated, csw, opensearch, whatever) and set a breakpoint on line 615 of CatalogFrameworkImpl.  Confirm that you arrive there, and that the source variable that is generated by executing that line of code is a cached version of the same source the variable represented prior to executing the code.

If you wish to get over zealous, Add some sources that have bad connectivity.  Use some network simulation tools and the like, or reach out to public csw sources.  To take it to the next level, do this on a version of DDF prior to this update, and repeat on this version.

#### Any background context you want to provide?
I believe cachedSources/source availability all went awry at the introduction of DescribableServiceMap in DDF-1811.  The DescribableServiceMap uses the ServiceContext to pull non-proxied instances of Sources, meanwhile the SourcePollerRunner uses the ServiceProxies.  Prior to that change, the same instance appeared in both sides.  So, prior to 1811, a hashMap worked to show the to sources matched, even though they used standard Object hashcodes.  Once 1811 was introduced, the hashMap failed to recognize that to different objects represented the same remote source, and so it never returned a cached Source.

#### What are the relevant tickets?
DDF-2097, DDF-1811
#### Screenshots (if appropriate) N/A
#### Checklist:
- [N/A] Documentation Updated
- [X] Update / Add Unit Tests
- [N/Aish] Update / Add Integration Tests
