### PR TITLE
DDF-2124 Updated registry federation admin api interfaces from ddf-re…

### DIFF
--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -68,6 +68,11 @@
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-federation-admin-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
                 <artifactId>registry-policy-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -133,6 +138,7 @@
         <module>registry-api-impl</module>
         <module>registry-federation-admin-service</module>
         <module>registry-federation-admin-service-impl</module>
+        <module>registry-federation-admin-api</module>
         <module>registry-app</module>
         <module>registry-admin-modules</module>
 

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-identification-plugin</artifactId>
         </dependency>
         <dependency>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -28,17 +28,26 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="registry-app" install="manual" version="${project.version}"
-             description="DDF Registry contains the base registry components, plugins, sources and interfaces needed for the registry to function">
-        <feature prerequisite="true">spatial-app</feature>
-        <bundle>mvn:org.codice.ddf.registry/registry-api/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-api-impl/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-schema-bindings/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-policy-plugin/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-ebrim-transformer/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
-    </feature>
+<feature name="registry-core-api" install="manual" version="${project.version}" >
+    <bundle>mvn:org.codice.ddf.registry/registry-api/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-api/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-schema-bindings/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-policy-plugin/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-ebrim-transformer/${project.version}</bundle>
+</feature>
+
+<feature name="registry-core" install="auto" version="${project.version}" >
+    <feature prerequisite="true">registry-app</feature>
+    <bundle>mvn:org.codice.ddf.registry/registry-api-impl/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
+</feature>
+
+<feature name="registry-app" install="auto" version="${project.version}"
+         description="DDF Registry contains the base registry components, plugins, sources and interfaces needed for the registry to function.::DDF Registry">
+    <feature prerequisite="true">spatial-app</feature>
+    <feature>registry-core-api</feature>
+</feature>
 
 </features>

--- a/catalog/spatial/registry/registry-federation-admin-api/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-api/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>registry</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>registry-federation-admin-api</artifactId>
+    <name>DDF :: Registry :: Federation :: Admin :: Api</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-federation-admin-api/src/main/java/org/codice/ddf/registry/federationadmin/FederationAdminMBean.java
+++ b/catalog/spatial/registry/registry-federation-admin-api/src/main/java/org/codice/ddf/registry/federationadmin/FederationAdminMBean.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.federationadmin;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+/**
+ * This is the external facing interface for the FederationAdminService. This is what should be used by the UI,
+ * for example, to interact with the FederationAdminService.
+ */
+public interface FederationAdminMBean {
+    String OBJECT_NAME = "org.codice.ddf.registry:type=FederationAdminMBean";
+
+    /**
+     * Create a local entry in the registry catalog for the given object map.
+     * The map will be converted to a {@link RegistryPackageType} using the {@link RegistryPackageWebConverter}.
+     * The resulting {@link RegistryPackageType} will be passed to {@link FederationAdminService#addLocalEntry}
+     * to create the entry.
+     *
+     * @param RegistryObjectMap A map of the registry object to create
+     * @return Id of the created metacard.
+     * @throws FederationAdminException Passes exception thrown by FederationAdminServiceImpl
+     */
+    String createLocalEntry(Map<String, Object> registryObjectMap) throws FederationAdminException;
+
+    /**
+     * Create a local entry in the registry catalog for the given string.
+     * The String provided is an Base64 encoded representation of a registry package xml.
+     * The RegistryTransformer transforms the Base64 decode stream into a registry metacard.
+     *
+     * @param base64EncodedXmlString Base64 encoded registry package xml.
+     * @return Id of the created metacard
+     * @throws FederationAdminException If Base64 decoding of the string fails
+     *                                  If the RegistryTransformer can't convert the stream into a metacard
+     *                                  Passes exceptions thrown by FederationAdminServiceImpl
+     */
+    String createLocalEntry(String base64EncodedXmlString) throws FederationAdminException;
+
+    /**
+     * Update a local entry in the registry catalog for the given object map.
+     * The map will be converted to a {@link RegistryPackageType} using the {@link RegistryPackageWebConverter}.
+     * The resulting {@link RegistryPackageType} will be passed to {@link FederationAdminService#addLocalEntry}
+     * to update the entry.
+     *
+     * @param registryObjectMap A map of the registry object to update
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    void updateLocalEntry(Map<String, Object> registryObjectMap) throws FederationAdminException;
+
+    /**
+     * Deletes a local entry in the registry catalog for each of the ids provided.
+     *
+     * @param ids List of registry ids to be deleted
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    void deleteLocalEntry(List<String> ids) throws FederationAdminException;
+
+    /**
+     * Returns a Map of RegistryPackage objects as converted using {@code RegistryPackageWebConverter}
+     *
+     * @return Map<String, Object>
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    Map<String, Object> getLocalNodes() throws FederationAdminException;
+
+    /**
+     * @param servicePID - The PID of the registry which will have the status checked
+     * @return the status of a single registry as a boolean, true if available, false otherwise
+     */
+    boolean registryStatus(String servicePID);
+
+    /**
+     * @return the list of registry metatypes
+     */
+    List<Map<String, Object>> allRegistryInfo();
+
+    /**
+     * @return the list of registry metacards as RegistryObjectWebMaps
+     */
+    List<Map<String, Object>> allRegistryMetacards();
+
+    /**
+     * @param source       - The id of the source that will be published to or unpublished
+     *                     from the following destinations
+     * @param destinations - List of ids of catalog stores that the source will be
+     *                     published to or unpublished from
+     * @return the list of currently published locations after attempting to perform
+     * the publish/unpublishes
+     */
+    List<Serializable> updatePublications(String source, List<String> destinations)
+            throws UnsupportedQueryException, SourceUnavailableException, FederationException;
+}

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
@@ -107,6 +107,48 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -13,72 +13,30 @@
  **/
 package org.codice.ddf.registry.federationadmin.service.impl;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
+import java.util.Set;
 
-import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
-import javax.xml.datatype.DatatypeConstants;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.configuration.SystemBaseUrl;
-import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.ParserConfigurator;
-import org.codice.ddf.parser.ParserException;
-import org.codice.ddf.registry.common.RegistryConstants;
-import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
 import org.codice.ddf.security.common.Security;
 import org.geotools.filter.FilterFactoryImpl;
-import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
-import org.opengis.filter.sort.SortBy;
-import org.opengis.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.CatalogFramework;
-import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.operation.CreateRequest;
-import ddf.catalog.operation.Query;
-import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.impl.CreateRequestImpl;
-import ddf.catalog.operation.impl.QueryImpl;
-import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.source.IngestException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
-import ddf.security.SecurityConstants;
-import ddf.security.Subject;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.InternationalStringType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.LocalizedStringType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ObjectFactory;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.ValueListType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.VersionInfoType;
 
 public class FederationAdminServiceImpl implements FederationAdminService {
 
@@ -108,204 +66,8 @@ public class FederationAdminServiceImpl implements FederationAdminService {
         this.security = security;
     }
 
-    @Override
-    public void addLocalEntry(Metacard metacard)
-            throws SourceUnavailableException, IngestException {
-        Subject systemSubject = security.getSystemSubject();
-        CreateRequest createRequest = new CreateRequestImpl(metacard);
-        createRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        catalogFramework.create(createRequest);
-    }
-
-    @Override
-    public List<Metacard> getRegistryMetacards()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-        List<Metacard> registryMetacards = new ArrayList<>();
-
-        Filter filter =
-                FILTER_FACTORY.and(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
-                        RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME),
-                        FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
-                                RegistryConstants.REGISTRY_TAG));
-        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
-
-        Query query = new QueryImpl(filter);
-        ((QueryImpl) query).setSortBy(sortBy);
-
-        Subject systemSubject = security.getSystemSubject();
-        QueryRequest queryRequest = new QueryRequestImpl(query);
-        queryRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        QueryResponse queryResponse = catalogFramework.query(queryRequest);
-
-        List<Result> results = queryResponse.getResults();
-
-        for (Result result : results) {
-            Metacard metacard = result.getMetacard();
-            if (metacard != null) {
-                registryMetacards.add(metacard);
-            }
-        }
-
-        return registryMetacards;
-    }
-
-    private Metacard getRegistryIdentityMetacard()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-        Metacard identityMetacard = null;
-
-        List<Filter> filters = new ArrayList<>();
-        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
-                RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
-        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
-                RegistryConstants.REGISTRY_TAG));
-        filters.add(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
-                .is()
-                .bool(true));
-
-        Filter filter = FILTER_FACTORY.and(filters);
-        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
-
-        Query query = new QueryImpl(filter);
-        ((QueryImpl) query).setSortBy(sortBy);
-
-        Subject systemSubject = security.getSystemSubject();
-        QueryRequest queryRequest = new QueryRequestImpl(query);
-        queryRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        QueryResponse queryResponse = catalogFramework.query(queryRequest);
-
-        List<Result> results = queryResponse.getResults();
-        if (CollectionUtils.isNotEmpty(results)) {
-            identityMetacard = results.get(0)
-                    .getMetacard();
-
-            if (results.size() > 1) {
-                LOGGER.error("There should only be one identity node. Found these: {}", results);
-            }
-        }
-
-        return identityMetacard;
-    }
-
     public void init() {
-        try {
-            if (getRegistryIdentityMetacard() == null) {
-                createIdentityNode();
-            }
-        } catch (SourceUnavailableException | UnsupportedQueryException | FederationException e) {
-            LOGGER.error("There was an error executing a query. Failed to come up properly.");
-        } catch (IngestException e) {
-            LOGGER.error(
-                    "There was an error creating the identity node. Failed to come up properly.");
-        }
-    }
 
-    private void createIdentityNode() throws SourceUnavailableException, IngestException {
-
-        String registryPackageId = UUID.randomUUID()
-                .toString()
-                .replaceAll("-", "");
-        RegistryPackageType registryPackage = RIM_FACTORY.createRegistryPackageType();
-        registryPackage.setId(registryPackageId);
-        registryPackage.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
-
-        ExtrinsicObjectType extrinsicObject = RIM_FACTORY.createExtrinsicObjectType();
-        extrinsicObject.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
-
-        String extrinsicObjectId = UUID.randomUUID()
-                .toString()
-                .replaceAll("-", "");
-        extrinsicObject.setId(extrinsicObjectId);
-
-        String siteName = SystemInfo.getSiteName();
-        if (StringUtils.isNotBlank(siteName)) {
-            extrinsicObject.setName(getInternationalStringTypeFromString(siteName));
-        }
-
-        String home = SystemBaseUrl.getBaseUrl();
-        if (StringUtils.isNotBlank(home)) {
-            extrinsicObject.setHome(home);
-        }
-
-        String version = SystemInfo.getVersion();
-        if (StringUtils.isNotBlank(version)) {
-            VersionInfoType versionInfo = RIM_FACTORY.createVersionInfoType();
-            versionInfo.setVersionName(version);
-
-            extrinsicObject.setVersionInfo(versionInfo);
-        }
-
-        OffsetDateTime now = OffsetDateTime.now(ZoneId.of(ZoneOffset.UTC.toString()));
-        String rightNow = now.toString();
-        ValueListType valueList = RIM_FACTORY.createValueListType();
-        valueList.getValue()
-                .add(rightNow);
-
-        SlotType1 lastUpdated = RIM_FACTORY.createSlotType1();
-        lastUpdated.setValueList(RIM_FACTORY.createValueList(valueList));
-        lastUpdated.setSlotType(DatatypeConstants.DATETIME.toString());
-        lastUpdated.setName(RegistryConstants.XML_LAST_UPDATED_NAME);
-        extrinsicObject.getSlot()
-                .add(lastUpdated);
-
-        SlotType1 liveDate = RIM_FACTORY.createSlotType1();
-        liveDate.setValueList(RIM_FACTORY.createValueList(valueList));
-        liveDate.setSlotType(DatatypeConstants.DATETIME.toString());
-        liveDate.setName(RegistryConstants.XML_LIVE_DATE_NAME);
-        extrinsicObject.getSlot()
-                .add(liveDate);
-
-        if (registryPackage.getRegistryObjectList() == null) {
-            registryPackage.setRegistryObjectList(RIM_FACTORY.createRegistryObjectListType());
-        }
-
-        registryPackage.getRegistryObjectList()
-                .getIdentifiable()
-                .add(RIM_FACTORY.createIdentifiable(extrinsicObject));
-
-        Metacard identityMetacard = jaxbToMetacard(registryPackage);
-        if (identityMetacard != null) {
-            Attribute registryNodeAttribute =
-                    new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true);
-            identityMetacard.setAttribute(registryNodeAttribute);
-
-            addLocalEntry(identityMetacard);
-        }
-    }
-
-    private Metacard jaxbToMetacard(RegistryPackageType registryPackage) {
-        Metacard metacard;
-
-        try {
-            JAXBElement<RegistryPackageType> jaxbRegistryObjectType =
-                    RIM_FACTORY.createRegistryPackage(registryPackage);
-
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            parser.marshal(configurator, jaxbRegistryObjectType, baos);
-            InputStream xmlInputStream = new ByteArrayInputStream(baos.toByteArray());
-            metacard = registryTransformer.transform(xmlInputStream);
-
-        } catch (IOException | CatalogTransformerException | ParserException e) {
-            LOGGER.error("Error creating metacard from registry package.", e);
-            metacard = null;
-        }
-
-        return metacard;
-    }
-
-    private InternationalStringType getInternationalStringTypeFromString(
-            String internationalizeThis) {
-        InternationalStringType ist = RIM_FACTORY.createInternationalStringType();
-        LocalizedStringType lst = RIM_FACTORY.createLocalizedStringType();
-        lst.setValue(internationalizeThis);
-        ist.setLocalizedString(Collections.singletonList(lst));
-
-        return ist;
     }
 
     public void setCatalogFramework(CatalogFramework catalogFramework) {
@@ -330,5 +92,121 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
     public void setRegistryTransformer(InputTransformer inputTransformer) {
         this.registryTransformer = inputTransformer;
+    }
+
+    @Override
+    public String addRegistryEntry(String xml) throws FederationAdminException {
+        return null;
+    }
+
+    @Override
+    public String addRegistryEntry(String xml, Set<String> destinations)
+            throws FederationAdminException {
+        return null;
+    }
+
+    @Override
+    public String addRegistryEntry(Metacard metacard) throws FederationAdminException {
+        return null;
+    }
+
+    @Override
+    public String addRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException {
+        return null;
+    }
+
+    @Override
+    public void deleteRegistryEntriesByRegistryIds(List<String> registryIds)
+            throws FederationAdminException {
+
+    }
+
+    @Override
+    public void deleteRegistryEntriesByRegistryIds(List<String> registryIds,
+            Set<String> destinations) throws FederationAdminException {
+
+    }
+
+    @Override
+    public void deleteRegistryEntriesByMetacardIds(List<String> metacardIds)
+            throws FederationAdminException {
+
+    }
+
+    @Override
+    public void deleteRegistryEntriesByMetacardIds(List<String> metacardIds,
+            Set<String> destinations) throws FederationAdminException {
+
+    }
+
+    @Override
+    public void updateRegistryEntry(Metacard metacard) throws FederationAdminException {
+
+    }
+
+    @Override
+    public void updateRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException {
+
+    }
+
+    @Override
+    public void updateRegistryEntry(String xml) throws FederationAdminException {
+
+    }
+
+    @Override
+    public void updateRegistryEntry(String xml, Set<String> destinations)
+            throws FederationAdminException {
+
+    }
+
+    @Override
+    public List<Metacard> getRegistryMetacards() throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Metacard> getLocalRegistryMetacards() throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<Metacard> getLocalRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<RegistryPackageType> getLocalRegistryObjects() throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<RegistryPackageType> getRegistryObjects() throws FederationAdminException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public RegistryPackageType getRegistryObjectByMetacardId(String metacardId)
+            throws FederationAdminException {
+        return null;
+    }
+
+    @Override
+    public RegistryPackageType getRegistryObjectByMetacardId(String metacardId,
+            List<String> sourceIds) throws FederationAdminException {
+        return null;
+    }
+
+    public void refreshRegistrySubscriptions() throws FederationAdminException {
+
     }
 }

--- a/catalog/spatial/registry/registry-federation-admin-service/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>registry-federation-admin-service</artifactId>
-    <name>DDF :: Registry :: Federation Admin Service</name>
+    <name>DDF :: Registry :: Federation :: Admin :: Service</name>
     <packaging>bundle</packaging>
 
     <dependencies>
@@ -51,6 +51,48 @@
                         <Bundle-Name>${project.name}</Bundle-Name>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminException.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminException.java
@@ -11,8 +11,19 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  **/
-package org.codice.ddf.registry.federationadmin.service.impl;
+package org.codice.ddf.registry.federationadmin.service;
 
-public class FederationAdminServiceImplTest {
+public class FederationAdminException extends Exception {
+    public FederationAdminException() {
+        super();
+    }
+
+    public FederationAdminException(String message) {
+        super(message);
+    }
+
+    public FederationAdminException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
@@ -14,42 +14,223 @@
 package org.codice.ddf.registry.federationadmin.service;
 
 import java.util.List;
+import java.util.Set;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.source.IngestException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 
 /**
  * Service that provides the interface to get and add registry metacards
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be removed in a future version of the library. </b>
  */
 public interface FederationAdminService {
 
     /**
-     * Add the given metacard to the catalog
+     * Add a registry metacard entry for the xml string provided. Converts the string to a
+     * registry metacard using the RegistryTransformer.
      *
-     * @param metacard
-     *          Metacard to be stored
-     * @throws SourceUnavailableException
-     *          If the local provider is not available.
-     * @throws IngestException
-     *          If any errors were encountered during ingest
+     * @param xml String representation of a registry package xml
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the xml string is blank.
+     *                                  If an exception is thrown from the registryTransformer.
+     *                                  The CatalogFramework throws an exception trying to add the metacard.
      */
-    void addLocalEntry(Metacard metacard) throws SourceUnavailableException, IngestException;
+    String addRegistryEntry(String xml) throws FederationAdminException;
 
     /**
-     *  Get a list of registry metacards
+     * Add a registry metacard entry for the xml string provided. Converts the string to a
+     * registry metacard using the RegistryTransformer.
+     *
+     * @param xml          String representation of a registry package xml
+     * @param destinations Set of destinations to add
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the xml string is blank.
+     *                                  If an exception is thrown from the registryTransformer.
+     *                                  The CatalogFramework throws an exception trying to add the metacard.
+     */
+    String addRegistryEntry(String xml, Set<String> destinations) throws FederationAdminException;
+
+    /**
+     * Add the given metacard to the registry catalog
+     *
+     * @param metacard Metacard to be stored
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the metacard provided was null.
+     *                                  The CatalogFramework.create call throws IngestException or SourceUnavailableException
+     */
+    String addRegistryEntry(Metacard metacard) throws FederationAdminException;
+
+    /**
+     * Add the given metacard to the registry catalog with the provided destinations
+     *
+     * @param metacard     Metacard to be stored
+     * @param destinations Set of destinations to add
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the metacard provided was null.
+     *                                  The CatalogFramework.create call throws IngestException or SourceUnavailableException
+     */
+    String addRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided registry ids.
+     *
+     * @param registryIds The list of registry ids to be deleted.
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByRegistryIds(List<String> registryIds)
+            throws FederationAdminException;
+
+    /**
+     * Deletes the registry entry from the registry catalog for each of the provided registry ids. A set of destinations is
+     * sent in the delete request
+     *
+     * @param registryIds  The list of registry ids to be deleted.
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByRegistryIds(List<String> registryIds, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided metacard ids.
+     *
+     * @param metacardIds The list of metacard ids to be deleted.
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByMetacardIds(List<String> metacardIds)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided metacard ids. A set of destinations is
+     * sent in the delete request
+     *
+     * @param metacardIds  The list of metacard ids to be deleted.
+     * @param destinations The set of destinations to be added
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByMetacardIds(List<String> metacardIds, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Write the provided metacard to the registry catalog. Updating the metacard currently stored.
+     *
+     * @param metacard Metacard with updates to be stored in the registry catalog
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(Metacard metacard) throws FederationAdminException;
+
+    /**
+     * Write the provided metacard to the registry catalog. Updating the metacard currently stored with the provided destinations.
+     *
+     * @param metacard     Metacard with updates to be stored in the registry catalog
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * Update a registry metacard for the xml string provided. The string will be converted to a registry metacard using the RegistryTransformer.
+     *
+     * @param xml String representation of a registry package xml
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If an exception is thrown from the RegistryTransformer
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(String xml) throws FederationAdminException;
+
+    /**
+     * Update a registry metacard for the xml string provided. The string will be converted to a registry metacard using the RegistryTransformer.
+     * The metacard will be updated with the provided destinations
+     *
+     * @param xml          String representation of a registry package xml
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If an exception is thrown from the RegistryTransformer
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(String xml, Set<String> destinations) throws FederationAdminException;
+
+    /**
+     * Get a list of registry metacards
      *
      * @return List<Metacard>
-     * @throws UnsupportedQueryException
-     *          If runtime exception occured while performing the query.
-     *          If the query fails validation.
-     * @throws SourceUnavailableException
-     *          If the local provider is not available.
-     * @throws FederationException
-     *          If any StopProcessing Exceptions were thrown by the catalog while processing the query
+     * @throws FederationAdminException If any exception was thrown by the call to CatalogFramework.query()
      */
-    List<Metacard> getRegistryMetacards()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException;
+    List<Metacard> getRegistryMetacards() throws FederationAdminException;
+
+    /**
+     * Get a list of local registry metacards
+     *
+     * @return List<Metacard>
+     * @throws FederationAdminException If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getLocalRegistryMetacards() throws FederationAdminException;
+
+    /**
+     * Get a list of registry metacards with the provided registry ids. It won't run the query
+     * if the list provided is empty.
+     *
+     * @param ids List of IDs to to get metacards for
+     * @return List<Metacard>
+     * @throws FederationAdminException If empty list of registry ids is provided
+     *                                  If the list of id filters isn't created
+     *                                  If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException;
+
+    /**
+     * Get a list of local registry metacards with the provided registry ids. It won't run the query
+     * if the list provided is empty.
+     *
+     * @param ids List of IDs to to get metacards for
+     * @return List<Metacard>
+     * @throws FederationAdminException If empty list of registry ids is provided
+     *                                  If the list of id filters isn't created
+     *                                  If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getLocalRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException;
+
+    /**
+     * Get a list of local registry objects
+     *
+     * @return List<RegistryPackageType>
+     * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
+     */
+    List<RegistryPackageType> getLocalRegistryObjects() throws FederationAdminException;
+
+    /**
+     * Get a list of all registry objects
+     *
+     * @return List<RegistryPackageType>
+     * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
+     */
+    List<RegistryPackageType> getRegistryObjects() throws FederationAdminException;
+
+    /**
+     * Get a registry object by id
+     *
+     * @return List<RegistryPackageType>
+     * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
+     */
+    RegistryPackageType getRegistryObjectByMetacardId(String metacardId)
+            throws FederationAdminException;
+
+    /**
+     * Get a registry object by id providing a list of source ids to be queried
+     *
+     * @return List<RegistryPackageType>
+     * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
+     */
+    RegistryPackageType getRegistryObjectByMetacardId(String metacardId, List<String> sourceIds)
+            throws FederationAdminException;
 }

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
@@ -31,13 +31,13 @@ import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
 
 import com.google.common.base.Charsets;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteRequest;
@@ -48,8 +48,6 @@ import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.plugin.PreIngestPlugin;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.Requests;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
@@ -228,8 +226,7 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
                 .toString();
     }
 
-    public void init()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    public void init() throws FederationAdminException {
 
         List<Metacard> registryMetacards = federationAdmin.getRegistryMetacards();
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -45,6 +45,8 @@ public class TestRegistry extends AbstractIntegrationTest {
 
     private static final String CATALOG_REGISTRY = "registry-app";
 
+    private static final String CATALOG_REGISTRY_CORE = "registry-core";
+
     private static final String REGISTRY_CATALOG_STORE_ID = "cswRegistryCatalogStore";
 
     @BeforeExam
@@ -54,6 +56,8 @@ public class TestRegistry extends AbstractIntegrationTest {
             getAdminConfig().setLogLevels();
             getServiceManager().waitForRequiredApps(getDefaultRequiredApps());
             getServiceManager().startFeature(true, CATALOG_REGISTRY);
+            getServiceManager().waitForAllBundles();
+            getServiceManager().startFeature(true, CATALOG_REGISTRY_CORE);
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query?_wadl");


### PR DESCRIPTION
#### What does this PR do?
Updates the registry-federation-admin-service interface and adds the registry-federation-admin-api interface. These are the interfaces that will be used in the other modules coming over from the ddf-registry repo.
This is one PR of many to come in the next few days to update the registry functionality.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@gordocanchola @tbatie 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris 
#### How should this be tested?
Unit and itests should be run. In this point of the transition from ddf-registry no other manual testing is needed. 
#### Any background context you want to provide?
These are changes that are being migrated over from the ddf-registry repo. The registry-federation-admin-service-impl was 'cleaned' out along with its unit tests since they will be updated in a pr from ddf-registry that implements the interface and has the needed unit tests. This pr is just trying to get the interfaces out there so that subsequent prs can be made for modules that depend on the interfaces.
#### What are the relevant tickets?
DDF-2124
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…gistry repo.