### PR TITLE
DDF-2123 send ffmpeg stdout and stderr to /dev/null

### DIFF
--- a/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
@@ -76,24 +76,11 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
 
     private static final int MAX_FFMPEG_PROCESSES = 4;
 
+    private static final PumpStreamHandler DEV_NULL = new PumpStreamHandler(null);
+
     private final Semaphore limitFFmpegProcessesSemaphore;
 
     private final String ffmpegPath;
-
-    private String getBundledFFmpegBinaryPath() {
-        if (SystemUtils.IS_OS_LINUX) {
-            return "linux/ffmpeg";
-        } else if (SystemUtils.IS_OS_MAC) {
-            return "osx/ffmpeg";
-        } else if (SystemUtils.IS_OS_SOLARIS) {
-            return "solaris/ffmpeg";
-        } else if (SystemUtils.IS_OS_WINDOWS) {
-            return "windows/ffmpeg.exe";
-        } else {
-            throw new RuntimeException("OS is not Linux, Mac, Solaris, or Windows."
-                    + " No FFmpeg binary is available for this OS, so the plugin will not work.");
-        }
-    }
 
     public VideoThumbnailPlugin(final BundleContext bundleContext) throws IOException {
         final String bundledFFmpegBinaryPath = getBundledFFmpegBinaryPath();
@@ -110,6 +97,21 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
         }
 
         limitFFmpegProcessesSemaphore = new Semaphore(MAX_FFMPEG_PROCESSES, true);
+    }
+
+    private String getBundledFFmpegBinaryPath() {
+        if (SystemUtils.IS_OS_LINUX) {
+            return "linux/ffmpeg";
+        } else if (SystemUtils.IS_OS_MAC) {
+            return "osx/ffmpeg";
+        } else if (SystemUtils.IS_OS_SOLARIS) {
+            return "solaris/ffmpeg";
+        } else if (SystemUtils.IS_OS_WINDOWS) {
+            return "windows/ffmpeg.exe";
+        } else {
+            throw new RuntimeException("OS is not Linux, Mac, Solaris, or Windows."
+                    + " No FFmpeg binary is available for this OS, so the plugin will not work.");
+        }
     }
 
     /**
@@ -292,7 +294,7 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
                     seek,
                     1);
 
-            final DefaultExecuteResultHandler resultHandler = executeFFmpeg(command, 15, null);
+            final DefaultExecuteResultHandler resultHandler = executeFFmpeg(command, 15, DEV_NULL);
             resultHandler.waitFor();
         }
 
@@ -308,7 +310,7 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
         final DefaultExecuteResultHandler resultHandler = executeFFmpeg(
                 getFFmpegCreateAnimatedGifCommand(),
                 3,
-                null);
+                DEV_NULL);
 
         resultHandler.waitFor();
 
@@ -408,7 +410,7 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
                 getThumbnailFilePath(),
                 null,
                 THUMBNAIL_COUNT);
-        final DefaultExecuteResultHandler resultHandler = executeFFmpeg(command, 15, null);
+        final DefaultExecuteResultHandler resultHandler = executeFFmpeg(command, 15, DEV_NULL);
 
         resultHandler.waitFor();
 


### PR DESCRIPTION
#### What does this PR do?
Send ffmpeg stderr and stdout to /dev/null instead of the console.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@rzwiefel @jrnorth @dcruver @kcwire 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@jlcsmith
#### How should this be tested?
Steps to recreate:
start and install DDF
open search UI
Click upload and select a movie clip (.mpg, .mov, .ts) and click Start Upload
Once the upload finishes, note the ffmpeg output is not being logged to System.out in the karaf console.
#### Any background context you want to provide?
There's no way to create a unit test for this, at least not that I know of.
#### What are the relevant tickets?
DDF-2123
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
