### PR TITLE
DDF-2117 Upgrades to log4j2 and adds sample configuration for failing over the security logs

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -13,203 +13,203 @@
 -->
 <component>
 
-  <fileSets>
+    <fileSets>
 
-    <!-- Expanded Karaf Standard Distribution -->
-    <fileSet>
-      <directory>${setup.folder}/${karaf.folder}
-      </directory>
-      <outputDirectory>/</outputDirectory>
-      <excludes>
-        <exclude>**/demos/**</exclude>
-        <exclude>bin/**</exclude>
-        <!-- Don't copy over config files that are customized -->
-        <exclude>etc/custom.properties</exclude>
-        <exclude>etc/jetty.xml</exclude>
-        <exclude>etc/profile.cfg</exclude>
-        <exclude>etc/org.apache.karaf.features.cfg</exclude>
-        <exclude>etc/org.ops4j.pax.logging.cfg</exclude>
-        <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
-        <exclude>etc/org.apache.karaf.log.cfg</exclude>
-        <exclude>etc/org.ops4j.pax.web.cfg</exclude>
-        <exclude>etc/users.properties</exclude>
-        <exclude>etc/system.properties</exclude>
-        <exclude>etc/shell.init.script</exclude>
-        <exclude>etc/org.apache.karaf.kar.cfg</exclude>
-        <!--
-        Since Karaf v2.2.9, Karaf includes a default user "karaf" with its own authentication key in it, thus
-        when running client script it logs in as "karaf" user without requiring a password.
-        So exclude this file from DDF distro to prevent unauthorized access.
-        -->
-        <exclude>etc/keys.properties</exclude>
-        <!-- Karaf comes with a README in deploy folder which throws warnings in log -->
-        <exclude>deploy/*</exclude>
-        <!-- All Karaf distributions take out the extra files when being distributed -->
-        <exclude>LICENSE</exclude>
-        <exclude>NOTICE</exclude>
-        <exclude>README</exclude>
-        <exclude>RELEASE-NOTES</exclude>
-        <exclude>karaf-manual*.html</exclude>
-        <exclude>karaf-manual*.pdf</exclude>
-      </excludes>
-    </fileSet>
+        <!-- Expanded Karaf Standard Distribution -->
+        <fileSet>
+            <directory>${setup.folder}/${karaf.folder}
+            </directory>
+            <outputDirectory>/</outputDirectory>
+            <excludes>
+                <exclude>**/demos/**</exclude>
+                <exclude>bin/**</exclude>
+                <!-- Don't copy over config files that are customized -->
+                <exclude>etc/custom.properties</exclude>
+                <exclude>etc/jetty.xml</exclude>
+                <exclude>etc/profile.cfg</exclude>
+                <exclude>etc/org.apache.karaf.features.cfg</exclude>
+                <exclude>etc/org.ops4j.pax.logging.cfg</exclude>
+                <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
+                <exclude>etc/org.apache.karaf.log.cfg</exclude>
+                <exclude>etc/org.ops4j.pax.web.cfg</exclude>
+                <exclude>etc/users.properties</exclude>
+                <exclude>etc/system.properties</exclude>
+                <exclude>etc/shell.init.script</exclude>
+                <exclude>etc/org.apache.karaf.kar.cfg</exclude>
+                <!--
+                Since Karaf v2.2.9, Karaf includes a default user "karaf" with its own authentication key in it, thus
+                when running client script it logs in as "karaf" user without requiring a password.
+                So exclude this file from DDF distro to prevent unauthorized access.
+                -->
+                <exclude>etc/keys.properties</exclude>
+                <!-- Karaf comes with a README in deploy folder which throws warnings in log -->
+                <exclude>deploy/*</exclude>
+                <!-- All Karaf distributions take out the extra files when being distributed -->
+                <exclude>LICENSE</exclude>
+                <exclude>NOTICE</exclude>
+                <exclude>README</exclude>
+                <exclude>RELEASE-NOTES</exclude>
+                <exclude>karaf-manual*.html</exclude>
+                <exclude>karaf-manual*.pdf</exclude>
+            </excludes>
+        </fileSet>
 
-    <!-- Copy over unix bin/* separately to get the correct file mode -->
-    <fileSet>
-      <directory>${setup.folder}/${karaf.folder}
-      </directory>
-      <outputDirectory>/</outputDirectory>
-      <includes>
-        <include>bin/admin</include>
-        <include>bin/karaf</include>
-        <include>bin/start</include>
-        <include>bin/stop</include>
-        <include>bin/shell</include>
-        <include>bin/client</include>
-      </includes>
-      <fileMode>0755</fileMode>
-    </fileSet>
-    
-    <!-- Copy over windows executable scripts -->
-    <fileSet>
-      <directory>${win.setup.folder}/${karaf.folder}
-      </directory>
-      <outputDirectory>/</outputDirectory>
-      <includes>
-        <include>bin/admin.bat</include>
-        <include>bin/karaf.bat</include>
-        <include>bin/start.bat</include>
-        <include>bin/stop.bat</include>
-        <include>bin/shell.bat</include>
-        <include>bin/client.bat</include>
-      </includes>
-      <lineEnding>dos</lineEnding>
-      <fileMode>0755</fileMode>
-    </fileSet>
+        <!-- Copy over unix bin/* separately to get the correct file mode -->
+        <fileSet>
+            <directory>${setup.folder}/${karaf.folder}
+            </directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>bin/admin</include>
+                <include>bin/karaf</include>
+                <include>bin/start</include>
+                <include>bin/stop</include>
+                <include>bin/shell</include>
+                <include>bin/client</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
 
-    <!-- HTML & PDF Documentation -->
-    <fileSet>
-      <directory>${setup.folder}/docs</directory>
-      <outputDirectory>/documentation</outputDirectory>
-    </fileSet>
+        <!-- Copy over windows executable scripts -->
+        <fileSet>
+            <directory>${win.setup.folder}/${karaf.folder}
+            </directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>bin/admin.bat</include>
+                <include>bin/karaf.bat</include>
+                <include>bin/start.bat</include>
+                <include>bin/stop.bat</include>
+                <include>bin/shell.bat</include>
+                <include>bin/client.bat</include>
+            </includes>
+            <lineEnding>dos</lineEnding>
+            <fileMode>0755</fileMode>
+        </fileSet>
 
-    <!-- Javadoc -->
-    <fileSet>
-      <directory>${setup.folder}/catalog_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/catalog_api_javadoc</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>${setup.folder}/mime_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/mime_api_javadoc</outputDirectory>
-    </fileSet>
-	<fileSet>
-      <directory>${setup.folder}/content_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/content_api_javadoc</outputDirectory>
-    </fileSet>
-	<fileSet>
-      <directory>${setup.folder}/action_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/action_api_javadoc</outputDirectory>
-    </fileSet>
-	<fileSet>
-      <directory>${setup.folder}/security_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/security_api_javadoc</outputDirectory>
-    </fileSet>
-	<fileSet>
-      <directory>${setup.folder}/encryption_api_javadoc</directory>
-      <outputDirectory>/docs/sdk/encryption_api_javadoc</outputDirectory>
-    </fileSet>
-    
-    <!-- Console Branding -->
-    <fileSet>
-      <directory>${setup.folder}</directory>
-      <includes>
-        <include>ddf-branding.jar</include>
-      </includes>
-      <outputDirectory>/lib/</outputDirectory>
-    </fileSet>
-    
-    <!-- Endorsed Libraries -->
-    <fileSet>
-      <directory>${setup.folder}/ext</directory>
-      <outputDirectory>/lib/ext</outputDirectory>
-    </fileSet>
-    
-    <!-- Deployable Files -->
-    <fileSet>
-      <directory>${setup.folder}/deploy</directory>
-      <outputDirectory>/deploy</outputDirectory>
-      <fileMode>0644</fileMode>
-    </fileSet>
-    
- 	 <!-- Static Config Files -->
-    <fileSet>
-      <directory>${setup.folder}/etc</directory>
-      <outputDirectory>/etc</outputDirectory>
-      <fileMode>0644</fileMode>
-    </fileSet>
+        <!-- HTML & PDF Documentation -->
+        <fileSet>
+            <directory>${setup.folder}/docs</directory>
+            <outputDirectory>/documentation</outputDirectory>
+        </fileSet>
 
-    <!-- Dynamic Config Files -->
-    <fileSet>
-      <directory>target/classes/etc</directory>
-      <outputDirectory>/etc</outputDirectory>
-      <fileMode>0644</fileMode>
-    </fileSet>
+        <!-- Javadoc -->
+        <fileSet>
+            <directory>${setup.folder}/catalog_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/catalog_api_javadoc</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${setup.folder}/mime_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/mime_api_javadoc</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${setup.folder}/content_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/content_api_javadoc</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${setup.folder}/action_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/action_api_javadoc</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${setup.folder}/security_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/security_api_javadoc</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${setup.folder}/encryption_api_javadoc</directory>
+            <outputDirectory>/docs/sdk/encryption_api_javadoc</outputDirectory>
+        </fileSet>
 
-    <!-- Static Executable Files -->
-    <fileSet>
-      <directory>${setup.folder}/bin</directory>
-      <outputDirectory>/bin</outputDirectory>
-      <fileMode>0755</fileMode>
-    </fileSet>
-	
-	<!-- Schema Files -->
-    <fileSet>
-      <directory>${setup.folder}/schema</directory>
-      <outputDirectory>/schema</outputDirectory>
-      <fileMode>0644</fileMode>
-    </fileSet>
-	
-	<!-- License Files -->
-	<fileSet>
-	  <directory>${setup.folder}/licenses</directory>
-      <outputDirectory>/licenses</outputDirectory>
-      <fileMode>0444</fileMode>
-	</fileSet>
-	
-	<!-- Legal files -->
-    <fileSet>
-	  <directory>${setup.folder}</directory>
-      <outputDirectory>/</outputDirectory>
-       <includes>
-        <include>*.txt</include> 
-        <include>README</include>
-        <include>NOTICE</include>      
-      </includes>
-      <fileMode>0444</fileMode>
-	</fileSet>
-	
-	<fileSet>
-      <directory>target/classes</directory>
-      <outputDirectory>/</outputDirectory>
-       <includes>
-        <include>*.txt</include>  
-       </includes>
-      <fileMode>0644</fileMode>
-    </fileSet>
-    
-    <!-- DDF Files -->
-    <fileSet>
-      <directory>${setup.folder}/security</directory>
-      <outputDirectory>/security</outputDirectory>
-      <fileMode>0644</fileMode>
-    </fileSet>
+        <!-- Console Branding -->
+        <fileSet>
+            <directory>${setup.folder}</directory>
+            <includes>
+                <include>ddf-branding.jar</include>
+            </includes>
+            <outputDirectory>/lib/</outputDirectory>
+        </fileSet>
 
-    <fileSet>
-      <directory>${setup.folder}/data</directory>
-      <outputDirectory>/data</outputDirectory>
-      <directoryMode>0775</directoryMode>
-    </fileSet>
-    
-  </fileSets>
-  
+        <!-- Endorsed Libraries -->
+        <fileSet>
+            <directory>${setup.folder}/ext</directory>
+            <outputDirectory>/lib/ext</outputDirectory>
+        </fileSet>
+
+        <!-- Deployable Files -->
+        <fileSet>
+            <directory>${setup.folder}/deploy</directory>
+            <outputDirectory>/deploy</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- Static Config Files -->
+        <fileSet>
+            <directory>${setup.folder}/etc</directory>
+            <outputDirectory>/etc</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- Dynamic Config Files -->
+        <fileSet>
+            <directory>target/classes/etc</directory>
+            <outputDirectory>/etc</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- Static Executable Files -->
+        <fileSet>
+            <directory>${setup.folder}/bin</directory>
+            <outputDirectory>/bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+
+        <!-- Schema Files -->
+        <fileSet>
+            <directory>${setup.folder}/schema</directory>
+            <outputDirectory>/schema</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- License Files -->
+        <fileSet>
+            <directory>${setup.folder}/licenses</directory>
+            <outputDirectory>/licenses</outputDirectory>
+            <fileMode>0444</fileMode>
+        </fileSet>
+
+        <!-- Legal files -->
+        <fileSet>
+            <directory>${setup.folder}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.txt</include>
+                <include>README</include>
+                <include>NOTICE</include>
+            </includes>
+            <fileMode>0444</fileMode>
+        </fileSet>
+
+        <fileSet>
+            <directory>target/classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.txt</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- DDF Files -->
+        <fileSet>
+            <directory>${setup.folder}/security</directory>
+            <outputDirectory>/security</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <fileSet>
+            <directory>${setup.folder}/data</directory>
+            <outputDirectory>/data</outputDirectory>
+            <directoryMode>0775</directoryMode>
+        </fileSet>
+
+    </fileSets>
+
 </component>

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<Configuration status="WARN">
+    <Properties>
+        <Property name="log-pattern">%-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id}
+            - %X{bundle.name} - %X{bundle.version} | %m%n
+        </Property>
+    </Properties>
+
+    <Appenders>
+        <PaxOsgi name="osgi-platformLogging"
+                 filter="org.codice.ddf.platform.logging.LoggingService"/>
+
+        <PaxOsgi name="osgi-all" filter="*"/>
+
+        <Syslog name="syslog" facility="AUTH" host="localhost" protocol="UDP" port="514"/>
+
+        <Console name="stdout" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+        </Console>
+
+        <RollingFile name="out" fileName="${sys:karaf.data}/log/ddf.log"
+                     filePattern="${sys:karaf.data}/log/ddf.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="ingestError" append="true"
+                     fileName="${sys:karaf.data}/log/ingest_error.log"
+                     filePattern="${sys:karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="securityMain" append="true" ignoreExceptions="false"
+                     fileName="${sys:karaf.data}/log/security.log"
+                     filePattern="${sys:karaf.data}/log/security.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
+                     fileName="${sys:karaf.data}/log/securityBackup.log"
+                     filePattern="${sys:karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <Failover name="securityFailover" primary="securityMain">
+            <Failovers>
+                <AppenderRef ref="securityBackup"/>
+            </Failovers>
+        </Failover>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="securityLogger" level="info" additivity="false">
+            <AppenderRef ref="securityFailover"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="ingestLogger" level="info" additivity="false">
+            <AppenderRef ref="ingestError"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <!-- CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console. -->
+        <Logger name="org.apache.cxf" level="warn"/>
+        <Logger name="org.apache.lucene" level="warn"/>
+        <Logger name="org.apache.solr" level="warn"/>
+        <Logger name="lux.solr" level="warn"/>
+        <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
+        <Logger name="org.apache.aries.spifly" level="warn"/>
+        <Logger name="org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper" level="error"/>
+        <Logger name="org.apache.cxf.phase.PhaseInterceptorChain" level="error"/>
+
+        <Root level="info">
+            <AppenderRef ref="out"/>
+            <AppenderRef ref="osgi-all"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -17,6 +17,16 @@
 #
 ################################################################################
 
+# In order to switch to Log4j2 and be able to take advantage of the newer appenders,
+# such as the Failover appender, uncomment the following line and remove all the
+# configuration beneath it.
+#
+# This change can be made permanent (or done in another way, depending upon
+# the implementation choices made) when we have upgraded to Karaf 4.1.0
+# https://codice.atlassian.net/browse/DDF-2132
+#
+# org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml
+
 # Root logger
 log4j.rootLogger=INFO, out, osgi:*
 log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -983,9 +983,16 @@
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
     </feature>
 
+    <!-- This can be removed when we have upgraded to Karaf 4.1.0
+    https://codice.atlassian.net/browse/DDF-2132 -->
+    <feature name="log4j2-temporary" install="manual" version="${project.version}" hidden="true">
+        <!-- This bundle can be removed when Karaf moves to Log4J2 as its default platform -->
+        <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.8.5</bundle>
+    </feature>
+
     <feature name="platform-all" install="manual" version="${project.version}" hidden="true">
         <feature prerequisite="true">platform-api</feature>
-        <bundle>mvn:ddf.platform/platform-logging/${project.version}</bundle>        
+        <bundle>mvn:ddf.platform/platform-logging/${project.version}</bundle>
         <feature prerequisite="true">platform-security-session</feature>
         <feature prerequisite="true">platform-migrate-all</feature>
         <feature>platform-scheduler</feature>


### PR DESCRIPTION
#### What does this PR do?

- Upgrade to log4j2
- Add XML configuration
- Add sample configuration for security log failover

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@roelens8 @tbatie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested?
1. Build and itests should all pass (logging should occur in itests)
2. DDF distro should be unzipped and the following pre-start steps should be performed:
    - edit `etc/org.ops4j.pax.logging.cfg`, uncommenting the line for log4j2 and deleting the subsequent lines
    - edit `etc/startup.properties` and replace the artifact `pax-logging-log4j2` with the artifact `pax-logging-service` (same version and group)
3. Start DDF and ensure that only the log4j2 service provider is started: `list -t 0` should show the `OPS4J Pax Logging - API` and `OPS4J Pax Logging - Log4j v2` bundles; the v1 Pax logging service should not appear.
4. Complete DDF installation.
5. Stop the server and update the log4j2 configuration.
    - Set the `securityMain` appender to point to a file on a mount point with very little or no free space. This can be accomplished pretty simply on OSX by using `Disk Utility` to create a tiny DMG, mounting it, and using up most of its free space with junk data. It can be accomplished on *nix systems by pointing the log to `/dev/full`.
    - Start the server and ensure that the security logs failover to the configured backup.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2117

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests