### PR TITLE
DDF-2048: Provides support for ingesting files through an FTP Endpoint

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -395,4 +395,11 @@
         <feature>catalog-core</feature>
     </feature>
 
+    <feature name="catalog-core-ftp" install="manual" version="${project.version}"
+             description="FTP endpoint for ingesting files into the DDF catalog. Supports PUT and MPUT operations only. Avoids the extra IO overhead of otherwise having to temporarily write the file to the file system.">
+        <feature prerequisite="true">catalog-app</feature>
+        <bundle>mvn:ddf.catalog.core/catalog-core-ftp/${project.version}</bundle>
+        <bundle>mvn:org.apache.mina/mina-core/${mina.version}</bundle>
+    </feature>
+
 </features>

--- a/catalog/core/catalog-core-ftp/pom.xml
+++ b/catalog/core/catalog-core-ftp/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>core</artifactId>
+        <groupId>ddf.catalog.core</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-core-ftp</artifactId>
+    <name>DDF :: Catalog :: Core :: Ftp</name>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <ftpserver-version>1.0.6</ftpserver-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>${mina.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ftpserver</groupId>
+            <artifactId>ftplet-api</artifactId>
+            <version>${ftpserver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ftpserver</groupId>
+            <artifactId>ftpserver-core</artifactId>
+            <version>${ftpserver-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.handler</groupId>
+            <artifactId>security-handler-basic</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-camelcomponent</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.58</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.56</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.31</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.59</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            ftplet-api,
+                            ftpserver-core,
+                            platform-util,
+                            catalog-core-api-impl,
+                            shiro-core,
+                            commons-beanutils,
+                            commons-lang3
+                        </Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/FtpServerStarter.java
+++ b/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/FtpServerStarter.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.Ftplet;
+import org.apache.ftpserver.ftplet.UserManager;
+import org.apache.ftpserver.listener.ListenerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.core.ftp.ftplets.FtpRequestHandler;
+
+/**
+ * Registers the {@link FtpRequestHandler} and starts the FTP server for the FTP Endpoint.
+ */
+public class FtpServerStarter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FtpServerStarter.class);
+
+    private static final int PORT = 8021;
+
+    private static final String DEFAULT_LISTENER = "default";
+
+    private static FtpServer server;
+
+    private static FtpServerFactory serverFactory;
+
+    private static UserManager userManager;
+
+    private static ListenerFactory listenerFactory;
+
+    private Ftplet ftplet;
+
+    public FtpServerStarter(Ftplet ftplet, FtpServerFactory serverFactory,
+            ListenerFactory listenerFactory, UserManager userManager) {
+        notNull(ftplet, "ftplet");
+        notNull(serverFactory, "serverFactory");
+        notNull(listenerFactory, "listenerFactory");
+        notNull(userManager, "userManager");
+
+        this.ftplet = ftplet;
+        this.serverFactory = serverFactory;
+        this.listenerFactory = listenerFactory;
+        this.userManager = userManager;
+    }
+
+    public void init() {
+        listenerFactory.setPort(PORT);
+
+        serverFactory.addListener(DEFAULT_LISTENER, listenerFactory.createListener());
+
+        Map<String, Ftplet> ftplets = new HashMap<>();
+        ftplets.put(FtpRequestHandler.class.getName(), ftplet);
+        serverFactory.setFtplets(ftplets);
+        serverFactory.setUserManager(userManager);
+
+        server = serverFactory.createServer();
+        try {
+            server.start();
+            LOGGER.debug("FTP server started on port {}", PORT);
+        } catch (Exception e) {
+            LOGGER.error("Failed to start FTP server", e);
+        }
+    }
+
+    public void destroy() {
+        if (!server.isStopped()) {
+            server.stop();
+            LOGGER.debug("FTP server on port {} was stopped", PORT);
+        }
+    }
+
+    private void notNull(Object object, String name) {
+        if (object == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+    }
+}

--- a/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/UserManagerImpl.java
+++ b/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/UserManagerImpl.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ftpserver.ftplet.Authentication;
+import org.apache.ftpserver.ftplet.AuthenticationFailedException;
+import org.apache.ftpserver.ftplet.Authority;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.User;
+import org.apache.ftpserver.ftplet.UserManager;
+import org.apache.ftpserver.usermanager.UsernamePasswordAuthentication;
+import org.apache.ftpserver.usermanager.impl.ConcurrentLoginPermission;
+import org.apache.ftpserver.usermanager.impl.TransferRatePermission;
+import org.apache.ftpserver.usermanager.impl.WritePermission;
+import org.codice.ddf.security.handler.api.UPAuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.core.ftp.user.FtpUser;
+import ddf.security.Subject;
+import ddf.security.service.SecurityManager;
+import ddf.security.service.SecurityServiceException;
+
+/**
+ * {@link UserManager} that is registered to an FTP server and performs user authorization.
+ */
+public class UserManagerImpl implements UserManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserManagerImpl.class);
+
+    private static final String UPLOAD_DIRECTORY = "";
+
+    private static SecurityManager securityManager;
+
+    private String admin;
+
+    private HashMap<String, User> users;
+
+    public UserManagerImpl(SecurityManager securityManager) {
+        notNull(securityManager, "securityManager");
+
+        this.securityManager = securityManager;
+        users = new HashMap<>();
+    }
+
+    public void save(User user) {
+        String username = user.getName();
+        if (!doesExist(username)) {
+            users.put(username, user);
+        }
+    }
+
+    public void delete(String usrName) throws FtpException {
+        users.remove(usrName);
+    }
+
+    public String[] getAllUserNames() {
+        return usersToStringArray(users.keySet()
+                .toArray());
+    }
+
+    public User getUserByName(String userName) {
+        return users.get(userName);
+    }
+
+    public boolean doesExist(String name) {
+        return users.containsKey(name);
+    }
+
+    /**
+     * @param authentication The {@link Authentication} that proves the users identity. {@link org.apache.ftpserver.usermanager.AnonymousAuthentication} is not permitted
+     * @return {@link User} upon successful authorization
+     * @throws AuthenticationFailedException upon unsuccessful authorization
+     */
+    public User authenticate(Authentication authentication) throws AuthenticationFailedException {
+        UPAuthenticationToken upAuthenticationToken;
+        String username;
+        User user;
+
+        if (authentication instanceof UsernamePasswordAuthentication) {
+            username = ((UsernamePasswordAuthentication) authentication).getUsername();
+            upAuthenticationToken = new UPAuthenticationToken(username,
+                    ((UsernamePasswordAuthentication) authentication).getPassword());
+
+            try {
+                Subject subject = securityManager.getSubject(upAuthenticationToken);
+
+                if (subject != null) {
+                    if (!doesExist(username)) {
+                        user = createUser(username, subject);
+                    } else {
+                        user = getUserByName(username);
+                    }
+                    return user;
+                }
+            } catch (SecurityServiceException e) {
+                LOGGER.error("Failure to retrieve subject.", e);
+                throw new AuthenticationFailedException("Failure to retrieve subject.");
+            }
+        }
+
+        throw new AuthenticationFailedException("Authentication failed");
+    }
+
+    @Override
+    public String getAdminName() {
+        return admin;
+    }
+
+    @Override
+    public boolean isAdmin(String username) {
+        return checkAdmin(username);
+    }
+
+    /**
+     * @param userName name of the user being authenticated
+     * @param subject {@link Subject} of the user
+     * @return {@link FtpUser}
+     */
+    protected FtpUser createUser(String userName, Subject subject) {
+        FtpUser user = new FtpUser();
+        user.setName(userName);
+        user.setEnabled(true);
+        user.setHomeDirectory(UPLOAD_DIRECTORY);
+
+        List<Authority> authorities = new ArrayList<>();
+
+        authorities.add(new WritePermission());
+        authorities.add(new ConcurrentLoginPermission(0, 0));
+        authorities.add(new TransferRatePermission(0, 0));
+
+        user.setAuthorities(authorities);
+        user.setMaxIdleTime(0);
+
+        user.setSubject(subject);
+
+        setAdmin(user);
+
+        save(user);
+
+        return user;
+    }
+
+    private String[] usersToStringArray(Object[] users) {
+        String[] strArray = new String[users.length];
+        for (int i = 0; i < users.length; i++) {
+            strArray[i] = (String) users[i];
+        }
+        return strArray;
+    }
+
+    private boolean checkAdmin(String username) {
+        return this.admin.equals(username);
+    }
+
+    private void setAdmin(User user) {
+        Subject subject = ((FtpUser) user).getSubject();
+        if (subject.hasRole("admin") && StringUtils.isEmpty(this.admin)) {
+            this.admin = user.getName();
+        }
+    }
+
+    private void notNull(Object object, String name) {
+        if (object == null) {
+            String msg = name + " cannot be null";
+            LOGGER.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+}

--- a/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/ftplets/FtpRequestHandler.java
+++ b/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/ftplets/FtpRequestHandler.java
@@ -1,0 +1,357 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp.ftplets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.ftpserver.ftplet.DataConnection;
+import org.apache.ftpserver.ftplet.DataConnectionFactory;
+import org.apache.ftpserver.ftplet.DefaultFtpReply;
+import org.apache.ftpserver.ftplet.DefaultFtplet;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.FtpFile;
+import org.apache.ftpserver.ftplet.FtpReply;
+import org.apache.ftpserver.ftplet.FtpRequest;
+import org.apache.ftpserver.ftplet.FtpSession;
+import org.apache.ftpserver.ftplet.FtpletResult;
+import org.apache.ftpserver.impl.IODataConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.FileBackedOutputStream;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.content.data.impl.ContentItemImpl;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.impl.CreateStorageRequestImpl;
+import ddf.catalog.core.ftp.user.FtpUser;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.mime.MimeTypeMapper;
+import ddf.mime.MimeTypeResolutionException;
+import ddf.security.SecurityConstants;
+import ddf.security.Subject;
+
+/**
+ * Handler for incoming FTP requests from the client. Supports the PUT and MPUT operations - all other operations respond with 550 request not taken response.
+ * When PUTing a new file, it is not temporarily written to the file system. Instead, the new file's data stream is ingested directly into the catalog.
+ */
+public class FtpRequestHandler extends DefaultFtplet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FtpRequestHandler.class);
+
+    private static final String UNSUPPORTED_METHOD_RESPONSE =
+            "Unsupported method, only PUT and MPUT are supported.";
+
+    private static final String SUBJECT = "subject";
+
+    private static final String STOR_REQUEST = "STOR";
+
+    private CatalogFramework catalogFramework;
+
+    private MimeTypeMapper mimeTypeMapper;
+
+    public FtpRequestHandler(CatalogFramework catalogFramework, MimeTypeMapper mimeTypeMapper) {
+        notNull(catalogFramework, "catalogFramework");
+        notNull(mimeTypeMapper, "mimeTypeMapper");
+
+        this.catalogFramework = catalogFramework;
+        this.mimeTypeMapper = mimeTypeMapper;
+    }
+
+    @Override
+    public FtpletResult onConnect(FtpSession session) throws FtpException, IOException {
+        return FtpletResult.DEFAULT;
+    }
+
+    @Override
+    public FtpletResult onDisconnect(FtpSession session) throws FtpException, IOException {
+        return FtpletResult.DEFAULT;
+    }
+
+    @Override
+    public FtpletResult onLogin(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.setAttribute(SUBJECT, ((FtpUser) session.getUser()).getSubject());
+        return FtpletResult.SKIP;
+    }
+
+    /**
+     * @param session The current {@link FtpSession}
+     * @param request The current {@link FtpRequest}
+     * @return {@link FtpletResult#SKIP} - signals successful ingest and to discontinue and further processing on the FTP request
+     * @throws FtpException general exception for Ftplets
+     * @throws IOException  thrown when there is an error fetching data from client
+     */
+    @Override
+    public FtpletResult onUploadStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+
+        LOGGER.debug("Beginning FTP ingest of {}", request.getArgument());
+
+        Subject shiroSubject = (Subject) session.getAttribute(SUBJECT);
+        if (shiroSubject != null) {
+            FtpFile ftpFile = null;
+            String fileName = request.getArgument();
+
+            try {
+                ftpFile = session.getFileSystemView()
+                        .getFile(fileName);
+            } catch (FtpException e) {
+                LOGGER.error("Failed to retrieve file from FTP session");
+            }
+
+            if (ftpFile == null) {
+                LOGGER.error(
+                        "Sending FTP status code 501 to client - syntax errors in request parameters");
+                session.write(new DefaultFtpReply(FtpReply.REPLY_501_SYNTAX_ERROR_IN_PARAMETERS_OR_ARGUMENTS,
+                        STOR_REQUEST));
+
+                throw new FtpException("File to be transferred from client did not exist");
+            }
+
+            DataConnectionFactory connFactory = session.getDataConnection();
+            if (connFactory instanceof IODataConnectionFactory) {
+                InetAddress address = ((IODataConnectionFactory) connFactory).getInetAddress();
+                if (address == null) {
+                    session.write(new DefaultFtpReply(FtpReply.REPLY_503_BAD_SEQUENCE_OF_COMMANDS,
+                            "PORT or PASV must be issued first"));
+                    LOGGER.error(
+                            "Sending FTP status code 503 to client - PORT or PASV must be issued before STOR");
+                    throw new FtpException("FTP client address was null");
+                }
+            }
+
+            if (!ftpFile.isWritable()) {
+                session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                        "Insufficient permissions"));
+                LOGGER.error(
+                        "Sending FTP status code 550 to client - insufficient permissions to write file.");
+                throw new FtpException("Insufficient permissions to write file");
+            }
+
+            session.write(new DefaultFtpReply(FtpReply.REPLY_150_FILE_STATUS_OKAY,
+                    STOR_REQUEST + " " + fileName));
+            LOGGER.debug("Replying to client with code 150 - file status okay");
+
+            try (FileBackedOutputStream outputStream = new FileBackedOutputStream(1000000);
+                    final AutoCloseable ac = outputStream::reset) {
+                DataConnection dataConnection = connFactory.openConnection();
+                dataConnection.transferFromClient(session, outputStream);
+
+                session.write(new DefaultFtpReply(FtpReply.REPLY_226_CLOSING_DATA_CONNECTION,
+                        "Closing data connection"));
+                LOGGER.debug("Sending FTP status code 226 to client - closing data connection");
+
+                String fileExtension = FilenameUtils.getExtension(ftpFile.getAbsolutePath());
+                String mimeType = getMimeType(fileExtension, outputStream);
+
+                ContentItem newItem = new ContentItemImpl(outputStream.asByteSource(),
+                        mimeType,
+                        fileName,
+                        null);
+
+                CreateStorageRequest createRequest =
+                        new CreateStorageRequestImpl(Collections.singletonList(newItem), null);
+                createRequest.getProperties()
+                        .put(SecurityConstants.SECURITY_SUBJECT, shiroSubject);
+
+                CreateResponse createResponse = catalogFramework.create(createRequest);
+                if (createResponse != null) {
+                    List<Metacard> createdMetacards = createResponse.getCreatedMetacards();
+
+                    for (Metacard metacard : createdMetacards) {
+                        LOGGER.info("Content item created with id = {}", metacard.getId());
+                    }
+                } else {
+                    throw new FtpException();
+                }
+            } catch (SourceUnavailableException | IngestException e) {
+                LOGGER.error("Failure to ingest file {}", fileName, e);
+                throw new FtpException("Failure to ingest file " + fileName);
+            } catch (FtpException fe) {
+                LOGGER.error("Failure to create metacard for file {}", fileName);
+                throw new FtpException("Failure to create metacard for file " + fileName);
+            } catch (Exception e) {
+                LOGGER.error("Error getting the output data stream from the FTP session");
+                throw new IOException("Error getting the output stream from FTP session");
+            } finally {
+                session.getDataConnection()
+                        .closeDataConnection();
+            }
+        }
+        return FtpletResult.SKIP;
+    }
+
+    protected String getMimeType(String fileExtension, FileBackedOutputStream outputStream) {
+        String mimeType = "";
+
+        if (mimeTypeMapper != null) {
+            try (InputStream inputStream = outputStream.asByteSource()
+                    .openBufferedStream()) {
+                if (fileExtension.equals("xml")) {
+                    mimeType = mimeTypeMapper.guessMimeType(inputStream, fileExtension);
+                } else {
+                    mimeType = mimeTypeMapper.getMimeTypeForFileExtension(fileExtension);
+                }
+
+            } catch (MimeTypeResolutionException | IOException e) {
+                LOGGER.warn(
+                        "Did not find the MimeTypeMapper service. Proceeding with empty mimetype");
+            }
+        } else {
+            LOGGER.warn("Did not find the MimeTypeMapper service. Proceeding with empty mimetype");
+        }
+
+        return mimeType;
+    }
+
+    @Override
+    public FtpletResult onUploadEnd(FtpSession session, FtpRequest request) {
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onDeleteStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onDeleteEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onDownloadStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onDownloadEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onRmdirStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onRmdirEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onMkdirStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onMkdirEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onAppendStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onAppendEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onUploadUniqueStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onUploadUniqueEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onRenameStart(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onRenameEnd(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    @Override
+    public FtpletResult onSite(FtpSession session, FtpRequest request)
+            throws FtpException, IOException {
+        session.write(new DefaultFtpReply(FtpReply.REPLY_550_REQUESTED_ACTION_NOT_TAKEN,
+                UNSUPPORTED_METHOD_RESPONSE));
+        return FtpletResult.SKIP;
+    }
+
+    private void notNull(Object object, String name) {
+        if (object == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+    }
+}

--- a/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/user/FtpUser.java
+++ b/catalog/core/catalog-core-ftp/src/main/java/ddf/catalog/core/ftp/user/FtpUser.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp.user;
+
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+
+import ddf.security.Subject;
+
+/**
+ * Wrapper for an FTP {@link BaseUser}. Contains a ShiroSubject for authorization.
+ */
+
+public class FtpUser extends BaseUser {
+
+    private Subject subject;
+
+    public Subject getSubject() {
+        return this.subject;
+    }
+
+    public void setSubject(Subject subject) {
+        this.subject = subject;
+    }
+}

--- a/catalog/core/catalog-core-ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <bean id="server" class="ddf.catalog.core.ftp.FtpServerStarter" init-method="init"
+          destroy-method="destroy">
+        <argument ref="ftplet"/>
+        <argument ref="serverFactory"/>
+        <argument ref="listenerFactory"/>
+        <argument ref="userManager"/>
+    </bean>
+
+    <bean id="ftplet" class="ddf.catalog.core.ftp.ftplets.FtpRequestHandler">
+        <argument ref="catalogFramework"/>
+        <argument ref="mimeTypeMapper"/>
+    </bean>
+    <bean id="userManager" class="ddf.catalog.core.ftp.UserManagerImpl">
+        <argument ref="securityManager"/>
+    </bean>
+
+    <bean id="serverFactory" class="org.apache.ftpserver.FtpServerFactory"/>
+    <bean id="listenerFactory" class="org.apache.ftpserver.listener.ListenerFactory"/>
+
+    <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
+    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+    <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>
+</blueprint>

--- a/catalog/core/catalog-core-ftp/src/test/java/ddf/catalog/core/ftp/UserManagerImplTest.java
+++ b/catalog/core/catalog-core-ftp/src/test/java/ddf/catalog/core/ftp/UserManagerImplTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.ftpserver.ftplet.Authentication;
+import org.apache.ftpserver.ftplet.AuthenticationFailedException;
+import org.apache.ftpserver.usermanager.AnonymousAuthentication;
+import org.apache.ftpserver.usermanager.UsernamePasswordAuthentication;
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.security.Subject;
+import ddf.security.service.SecurityManager;
+import ddf.security.service.SecurityServiceException;
+
+public class UserManagerImplTest {
+
+    private static final String USER = "user";
+
+    private static final String PASSWORD = "password";
+
+    private UserManagerImpl userManager;
+
+    private SecurityManager securityManager;
+
+    @Before
+    public void setUp() {
+        securityManager = mock(SecurityManager.class);
+        userManager = new UserManagerImpl(securityManager);
+    }
+
+    @Test(expected = AuthenticationFailedException.class)
+    public void wrongAuthType() throws AuthenticationFailedException {
+        AnonymousAuthentication anonAuthentication = mock(AnonymousAuthentication.class);
+
+        userManager.authenticate(anonAuthentication);
+    }
+
+    @Test(expected = AuthenticationFailedException.class)
+    public void nullShiroSubject() throws SecurityServiceException, AuthenticationFailedException {
+        UsernamePasswordAuthentication upa = mock(UsernamePasswordAuthentication.class);
+
+        when(upa.getUsername()).thenReturn(USER);
+        when(upa.getPassword()).thenReturn(PASSWORD);
+        when(securityManager.getSubject(upa)).thenReturn(null);
+
+        userManager.authenticate(upa);
+    }
+
+    @Test(expected = AuthenticationFailedException.class)
+    public void shiroUnsupportedAuthentication()
+            throws SecurityServiceException, AuthenticationFailedException {
+        UsernamePasswordAuthentication upa = mock(UsernamePasswordAuthentication.class);
+
+        when(upa.getUsername()).thenReturn(USER);
+        when(upa.getPassword()).thenReturn(PASSWORD);
+        when(securityManager.getSubject(any(Authentication.class))).thenThrow(
+                SecurityServiceException.class);
+
+        userManager.authenticate(upa);
+    }
+
+    @Test
+    public void authenticationSuccess()
+            throws SecurityServiceException, AuthenticationFailedException {
+        UsernamePasswordAuthentication upa = mock(UsernamePasswordAuthentication.class);
+        Subject subject = mock(Subject.class);
+
+        when(upa.getUsername()).thenReturn(USER);
+        when(upa.getPassword()).thenReturn(PASSWORD);
+        when(securityManager.getSubject(any(Authentication.class))).thenReturn(subject);
+
+        assertEquals(userManager.createUser(USER, subject), userManager.authenticate(upa));
+    }
+}

--- a/catalog/core/catalog-core-ftp/src/test/java/ddf/catalog/core/ftp/ftplets/FtpRequestHandlerTest.java
+++ b/catalog/core/catalog-core-ftp/src/test/java/ddf/catalog/core/ftp/ftplets/FtpRequestHandlerTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.ftp.ftplets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.FtpFile;
+import org.apache.ftpserver.ftplet.FtpRequest;
+import org.apache.ftpserver.ftplet.FtpSession;
+import org.apache.ftpserver.ftplet.FtpletResult;
+import org.apache.ftpserver.impl.IODataConnectionFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.FileBackedOutputStream;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.mime.MimeTypeMapper;
+import ddf.mime.MimeTypeResolutionException;
+import ddf.security.Subject;
+
+public class FtpRequestHandlerTest {
+
+    private static final String FILE_NAME = "SomeFile.xml";
+
+    private static final String SUBJECT = "subject";
+
+    private FtpRequestHandler ftplet;
+
+    private FtpletResult result;
+
+    private FtpSession session;
+
+    private FtpRequest request;
+
+    private static CatalogFramework catalogFramework;
+
+    private static MimeTypeMapper mimeTypeMapper;
+
+    @Before
+    public void setUp() {
+        session = mock(FtpSession.class, RETURNS_DEEP_STUBS);
+        request = mock(FtpRequest.class);
+
+        catalogFramework = mock(CatalogFramework.class);
+        mimeTypeMapper = mock(MimeTypeMapper.class);
+
+        ftplet = new FtpRequestHandler(catalogFramework, mimeTypeMapper);
+    }
+
+    @Test(expected = FtpException.class)
+    public void testOnUploadStartNullFtpFile() throws FtpException, IOException {
+        Subject subject = mock(Subject.class);
+
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)).thenReturn(null);
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test(expected = FtpException.class)
+    public void testOnUploadStartNoClientAddress() throws FtpException, IOException {
+        Subject subject = mock(Subject.class);
+        IODataConnectionFactory dataConnectionFactory = mock(IODataConnectionFactory.class);
+
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(session.getDataConnection()).thenReturn(dataConnectionFactory);
+        when(dataConnectionFactory.getInetAddress()).thenReturn(null);
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test(expected = FtpException.class)
+    public void testOnUploadStartNoFileWritePermission() throws FtpException, IOException {
+        Subject subject = mock(Subject.class);
+
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)
+                .isWritable()).thenReturn(false);
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test(expected = IOException.class)
+    public void testOnUploadStartFailFileTransfer() throws Exception {
+        Subject subject = mock(Subject.class);
+
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)
+                .isWritable()).thenReturn(true);
+        when(session.getDataConnection()
+                .openConnection()
+                .transferFromClient(eq(session),
+                        any(FileBackedOutputStream.class))).thenThrow(new IOException());
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test(expected = FtpException.class)
+    public void testCreateResponseNull()
+            throws FtpException, IOException, MimeTypeResolutionException,
+            SourceUnavailableException, IngestException {
+        Subject subject = mock(Subject.class);
+        FtpFile ftpFile = mock(FtpFile.class);
+
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)).thenReturn(ftpFile);
+        when(ftpFile.isWritable()).thenReturn(true);
+        when(ftpFile.getAbsolutePath()).thenReturn(FILE_NAME);
+        when(catalogFramework.create(any(CreateStorageRequest.class))).thenReturn(null);
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test(expected = FtpException.class)
+    public void testCreateStorageRequestFail()
+            throws FtpException, IOException, MimeTypeResolutionException,
+            SourceUnavailableException, IngestException {
+        Subject subject = mock(Subject.class);
+        FtpFile ftpFile = mock(FtpFile.class);
+
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)).thenReturn(ftpFile);
+        when(ftpFile.isWritable()).thenReturn(true);
+        when(ftpFile.getAbsolutePath()).thenReturn(FILE_NAME);
+        when(catalogFramework.create(any(CreateStorageRequest.class))).thenThrow(new IngestException());
+
+        ftplet.onUploadStart(session, request);
+    }
+
+    @Test
+    public void testGetMimeTypeXml() throws MimeTypeResolutionException {
+        String mimeType;
+
+        when(mimeTypeMapper.guessMimeType(any(InputStream.class),
+                eq("xml"))).thenReturn("text/xml");
+
+        mimeType = ftplet.getMimeType("xml", new FileBackedOutputStream(10000));
+        assertEquals("text/xml", mimeType);
+    }
+
+    @Test
+    public void testGetMimeTypeOther() throws MimeTypeResolutionException {
+        String mimeType;
+
+        when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
+
+        mimeType = ftplet.getMimeType("txt", new FileBackedOutputStream(10000));
+        assertEquals("text/plain", mimeType);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMimeTypeMapperNull() {
+        String mimeType;
+        catalogFramework = mock(CatalogFramework.class);
+        mimeTypeMapper = null;
+
+        FtpRequestHandler ftplett = new FtpRequestHandler(catalogFramework, mimeTypeMapper);
+
+        mimeType = ftplett.getMimeType("xml", new FileBackedOutputStream(10000));
+        assertEquals("", mimeType);
+    }
+
+    @Test
+    public void testMimeTypeResolutionFailure() throws MimeTypeResolutionException {
+        String mimeType;
+
+        when(mimeTypeMapper.guessMimeType(any(InputStream.class),
+                eq("xml"))).thenThrow(new MimeTypeResolutionException());
+
+        mimeType = ftplet.getMimeType("xml", new FileBackedOutputStream(10000));
+        assertEquals("", mimeType);
+    }
+
+    @Test
+    public void testFileIngestSuccess()
+            throws FtpException, IOException, SourceUnavailableException, IngestException {
+        Subject subject = mock(Subject.class);
+        FtpFile ftpFile = mock(FtpFile.class);
+        CreateResponse createResponse = mock(CreateResponse.class);
+
+        when(session.getAttribute(SUBJECT)).thenReturn(subject);
+        when(request.getArgument()).thenReturn(FILE_NAME);
+        when(session.getFileSystemView()
+                .getFile(FILE_NAME)).thenReturn(ftpFile);
+        when(ftpFile.isWritable()).thenReturn(true);
+        when(ftpFile.getAbsolutePath()).thenReturn(FILE_NAME);
+        when(catalogFramework.create(any(CreateStorageRequest.class))).thenReturn(createResponse);
+
+        ftplet.onUploadStart(session, request);
+
+        result = ftplet.onUploadStart(session, request);
+        assertEquals(FtpletResult.SKIP, result);
+    }
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -114,5 +114,6 @@
         <module>catalog-core-versioning</module>
         <module>catalog-core-validator</module>
         <module>catalog-core-attribute-registry</module>
+        <module>catalog-core-ftp</module>
     </modules>
 </project>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -49,6 +49,7 @@
         <catalog.joda.time.version>2.2</catalog.joda.time.version>
         <lucene.bundle.version>5.1.0_1</lucene.bundle.version>
         <lucene.version>5.1.0</lucene.version>
+        <mina.version>2.0.13</mina.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
@@ -1106,6 +1106,41 @@ The OpenSearch Description Document is an XML file is found inside of the OpenSe
 
 None
 
+==== FTP Endpoint
+
+The FTP Endpoint provides a method for ingesting files directly into the ${branding} Catalog using the FTP protocol. The files sent over FTP are not first written to the file system, like the Directory Monitor, but instead the FTP stream of the file is ingested directly into the ${branding} catalog, thus avoiding extra I/O overhead.
+
+===== Installing and Uninstalling
+
+Use the Admin Menu to install the FTP feature in the ${branding} Catalog. The FTP Endpoint is not installed by default.
+
+===== Configuring
+
+The FTP Endpoint has no configurable properties. It can only be installed or uninstalled.
+
+===== Using the FTP Endpoint
+
+====== Using the endpoint
+
+The FTP endpoint supports the PUT and MPUT operations. Any other operation, such as DELETE, will return a 550 action not taken response.
+
+====== From Code:
+
+Custom Ftplets can be implemented by extending the `DefaultFtplet` class provided by Apache FTP Server. Doing this will allow custom handling of various FTP commands by overriding the methods of the `DefaultFtplet`. Refer to `https://mina.apache.org/ftpserver-project/ftplet.html` for available methods that can be overridden.
+After creating a custom Ftplet, it needs to be added to the FTP server’s Ftplets before the server is started. Any Ftplets that are registered to the FTP server will execute the FTP command in the order that they were registered.
+
+====== From an FTP client:
+
+The FTP endpoint can be accessed from any FTP client of choice. Some common clients are FileZilla, PuTTY, or the FTP client provided in the terminal. The default port number is *8021*. Valid usernames and password are stored in the `<INSTALL_DIR>/etc/users.properties` file.
+
+===== Implementation Details
+
+The FTP endpoint is implemented using the Apache FTP Server and Apache Mina. Apache Mina provides an API for transport protocols such as TCP and UDP. The FTP server is built on top of Apache Mina to transport its messages. ${branding} implements a custom Ftplet by overriding the `DefaultFtplet` class provided by Apache FTP Server.
+
+====== Known Issues
+
+None
+
 === Developing a New Endpoint
 
 Complete the following procedure to create an endpoint. 


### PR DESCRIPTION
#### What does this PR do?
This PR provides an FTP endpoint for ingesting files into the DDF catalog. Features:
-Basic Auth
-PUT & MPUT operations

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mweser @troymohl @dcruver @ricklarsen 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
#### How should this be tested?
-Install the FTP feature in DDF Catalog -> Features
-Connect to the FTP server using your favorite client. Address is `localhost` and default port is `8021`. The login is the /etc/users.properties users. Default is admin/admin
-Ingest a file with the PUT or MPUT commands and verify it is correctly ingested and searchable in the Search UI.
_NOTE:_ Ingesting a .ntf file without first installing the Alliance Imagery App will cause Tika to throw an error and cause the FTP server to hang. There is a bug in Tika which is fixed in 1.12. DDF-2127 has been created to address this.
#### Any background context you want to provide?
The purpose of the ticket is to directly ingest a file without first temporarily writing the file to the file system, thus avoiding extra IO overhead.
#### What are the relevant tickets?
[DDF-2048](https://codice.atlassian.net/browse/DDF-2048)
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests