### PR TITLE
DDF-2115 Updated the setenv script to use standard posix commands

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -40,12 +40,18 @@ export DDF_HOME
 
 # Prefer /dev/urandom over /dev/random on Linux systems.
 OS="`uname`"
+LINUX="Linux"
 
-if [[ $OS == Linux* ]]; then
+if [ "$OS" != "${OS%$LINUX*}" ]; then
    if [ -e /dev/urandom ]; then
-      RANDOM_DEVICE_OPTION="-Djava.security.egd=file:/dev/./urandom"
+      EXTRA_JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom"
    fi
 fi
+
+# uncomment to enable cxf logging interceptors
+# EXTRA_JAVA_OPTS="$EXTRA_JAVA_OPTS -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
+
+export EXTRA_JAVA_OPTS
 
 #
 # The following section shows the possible configuration options for the default 
@@ -58,4 +64,4 @@ export JAVA_MAX_MEM=2048M
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder
 
-export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME $RANDOM_DEVICE_OPTION"
+export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME"

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -58,5 +58,8 @@ rem SET KARAF_BASE
 rem Additional available Karaf options
 rem SET KARAF_OPTS=-Dderby.system.home="..\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dcom.sun.management.jmxremote -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
 
+rem comment out the line below to enable cxf logging interceptors
+rem set EXTRA_JAVA_OPTS="-Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
+
 set JAVA_OPTS=-server -Xmx2048M -Dderby.system.home="%DDF_HOME%\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dcom.sun.management.jmxremote -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
 :: set JAVA_OPTS=-server -Xmx2048M -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore=../etc/keystores/serverKeystore.jks -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=../etc/keystores/serverTruststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Dddf.home=%DDF_HOME%


### PR DESCRIPTION
#### What does this PR do?
Updates the setenv file to only use posix shell commands (instead of the currently-used bash commands). Also moved the added -D option to the EXTRA_JAVA_OPS environment variable.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver @jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb 
@kcwire
#### How should this be tested?
Unzip and run on ubuntu - verify that the environment variable is added (assuming /bin/sh is pointing to dash instead of bash). You can echo the karaf executable line in the karaf file instead of executing it to see the actual final command execution.
#### Any background context you want to provide?
Installing on CentOS 7 uncovered the fact that the current script was failing and not adding the -D option correctly, resulting in system hang. CentOS 7 by default uses dash instead of bash as /bin/sh.
#### What are the relevant tickets?
DDF-2115
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

