### PR TITLE
DDF-2122 - updated EndpointOperationInfoResourceComparator to return …

### DIFF
--- a/catalog/spatial/ogc/spatial-ogc-common/src/main/java/org/codice/ddf/spatial/ogc/catalog/common/EndpointOperationInfoResourceComparator.java
+++ b/catalog/spatial/ogc/spatial-ogc-common/src/main/java/org/codice/ddf/spatial/ogc/catalog/common/EndpointOperationInfoResourceComparator.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * HTTP method, Consumes Media Type, and Produces Media Type to determine which method to execute.
  * The {@link WfsEndpoint} and {@link CswEndpoint} require the decision to made based on the
  * "request" query parameter or the type of XML document.
- *
  */
 public class EndpointOperationInfoResourceComparator extends OperationResourceInfoComparator
         implements ResourceComparator {
@@ -85,7 +84,7 @@ public class EndpointOperationInfoResourceComparator extends OperationResourceIn
     public int compare(OperationResourceInfo oper1, OperationResourceInfo oper2, Message message) {
         if (null == oper1 || null == oper2 || null == message) {
             LOGGER.warn("Found NULL parameters in the compare method.");
-            return 0;
+            return -1;
         }
         String httpMethod = (String) message.get(Message.HTTP_REQUEST_METHOD);
         LOGGER.debug("HTTP METHOD = {}", httpMethod);
@@ -153,16 +152,15 @@ public class EndpointOperationInfoResourceComparator extends OperationResourceIn
 
         } else {
             LOGGER.warn("Got unknown HTTP Method {}", httpMethod);
-            return 0;
-        }
-
-        if (StringUtils.isEmpty(requestName)) {
-            LOGGER.warn("Unable to determine the request name");
-            return 0;
+            return -1;
         }
 
         int op1Rank = getOperationRank(oper1, requestName, requestedService);
         int op2Rank = getOperationRank(oper2, requestName, requestedService);
+
+        if (op1Rank == -1 && op2Rank == -1) {
+            return -1;
+        }
 
         return (op1Rank == op2Rank) ? 0 : (op1Rank < op2Rank) ? 1 : -1;
     }
@@ -184,5 +182,4 @@ public class EndpointOperationInfoResourceComparator extends OperationResourceIn
                         .getName()
                         .equalsIgnoreCase(UNKNOWN_OPERATION) ? 0 : -1);
     }
-
 }

--- a/catalog/spatial/ogc/spatial-ogc-common/src/test/java/org/codice/ddf/spatial/ogc/catalog/common/TestEndpointOperationInfoResourceComparator.java
+++ b/catalog/spatial/ogc/spatial-ogc-common/src/test/java/org/codice/ddf/spatial/ogc/catalog/common/TestEndpointOperationInfoResourceComparator.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 import org.apache.cxf.message.Message;
 import org.junit.Before;
@@ -24,13 +27,17 @@ import org.junit.Test;
 
 public class TestEndpointOperationInfoResourceComparator {
 
-    private static final String DESCRIBE_FEATURES = "describeFeatureType";
+    private static final String SECOND_OPERATION = "secondOperation";
 
-    private static final String GET_CAPABILITIES = "getCapabilities";
+    private static final String FIRST_OPERATION = "firstOperation";
 
-    private OperationResourceInfo getCapabilities;
+    private static final String UNKNOWN_SERVICE = "unknownService";
 
-    private OperationResourceInfo describeFeatureType;
+    private static final String UNKNOWN_OPERATION = "unknownOperation";
+
+    private OperationResourceInfo firstOperation;
+
+    private OperationResourceInfo secondOperation;
 
     private OperationResourceInfo unknownService;
 
@@ -38,14 +45,36 @@ public class TestEndpointOperationInfoResourceComparator {
 
     private Message mockMessage = mock(Message.class);
 
+    private static final String FIRST_OPERATION_BODY =
+            "<csw:firstOperation resultType=\"results\" outputFormat=\"application/xml\" outputSchema=\"http://www.opengis.net/cat/csw/2.0.2\" startPosition=\"1\" maxRecords=\"10\" service=\"CSW\" version=\"2.0.2\" xmlns:ns2=\"http://www.opengis.net/ogc\" xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" xmlns:ns4=\"http://www.w3.org/1999/xlink\" xmlns:ns3=\"http://www.opengis.net/gml\" xmlns:ns9=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns5=\"http://www.opengis.net/ows\" xmlns:ns6=\"http://purl.org/dc/elements/1.1/\" xmlns:ns7=\"http://purl.org/dc/terms/\" xmlns:ns8=\"http://www.w3.org/2001/SMIL20/\">\n"
+                    + "    <ns10:Query typeNames=\"csw:Record\" xmlns=\"\" xmlns:ns10=\"http://www.opengis.net/cat/csw/2.0.2\">\n"
+                    + "        <ns10:ElementSetName>full</ns10:ElementSetName>\n"
+                    + "        <ns10:Constraint version=\"1.1.0\">\n" + "            <ns2:Filter>\n"
+                    + "                <ns2:PropertyIsLike wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">\n"
+                    + "                  <ns2:PropertyName>title</ns2:PropertyName>\n"
+                    + "                    <ns2:Literal>Aliquam</ns2:Literal>\n"
+                    + "                </ns2:PropertyIsLike>\n" + "            </ns2:Filter>\n"
+                    + "        </ns10:Constraint>\n" + "    </ns10:Query>\n"
+                    + "</csw:firstOperation>";
+
+    private static final String SECOND_OPERATION_BODY =
+            "<csw:secondOperation resultType=\"results\" outputFormat=\"application/xml\" outputSchema=\"http://www.opengis.net/cat/csw/2.0.2\" startPosition=\"1\" maxRecords=\"10\" service=\"CSW\" version=\"2.0.2\" xmlns:ns2=\"http://www.opengis.net/ogc\" xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" xmlns:ns4=\"http://www.w3.org/1999/xlink\" xmlns:ns3=\"http://www.opengis.net/gml\" xmlns:ns9=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns5=\"http://www.opengis.net/ows\" xmlns:ns6=\"http://purl.org/dc/elements/1.1/\" xmlns:ns7=\"http://purl.org/dc/terms/\" xmlns:ns8=\"http://www.w3.org/2001/SMIL20/\">\n"
+                    + "    <ns10:Query typeNames=\"csw:Record\" xmlns=\"\" xmlns:ns10=\"http://www.opengis.net/cat/csw/2.0.2\">\n"
+                    + "        <ns10:ElementSetName>full</ns10:ElementSetName>\n"
+                    + "        <ns10:Constraint version=\"1.1.0\">\n" + "            <ns2:Filter>\n"
+                    + "                <ns2:PropertyIsLike wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">\n"
+                    + "                  <ns2:PropertyName>title</ns2:PropertyName>\n"
+                    + "                    <ns2:Literal>Aliquam</ns2:Literal>\n"
+                    + "                </ns2:PropertyIsLike>\n" + "            </ns2:Filter>\n"
+                    + "        </ns10:Constraint>\n" + "    </ns10:Query>\n"
+                    + "</csw:secondOperation>";
+
     @Before
     public void setUp() throws NoSuchMethodException {
-        getCapabilities = new OperationResourceInfo(getClass().getMethod(GET_CAPABILITIES), null);
-        describeFeatureType = new OperationResourceInfo(getClass().getMethod(DESCRIBE_FEATURES),
-                null);
-        unknownService = new OperationResourceInfo(getClass().getMethod("unknownService"), null);
-        unknownOperation = new OperationResourceInfo(getClass().getMethod("unknownOperation"),
-                null);
+        firstOperation = new OperationResourceInfo(getClass().getMethod(FIRST_OPERATION), null);
+        secondOperation = new OperationResourceInfo(getClass().getMethod(SECOND_OPERATION), null);
+        unknownService = new OperationResourceInfo(getClass().getMethod(UNKNOWN_SERVICE), null);
+        unknownOperation = new OperationResourceInfo(getClass().getMethod(UNKNOWN_OPERATION), null);
     }
 
     @Test
@@ -53,10 +82,10 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + GET_CAPABILITIES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + FIRST_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(-1, comparator.compare(getCapabilities, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     @Test
@@ -64,10 +93,10 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(1, comparator.compare(getCapabilities, describeFeatureType, mockMessage));
+        assertEquals(1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     @Test
@@ -78,17 +107,17 @@ public class TestEndpointOperationInfoResourceComparator {
                 EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=getFeature");
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(getCapabilities, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     @Test
     public void testCompareUnknownHttpMethod() {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn("WFS");
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + GET_CAPABILITIES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + FIRST_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(getCapabilities, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     @Test
@@ -99,28 +128,28 @@ public class TestEndpointOperationInfoResourceComparator {
                 EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=badFunction");
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(getCapabilities, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     @Test
     public void testCompareNullOper1() {
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(null, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(null, secondOperation, mockMessage));
     }
 
     @Test
     public void testCompareNullOper2() {
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(getCapabilities, null, mockMessage));
+        assertEquals(-1, comparator.compare(firstOperation, null, mockMessage));
     }
 
     @Test
     public void testCompareNullMessage() {
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(0, comparator.compare(getCapabilities, describeFeatureType, null));
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, null));
     }
 
     @Test
@@ -128,14 +157,14 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
                 EndpointOperationInfoResourceComparator.SERVICE_PARAM + "=noGood&" +
                         EndpointOperationInfoResourceComparator.REQUEST_PARAM + "="
-                        + DESCRIBE_FEATURES);
+                        + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(1, comparator.compare(unknownService, describeFeatureType, mockMessage));
+        assertEquals(1, comparator.compare(unknownService, secondOperation, mockMessage));
     }
 
     @Test
@@ -143,14 +172,14 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
                 EndpointOperationInfoResourceComparator.SERVICE_PARAM + "=CSW&" +
                         EndpointOperationInfoResourceComparator.REQUEST_PARAM + "="
-                        + DESCRIBE_FEATURES);
+                        + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator("CSW");
-        assertEquals(1, comparator.compare(unknownService, describeFeatureType, mockMessage));
+        assertEquals(1, comparator.compare(unknownService, secondOperation, mockMessage));
     }
 
     @Test
@@ -158,14 +187,14 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
                 EndpointOperationInfoResourceComparator.SERVICE_PARAM + "=noGood&" +
                         EndpointOperationInfoResourceComparator.REQUEST_PARAM + "="
-                        + DESCRIBE_FEATURES);
+                        + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator("CSW");
-        assertEquals(-1, comparator.compare(unknownService, describeFeatureType, mockMessage));
+        assertEquals(-1, comparator.compare(unknownService, secondOperation, mockMessage));
     }
 
     @Test
@@ -173,12 +202,12 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(1, comparator.compare(unknownOperation, describeFeatureType, mockMessage));
+        assertEquals(1, comparator.compare(unknownOperation, secondOperation, mockMessage));
     }
 
     @Test
@@ -186,20 +215,42 @@ public class TestEndpointOperationInfoResourceComparator {
         when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
                 EndpointOperationInfoResourceComparator.HTTP_GET);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         when(mockMessage.get(Message.QUERY_STRING)).thenReturn(
-                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + DESCRIBE_FEATURES);
+                EndpointOperationInfoResourceComparator.REQUEST_PARAM + "=" + SECOND_OPERATION);
         EndpointOperationInfoResourceComparator comparator =
                 new EndpointOperationInfoResourceComparator();
-        assertEquals(-1, comparator.compare(unknownOperation, getCapabilities, mockMessage));
+        assertEquals(-1, comparator.compare(unknownOperation, firstOperation, mockMessage));
+    }
+
+    @Test
+    public void testHttpPostMatchesFirst() {
+        when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
+                EndpointOperationInfoResourceComparator.HTTP_POST);
+        when(mockMessage.getContent(InputStream.class)).thenReturn(IOUtils.toInputStream(
+                FIRST_OPERATION_BODY));
+        EndpointOperationInfoResourceComparator comparator =
+                new EndpointOperationInfoResourceComparator("CSW");
+        assertEquals(-1, comparator.compare(firstOperation, secondOperation, mockMessage));
+    }
+
+    @Test
+    public void testHttpPostMatchesSecond() {
+        when(mockMessage.get(Message.HTTP_REQUEST_METHOD)).thenReturn(
+                EndpointOperationInfoResourceComparator.HTTP_POST);
+        when(mockMessage.getContent(InputStream.class)).thenReturn(IOUtils.toInputStream(
+                SECOND_OPERATION_BODY));
+        EndpointOperationInfoResourceComparator comparator =
+                new EndpointOperationInfoResourceComparator("CSW");
+        assertEquals(1, comparator.compare(firstOperation, secondOperation, mockMessage));
     }
 
     // Allows us to create a "mockMethod" with the name of the method
-    public void getCapabilities() {
+    public void firstOperation() {
     }
 
     // Allows us to create a "mockMethod" with the name of the method
-    public void describeFeatureType() {
+    public void secondOperation() {
     }
 
     // Allows us to create a "mockMethod" with the name of the method


### PR DESCRIPTION
#### What does this PR do?
Addresses EndpointOperationInfoResourceComparator returning 0 when 2 operations were not equal.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@peterhuffer @mweser
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie 
@kcwire
#### How should this be tested?
itests :) - also visually verify the logs from CXF are no longer present by running DDF & submitting various requests to the CSW Endpoint (HTTP GET & POST)
#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
DDF-2122
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…-1 when no match is found