### PR TITLE
DDF-2035 - update Csw MetacardTransformer to return metadata if it is…

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -47,8 +47,9 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
     protected void applyCreatedOperationRules(CreateRequest createRequest, Metacard aMetacard,
             Date now) {
         LOGGER.debug("Applying standard rules on CreateRequest");
-        if (!isCatalogResourceUri(aMetacard.getResourceURI())
-                || !isCorrectFormatId(aMetacard.getId())) {
+        if ((aMetacard.getResourceURI() != null
+                && !isCatalogResourceUri(aMetacard.getResourceURI())) || !isCorrectFormatId(
+                aMetacard.getId())) {
             aMetacard.setAttribute(new AttributeImpl(Metacard.ID,
                     UUID.randomUUID()
                             .toString()

--- a/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/TestMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/TestMetacardGroomerPlugin.java
@@ -235,7 +235,7 @@ public class TestMetacardGroomerPlugin {
 
         Metacard outputMetacard = processCreate(inputMetacard);
 
-        assertNotEquals(id, outputMetacard.getId());
+        assertEquals(id, outputMetacard.getId());
         assertEquals(DEFAULT_TITLE, outputMetacard.getTitle());
         assertEquals(DEFAULT_LOCATION, outputMetacard.getLocation());
         assertEquals(DEFAULT_TYPE, outputMetacard.getContentTypeName());

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestCswRecordConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestCswRecordConverter.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -113,6 +113,8 @@ public class TestCswRecordConverter {
 
     private static CswRecordConverter converter;
 
+    private static String cswRecordXml;
+
     static {
         DatatypeFactory factory = null;
         try {
@@ -134,6 +136,9 @@ public class TestCswRecordConverter {
                 .toXMLFormat();
 
         converter = new CswRecordConverter();
+
+        cswRecordXml = IOUtils.toString(TestCswRecordConverter.class.getResourceAsStream(
+                "/Csw_Record_Text.xml"));
     }
 
     @Test
@@ -748,6 +753,24 @@ public class TestCswRecordConverter {
     }
 
     @Test
+    public void testMetacardTransformWithCswRecordMetadata()
+            throws IOException, JAXBException, SAXException, XpathException,
+            CatalogTransformerException {
+        Metacard metacard = getCswRecordMetacard();
+
+        Map<String, Serializable> args = new HashMap<>();
+        args.put(CswConstants.WRITE_NAMESPACES, true);
+
+        BinaryContent content = converter.transform(metacard, args);
+
+        String xml = IOUtils.toString(content.getInputStream());
+        assertThat(xml,
+                containsString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        XMLUnit.setIgnoreWhitespace(true);
+        assertXMLEqual(cswRecordXml, xml);
+    }
+
+    @Test
     public void testInputTransformWithNoNamespaceDeclaration()
             throws IOException, CatalogTransformerException {
         InputStream is = IOUtils.toInputStream(getRecordNoNamespaceDeclaration());
@@ -787,7 +810,7 @@ public class TestCswRecordConverter {
         metacard.setEffectiveDate(EFFECTIVE_DATE.getTime());
         metacard.setId("ID");
         metacard.setLocation("POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))");
-        metacard.setMetadata("metadata a whole bunch of metadata");
+        metacard.setMetadata("<xml>metadata a whole bunch of metadata</xml>");
         metacard.setModifiedDate(MODIFIED_DATE.getTime());
         metacard.setResourceSize("123TB");
         metacard.setSourceId("sourceID");
@@ -798,6 +821,12 @@ public class TestCswRecordConverter {
             LOGGER.debug("URISyntaxException", e);
         }
 
+        return metacard;
+    }
+
+    private MetacardImpl getCswRecordMetacard() throws IOException {
+        MetacardImpl metacard = getTestMetacard();
+        metacard.setMetadata(cswRecordXml);
         return metacard;
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -64,10 +64,9 @@ public final class Library {
                 + "        <value>2013-04-18T10:50:27.371-07:00</value>\n" + "    </dateTime>\n"
                 + "    <dateTime name=\"modified\">\n"
                 + "        <value>2013-04-18T10:50:27.371-07:00</value>\n" + "    </dateTime>\n"
-                + "    <base64Binary name=\"thumbnail\">\n" 
+                + "    <base64Binary name=\"thumbnail\">\n"
                 + "        <value>/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=</value>\n"
-                + "    </base64Binary>\n" 
-                + "    <stringxml name=\"metadata\">\n"
+                + "    </base64Binary>\n" + "    <stringxml name=\"metadata\">\n"
                 + "        <value>\n"
                 + "            <xml xmlns:ns6=\"urn:catalog:metacard\" xmlns=\"\">text</xml>\n"
                 + "        </value>\n" + "    </stringxml>\n"
@@ -152,7 +151,8 @@ public final class Library {
     public static String getCswIngest() {
         return getCswInsert("csw:Record",
                 getCswRecord(UUID.randomUUID()
-                        .toString()));
+                        .toString()
+                        .replaceAll("-", "")));
     }
 
     public static String getCswRecord(String id) {
@@ -194,8 +194,7 @@ public final class Library {
         return "<csw:Transaction\n" + "    service=\"CSW\"\n" + "    version=\"2.0.2\"\n"
                 + "    verboseResponse=\"true\"\n"
                 + "    xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\">\n"
-                + "    <csw:Update typeName=\"rim:RegistryPackage\">\n"
-                + getRegistryNode() + "\n"
+                + "    <csw:Update typeName=\"rim:RegistryPackage\">\n" + getRegistryNode() + "\n"
                 + "    </csw:Update>\n" + "</csw:Transaction>";
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/TestSpatial/csw/record/CswRecord.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/TestSpatial/csw/record/CswRecord.xml
@@ -15,7 +15,7 @@
             xmlns:dc="http://purl.org/dc/elements/1.1/"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-            <dc:identifier>324asdfaf242</dc:identifier>
+            <dc:identifier>7c8da3209c994668b76102309b8f4769</dc:identifier>
             <dc:title>Aliquam asdfaasdfsdffermentum purus quis arcu</dc:title>
             <dc:type>http://pasdfurl.asdforg/dc/dcmitype/Text</dc:type>
             <dc:subject>Hydroasfdgafsdraphy--Dictionaries</dc:subject>

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/TestSpatial/csw/request/query/CswEqualToTextQuery.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/TestSpatial/csw/request/query/CswEqualToTextQuery.xml
@@ -24,7 +24,7 @@
             <ogc:Filter>
                 <ogc:PropertyIsEqualTo matchCase="true">
                     <ogc:PropertyName>AnyText</ogc:PropertyName>
-                    <ogc:Literal>324asdfaf242</ogc:Literal>
+                    <ogc:Literal>7c8da3209c994668b76102309b8f4769</ogc:Literal>
                 </ogc:PropertyIsEqualTo>
             </ogc:Filter>
         </csw:Constraint>


### PR DESCRIPTION
#### What does this PR do?
Maintains the integrity of a Metacard created using the csw:Record XML schema by first checking if the metacard's metadata is csw:Record and simply returning it instead of transforming that metacard based on it's attributes.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @bcwaters 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@millerw8
#### How should this be tested?
Use the test data from the ticket.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2035 - https://codice.atlassian.net/browse/DDF-2035
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

… csw:Record instead of doing a new transformation