### PR TITLE
DDF-2098 Fix possible null pointer exception in pdf transformer

### DIFF
--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -119,15 +119,15 @@ public class PdfInputTransformer implements InputTransformer {
         if (creationDate != null) {
             metacard.setCreatedDate(creationDate.getTime());
             addXmlElement("creationDate", DATE_FORMAT.format(creationDate), metadataField);
+            LOGGER.info("PDF Creation date was: {}", DATE_FORMAT.format(creationDate));
         }
-        LOGGER.info("PDF Creation date was: {}", DATE_FORMAT.format(creationDate));
 
         Calendar modificationDate = documentInformation.getModificationDate();
         if (modificationDate != null) {
             metacard.setModifiedDate(modificationDate.getTime());
             addXmlElement("modificationDate", DATE_FORMAT.format(modificationDate), metadataField);
+            LOGGER.info("PDF Modification date was: {}", DATE_FORMAT.format(modificationDate));
         }
-        LOGGER.info("PDF Modification date was: {}", DATE_FORMAT.format(modificationDate));
 
         String title = documentInformation.getTitle();
         if (StringUtils.isNotBlank(title)) {

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -119,14 +119,14 @@ public class PdfInputTransformer implements InputTransformer {
         if (creationDate != null) {
             metacard.setCreatedDate(creationDate.getTime());
             addXmlElement("creationDate", DATE_FORMAT.format(creationDate), metadataField);
-            LOGGER.info("PDF Creation date was: {}", DATE_FORMAT.format(creationDate));
+            LOGGER.debug("PDF Creation date was: {}", DATE_FORMAT.format(creationDate));
         }
 
         Calendar modificationDate = documentInformation.getModificationDate();
         if (modificationDate != null) {
             metacard.setModifiedDate(modificationDate.getTime());
             addXmlElement("modificationDate", DATE_FORMAT.format(modificationDate), metadataField);
-            LOGGER.info("PDF Modification date was: {}", DATE_FORMAT.format(modificationDate));
+            LOGGER.debug("PDF Modification date was: {}", DATE_FORMAT.format(modificationDate));
         }
 
         String title = documentInformation.getTitle();


### PR DESCRIPTION
#### What does this PR do?
Fix possible NPE with pdf transformer
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jlcsmith @bdeining @kcwire @jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@jlcsmith
#### How should this be tested?
Upload a PDF, search for it, verify it appears in the search results. Look at the ddf log and make sure there is a log statement that contains "PDF Creation date was" if the PDF did have a creation date, and make sure there is a log statement that contains "PDF Modification date was" if the PDF did have a modification date.
#### Any background context you want to provide?
I don't have a test PDF that is missing a creation date or modification date.
#### What are the relevant tickets?
DDF-2098
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

If the PDF document has a null creation date or modification date, then
an NPE would be thrown from a log statement.