### PR TITLE
DDF-519 DDF-1460 DDF-2090 GeoJSON multivalued attribute support

### DIFF
--- a/catalog/transformer/catalog-transformer-geojson-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-geojson-input/pom.xml
@@ -33,12 +33,6 @@
             <artifactId>geo-formatter</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>metacard-type-registry</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.fastjson</groupId>
             <artifactId>boon</artifactId>
             <version>0.33</version>
@@ -52,15 +46,15 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            boon,
+                            catalog-core-api-impl
+                        </Embed-Dependency>
                         <Import-Package>
-                          !com.sun.management,
-                          *
+                            !org.codice.ddf.platform.util,
+                            !com.sun.management,
+                            *
                         </Import-Package>
-                        <Private-Package>
-                            ddf.catalog.transformer.input.geojson,
-                            ddf.catalog.data.impl
-                        </Private-Package>
-                        <Embed-Dependency>boon</Embed-Dependency>
                         <Export-Package/>
                     </instructions>
                 </configuration>

--- a/catalog/transformer/catalog-transformer-geojson-input/src/main/java/ddf/catalog/transformer/input/geojson/GeoJsonInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/main/java/ddf/catalog/transformer/input/geojson/GeoJsonInputTransformer.java
@@ -120,8 +120,9 @@ public class GeoJsonInputTransformer implements InputTransformer {
                 (Map<String, Object>) rootObject.get(CompositeGeometry.GEOMETRY_KEY);
         CompositeGeometry geoJsonGeometry = null;
         if (geometryJson != null) {
-            if (geometryJson.get(CompositeGeometry.TYPE_KEY) != null && geometryJson.get(
-                    CompositeGeometry.COORDINATES_KEY) != null) {
+            if (geometryJson.get(CompositeGeometry.TYPE_KEY) != null && (geometryJson.get(
+                    CompositeGeometry.COORDINATES_KEY) != null || geometryJson.get(
+                    CompositeGeometry.GEOMETRIES_KEY) != null)) {
 
                 String geometryTypeJson = geometryJson.get(CompositeGeometry.TYPE_KEY)
                         .toString();

--- a/catalog/transformer/catalog-transformer-geojson-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,7 +18,9 @@
 
 	<bean id="transformer"
           class="ddf.catalog.transformer.input.geojson.GeoJsonInputTransformer">
-		<argument ref="metacardTypeRegistry"/>	
+		<property name="metacardTypes">
+			<reference-list interface="ddf.catalog.data.MetacardType" availability="optional"/>
+		</property>
 	</bean>
 
 	<service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
@@ -32,7 +34,5 @@
 			</entry>
 		</service-properties>
 	</service>
-	
-	<reference id="metacardTypeRegistry" interface="ddf.catalog.data.MetacardTypeRegistry"/>
 
 </blueprint>

--- a/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonExtensible.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonExtensible.java
@@ -104,6 +104,7 @@ public class TestGeoJsonExtensible {
 
     private static final String sampleJsonExtensibleA() {
         return "{" + "    \"properties\":{" + "        \"title\":\"myTitle\","
+                + "        \"multi-string\":[\"foo\", \"bar\"],"
                 + "        \"frequency\":\"14000000\"," + "        \"min-frequency\":\"10000000\","
                 + "        \"max-frequency\":\"20000000\"," + "        \"angle\":\"180\","
                 + "        \"id\":\"myId\"," + "        \"metacard-type\":\"MetacardTypeA\""
@@ -456,6 +457,12 @@ public class TestGeoJsonExtensible {
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
+        descriptors.add(new AttributeDescriptorImpl("multi-string",
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                true /* multivalued */,
+                BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(Metacard.ID,
                 true /* indexed */,
                 true /* stored */,

--- a/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonExtensible.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonExtensible.java
@@ -24,10 +24,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vividsolutions.jts.geom.Coordinate;
@@ -37,15 +40,16 @@ import com.vividsolutions.jts.io.WKTReader;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardTypeRegistry;
-import ddf.catalog.data.QualifiedMetacardType;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
-import ddf.catalog.data.impl.QualifiedMetacardTypeImpl;
-import ddf.catalog.data.metacardtype.MetacardTypeRegistryImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 
 public class TestGeoJsonExtensible {
+
+    private GeoJsonInputTransformer transformer = new GeoJsonInputTransformer();
+
     public static final String DEFAULT_TITLE = "myTitle";
 
     public static final String DEFAULT_ID = "myId";
@@ -195,13 +199,16 @@ public class TestGeoJsonExtensible {
                 + "        ]" + "    }" + "}";
     }
 
+    @Before
+    public void setup() {
+        transformer.setMetacardTypes(prepareMetacardTypes());
+    }
+
     @Test
     public void testExtensibleGeoJsonA() throws IOException, CatalogTransformerException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
-
         ByteArrayInputStream geoJsonInput =
                 new ByteArrayInputStream(sampleJsonExtensibleA().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         assertEquals(DEFAULT_TITLE, metacard.getTitle());
         assertEquals(DEFAULT_ID, metacard.getId());
@@ -234,11 +241,9 @@ public class TestGeoJsonExtensible {
 
     @Test
     public void testExtensibleGeoJsonB() throws IOException, CatalogTransformerException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
-
         ByteArrayInputStream geoJsonInput =
                 new ByteArrayInputStream(sampleJsonExtensibleB().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         assertEquals(DEFAULT_TITLE, metacard.getTitle());
         assertEquals(DEFAULT_ID, metacard.getId());
@@ -289,11 +294,9 @@ public class TestGeoJsonExtensible {
     @Test
     public void testExtensibleGeoJsonBNonParseableField()
             throws IOException, CatalogTransformerException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
-
         ByteArrayInputStream geoJsonInput = new ByteArrayInputStream(
                 sampleJsonExtensibleBWithBadField().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         // all sample B fields should be added to metacard except the non-parseable one
         assertEquals(DEFAULT_TITLE, metacard.getTitle());
@@ -337,11 +340,9 @@ public class TestGeoJsonExtensible {
     @Test
     public void testExtensibleGeoJsonNoMetacardType()
             throws IOException, CatalogTransformerException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
-
         ByteArrayInputStream geoJsonInput = new ByteArrayInputStream(
                 sampleJsonExtensibleANoMetacardType().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         // since no metacard type was specified only the Basic Metacard Type attributes should be
         // available. These are defined in BasicTypes.BASIC_METACARD
@@ -362,20 +363,17 @@ public class TestGeoJsonExtensible {
     @Test(expected = CatalogTransformerException.class)
     public void testExtensibleGeoJsonUnregisteredMetacardType()
             throws IOException, CatalogTransformerException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
-
         ByteArrayInputStream geoJsonInput = new ByteArrayInputStream(
                 sampleJsonExtensibleAUnregisteredMetacardType().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
     }
 
     @Test
     public void testBasicMetacardType()
             throws IOException, CatalogTransformerException, ParseException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
         ByteArrayInputStream geoJsonInput =
                 new ByteArrayInputStream(sampleBasicMetacard().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         verifyBasics(metacard);
     }
@@ -383,22 +381,17 @@ public class TestGeoJsonExtensible {
     @Test
     public void testBasicMetacardTypeNoMetacardType()
             throws IOException, CatalogTransformerException, ParseException {
-        MetacardTypeRegistry mtr = prepareMetacardTypeRegistry();
         ByteArrayInputStream geoJsonInput =
                 new ByteArrayInputStream(sampleBasicMetacardNoMetacard().getBytes());
-        Metacard metacard = new GeoJsonInputTransformer(mtr).transform(geoJsonInput);
+        Metacard metacard = transformer.transform(geoJsonInput);
 
         verifyBasics(metacard);
     }
 
-    private MetacardTypeRegistry prepareMetacardTypeRegistry() {
-
-        MetacardTypeRegistry mtr = MetacardTypeRegistryImpl.getInstance();
-        mtr.register(sampleMetacardTypeA());
-        mtr.register(sampleMetacardTypeB());
-        mtr.register(new QualifiedMetacardTypeImpl(BasicTypes.BASIC_METACARD));
-
-        return mtr;
+    private List<MetacardType> prepareMetacardTypes() {
+        return Arrays.asList(sampleMetacardTypeA(),
+                sampleMetacardTypeB(),
+                BasicTypes.BASIC_METACARD);
     }
 
     protected void verifyBasics(Metacard metacard) throws ParseException {
@@ -437,7 +430,7 @@ public class TestGeoJsonExtensible {
         assertThat(coords[2].y, is(40.0));
     }
 
-    private QualifiedMetacardType sampleMetacardTypeA() {
+    private MetacardType sampleMetacardTypeA() {
         Set<AttributeDescriptor> descriptors = new HashSet<AttributeDescriptor>();
         descriptors.add(new AttributeDescriptorImpl("frequency",
                 true /* indexed */,
@@ -476,10 +469,10 @@ public class TestGeoJsonExtensible {
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
 
-        return new QualifiedMetacardTypeImpl("", SAMPLE_A_METACARD_TYPE_NAME, descriptors);
+        return new MetacardTypeImpl(SAMPLE_A_METACARD_TYPE_NAME, descriptors);
     }
 
-    private QualifiedMetacardType sampleMetacardTypeB() {
+    private MetacardType sampleMetacardTypeB() {
         Set<AttributeDescriptor> descriptors = new HashSet<AttributeDescriptor>();
         descriptors.add(new AttributeDescriptorImpl(COLUMNS_ATTRIBUTE_KEY,
                 true /* indexed */,
@@ -536,6 +529,6 @@ public class TestGeoJsonExtensible {
                 false /* multivalued */,
                 BasicTypes.SHORT_TYPE));
 
-        return new QualifiedMetacardTypeImpl("", "MetacardTypeB", descriptors);
+        return new MetacardTypeImpl("MetacardTypeB", descriptors);
     }
 }

--- a/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonInputTransformer.java
@@ -57,7 +57,7 @@ public class TestGeoJsonInputTransformer {
                 "    }," +
                 "    \"geometry\":{" +
                 "        \"type\":\"GeometryCollection\"," +
-                "        \"coordinates\":[" +
+                "        \"geometries\":[" +
                 "            {" +
                 "                \"type\":\"Point\"," +
                 "                \"coordinates\":[" +
@@ -172,6 +172,47 @@ public class TestGeoJsonInputTransformer {
                 "}";
     }
 
+    private static final String sampleGeometryCollectionJsonText() {
+        return "{" +
+                "    \"properties\":{" +
+                "        \"title\":\"myTitle\"," +
+                "        \"thumbnail\":\"CA==\"," +
+                "        \"resource-uri\":\"http:\\/\\/example.com\"," +
+                "        \"created\":\"2012-09-01T00:09:19.368+0000\"," +
+                "        \"metadata-content-type-version\":\"myVersion\"," +
+                "        \"metadata-content-type\":\"myType\"," +
+                "        \"metadata\":\"<xml><\\/xml>\"," +
+                "        \"modified\":\"2012-09-01T00:09:19.368+0000\"" +
+                "    }," +
+                "    \"type\":\"Feature\"," +
+                "    \"geometry\":{" +
+                "        \"type\":\"GeometryCollection\"," +
+                "        \"geometries\":[" +
+                "            {" +
+                "                \"type\":\"Point\"," +
+                "                \"coordinates\":[" +
+                "                    4.0," +
+                "                    6.0" +
+                "                ]" +
+                "            }," +
+                "            {" +
+                "                \"type\":\"LineString\"," +
+                "                \"coordinates\":[" +
+                "                    [" +
+                "                        4.0," +
+                "                        6.0" +
+                "                    ]," +
+                "                    [" +
+                "                        7.0," +
+                "                        10.0" +
+                "                    ]" +
+                "                ]" +
+                "            }" +
+                "        ]" +
+                "    }" +
+                "}";
+    }
+
     private static final String noGeoJsonText() {
         return "{" +
                 "    \"properties\":{" +
@@ -271,6 +312,25 @@ public class TestGeoJsonInputTransformer {
 
         assertThat(coords[2].x, is(40.0));
         assertThat(coords[2].y, is(40.0));
+    }
+
+    @Test
+    public void testGeometryCollectionStringGeo()
+            throws IOException, CatalogTransformerException, ParseException {
+
+        GeoJsonInputTransformer transformer = new GeoJsonInputTransformer();
+
+        InputStream inputStream = new ByteArrayInputStream(sampleGeometryCollectionJsonText().getBytes());
+
+        Metacard metacard = transformer.transform(inputStream);
+
+        verifyBasics(metacard);
+
+        WKTReader reader = new WKTReader();
+
+        Geometry geometry = reader.read(metacard.getLocation());
+
+        assertThat(geometry.getNumGeometries(), is(2));
     }
 
     @Test

--- a/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/TestGeoJsonInputTransformer.java
@@ -17,18 +17,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 
 import org.junit.Test;
-import org.osgi.framework.BundleContext;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
@@ -36,9 +32,6 @@ import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardTypeRegistry;
-import ddf.catalog.data.QualifiedMetacardType;
-import ddf.catalog.data.metacardtype.MetacardTypeRegistryImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 
 public class TestGeoJsonInputTransformer {
@@ -53,12 +46,6 @@ public class TestGeoJsonInputTransformer {
     private static final String SAMPLE_ID = "myId";
 
     private static final String DEFAULT_URI = "http://example.com";
-
-    private static final BundleContext CONTEXT = mock(BundleContext.class);
-
-    private static final MetacardTypeRegistry MTR = MetacardTypeRegistryImpl.getInstance();
-
-    private static List<QualifiedMetacardType> qmtList = new ArrayList<QualifiedMetacardType>();
 
     // @formatter:off
     private static final String noTypeJsonText() {
@@ -204,36 +191,36 @@ public class TestGeoJsonInputTransformer {
 
     @Test(expected = CatalogTransformerException.class)
     public void testNullInput() throws IOException, CatalogTransformerException {
-        new GeoJsonInputTransformer(MTR).transform(null);
+        new GeoJsonInputTransformer().transform(null);
     }
 
     @Test(expected = CatalogTransformerException.class)
     public void testBadInput() throws IOException, CatalogTransformerException {
-        new GeoJsonInputTransformer(MTR).transform(new ByteArrayInputStream("{key=".getBytes()));
+        new GeoJsonInputTransformer().transform(new ByteArrayInputStream("{key=".getBytes()));
     }
 
     @Test(expected = CatalogTransformerException.class)
     public void testFeatureCollectionType() throws IOException, CatalogTransformerException {
-        new GeoJsonInputTransformer(MTR)
+        new GeoJsonInputTransformer()
                 .transform(new ByteArrayInputStream(sampleFeatureCollectionJsonText().getBytes()));
     }
 
     @Test(expected = CatalogTransformerException.class)
     public void testNoType() throws IOException, CatalogTransformerException {
-        new GeoJsonInputTransformer(MTR)
+        new GeoJsonInputTransformer()
                 .transform(new ByteArrayInputStream(noTypeJsonText().getBytes()));
     }
 
     @Test(expected = CatalogTransformerException.class)
     public void testNoProperties() throws IOException, CatalogTransformerException {
-        new GeoJsonInputTransformer(MTR).transform(
+        new GeoJsonInputTransformer().transform(
                 new ByteArrayInputStream("{ \"type\": \"FeatureCollection\"}".getBytes()));
     }
 
     @Test()
     public void testNoGeo() throws IOException, CatalogTransformerException {
 
-        Metacard metacard = new GeoJsonInputTransformer(MTR)
+        Metacard metacard = new GeoJsonInputTransformer()
                 .transform(new ByteArrayInputStream(noGeoJsonText().getBytes()));
 
         verifyBasics(metacard);
@@ -243,7 +230,7 @@ public class TestGeoJsonInputTransformer {
     @Test()
     public void testPointGeo() throws IOException, CatalogTransformerException, ParseException {
 
-        Metacard metacard = new GeoJsonInputTransformer(MTR)
+        Metacard metacard = new GeoJsonInputTransformer()
                 .transform(new ByteArrayInputStream(samplePointJsonText().getBytes()));
 
         verifyBasics(metacard);
@@ -262,7 +249,7 @@ public class TestGeoJsonInputTransformer {
     public void testLineStringGeo()
             throws IOException, CatalogTransformerException, ParseException {
 
-        GeoJsonInputTransformer transformer = new GeoJsonInputTransformer(MTR);
+        GeoJsonInputTransformer transformer = new GeoJsonInputTransformer();
 
         InputStream inputStream = new ByteArrayInputStream(sampleLineStringJsonText().getBytes());
 
@@ -289,7 +276,7 @@ public class TestGeoJsonInputTransformer {
     @Test
     public void testSetId() throws IOException, CatalogTransformerException {
 
-        Metacard metacard = new GeoJsonInputTransformer(MTR)
+        Metacard metacard = new GeoJsonInputTransformer()
                 .transform(new ByteArrayInputStream(samplePointJsonText().getBytes()), SAMPLE_ID);
 
         verifyBasics(metacard);

--- a/catalog/transformer/catalog-transformer-geojson-metacard/src/main/java/ddf/catalog/transformer/metacard/geojson/GeoJsonMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-metacard/src/main/java/ddf/catalog/transformer/metacard/geojson/GeoJsonMetacardTransformer.java
@@ -17,7 +17,9 @@ import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -36,6 +38,7 @@ import com.vividsolutions.jts.io.WKTReader;
 
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.BinaryContentImpl;
@@ -95,79 +98,16 @@ public class GeoJsonMetacardTransformer implements MetacardTransformer {
                 .getAttributeDescriptors()) {
 
             Attribute attribute = metacard.getAttribute(ad.getName());
-
             if (attribute != null) {
-                switch (ad.getType()
-                        .getAttributeFormat()) {
-                case BOOLEAN:
-                    properties.put(attribute.getName(), (Boolean) attribute.getValue());
-                    break;
-                case DATE:
-                    if (attribute.getValue() != null) {
-                        SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_8601_DATE_FORMAT);
-                        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-                        properties.put(attribute.getName(),
-                                dateFormat.format(((Date) attribute.getValue())));
+                Object value = convertAttribute(attribute, ad);
+                if (value != null) {
+                    if (Metacard.GEOGRAPHY.equals(attribute.getName())) {
+                        rootObject.put(CompositeGeometry.GEOMETRY_KEY, value);
+                    } else {
+                        properties.put(attribute.getName(), value);
                     }
-                    break;
-                case BINARY:
-                    if (attribute.getValue() != null) {
-                        byte[] bytes = ((byte[]) attribute.getValue());
-
-                        String base64 = DatatypeConverter.printBase64Binary(bytes);
-
-                        properties.put(attribute.getName(), base64);
-                    }
-                    break;
-                // Since we just need the string version of Doubles, Longs, Floats, Integers, or
-                // Shorts, no conversion
-                // or processing is necessary. The toString method on each of those classes
-                // suffices.
-                case DOUBLE:
-                case LONG:
-                case FLOAT:
-                case INTEGER:
-                case SHORT:
-                case STRING:
-                case XML:
-                    if (attribute.getValue() != null) {
-                        // xml is automatically escaped by json library
-                        properties.put(attribute.getName(),
-                                attribute.getValue()
-                                        .toString());
-                    }
-                    break;
-                case GEOMETRY:
-                    if (attribute.getValue() != null) {
-                        WKTReader reader = new WKTReader();
-                        try {
-                            Geometry geometry = reader.read(attribute.getValue()
-                                    .toString());
-                            CompositeGeometry geoJsonGeometry =
-                                    CompositeGeometry.getCompositeGeometry(geometry);
-                            if (geoJsonGeometry == null) {
-                                throw new CatalogTransformerException(
-                                        "Could not perform transform: unsupported geometry ["
-                                                + attribute.getValue() + "]");
-                            }
-                            rootObject.put(CompositeGeometry.GEOMETRY_KEY,
-                                    geoJsonGeometry.toJsonMap());
-                        } catch (ParseException e) {
-                            LOGGER.warn("Parse exception during reading of geometry", e);
-                            throw new CatalogTransformerException(
-                                    "Could not perform transform: could not parse geometry.",
-                                    e);
-                        }
-
-                    }
-
-                    break;
-                default:
-                    break;
                 }
-
             }
-
         }
 
         if (rootObject.get(CompositeGeometry.GEOMETRY_KEY) == null) {
@@ -202,6 +142,72 @@ public class GeoJsonMetacardTransformer implements MetacardTransformer {
     public String toString() {
         return MetacardTransformer.class.getName() + " {Impl=" + this.getClass()
                 .getName() + ", id=" + ID + ", MIME Type=" + DEFAULT_MIME_TYPE + "}";
+    }
+
+    private static Object convertAttribute(Attribute attribute, AttributeDescriptor descriptor)
+            throws CatalogTransformerException {
+        if (descriptor.isMultiValued()) {
+            List<Object> values = new ArrayList<>();
+            for (Serializable value : attribute.getValues()) {
+                values.add(convertValue(value,
+                        descriptor.getType()
+                                .getAttributeFormat()));
+            }
+            return values;
+        } else {
+            return convertValue(attribute.getValue(),
+                    descriptor.getType()
+                            .getAttributeFormat());
+        }
+    }
+
+    private static Object convertValue(Serializable value, AttributeType.AttributeFormat format)
+            throws CatalogTransformerException {
+        if (value == null) {
+            return null;
+        }
+
+        switch (format) {
+        case BOOLEAN:
+            return value;
+        case DATE:
+            SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_8601_DATE_FORMAT);
+            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+            return dateFormat.format((Date) value);
+        case BINARY:
+            byte[] bytes = (byte[]) value;
+            String base64 = DatatypeConverter.printBase64Binary(bytes);
+
+            return base64;
+        case DOUBLE:
+        case LONG:
+        case FLOAT:
+        case INTEGER:
+        case SHORT:
+        case STRING:
+        case XML:
+            return value.toString();
+        case GEOMETRY:
+            WKTReader reader = new WKTReader();
+            try {
+                Geometry geometry = reader.read(value.toString());
+                CompositeGeometry geoJsonGeometry =
+                        CompositeGeometry.getCompositeGeometry(geometry);
+                if (geoJsonGeometry == null) {
+                    throw new CatalogTransformerException(
+                            "Could not perform transform: unsupported geometry [" + value + "]");
+                }
+                return geoJsonGeometry.toJsonMap();
+            } catch (ParseException e) {
+                throw new CatalogTransformerException(
+                        "Could not perform transform: could not parse geometry [" + value + "]",
+                        e);
+            }
+        case OBJECT:
+        default:
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for multivalued attributes with the GeoJSON transformers.  It also replaces the MetacardTypeRegistry with MetacardType OSGi services and fixes a bug with geometry collection handling.

#### Who is reviewing it
@rzwiefel 
@djblue 

#### Choose 2 committers to review/merge the PR
@kcwire
@pklinef

#### How should this be tested?
Using any metacard with multivalued attributes, export and import the metacard using the GeoJSON transformer and verify the multivalued attributes are intact.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-519
https://codice.atlassian.net/browse/DDF-1460
https://codice.atlassian.net/browse/DDF-2090

#### Screenshots (if appropriate)

#### Checklist:
- [n/a] Documentation Updated
- [x] Update / Add Unit Tests
- [n/a] Update / Add Integration Tests