### PR TITLE
DDF-2121 Added binaries for export/import

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -85,6 +85,12 @@
         <configfile finalname="/data/solr/metacard_cache/conf/synonyms.txt">
             mvn:ddf.platform.solr/platform-solr-server-standalone/${project.version}/txt/synonyms
         </configfile>
+        <configfile finalname="/bin/export">
+            mvn:ddf.catalog.core/catalog-core-commands/${project.version}/bin/export
+        </configfile>
+        <configfile finalname="/bin/export.bat">
+            mvn:ddf.catalog.core/catalog-core-commands/${project.version}/bin/batexport
+        </configfile>
     </feature>
 
     <feature name="catalog-core-content" install="auto" version="${project.version}"

--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -150,6 +150,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <inherited>false</inherited>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/bin/export</file>
+                                    <type>bin</type>
+                                    <classifier>export</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>target/classes/bin/export.bat</file>
+                                    <type>bin</type>
+                                    <classifier>batexport</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>

--- a/catalog/core/catalog-core-commands/src/main/resources/bin/export
+++ b/catalog/core/catalog-core-commands/src/main/resources/bin/export
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Copyright (c) Codice Foundation
+#
+# This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+# version 3 of the License, or any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+# <http://www.gnu.org/licenses/lgpl.html>.
+
+usage() { echo "Usage: $0 <-d directory> <-z zipname> <-k keystore location> [-a alias]" 1>&2; exit 1; }
+
+while getopts ":d:z:k:a:" o; do
+    case "${o}" in
+        d)
+            d=${OPTARG}
+            ;;
+        z)
+            z=${OPTARG}
+            ;;
+        k)
+            k=${OPTARG}
+            ;;
+        a)
+            a=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${a}" ]; then
+    a=localhost
+fi
+
+if [ -z "${d}" ] || [ -z "${z}" ] || [ -z "${k}" ]; then
+    usage
+fi
+
+./client "catalog:dump --include-content=${z} ${d}"
+if which jarsigner >/dev/null; then
+        jarsigner -keystore ${k} ${d}/${z} ${a}
+else
+    echo "Unable to find jarsigner, ensure that $JAVA_HOME and $JAVA_HOME/bin are set on the path."
+fi

--- a/catalog/core/catalog-core-commands/src/main/resources/bin/export.bat
+++ b/catalog/core/catalog-core-commands/src/main/resources/bin/export.bat
@@ -1,0 +1,56 @@
+@echo off
+:: Copyright (c) Codice Foundation
+::
+:: This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+:: version 3 of the License, or any later version.
+::
+:: This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+:: See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+:: <http://www.gnu.org/licenses/lgpl.html>.
+
+if "%1" == "" goto USAGE
+
+setlocal
+set ALIAS=localhost
+setlocal
+set HOST=127.0.0.1
+
+:GETOPTS
+if %1 == -d (
+	setlocal
+	set DIR=%~2& shift
+)
+if %1 == -z (
+	setlocal
+	set FILENAME=%~2& shift
+)
+if %1 == -k (
+	setlocal
+	set KEYSTORE=%~2& shift
+)
+if %1 == -a (
+	setlocal
+	set ALIAS=%~2& shift
+)
+if %1 == -h (
+	setlocal
+	set HOST=%~2& shift
+)
+shift
+if not (%1)==() goto GETOPTS
+if "%DIR%"=="" goto USAGE
+if "%FILENAME%"=="" goto USAGE
+if "%KEYSTORE%"=="" goto USAGE
+
+call client.bat -h %HOST% "catalog:dump --include-content=%FILENAME% %DIR% "
+
+where jarsigner >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+	echo Unable to find jarsigner, ensure that $JAVA_HOME and $JAVA_HOME/bin are set on the path.
+) else (
+	call jarsigner -keystore %KEYSTORE% %DIR%/%FILENAME% %ALIAS% -signedJar %DIR%signed%FILENAME%
+)
+goto :eof
+
+:USAGE
+echo Usage: ^<-d directory^> ^<-z zipname^> ^<-k keystore location^> [-a alias] [-h hostname]


### PR DESCRIPTION
#### What does this PR do?
This PR adds a Unix and Windows script for the catalog:dump --include-content and signs the exported jar.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver 
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@beyelerb 
#### How should this be tested?
Build DDF and Install the catalog-app.  Use the added scripts to dump the catalog and verify that the zip is signed correctly.
#### Any background context you want to provide?
This PR is dependent on the merge of DDF-2050
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2050
https://codice.atlassian.net/browse/DDF-2121
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
