### PR TITLE
DDF-2044 Added RegistryPublicationHandler to send registry updates to remote registry the local registry has published to

### DIFF
--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -82,6 +82,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-publication-update-handler</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codice.ddf.spatial</groupId>
                 <artifactId>spatial-ogc-common</artifactId>
                 <version>${project.version}</version>
@@ -141,6 +146,6 @@
         <module>registry-federation-admin-api</module>
         <module>registry-app</module>
         <module>registry-admin-modules</module>
-
+        <module>registry-publication-update-handler</module>
     </modules>
 </project>

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-schema-bindings</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-publication-update-handler</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -42,6 +42,7 @@
     <bundle>mvn:org.codice.ddf.registry/registry-api-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
 </feature>
 
 <feature name="registry-app" install="auto" version="${project.version}"

--- a/catalog/spatial/registry/registry-publication-update-handler/pom.xml
+++ b/catalog/spatial/registry/registry-publication-update-handler/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>registry</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>registry-publication-update-handler</artifactId>
+    <name>DDF :: Registry :: Publication :: Update Handler</name>
+    <description>Forwards local registry changes to published locations.</description>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-ebrim-transformer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-standardframework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-parser-xml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Embed-Dependency>
+                            catalog-core-api-impl;scope=!test,
+                            registry-common,
+                            ddf-security-common
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util.http,
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.99</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.88</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.86</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.99</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * RegistryPublicationHandler is an org.osgi.service.event.EventHandler that listens for registry
+ * metacard updates and forwards changes on to any publish locations.
+ */
+public class RegistryPublicationHandler implements EventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryPublicationHandler.class);
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private final FederationAdminService adminService;
+
+    private final ExecutorService executor;
+
+    public RegistryPublicationHandler(FederationAdminService adminService,
+            ExecutorService service) {
+        this.adminService = adminService;
+        this.executor = service;
+    }
+
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.error("Thread pool didn't terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        if (mcard == null || !mcard.getTags()
+                .contains(RegistryConstants.REGISTRY_TAG)) {
+            return;
+        }
+        executor.execute(() -> processUpdate(mcard));
+    }
+
+    private void processUpdate(Metacard mcard) {
+        Attribute publishedLocations =
+                mcard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        if (publishedLocations == null) {
+            return;
+        }
+
+        Attribute lastPublished = mcard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        Date datePublished = null;
+        if (lastPublished != null) {
+            datePublished = (Date) lastPublished.getValue();
+        }
+
+        Set<String> locations = publishedLocations.getValues()
+                .stream()
+                .map(Object::toString)
+                .collect(Collectors.toCollection(HashSet::new));
+
+        //If we haven't published this metacard before or if we have had an update
+        //since the last time we published send an update to the remote location
+        if ((datePublished == null || datePublished.before(mcard.getModifiedDate()))
+                && CollectionUtils.isNotEmpty(locations)) {
+            try {
+                adminService.updateRegistryEntry(mcard, locations);
+                mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
+                        mcard.getModifiedDate()));
+                adminService.updateRegistryEntry(mcard);
+            } catch (FederationAdminException e) {
+                LOGGER.warn("Unable to send update for {} to {}", mcard.getTitle(), locations);
+            }
+        }
+
+    }
+}

--- a/catalog/spatial/registry/registry-publication-update-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <reference id="federationAdminService"
+               interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+
+    <bean id="executor" class="java.util.concurrent.Executors" factory-method="newFixedThreadPool">
+        <argument value="1"/>
+    </bean>
+
+    <bean id="registryEventManager" class="org.codice.ddf.registry.publication.RegistryPublicationHandler" destroy-method="destroy">
+        <argument ref="federationAdminService"/>
+        <argument ref="executor"/>
+    </bean>
+
+    <service ref="registryEventManager" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>ddf/catalog/event/UPDATED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+</blueprint>

--- a/catalog/spatial/registry/registry-publication-update-handler/src/test/java/org/codice/ddf/registry/publication/RegistryPublicationHandlerTest.java
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/test/java/org/codice/ddf/registry/publication/RegistryPublicationHandlerTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.osgi.service.event.Event;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class RegistryPublicationHandlerTest {
+
+    @Mock
+    private FederationAdminService service;
+
+    @Mock
+    private ExecutorService executorService;
+
+    private MetacardImpl mcard;
+
+    private RegistryPublicationHandler rph;
+
+    private Event event;
+
+    private Dictionary<String, Object> eventProperties;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        mcard = new MetacardImpl();
+        mcard.setAttribute(Metacard.TAGS, RegistryConstants.REGISTRY_TAG);
+        rph = new RegistryPublicationHandler(service, executorService);
+        eventProperties = new Hashtable<>();
+        eventProperties.put("ddf.catalog.event.metacard", mcard);
+        event = new Event("myevent", eventProperties);
+    }
+
+    @Test
+    public void testNullMetacard() {
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Event event = new Event("myevent", eventProperties);
+        doNothing().when(executorService)
+                .execute(any(Runnable.class));
+        rph.handleEvent(event);
+        verify(executorService, never()).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testNonRegistryMetacard() {
+        mcard.setAttribute(Metacard.TAGS, Metacard.DEFAULT_TAG);
+        doNothing().when(executorService)
+                .execute(any(Runnable.class));
+        rph.handleEvent(event);
+        verify(executorService, never()).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testRegistryMetacardExecutorCall() {
+        doNothing().when(executorService)
+                .execute(any(Runnable.class));
+        rph.handleEvent(event);
+        verify(executorService, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testProcessUpdateNoPublications() throws Exception {
+        mcard.setAttribute(Metacard.TAGS, Metacard.DEFAULT_TAG);
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, new ArrayList<>());
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, never()).updateRegistryEntry(mcard);
+    }
+
+    @Test
+    public void testProcessUpdateEmptyPublications() throws Exception {
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, never()).updateRegistryEntry(mcard);
+    }
+
+    @Test
+    public void testProcessUpdateNoLastPublishDate() throws Exception {
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "mylocation");
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, times(1)).updateRegistryEntry(mcard);
+    }
+
+    @Test
+    public void testProcessUpdateNoUpdateNeeded() throws Exception {
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "mylocation");
+        Date now = new Date();
+        mcard.setModifiedDate(now);
+        mcard.setAttribute(RegistryObjectMetacardType.LAST_PUBLISHED, now);
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, never()).updateRegistryEntry(mcard);
+    }
+
+    @Test
+    public void testProcessUpdate() throws Exception {
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "mylocation");
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+        mcard.setModifiedDate(now);
+        mcard.setAttribute(RegistryObjectMetacardType.LAST_PUBLISHED, before);
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, times(1)).updateRegistryEntry(mcard);
+        assertThat(mcard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED)
+                .getValue(), equalTo(now));
+    }
+
+    @Test
+    public void testProcessUpdateException() throws Exception {
+        doThrow(new FederationAdminException("Test Error")).when(service)
+                .updateRegistryEntry(any(Metacard.class), any(Set.class));
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "mylocation");
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+        mcard.setModifiedDate(now);
+        mcard.setAttribute(RegistryObjectMetacardType.LAST_PUBLISHED, before);
+        setupSerialExecutor();
+        rph.handleEvent(event);
+        verify(service, never()).updateRegistryEntry(mcard);
+        assertThat(mcard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED)
+                .getValue(), equalTo(before));
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        rph.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyTerminateTasks() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        rph.destroy();
+        verify(executorService, times(2)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterupt() throws Exception {
+        when(executorService.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException("interrupt"));
+        rph.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    private void setupSerialExecutor() {
+        doAnswer((args) -> {
+            ((Runnable) args.getArguments()[0]).run();
+            return null;
+        }).when(executorService)
+                .execute(any());
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds a handler to forward registry updates to remote registry the local registry has published to. This is being pulled from the ddf-registry repo
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@roelens8  @lessarderic 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef 
#### How should this be tested?
Right now prbs is the only way to test
#### Any background context you want to provide?
Coming over from the ddf-registry repo
#### What are the relevant tickets?
DDF-2044
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
