### PR TITLE
DDF-2114: Add modal pop up support for the admin UI

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_admin-contents/managing-admin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_admin-contents/managing-admin-contents.adoc
@@ -10,18 +10,75 @@ This includes adding, removing, starting, stopping, and showing status.
 
 The ${ddf-admin} application is installed by default with a standard installation.
 
-=== Configuring ${ddf-admin}
+==== Configurable Properties ${ddf-admin}
 
-[cols="1,1,3" options="header"]
+The following configuration properties can be changed under the Configuration tab under Admin UI
+
+[cols="6" options="header"]
 |===
 
-|Configuration
-|ID
+|Title
+|Property
+|Type
 |Description
+|Default Value
+|Required
 
-|${admin-console} Configuration
-|`org.codice.admin.ui.configuration`
-|Customization options for ${admin-console} elements.
+|Enable System Usage Message
+|`systemUsageEnabled`
+|Boolean
+|Turns on a system usage message, which is shown when the Admin Application is opened
+|
+|yes
+
+|System Usage Message Title
+|`systemUsageTitle`
+|String
+|A title for the system usage Message when the application is opened
+|
+|yes
+
+|System Usage Message
+|`systemUsageMessage`
+|String
+|A system usage message to be displayed to the user each time the user opens the application
+|
+|yes
+
+|Show System Usage Message once per session
+|`systemUsageOncePerSession`
+|Boolean
+|With this selected, the system usage message will be shown once for each browser session. Uncheck this to have the usage message appear every time the admin page is opened or refreshed.
+|true
+|yes
+
+|Header
+|`header`
+|String
+|Specifies the header text to be rendered on all pages.
+|
+|yes
+
+|Footer
+|`footer`
+|String
+|Specifies the footer text to be rendered on all pages.
+|
+|yes
+
+|Style
+|`color`
+|String
+|Specifies the Style of the Header and Footer. Use html css colors or `#rrggbb`.
+|
+|yes
+
+|Text Color
+|`color`
+|String
+|Specifies the Text Color of the Header and Footer. Use html css colors or `#rrggbb`.
+|
+|yes
 
 |===
 

--- a/platform/admin/ui/bower.json
+++ b/platform/admin/ui/bower.json
@@ -15,6 +15,7 @@
     "html5shiv": "3.7.2",
     "jquery": "components/jquery#1.11.0",
     "jquery-ui": "1.10.4",
+    "js-cookie": "2.1.1",
     "lodash": "2.4.1",
     "marionette": "1.8.8",
     "perfect-scrollbar": "0.4.8",

--- a/platform/admin/ui/src/main/java/org/codice/admin/ui/configuration/Configuration.java
+++ b/platform/admin/ui/src/main/java/org/codice/admin/ui/configuration/Configuration.java
@@ -41,6 +41,12 @@ import net.minidev.json.JSONValue;
 public class Configuration {
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
+    public static final String SYSTEM_USAGE_TITLE = "systemUsageTitle";
+
+    public static final String SYSTEM_USAGE_MESSAGE = "systemUsageMessage";
+
+    public static final String SYSTEM_USAGE_ONCE_PER_SESSION = "systemUsageOncePerSession";
+
     private static Configuration uniqueInstance;
 
     private static final String JSON_MIME_TYPE_STRING = "application/json";
@@ -64,6 +70,14 @@ public class Configuration {
     private String style = "";
 
     private String textColor = "";
+
+    private boolean systemUsageEnabled;
+
+    private String systemUsageTitle;
+
+    private String systemUsageMessage;
+
+    private boolean systemUsageOncePerSession;
 
     private String disabledInstallerApps = "";
 
@@ -94,6 +108,13 @@ public class Configuration {
     public Response getDocument(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest) {
         Response response;
         JSONObject configObj = new JSONObject();
+
+        if (systemUsageEnabled) {
+            configObj.put(SYSTEM_USAGE_TITLE, systemUsageTitle);
+            configObj.put(SYSTEM_USAGE_MESSAGE, systemUsageMessage);
+            configObj.put(SYSTEM_USAGE_ONCE_PER_SESSION, systemUsageOncePerSession);
+        }
+
         configObj.put("text", header);
         configObj.put("footer", footer);
         configObj.put("style", style);
@@ -148,6 +169,38 @@ public class Configuration {
 
     public void setDisabledInstallerApps(String disabledInstallerApps) {
         this.disabledInstallerApps = disabledInstallerApps;
+    }
+
+    public boolean getSystemUsageEnabled() {
+        return systemUsageEnabled;
+    }
+
+    public void setSystemUsageEnabled(boolean systemUsageEnabled) {
+        this.systemUsageEnabled = systemUsageEnabled;
+    }
+
+    public String getSystemUsageTitle() {
+        return systemUsageTitle;
+    }
+
+    public void setSystemUsageTitle(String systemUsageTitle) {
+        this.systemUsageTitle = systemUsageTitle;
+    }
+
+    public String getSystemUsageMessage() {
+        return systemUsageMessage;
+    }
+
+    public void setSystemUsageMessage(String systemUsageMessage) {
+        this.systemUsageMessage = systemUsageMessage;
+    }
+
+    public boolean getSystemUsageOncePerSession() {
+        return systemUsageOncePerSession;
+    }
+
+    public void setSystemUsageOncePerSession(boolean systemUsageOncePerSession) {
+        this.systemUsageOncePerSession = systemUsageOncePerSession;
     }
 
     public String getProductName() {

--- a/platform/admin/ui/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/admin/ui/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,6 +17,30 @@
 
     <OCD name="Admin UI Configuration" id="org.codice.admin.ui.configuration">
         <AD
+                description="Turns on a system usage message, which is shown when the Admin Application is opened"
+                name="Enable System Usage message" id="systemUsageEnabled" required="true"
+                type="Boolean"
+                default="false"
+        />
+        <AD
+                description="A title for the system usage message when the application is opened"
+                name="System Usage Message Title" id="systemUsageTitle" required="true"
+                type="String"
+                default=""
+        />
+        <AD
+                description="A system usage message to be displayed to the user each time the user opens the application"
+                name="System Usage Message" id="systemUsageMessage" required="true" type="String"
+                default=""
+        />
+        <AD
+                description="With this selected, the system usage message will be shown once for each browser session.  Uncheck this to have the usage message appear every time the admin page is opened or refreshed."
+                name="Show System Usage Message once per session" id="systemUsageOncePerSession"
+                required="true" type="Boolean"
+                default="true"
+        />
+
+        <AD
                 description="Specifies the header text to be rendered on the Administrator Console"
                 name="Header" id="header" required="true" type="String"
                 default=""

--- a/platform/admin/ui/src/main/webapp/index.html
+++ b/platform/admin/ui/src/main/webapp/index.html
@@ -38,6 +38,7 @@
     <div id="appHeader">
 
     </div>
+    <div id="modalRegion"></div>
     <div class="container">
         <div class="alerts"></div>
         <!--<h2 id="pageHeader"></h2>-->

--- a/platform/admin/ui/src/main/webapp/js/application.js
+++ b/platform/admin/ui/src/main/webapp/js/application.js
@@ -26,8 +26,10 @@ define([
     'text!templates/appHeader.handlebars',
     'text!templates/header.handlebars',
     'text!templates/footer.handlebars',
+    'js/controllers/Modal.controller',
+    'js/controllers/SystemUsage.controller',
     'text!templates/moduleTab.handlebars'
-    ],function (_, Backbone, Marionette, ich, $, poller, wreqr, Module, AppModel, tabs, appHeader, header, footer, moduleTab) {
+    ],function (_, Backbone, Marionette, ich, $, poller, wreqr, Module, AppModel, tabs, appHeader, header, footer, ModalController, SystemUsageController, moduleTab) {
     'use strict';
 
     var Application = {};
@@ -48,6 +50,10 @@ define([
 
     Application.App = new Marionette.Application();
 
+    Application.Controllers = {
+        modalController: new ModalController({application: Application.App})
+    };
+
     //add regions
     Application.App.addRegions({
         pageHeader: '#pageHeader',
@@ -55,6 +61,7 @@ define([
         footerRegion: 'footer',
         mainRegion: 'main',
         appHeader: '#appHeader',
+        modalRegion: '#modalRegion',
         alertsRegion: '.alerts'
     });
 
@@ -101,6 +108,11 @@ define([
 
     wreqr.vent.on('modulePoller:stop', function(){
         modulePoller.stop();
+    });
+
+    // show System Notification Banner
+    Application.App.addInitializer(function () {
+        new SystemUsageController();
     });
 
     //configure the router (we aren't using this yet)

--- a/platform/admin/ui/src/main/webapp/js/controllers/Modal.controller.js
+++ b/platform/admin/ui/src/main/webapp/js/controllers/Modal.controller.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define */
+define(['jquery',
+        'underscore',
+        'marionette',
+        'js/wreqr'
+    ], function ($, _, Marionette, wreqr) {
+        'use strict';
+        var ModalController;
+
+        ModalController = Marionette.Controller.extend({
+            initialize: function (options) {
+                this.application = options.application;
+                this.listenTo(wreqr.vent, "showModal", this.showModal);
+            },
+            showModal: function(modalView) {
+                this.application.modalRegion.show(modalView);
+                modalView.show();
+            }
+
+        });
+
+        return ModalController;
+    }
+);

--- a/platform/admin/ui/src/main/webapp/js/controllers/SystemUsage.controller.js
+++ b/platform/admin/ui/src/main/webapp/js/controllers/SystemUsage.controller.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define */
+define(['jquery',
+        'underscore',
+        'marionette',
+        'js/wreqr',
+        'properties',
+        'js/views/SystemUsageModal.view',
+        'jsCookie'
+    ], function ($, _, Marionette, wreqr, properties, SystemUsageModal, Cookies) {
+               'use strict';
+               var SystemUsageController;
+
+               SystemUsageController = Marionette.Controller.extend({
+                   initialize: function () {
+                       if(properties.admin.systemUsageTitle && (_.isUndefined(Cookies.get("admin.systemUsage")) ||
+                               !properties.admin.systemUsageOncePerSession)) {
+                           Cookies.set("admin.systemUsage", true);
+                           var modal = new SystemUsageModal();
+                           wreqr.vent.trigger('showModal', modal);
+                       }
+                   }
+
+               });
+
+               return SystemUsageController;
+           }
+);

--- a/platform/admin/ui/src/main/webapp/js/views/SystemUsageModal.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/SystemUsageModal.view.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/* global define */
+define([
+        'icanhaz',
+        'backbone',
+        'js/views/Modal',
+        'properties',
+        'text!templates/systemUsage.layout.handlebars'
+    ],
+    function (ich, Backbone, Modal, properties, systemUsageTemplate) {
+        ich.addTemplate('systemUsageTemplate', systemUsageTemplate);
+
+        var SystemUsageModal = Modal.extend({
+            template: 'systemUsageTemplate',
+            model: new Backbone.Model(properties),
+            initialize: function () {
+                // there is no automatic chaining of initialize.
+                Modal.prototype.initialize.apply(this, arguments);
+            }
+        });
+        return SystemUsageModal;
+    });

--- a/platform/admin/ui/src/main/webapp/main.js
+++ b/platform/admin/ui/src/main/webapp/main.js
@@ -38,6 +38,7 @@
 
             // jquery
             jquery: 'lib/jquery/jquery.min',
+            jsCookie: 'lib/js-cookie/src/js.cookie',
             jqueryui: 'lib/jquery-ui/ui/minified/jquery-ui.min',
             'jquery.ui.widget': 'lib/jquery-ui/ui/minified/jquery.ui.widget.min',
             multiselect: 'lib/bootstrap-multiselect/js/bootstrap-multiselect',
@@ -106,6 +107,7 @@
             fileupload: ['jquery', 'jquery.ui.widget'],
 
             jqueryui: ['jquery'],
+            jsCookie: ['jquery'],
             bootstrap: ['jqueryui'],
             moment: {exports: 'moment'},
 

--- a/platform/admin/ui/src/main/webapp/templates/systemUsage.layout.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/systemUsage.layout.handlebars
@@ -1,0 +1,26 @@
+{{!--
+/**
+* Copyright (c) Codice Foundation
+*
+* This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+* version 3 of the License, or any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+* <http://www.gnu.org/licenses/lgpl.html>.
+*
+**/
+--}}
+<div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-header banner-container">
+            <h5 class="modal-title">{{admin.systemUsageTitle}}</h5>
+        </div>
+        <div class="modal-body">
+            {{{admin.systemUsageMessage}}}
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true">OK</button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#### What does this PR do?
Adds support for a modal to appear when hitting the admin page via a config file in the DDF_HOME/etc folder.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@pklinef 
#### How should this be tested?
1. Go to: Admin -> DDF Admin -> Admin UI Configuration
2. Add an entry to System Usage Message Title, System Usage Message, and check Enable System Usage Message
3. Refresh the page and a modal should appear
#### Any background context you want to provide?
I used the modal architecture we currently have implemented in the search ui
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests