### PR TITLE
DDF-2112 Changed default transformer in catalog-core-commands to XML

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
@@ -57,7 +57,9 @@ public abstract class CatalogCommands extends SubjectCommands {
 
     protected static final String WILDCARD = "*";
 
-    protected static final String DEFAULT_TRANSFORMER_ID = "ser";
+    protected static final String DEFAULT_TRANSFORMER_ID = "xml";
+
+    protected static final String SERIALIZED_OBJECT_ID = "ser";
 
     // DDF-535: remove "-provider" alias in DDF 3.0
     @Option(name = "--provider", required = false, aliases = {"-p",

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -100,7 +100,9 @@ public class DumpCommand extends CatalogCommands {
 
     // DDF-535: remove "Transformer" alias in DDF 3.0
     @Option(name = "--transformer", required = false, aliases = {"-t",
-            "Transformer"}, multiValued = false, description = "The metacard transformer ID to use to transform metacards into data files. The default metacard transformer is the Java serialization transformer.")
+            "Transformer"}, multiValued = false, description =
+            "The metacard transformer ID to use to transform metacards into data files. "
+                    + "The default metacard transformer is the XML transformer.")
     String transformerId = DEFAULT_TRANSFORMER_ID;
 
     // DDF-535: remove "Extension" alias in DDF 3.0
@@ -166,7 +168,7 @@ public class DumpCommand extends CatalogCommands {
             return null;
         }
 
-        if (!DEFAULT_TRANSFORMER_ID.matches(transformerId)) {
+        if (!SERIALIZED_OBJECT_ID.matches(transformerId)) {
             transformers = getTransformers();
             if (transformers == null) {
                 console.println(transformerId + " is an invalid metacard transformer.");
@@ -358,7 +360,7 @@ public class DumpCommand extends CatalogCommands {
     private void exportMetacard(File dumpLocation, Metacard metacard)
             throws IOException, CatalogTransformerException {
 
-        if (DEFAULT_TRANSFORMER_ID.matches(transformerId)) {
+        if (SERIALIZED_OBJECT_ID.matches(transformerId)) {
             try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(getOutputFile(
                     dumpLocation,
                     metacard)))) {
@@ -366,7 +368,6 @@ public class DumpCommand extends CatalogCommands {
                 oos.flush();
             }
         } else {
-
             BinaryContent binaryContent;
             if (metacard != null) {
                 try (FileOutputStream fos = new FileOutputStream(getOutputFile(dumpLocation,

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestDumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestDumpCommand.java
@@ -83,6 +83,7 @@ public class TestDumpCommand extends TestAbstractCommand {
             }
         };
         command.dirPath = "nosuchdirectoryanywherehereman";
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
 
         // when
         command.doExecute();
@@ -122,7 +123,7 @@ public class TestDumpCommand extends TestAbstractCommand {
         File testFile = testFolder.newFile("somefile.txt");
         String testFilePath = testFile.getAbsolutePath();
         command.dirPath = testFilePath;
-
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
         // when
         command.doExecute();
 
@@ -174,7 +175,7 @@ public class TestDumpCommand extends TestAbstractCommand {
         File outputDirectory = testFolder.newFolder("somedirectory");
         String outputDirectoryPath = outputDirectory.getAbsolutePath();
         command.dirPath = outputDirectoryPath;
-
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
         // when
         command.doExecute();
 
@@ -221,7 +222,7 @@ public class TestDumpCommand extends TestAbstractCommand {
         File outputDirectory = testFolder.newFolder("somedirectory");
         String outputDirectoryPath = outputDirectory.getAbsolutePath();
         command.dirPath = outputDirectoryPath;
-
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
         // when
         command.doExecute();
 
@@ -289,7 +290,8 @@ public class TestDumpCommand extends TestAbstractCommand {
         File outputDirectory = testFolder.newFolder("somedirectory");
         String outputDirectoryPath = outputDirectory.getAbsolutePath();
         command.dirPath = outputDirectoryPath;
-
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
+        
         // when
         command.doExecute();
 

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestIngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestIngestCommand.java
@@ -81,6 +81,7 @@ public class TestIngestCommand extends TestAbstractCommand {
                 return bundleContext;
             }
         };
+        command.transformerId = CatalogCommands.SERIALIZED_OBJECT_ID;
         command.filePath = testFolder.getRoot()
                 .getAbsolutePath();
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -88,7 +88,7 @@ public class TestConfiguration extends AbstractIntegrationTest {
 
     private static final String CATALOG_REMOVE_ALL_COMMAND = "catalog:removeall --force";
 
-    private static final String CATALOG_INGEST_COMMAND = "catalog:ingest";
+    private static final String CATALOG_INGEST_COMMAND = "catalog:ingest -t ser";
 
     private static final String SUCCESSFUL_IMPORT_MESSAGE =
             "All config files imported successfully.";


### PR DESCRIPTION
#### What does this PR do?
This PR changes the default transformer in dump/ingest commands to use the XML transformer as opposed to using Java Serialized Objects.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver 
@glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire 
#### How should this be tested?
Build and Run DDF.  Run catalog:ingest and catalog:dump and verify that the transformers are correct.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2112
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests