### PR TITLE
DDF-1886 Added admin ui for adding/editing local registry node information

### DIFF
--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -78,6 +78,11 @@
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-admin-local-ui</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
                 <artifactId>registry-policy-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/.bowerrc
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/.bowerrc
@@ -1,0 +1,3 @@
+{
+   "directory": "target/webapp/lib"
+}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/Gruntfile.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/Gruntfile.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global module,require*/
+
+module.exports = function (grunt) {
+
+    require('load-grunt-tasks')(grunt);
+    grunt.loadTasks('src/main/grunt/tasks');
+
+    grunt.initConfig({
+       
+        pkg: grunt.file.readJSON('package.json'),
+
+        clean: {
+          build: ['target/webapp']
+        },
+        bower: {
+            install: {
+                options: {
+                    bowerOptions: {"--offline": true}
+                }
+
+            }
+        },
+        less: {
+            css: {
+                options: {
+                    cleancss: true
+                },
+                files: {
+                    "target/webapp/css/styles.css":"src/main/webapp/less/styles.less"
+                }
+            }
+        },
+        jshint: {
+            files: ['Gruntfile.js', 'src/main/webapp/js/**/*.js'],
+            options: {
+                bitwise: true,        // Prohibits the use of bitwise operators such as ^ (XOR), | (OR) and others.
+                forin: true,          // Requires all for in loops to filter object's items.
+                latedef: true,        // Prohibits the use of a variable before it was defined.
+                newcap: true,         // Requires you to capitalize names of constructor functions.
+                noarg: true,          // Prohibits the use of arguments.caller and arguments.callee. Both .caller and .callee make quite a few optimizations impossible so they were deprecated in future versions of JavaScript.
+                noempty: true,         // Warns when you have an empty block in your code.
+                regexp: true,         // Prohibits the use of unsafe . in regular expressions.
+                undef: true,          // Prohibits the use of explicitly undeclared variables.
+                unused: true,         // Warns when you define and never use your variables.
+                maxlen: 250,          // Set the maximum length of a line to 250 characters.  If triggered, the line should be wrapped.
+                eqeqeq: true,         // Prohibits the use of == and != in favor of === and !==
+
+                // Relaxing Options
+                scripturl: true,      // This option suppresses warnings about the use of script-targeted URLsâ€”such as
+
+                // options here to override JSHint defaults
+                globals: {
+                    console: true,
+                    module: true
+                }
+            }
+        },
+        watch: {
+            jsFiles: {
+                files: ['<%= jshint.files %>'],
+                tasks: ['jshint']
+            },
+            livereload : {
+                options : {livereload :true},
+                files : ['target/webapp/css/style.css'
+                    // this one is more dangerous, tends to reload the page if one file changes
+                    // probably too annoying to be useful, uncomment if you want to try it out
+//                    '<%= jshint.files %>'
+                ]
+            },
+            lessFiles: {
+                files: ['src/main/webapp/less/*.less','src/main/webapp/less/**/*.less','src/main/webapp/less/***/*.less'],
+                tasks: ['less']
+            },
+            bowerFile: {
+                files: ['src/main/webapp/bower.json'],
+                tasks: ['bower']
+            }
+        },
+        express: {
+            options: {
+                port: 8282,
+                hostname: '*'
+            },
+            
+            server: {
+                options: {
+                    server: './server.js'
+                }
+            }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-bower-task');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-less');
+    grunt.loadNpmTasks('grunt-express');
+
+    var buildTasks = ['clean', 'bower-offline-install', 'less', 'jshint'];
+
+    grunt.registerTask('build', buildTasks);
+    grunt.registerTask('default', ['build','express', 'watch']);
+};

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/README.md
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/README.md
@@ -1,0 +1,15 @@
+<!--
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+-->
+# registry-module: The Registry Admin Local Module.
+## Part of [Distributed Data Framework \(DDF\)](http://ddf.codice.org/)
+

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/bower.json
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "catalog-admin-module-registry",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "backbone.modelbinder": "v1.0.5",
+    "components-backbone": "1.1.0",
+    "backbone-poller": "0.2.8",
+    "components-bootstrap": "3.1.1",
+    "components-font-awesome": "4.0.3",
+    "icanhandlebarz": "atomicobject/ICanHandlebarz.js#f6ac1d1f8e1d796045563f1483eca6c4911ed7d1",
+    "bootstrap-multiselect": "v0.9.3",
+    "handlebars": "2.0.0-alpha.2",
+    "html5shiv": "3.7.2",
+    "jquery": "components/jquery#1.11.0",
+    "jquery-ui": "1.10.4",
+    "lodash": "2.4.1",
+    "marionette": "1.8.8",
+    "perfect-scrollbar": "0.4.8",
+    "q": "v1.0.1",
+    "requirejs": "2.1.14",
+    "requirejs-plugins": "v1.0.2",
+    "require-css": "0.1.5",
+    "spin.js": "1.3.3",
+    "bootswatch": "=v3.1.1",
+    "lato": "0.2.0",
+    "moment": "2.5.1",
+    "backbone-associations": "v0.6.2",
+    "iframe-resizer": "2.6.2"
+  },
+  "resolutions": {
+    "jquery": "~1.11.0",
+    "underscore": "~1.8.2"
+  }
+}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/package.json
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "registry-module",
+  "author": "Codice",
+  "description": "The Catalog Admin Registry Module",
+  "version": "2.5.0",
+  "license": "LGPL-3.0",
+  "keywords": [
+    "backbone",
+    "express"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codice/ddf.git"
+  },
+  "engines": {
+    "node": ">=0.10.5"
+  },
+  "devDependencies": {
+    "grunt": "0.4.1",
+    "grunt-cli": "0.1.13",
+    "bower": "1.4.1",
+    "grunt-bower-task": "0.4.0",
+    "grunt-contrib-jshint": "0.3.0",
+    "grunt-contrib-clean": "0.4.0",
+    "grunt-contrib-watch": "0.4.4",
+    "grunt-contrib-cssmin": "0.5.0",
+    "grunt-contrib-less": "0.11.0",
+    "connect-livereload": "0.3.2",
+    "grunt-express": "1.2.1",
+    "load-grunt-tasks": "1.0.0"
+  },
+  "dependencies": {
+    "lodash": "2.4.1",
+    "http-proxy": "0.10.0",
+    "express": "3.3.8",
+    "node-fs": "0.1.7",
+    "node-options": "0.0.3",
+    "path": "0.4.9"
+  }
+}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/pom.xml
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>registry-admin-modules</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>DDF :: Registry :: Admin :: Local UI</name>
+    <artifactId>registry-admin-local-ui</artifactId>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <version>${project.version}</version>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-appservice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>grunt install</id>
+                        <goals>
+                            <goal>grunt</goal>
+                        </goals>
+                        <phase>install</phase>
+                        <configuration>
+                            <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Web-ContextPath>/admin/registry/local</Web-ContextPath>
+                        <_wab>src/main/webapp,${project.build.directory}/webapp</_wab>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/server-impl.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/server-impl.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+var URL = require('url'),
+    httpProxy = require('http-proxy'),
+    proxy = new httpProxy.RoutingProxy(),
+    fs = require('node-fs'),
+    path = require('path'),
+    _ = require('lodash');
+
+function stringFormat(format /* arg1, arg2... */) {
+    if (arguments.length === 0) {
+        return undefined;
+    }
+    if (arguments.length === 1) {
+        return format;
+    }
+    var args = Array.prototype.slice.call(arguments, 1);
+    return format.replace(/\{\{|\}\}|\{(\d+)\}/g, function (m, n) {
+        if (m === "{{") {
+            return "{";
+        }
+        if (m === "}}") {
+            return "}";
+        }
+        return args[n];
+    });
+}
+
+var server = {};
+
+server.requestProxy = function (req, res) {
+    "use strict";
+
+    req.url = "https://localhost:8993" + req.url;
+    var urlObj = URL.parse(req.url);
+    req.url = urlObj.path;
+    // Buffer requests so that eventing and async methods still work
+    // https://github.com/nodejitsu/node-http-proxy#post-requests-and-buffering
+    var buffer = httpProxy.buffer(req);
+    console.log('Proxying Request "' + req.url + '"');
+
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    proxy.proxyRequest(req, res, {
+        host: urlObj.hostname,
+        port: urlObj.port || 80,
+        buffer: buffer,
+        changeOrigin: true,
+        secure: false,
+        target: {
+            https: true
+        }
+    });
+
+};
+
+server.mockQueryServer = function (req, res) {
+    var keyword = req.query.q;
+    var resourceDir = path.resolve('.', 'src/test/resources');
+
+    if (fs.existsSync(resourceDir)) {
+        var files = fs.readdirSync(resourceDir);
+        if (files.length === 0) {
+            var message = stringFormat('There was no file in the resource path \'{0}\'', resourceDir);
+            res.status(404).send(message);
+            res.end();
+        } else if (files.length > 1) {
+            var fileIdx = _.indexOf(files, keyword+".json");
+            if (fileIdx !== -1) {
+                var resourcePath = path.resolve(resourceDir, files[fileIdx]);
+                res.contentType('application/json');
+                res.status(200).send(fs.readFileSync(resourcePath));
+            } else {
+                var message = stringFormat('The specified query does not map to a cached file: \'{0}\'', keyword);
+                res.status(404).send(message);
+                res.end();
+            }
+        } else {
+            var message = stringFormat('The specified resource does not exist.');
+            res.status(404).send(message);
+            res.end();
+        }
+    }
+};
+
+function getTestResource(name) {
+    var resourceDir = path.resolve('.', 'src/test/resources');
+    if (fs.existsSync(resourceDir)) {
+        var resourcePath = path.resolve(resourceDir, name);
+        return fs.readFileSync(resourcePath);
+    }
+    return undefined;
+}
+
+function mockTestResource (name, res) {
+    var resource = getTestResource(name);
+    if (resource) {
+        res.contentType('application/json');
+        res.status(200).send(resource);
+    } else {
+        var message = stringFormat('The specified resource does not exist.');
+        res.status(404).send(message);
+        res.end();
+    }
+}
+
+module.exports = server;

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/server.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/server.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require,__dirname*/
+var express = require('express'),
+    server = require('./server-impl');
+
+var app = express();
+// uncomment to get some debugging
+//app.use(express.logger());
+//enable the live reload
+app.use(require('connect-livereload')());
+
+// our compiled css gets moved to /target/webapp/css so use it there
+app.use('/admin/registry/local',express.static(__dirname + '/target/webapp'));
+app.use('/admin/registry/local',express.static(__dirname + '/src/main/webapp'));
+
+//if we're mocking, it is being run by grunt
+console.log('setting up proxy only');
+app.all('/*', server.requestProxy);
+
+exports = module.exports = app;
+
+exports.use = function() {
+	app.use.apply(app, arguments);
+};

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/grunt/tasks/bower.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/grunt/tasks/bower.js
@@ -1,0 +1,50 @@
+/*
+ * *
+ *  * Copyright (c) Codice Foundation
+ *  *
+ *  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  * General Public License as published by the Free Software Foundation, either version 3 of the
+ *  * License, or any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ *  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ *  * is distributed along with this program and can be found at
+ *  * <http://www.gnu.org/licenses/lgpl.html>.
+ *  *
+ *  *
+ */
+
+module.exports = function(grunt) {
+    grunt.registerTask('bower-offline-install', 'Offline first Bower install', function() {
+        var bower = require('bower');
+        var done = this.async();
+        grunt.log.debug("Trying to install bower packages offline.");
+        bower.commands
+            .install([], {'save': false, 'save-dev': false}, {offline: true})
+            .on('data', function (data) {
+                grunt.log.debug(data);
+            })
+            .on('error', function (data) {
+                grunt.log.debug(data);
+                grunt.log.debug("Trying to install bower packages online.");
+                bower.commands
+                    .install([], {'save': false, 'save-dev': false})
+                    .on('data', function (data) {
+                        grunt.log.debug(data);
+                    })
+                    .on('error', function (data) {
+                        grunt.log.error(data);
+                        done(false);
+                    })
+                    .on('end', function () {
+                        grunt.log.debug("Bower installed online.");
+                        done();
+                    });
+            })
+            .on('end', function () {
+                grunt.log.debug("Bower installed offline.");
+                done();
+            });
+    });
+};

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/java/org/codice/ddf/registry/admin/plugin/RegistryPlugin.java
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/java/org/codice/ddf/registry/admin/plugin/RegistryPlugin.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.admin.plugin;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codice.ddf.admin.application.plugin.AbstractApplicationPlugin;
+
+
+public class RegistryPlugin extends AbstractApplicationPlugin {
+
+    /**
+     * Constructor.
+     */
+    public RegistryPlugin() {
+        this.displayName = "Local Node Information";
+        this.iframeLocation = URI.create("/admin/registry/local/index.html");
+        List<String> apps = new ArrayList<>();
+        apps.add("registry-app");
+        apps.add("catalog-app");
+        this.setAssociations(apps);
+    }
+}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -12,22 +11,15 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>registry</artifactId>
-        <groupId>org.codice.ddf.registry</groupId>
-        <version>2.10.0-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="
+  http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
-    <artifactId>registry-admin-modules</artifactId>
-    <packaging>pom</packaging>
-    <name>DDF :: Registry :: Admin :: Modules</name>
 
-    <modules>
-        <module>registry-admin-local-ui</module>
-    </modules>
+    <bean id="registryLocalPlugin" class="org.codice.ddf.registry.admin.plugin.RegistryPlugin"></bean>
 
-</project>
+    <service interface="org.codice.ddf.admin.application.plugin.ApplicationPlugin"
+             ref="registryLocalPlugin"/>
+
+</blueprint>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/WEB-INF/web.xml
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/j2ee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+	      http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
+
+    <description>Admin UI - Local Node Information</description>
+    <display-name>Admin UI - Local Node Information</display-name>
+
+    <!-- Default page to serve -->
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+
+</web-app>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/index.html
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/index.html
@@ -1,0 +1,39 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>Admin Console - Registry</title>
+    <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
+    <!-- Stylesheets -->
+    <link href="lib/components-font-awesome/css/font-awesome.min.css" rel="stylesheet"/>
+    <link href="lib/bootswatch/flatly/bootstrap.min.css" rel="stylesheet"/>
+    <link href="lib/perfect-scrollbar/min/perfect-scrollbar-0.4.8.min.css" rel="stylesheet"/>
+
+    <link href="css/styles.css" rel="stylesheet"/>
+
+    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+    <script src="lib/html5shiv/dist/html5shiv.js"></script>
+    <![endif]-->
+</head>
+<body>
+<main class="container" role="main"></main>
+<script data-main="main" src="lib/requirejs/require.js"></script>
+<script data-main="main" src="lib/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
+</body>
+</html>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/HandlebarsHelpers.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/HandlebarsHelpers.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'underscore',
+        'handlebars'
+    ],
+    function (ich, _, Handlebars) {
+        "use strict";
+
+        // The module to be exported
+        var helper, helpers = {
+            isNotBlank: function (context, block) {
+                if (context && context !== "") {
+                    return block.fn(this);
+                }
+                else {
+                    return block.inverse(this);
+                }
+            },
+            is: function (value, test, options) {
+                if (value === test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            isnt: function (value, test, options) {
+                if (value !== test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            isUrl: function (value, options) {
+                if (value && value !== "" && _.isString(value)) {
+                    var protocol = value.toLowerCase().split("/")[0];
+                    if (protocol && (protocol === "http:" || protocol === "https:")) {
+                        return options.fn(this);
+                    }
+                }
+                return options.inverse(this);
+            },
+            gt: function (value, test, options) {
+                if (value > test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+
+            gte: function (value, test, options) {
+                if (value >= test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            lt: function (value, test, options) {
+                if (value < test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+
+            lte: function (value, test, options) {
+                if (value <= test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            ifAnd: function () {
+                var args = _.flatten(arguments);
+                var items = _.initial(args);
+                var result = true;
+                var block = _.last(args);
+                _.each(items, function (item) {
+                    if (!item) {
+                        result = false;
+                    }
+                });
+                if (result) {
+                    return block.fn(this);
+                }
+                else {
+                    return block.inverse(this);
+                }
+            },
+            ifOr: function () {
+                var args = _.flatten(arguments);
+                var items = _.initial(args);
+                var result = false;
+                var block = _.last(args);
+                _.each(items, function (item) {
+                    if (item) {
+                        result = true;
+                    }
+                });
+                if (result) {
+                    return block.fn(this);
+                }
+                else {
+                    return block.inverse(this);
+                }
+            },
+            ifNotAnd: function () {
+                var args = _.flatten(arguments);
+                var items = _.initial(args);
+                var result = true;
+                var block = _.last(args);
+                _.each(items, function (item) {
+                    if (!item) {
+                        result = false;
+                    }
+                });
+                if (result) {
+                    return block.inverse(this);
+                }
+                else {
+                    return block.fn(this);
+                }
+            },
+            ifNotOr: function () {
+                var args = _.flatten(arguments);
+                var items = _.initial(args);
+                var result = false;
+                var block = _.last(args);
+                _.each(items, function (item) {
+                    if (item) {
+                        result = true;
+                    }
+                });
+                if (result) {
+                    return block.inverse(this);
+                }
+                else {
+                    return block.fn(this);
+                }
+            },
+            propertyTitle: function (str) {
+                if (_.isString(str)) {
+                    return _.chain(str).words().map(function (word) {
+                        return _.capitalize(word);
+                    }).join(' ');
+                }
+                return str;
+            },
+            safeString: function (str) {
+                if (_.isString(str)) {
+                    return new Handlebars.SafeString(str);
+                }
+                return str;
+            },
+            splitDashes: function (str) {
+                return str.split('-').join(' ');
+            },
+            encodeString: function (str) {
+                if (_.isString(str)) {
+                    return encodeURIComponent(str);
+                }
+                return str;
+            },
+            debug : function() {
+            console.log("Current Context");
+            console.log("====================");
+            console.log(this);
+
+            }
+        };
+
+        // Export helpers
+        for (helper in helpers) {
+            if (helpers.hasOwnProperty(helper)) {
+                ich.addHelper(helper, helpers[helper]);
+            }
+        }
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/application.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/application.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define,require*/
+
+// #Main Application
+define([
+    'marionette',
+    'icanhaz'
+], function (Marionette,ich) {
+    'use strict';
+
+    var Application = {};
+
+    // This was moved from the main.js file into here.
+    // Since this modules has ui components, and it gets loaded before main.js, we need to init the renderer here for now until we sort this out.
+    Marionette.Renderer.render = function (template, data) {
+        if(!template){return '';}
+        return ich[template](data);
+    };
+
+
+    Application.App = new Marionette.Application();
+
+    //add regions
+    Application.App.addRegions({
+        mainRegion: 'main'
+    });
+
+    Application.App.addInitializer(function () {
+        require(['js/module']);
+    });
+
+    return Application;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Association.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Association.js
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/*jshint -W024*/
+define([
+    'backbone',
+    'underscore',
+    'js/model/FieldDescriptors.js',
+    'js/model/Segment.js',
+    'wreqr',
+    'backboneassociation'
+
+
+], function (Backbone, _, FieldDescriptors, Segment, wreqr) {
+
+    var counter = 0;
+
+    function generateId() {
+        counter++;
+        return 'urn:association:id:' + new Date().getTime() + "-" + counter;
+
+    }
+
+    function getSegmentModel(segment, id) {
+        if (segment.get('segmentId') === id) {
+            return segment;
+        }
+        for (var index = 0; index < segment.get('segments').models.length; index++) {
+            var seg = getSegmentModel(segment.get('segments').models[index], id);
+            if (seg) {
+                return seg;
+            }
+        }
+    }
+
+    var Association = {};
+
+    Association.Association = Backbone.AssociatedModel.extend({
+        defaults: {
+            id: undefined,
+            type: undefined,
+            sourceId: undefined,
+            sourceName: undefined,
+            targetId: undefined,
+            targetName: undefined,
+            targetType: undefined
+        },
+        populateFromModel: function (association, topLevelSegment) {
+            if (association) {
+                this.set('id', association.id);
+                this.set('type', association.associationType);
+                this.set('sourceId', association.sourceObject);
+                this.set('targetId', association.targetObject);
+            }
+            var sourceSeg = getSegmentModel(topLevelSegment, this.get('sourceId'));
+            var targetSeg = getSegmentModel(topLevelSegment, this.get('targetId'));
+            this.set('targetType', targetSeg.get('segmentType'));
+            this.set('sourceName', sourceSeg.constructTitle ? sourceSeg.constructTitle() : sourceSeg.getField('Name').get('value'));
+            this.set('targetName', targetSeg.constructTitle ? targetSeg.constructTitle() : targetSeg.getField('Name').get('value'));
+        }
+
+    });
+    Association.Associations = Backbone.Collection.extend({
+        model: Association.Association
+    });
+
+    Association.AssociationModel = Backbone.AssociatedModel.extend({
+        relations: [
+            {
+                type: Backbone.Many,
+                key: 'associations',
+                collectionType: function () {
+                    return Association.Associations;
+                },
+                relatedModel: function () {
+                    return Association.Association;
+                }
+            },
+            {
+                type: Backbone.Many,
+                key: 'associationSegments',
+                collectionType: function () {
+                    return Association.SegmentIds;
+                },
+                relatedModel: function () {
+                    return Association.SegmentId;
+                }
+            },
+            {
+                type: Backbone.One,
+                key: 'topSegment',
+                relatedModel: function () {
+                    return Segment.Segment;
+                }
+            }
+        ],
+        defaults: {
+            associations: [],
+            associationSegments: [],
+            topSegment: null
+        },
+        populateFromModel: function (associations) {
+            var model = this;
+            var collectionModel = this.get('associations');
+            this.dataModel = associations;
+            _.each(associations, function (association) {
+                var newAssociation = new Association.Association();
+                newAssociation.populateFromModel(association, model.get('topSegment'));
+                collectionModel.add(newAssociation);
+            });
+            this.populateAssociationSegmentIds(this.get('topSegment'));
+        },
+        addAssociation: function (source, target, type) {
+            var association = new Association.Association({
+                id: generateId(),
+                sourceId: source,
+                targetId: target,
+                type: type
+            });
+            association.populateFromModel(undefined, this.get('topSegment'));
+            this.get('associations').add(association);
+            return association;
+        },
+        removeAssociation: function (id) {
+            var removedAssociation = _.find(this.get('associations').models, function (association) {
+                return association.get('id') === id;
+            });
+            this.get('associations').remove(removedAssociation);
+            return removedAssociation;
+        },
+        removeSegment: function (segment) {
+            var model = this;
+            var updatedAssociations = [];
+            var associations = this.get('associations').models;
+            var segId = segment.get('segmentId');
+            _.each(associations, function (association) {
+                if (association.get('sourceId') !== segId && association.get('targetId') !== segId) {
+                    updatedAssociations.push(association);
+                }
+            });
+            this.set('associations', updatedAssociations);
+
+            var seg = _.find(this.get('associationSegments').models, function (seg) {
+                return seg.get('segmentId') === segId;
+            });
+            this.get('associationSegments').remove(seg);
+            _.each(segment.get('segments').models, function(curSeg){
+               if(FieldDescriptors.isCustomizableSegment(curSeg.get('segmentType'))){
+                   model.removeSegment(curSeg);
+               }
+            });
+            wreqr.vent.trigger('associationSegmentRemoved',segId);
+        },
+        getAssociationsForId: function (id) {
+            var associations = this.get('associations').models;
+            var results = [];
+            _.each(associations, function (association) {
+                if (association.get('sourceId') === id) {
+                    results.push(association);
+                }
+            });
+            return results;
+        },
+        getAvailableAssociationSegments: function (id) {
+            var segs = [];
+            var curAssociations = this.getAssociationsForId(id);
+            var model = this;
+            var allSegs = this.get('associationSegments').models;
+            _.each(allSegs, function (seg) {
+                if (seg.get('segmentId') !== id && !model.existingAssociation(curAssociations, seg.get('segmentId'))) {
+                    segs.push(seg.attributes);
+                }
+            });
+            return segs;
+        },
+        existingAssociation: function (associations, id) {
+            for (var index = 0; index < associations.length; index++) {
+                if (associations[index].get('targetId') === id) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        populateAssociationSegmentIds: function (segment) {
+            if (segment && FieldDescriptors.isCustomizableSegment(segment.get("segmentType")) && segment.get('fields').models.length > 0) {
+                this.get('associationSegments').push(new Association.SegmentId({
+                    segmentId: segment.get('segmentId'),
+                    segmentType: segment.get('segmentType'),
+                    segmentName: segment.constructTitle ? segment.constructTitle() : segment.getField('Name').get('value')
+                }));
+            }
+            var model = this;
+            if (segment.get('segments') && segment.get('segments').models) {
+                segment.get('segments').models.forEach(function (seg) {
+                    model.populateAssociationSegmentIds(seg);
+                });
+            }
+        },
+        addAssociationSegment: function(id, type, name){
+            if(FieldDescriptors.isCustomizableSegment(type)) {
+                this.get('associationSegments').add(new Association.SegmentId({
+                    segmentId: id,
+                    segmentType: type,
+                    segmentName: name
+                }));
+                wreqr.vent.trigger('associationSegmentAdded', id);
+            }
+        },
+        saveData: function () {
+            var data = this.dataModel;
+            this.dataModel.length = 0;
+            var associations = this.get('associations').models;
+            _.each(associations, function (association) {
+                data.push({
+                    targetObject: association.get('targetId'),
+                    associationType: association.get('type'),
+                    sourceObject: association.get('sourceId'),
+                    id: association.get('id')
+                });
+
+            });
+        }
+    });
+
+    Association.SegmentId = Backbone.AssociatedModel.extend({
+        defaults: {
+            segmentId: undefined,
+            segmentType: undefined,
+            segmentName: undefined
+        }
+    });
+
+    Association.SegmentIds = Backbone.Collection.extend({
+        model: Association.SegmentId
+    });
+
+    return Association;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Field.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Field.js
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/*jshint -W024*/
+define([
+    'backbone',
+    'underscore',
+    'js/model/FieldDescriptors.js',
+    'wreqr',
+    'jquery',
+    'backboneassociation'
+
+
+], function (Backbone, _, FieldDescriptors, wreqr) {
+
+    function getSlot(slots, key) {
+        for (var index = 0; index < slots.length; index++) {
+            if (slots[index].name === key) {
+                return slots[index];
+            }
+        }
+    }
+
+
+    var Field = {};
+
+    Field.FormField = Backbone.AssociatedModel.extend({
+        defaults: {
+            key: '',
+            name: 'unknown',
+            desc: 'none',
+            type: 'string',  //string,boolean,decimal,integer,data,time,point,bounds,custom
+            value: undefined,
+            custom: false,
+            isSlot: false,
+            multiValued: false,
+            editable: true,
+            required: false
+
+        },
+        addValue: function (val) {
+            if (!this.get('value')) {
+                this.set('value', [val]);
+            } else if (_.isArray(this.get('value'))) {
+                this.get('value').push(val);
+            } else {
+                this.set('value', [this.get('value'), val]);
+            }
+            this.set('value' + (this.get('value').length - 1), val);
+        },
+        removeValue: function (index) {
+            var values = this.get('value');
+            for (var count = 0; count < values.length; count++){
+                values[count] = this.get('value'+count);
+            }
+
+            values.splice(index, 1);
+            for (count = 0; count < values.length; count++) {
+                this.set('value' + count, values[count]);
+            }
+            this.unset('value' + values.length);
+        },
+        validate: function() {
+            var error;
+            var indices = [];
+            if(!this.get('value') && !this.get('regex') && !this.get('required')){
+                if(this.hadError){
+                    this.hadError = undefined;
+                    wreqr.vent.trigger('fieldErrorChange:'+this.get('key'));
+                }
+                return;
+            }
+
+            var regex;
+            if(this.get('regex')){
+                var flags = this.get('regex').replace(/.*\/([gimy]*)$/, '$1');
+                var pattern = this.get('regex').replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
+                regex = new RegExp(pattern, flags);
+            }
+
+            if(!this.get('multiValued')) {
+                if(this.get('type') === 'number'){
+                    if(this.get('min') && this.get('value') < this.get('min')){
+                        error = 'Value is less than minimum of ' + this.get('min');
+                    } else if (this.get('max') && this.get('value') > this.get('max')) {
+                        error =  'Value is greater than maximum of ' + this.get('max');
+                    }
+                } else if(this.get('type') === 'string' && regex){
+                    if(!regex.test(this.get('value'))){
+                        error =  this.get('regexMessage') ? this.get('regexMessage') : 'Invalid input value. Must match ' + this.get('regex');
+                    }
+                } else if(this.get('type') === 'point'){
+                    if(this.get('valueLat') && (this.get('valueLat') > 90 || this.get('valueLat') < -90)){
+                        error = 'Invalid decimal latitude value. Must be -90 < lat < 90';
+                    } else if(this.get('valueLon') && (this.get('valueLon') > 180 || this.get('valueLon')< -180)){
+                        error = 'Invalid decimal longitude value. Must be -180 < lat < 180';
+                    }
+                }
+            } else {
+                if(this.get('type') === 'string' && regex) {
+                    for (var index = 0; index < this.get('value').length; index++) {
+                        if(this.get('value' + index)) {
+                            if (!regex.test(this.get('value' + index))) {
+                                indices.push(index);
+                                error = this.get('regexMessage') ? this.get('regexMessage') : 'Invalid input value. Must match ' + this.get('regex');
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!error && (!this.get('value') || (_.isArray(this.get('value')) && this.get('value').length === 0) ) && this.get('required')) {
+                error = 'Required Field';
+            }
+
+            this.errorIndices = indices;
+            if((!this.hadError && error) || (!error && this.hadError)){
+                this.hadError = error;
+                wreqr.vent.trigger('fieldErrorChange:'+this.get('key'));
+            }
+            wreqr.vent.trigger('fieldChanged:'+this.get('parentId'));
+            return error;
+        },
+        saveData: function(backingData, ebrimTypes) {
+            if(this.validationError){
+                return this.validationError;
+            }
+            if (!this.get('isSlot')) {
+                if (this.get('value') && !(_.isArray(this.get('value')) && this.get('value').length === 0)) {
+                    backingData[this.get('key')] = this.get('value');
+                } else if( backingData[this.get('key')]){
+                    delete backingData[this.get('key')];
+                }
+
+            } else {
+                var slot = getSlot(backingData.Slot, this.get('key'));
+                var newSlot = false;
+                if (!slot) {
+                    slot = {
+                        slotType: ebrimTypes[this.get('type')],
+                        name: this.get('key')
+                    };
+                    newSlot = true;
+                }
+                slot.value = undefined;
+
+                if (this.get('type') === 'date') {
+                    if (this.get('valueDate')) {
+                        var time = '00:00';
+                        if (this.get('valueTime')) {
+                            time = this.get('valueTime');
+                        }
+                        slot.value = [this.get('valueDate') + 'T' + time + 'Z'];
+                    }
+                } else if (this.get('type') === 'point') {
+                    if (this.get('valueLat') && this.get('valueLon')) {
+                        slot.value = {
+                            Point: {
+                                srsName: 'urn:ogc:def:crs:EPSG::4326',
+                                srsDimension: 2,
+                                pos:  this.get('valueLon') + ' ' +this.get('valueLat') 
+                            }
+                        };
+                    }
+                } else if (this.get('type') === 'boolean') {
+                    slot.value = this.get('value') ? 'true' : 'false';
+                } else if (this.get('multiValued')) {
+                    var values = [];
+                    for (var index = 0; index < this.get('value').length; index++) {
+                        if(this.get('value' + index)) {
+                            values.push(this.get('value' + index));
+                        }
+                    }
+                    slot.value = values.length > 0 ? values : undefined;
+                } else {
+                    if (this.get('value')) {
+                        slot.value = this.get('value');
+                    }
+                }
+
+                if (newSlot && slot.value) {
+                    backingData.Slot.push(slot);
+                }
+
+                if (!newSlot && !slot.value) {
+                    var slotIndex = backingData.Slot.map(function (e) {
+                        return e.name;
+                    }).indexOf(slot.name);
+                    backingData.Slot.splice(slotIndex, 1);
+                }
+            }
+        }
+    });
+
+    Field.FormFields = Backbone.Collection.extend({
+        model: Field.FormField
+    });
+
+    return Field;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/FieldDescriptors.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/FieldDescriptors.js
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+//get descriptors for well known registry slot fields.
+/*global define*/
+define(['underscore'], function (_) {
+    var FieldDescriptors = {
+        isCustomizableSegment: function (name) {
+            return _.contains(['General', 'Person', 'Service', 'ServiceBinding', 'Content', 'Organization'], name);
+        },
+        isContainerOnly: function (name) {
+            return _.contains(['Address', 'TelephoneNumber', 'EmailAddress'], name);
+        },
+
+        getSlotTypes: function () {
+            return {
+                string: 'xs:string',
+                date: 'xs:dateTime',
+                number: 'xs:decimal',
+                boolean: 'xs:boolean',
+                point: 'urn:ogc:def:dataType:ISO-19107:2003:GM_Point'
+            };
+        },
+        getFieldType: function (name) {
+            var types = this.getSlotTypes();
+            var fieldType;
+            _.each(_.keys(types), function (key) {
+                if (types[key] === name) {
+                    fieldType = key;
+                }
+            });
+            return fieldType;
+        },
+        retrieveFieldDescriptors: function () {
+            var descriptors = {
+                General: {
+                    Name: {
+                        displayName: 'Node Name',
+                        description: 'This node\'s name as it should appear to external systems',
+                        values: [],
+                        type: 'string',
+                        regex: '/^(\\w|\\d)/',
+                        regexMessage: "Must supply a name starting with a letter or digit",
+                        required: true
+                    },
+                    Description: {
+                        displayName: 'Node Description',
+                        description: 'Short description for this node',
+                        values: [],
+                        type: 'string'
+                    },
+                    VersionInfo: {
+                        displayName: 'Node Version',
+                        description: 'This node\'s Version',
+                        values: [],
+                        type: 'string'
+                    }
+                },
+                Organization: {
+                    Name: {
+                        displayName: 'Organization Name',
+                        description: 'This organization\'s name',
+                        values: [],
+                        type: 'string',
+                        required: true
+                    },
+                    Address: {
+                        isGroup: true,
+                        displayName: "Address",
+                        multiValued: true,
+                        constructTitle: this.constructAddressTitle
+                    },
+                    TelephoneNumber: {
+                        isGroup: true,
+                        displayName: "Phone Number",
+                        multiValued: true,
+                        constructTitle: this.constructPhoneTitle
+                    },
+                    EmailAddress: {
+                        isGroup: true,
+                        displayName: "Email",
+                        multiValued: true,
+                        constructTitle: this.constructEmailTitle
+                    }
+                },
+                Person: {
+                    Name: {
+                        displayName: 'Contact Title',
+                        description: 'Contact Title',
+                        values: [],
+                        type: 'string'
+                    },
+                    PersonName: {
+                        isGroup: true,
+                        multiValued: false
+                    },
+                    Address: {
+                        isGroup: true,
+                        displayName: "Address",
+                        multiValued: true,
+                        constructTitle: this.constructAddressTitle
+                    },
+                    TelephoneNumber: {
+                        isGroup: true,
+                        displayName: "Phone Number",
+                        multiValued: true,
+                        constructTitle: this.constructPhoneTitle
+                    },
+                    EmailAddress: {
+                        isGroup: true,
+                        displayName: "Email",
+                        multiValued: true,
+                        constructTitle: this.constructEmailTitle
+                    }
+                },
+                Service: {
+                    Name: {
+                        displayName: 'Service Name',
+                        description: 'This service name',
+                        values: [],
+                        type: 'string'
+                    },
+                    Description: {
+                        displayName: 'Service Description',
+                        description: 'Short description for this service',
+                        values: [],
+                        type: 'string'
+                    },
+                    VersionInfo: {
+                        displayName: 'Service Version',
+                        description: 'This service version',
+                        values: [],
+                        type: 'string'
+                    },
+                    objectType: {
+                        displayName: 'Service Type',
+                        description: 'Identifies the type of service this is by a urn',
+                        values: 'urn:registry:federation:service',
+                        type: 'string',
+                        multiValued: false
+                    },
+                    ServiceBinding: {
+                        isGroup: true,
+                        displayName: 'Bindings',
+                        multiValued: true,
+                        constructTitle: this.constructNameVersionTitle,
+                        autoPopulateFunction: this.populateFromEndpointProps,
+                        autoPopulateId: 'id',
+                        autoPopulateName: 'name'
+                    }
+                },
+                ServiceBinding: {
+                    Name: {
+                        displayName: 'Binding Name',
+                        description: 'This binding name',
+                        values: [],
+                        type: 'string'
+                    },
+                    Description: {
+                        displayName: 'Binding Description',
+                        description: 'Short description for this binding',
+                        values: [],
+                        type: 'string'
+                    },
+                    VersionInfo: {
+                        displayName: 'Binding Version',
+                        description: 'This binding version',
+                        values: [],
+                        type: 'string'
+                    },
+                    accessUri: {
+                        displayName: 'Access URL',
+                        description: 'The url used to access this binding',
+                        values: [],
+                        type: 'string',
+                        required: true
+                    }
+                },
+                Content: {
+                    Name: {
+                        displayName: 'Content Name',
+                        description: 'Name for this metadata content',
+                        values: [],
+                        type: 'string',
+                        required: true
+                    },
+                    Description: {
+                        displayName: 'Content Description',
+                        description: 'Short description for this metadata content',
+                        values: [],
+                        type: 'string'
+                    },
+                    objectType: {
+                        displayName: 'Content Object Type',
+                        description: 'The kind of content object this will be. Default value should be used in most cases.',
+                        type: 'string',
+                        values: 'urn:registry:content:collection',
+                        multiValued: false
+                    }
+                },
+                PersonName: {
+                    firstName: {
+                        displayName: 'First Name',
+                        description: 'First name',
+                        values: [],
+                        type: 'string'
+                    },
+                    lastName: {
+                        displayName: 'Last Name',
+                        description: 'Last name',
+                        values: [],
+                        type: 'string',
+                        required: true
+                    }
+                },
+                TelephoneNumber: {
+                    phoneType: {
+                        displayName: 'Phone Type',
+                        description: 'Phone type could be work, home, mobile etc.',
+                        type: 'string'
+                    },
+                    countryCode: {
+                        displayName: 'Country Code',
+                        description: 'Country code, i.e. USA=1',
+                        type: 'number',
+                        value: 1
+                    },
+                    areaCode: {
+                        displayName: 'Area Code',
+                        description: 'Area Code',
+                        type: 'number'
+                    },
+                    number: {
+                        displayName: 'Number',
+                        description: 'Number',
+                        type: 'string',
+                        required: true
+                    },
+                    extension: {
+                        displayName: 'Extension',
+                        description: 'Extension',
+                        type: 'number'
+                    }
+                },
+                EmailAddress: {
+                    type: {
+                        displayName: 'Email Type',
+                        description: 'Email Type could be work, personal, primary etc.',
+                        values: [],
+                        type: 'string'
+                    },
+                    address: {
+                        displayName: 'Address',
+                        description: 'Email Address',
+                        values: [],
+                        type: 'string',
+                        required: true
+                    }
+                },
+                Address: {
+                    street: {
+                        displayName: 'Street',
+                        description: 'Street',
+                        values: [],
+                        type: 'string'
+                    },
+                    city: {
+                        displayName: 'City',
+                        description: 'City',
+                        values: [],
+                        type: 'string'
+                    },
+                    country: {
+                        displayName: 'Country',
+                        description: 'Country',
+                        values: [],
+                        type: 'string'
+                    },
+                    stateOrProvince: {
+                        displayName: 'State or Province',
+                        description: 'State or Province',
+                        values: [],
+                        type: 'string'
+                    },
+                    postalCode: {
+                        displayName: 'Postal Code',
+                        description: 'Postal Code',
+                        values: [],
+                        type: 'string'
+                    }
+                }
+            };
+            if (this.customSlots) {
+                for (var prop in this.customSlots) {
+                    if (this.customSlots.hasOwnProperty(prop)) {
+                        this.mixInCustomSlots(descriptors[prop], this.customSlots[prop]);
+                    }
+                }
+            }
+            return descriptors;
+        },
+        mixInCustomSlots: function (base, custom) {
+            for (var prop in custom) {
+                if (custom.hasOwnProperty(prop)) {
+                    base[prop] = custom[prop];
+                    base[prop].isSlot = true;
+                }
+            }
+        },
+        constructEmailTitle: function () {
+            var title = [];
+            title.push(this.getField('type').get('value'));
+            title.push(this.getField('address').get('value'));
+            var stringTitle = title.filter(function(val){return val !== undefined;}).join(' ').trim();
+            if (!stringTitle) {
+                stringTitle = 'Empty Email';
+            }
+            return stringTitle;
+        },
+        constructPhoneTitle: function () {
+            var title = [];
+            title.push(this.getField('phoneType').get('value'));
+            if (this.getField('areaCode').get('value')) {
+                title.push('(' + this.getField('areaCode').get('value') + ')' );
+            }
+            title.push(this.getField('number').get('value'));
+            if (this.getField('extension').get('value')) {
+                title.push(' x' + this.getField('extension').get('value'));
+            }
+            var stringTitle = title.filter(function(val){return val !== undefined;}).join(' ').trim();
+            if (!stringTitle || stringTitle === '()  x') {
+                stringTitle = 'Empty Phone Number';
+            }
+            return stringTitle;
+        },
+        constructAddressTitle: function () {
+            var title = [];
+            title.push(this.getField('street').get('value'));
+            title.push(this.getField('city').get('value'));
+            title.push(this.getField('stateOrProvince').get('value'));
+            var stringTitle = title.filter(function(val){return val !== undefined;}).join(' ').trim();
+            if (!stringTitle) {
+                stringTitle = 'Empty Address';
+            }
+            return stringTitle;
+        },
+        constructNameTitle: function () {
+            var title = this.getField('Name').get('value');
+            if (!title || (_.isArray(title) && title.length === 0)) {
+                title = this.get('segmentType');
+            }
+            return title;
+        },
+        constructNameVersionTitle: function () {
+            var name = this.getField('Name').get('value');
+            var version = this.getField('VersionInfo').get('value');
+            var title;
+            if (!name || (_.isArray(name) && name.length === 0)) {
+                title = this.get('segmentType');
+            } else {
+                title = name + '  Version: ' + version;
+            }
+            return title;
+        },
+        constructPersonNameTitle: function () {
+            var personName;
+            for (var index = 0; index < this.get('segments').models.length; index++) {
+                if (this.get('segments').models[index].get('segmentType') === 'PersonName') {
+                    personName = this.get('segments').models[index];
+                    break;
+                }
+            }
+            var title = [];
+            if (personName) {
+                title.push(personName.getField('firstName').get('value'));
+                title.push(personName.getField('lastName').get('value'));
+                if (this.getField('Name').get('value').length > 0) {
+                    title.push(' [ ' + this.getField('Name').get('value') + ' ]');
+                }
+            }
+
+            var stringTitle = title.filter(function(val){return val !== undefined;}).join(' ').trim();
+            if (!stringTitle) {
+                stringTitle = this.get('segmentType');
+            }
+            return stringTitle;
+        },
+        populateFromEndpointProps: function (segment, prePopObj) {
+            segment.getField('Name').set('value', prePopObj.name);
+            segment.getField('Description').set('value', prePopObj.description);
+            segment.getField('VersionInfo').set('value', prePopObj.version);
+            segment.getField('accessUri').set('value', prePopObj.url);
+
+            for (var prop in prePopObj) {
+                if (prePopObj.hasOwnProperty(prop) && prop !== 'name' && prop !== 'description' && prop !== 'version' && prop !== 'accessURI' && prop !== 'id') {
+                    var field = segment.getField(prop);
+                    if (!field) {
+                        segment.addField(prop, 'string', [prePopObj[prop]]);
+
+                    } else {
+                        segment.setFieldValue(field, [prePopObj[prop]]);
+                    }
+                }
+            }
+        }
+    };
+    return FieldDescriptors;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/*jshint -W024*/
+define([
+    'backbone',
+    'underscore',
+    'js/model/FieldDescriptors.js',
+    'js/model/Segment.js',
+    'js/model/Association.js',
+    'jquery',
+    'wreqr',
+    'backboneassociation'
+
+
+], function (Backbone, _, FieldDescriptors, Segment, Association, $, wreqr) {
+
+    var Node = {};
+
+    Node.Model = Backbone.Model.extend({
+        createUrl: '/admin/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/createLocalEntry',
+        updateUrl: '/admin/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/updateLocalEntry',
+
+        initialize: function () {
+            this.descriptors = FieldDescriptors.retrieveFieldDescriptors();
+            var model = this;
+            if (!model.get('id')) {
+                model.set('id', 'temp-id'); //this id will be replaced on the server with a real uuid
+            }
+
+            if (!model.get('objectType')) {
+                model.set('objectType', 'urn:registry:federation:node');
+            }
+
+            if (!model.get('RegistryObjectList')) {
+                model.set('RegistryObjectList', {});
+            }
+
+            if (!model.get('RegistryObjectList').ExtrinsicObject) {
+                model.get('RegistryObjectList').ExtrinsicObject = [];
+            }
+
+            var nodeDef = this.getObjectOfType('urn:registry:federation:node');
+            if (!nodeDef || nodeDef.length === 0) {
+                model.get('RegistryObjectList').ExtrinsicObject.push({
+                    id: 'urn:registry:node',
+                    objectType: 'urn:registry:federation:node',
+                    Name: ''
+                });
+            }
+
+            if (!model.get('RegistryObjectList').Service) {
+                model.get('RegistryObjectList').Service = [];
+            }
+
+
+            if (!model.get('RegistryObjectList').Organization) {
+                model.get('RegistryObjectList').Organization = [];
+            }
+
+            if (!model.get('RegistryObjectList').Person) {
+                model.get('RegistryObjectList').Person = [];
+            }
+
+            if (!model.get('RegistryObjectList').Association) {
+                model.get('RegistryObjectList').Association = [];
+            }
+
+
+            this.refreshData();
+
+        },
+        refreshData: function () {
+            this.associationModel = new Association.AssociationModel({
+                associations: new Association.Associations(),
+                associationSegments: new Association.SegmentIds(),
+                topSegment: new Segment.Segment()
+            });
+            
+            this.generalInfo = new Segment.Segment({
+                segmentName: 'General Information',
+                multiValued: false,
+                segmentType: 'General',
+                associationModel: this.associationModel
+            });
+            this.generalInfo.populateFromModel(this.getObjectOfType('urn:registry:federation:node'), this.descriptors);
+
+            this.serviceInfo = new Segment.Segment({
+                segmentName: 'Services',
+                multiValued: true,
+                segmentType: 'Service',
+                associationModel: this.associationModel
+            });
+            this.serviceInfo.constructTitle = FieldDescriptors.constructNameTitle;
+            this.serviceInfo.populateFromModel(this.get('RegistryObjectList').Service, this.descriptors);
+
+            this.organizationInfo = new Segment.Segment({
+                segmentName: 'Organizations',
+                multiValued: true,
+                segmentType: 'Organization',
+                associationModel: this.associationModel
+            });
+            this.organizationInfo.constructTitle = FieldDescriptors.constructNameTitle;
+            this.organizationInfo.populateFromModel(this.get('RegistryObjectList').Organization, this.descriptors);
+
+            this.contactInfo = new Segment.Segment({
+                segmentName: 'Contacts',
+                multiValued: true,
+                segmentType: 'Person',
+                associationModel: this.associationModel
+            });
+            this.contactInfo.constructTitle = FieldDescriptors.constructPersonNameTitle;
+            this.contactInfo.populateFromModel(this.get('RegistryObjectList').Person, this.descriptors);
+
+            this.contentInfo = new Segment.Segment({
+                segmentName: 'Content Collections',
+                multiValued: true,
+                segmentType: 'Content',
+                associationModel: this.associationModel
+            });
+            this.contentInfo.constructTitle = FieldDescriptors.constructNameTitle;
+            var extrinsics = this.get('RegistryObjectList').ExtrinsicObject;
+            var contentOnly = _.without(extrinsics, _.findWhere(extrinsics, {objectType: 'urn:registry:federation:node'}));
+            this.contentInfo.populateFromModel(contentOnly, this.descriptors);
+
+            this.associationModel.get('topSegment').set('segments', new Backbone.Collection([this.generalInfo, this.serviceInfo, this.organizationInfo, this.contactInfo, this.contentInfo]));
+            this.associationModel.populateFromModel(this.get('RegistryObjectList').Association);
+        },
+        saveData: function () {
+            this.generalInfo.saveData();
+            this.serviceInfo.saveData();
+            this.organizationInfo.saveData();
+            this.contactInfo.saveData();
+            this.contentInfo.saveData();
+            var model = this;
+            model.get('RegistryObjectList').ExtrinsicObject = [this.generalInfo.get('backingData')[0]];
+            _.each(this.contentInfo.get('backingData'), function (content) {
+                model.get('RegistryObjectList').ExtrinsicObject.push(content);
+            });
+            this.associationModel.saveData();
+        },
+        validate: function(){
+            var errors = [];
+            this.appendErrors(errors, this.generalInfo.validate());
+            this.appendErrors(errors, this.serviceInfo.validate());
+            this.appendErrors(errors, this.organizationInfo.validate());
+            this.appendErrors(errors, this.contactInfo.validate());
+            this.appendErrors(errors, this.contentInfo.validate());
+            if(errors.length > 0){
+                return errors;
+            }
+            //no errors save data to backingData
+            this.saveData();
+        },
+        appendErrors: function(errorArray,errors){
+          if(errors){
+              _.each(errors, function(error){
+                 errorArray.push(error);
+              });
+          }
+        },
+        sync: function () {
+
+            var model = this;
+            var mbean = 'org.codice.ddf.registry:type=FederationAdminMBean';
+            var operation = 'updateLocalEntry(java.util.Map)';
+            var url = this.updateUrl;
+            var curId = model.get('id');
+            var addOperation = false;
+            if (curId === 'temp-id') {
+                addOperation = true;
+                operation = 'createLocalEntry(java.util.Map)';
+                url = this.createUrl;
+                model.unset("id", {silent: true});
+            }
+
+            var data = {
+                type: 'EXEC',
+                mbean: mbean,
+                operation: operation
+            };
+
+            data.arguments = [model];
+            data = JSON.stringify(data);
+            var response = $.ajax({
+                type: 'POST',
+                contentType: 'application/json',
+                data: data,
+                url: url
+            });
+            response.addOperation = addOperation;
+            return response;
+        },
+        getObjectOfType: function (type) {
+            var foundObjects = [];
+            var prop;
+            var registryList = this.get('RegistryObjectList');
+            for (prop in registryList) {
+                if (registryList.hasOwnProperty(prop)) {
+                    var objArray = registryList[prop];
+                    for (var i = 0; i < objArray.length; i++) {
+                        if (objArray[i].objectType === type) {
+                            foundObjects.push(objArray[i]);
+                        }
+                    }
+                }
+            }
+            return foundObjects.length > 0 ? foundObjects : [];
+        }
+    });
+
+    Node.Models = Backbone.Collection.extend({
+        model: Node.Model,
+        url: '/admin/jolokia/read/org.codice.ddf.registry:type=FederationAdminMBean/LocalNodes',
+        deleteUrl: '/admin/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/deleteLocalEntry',
+
+        parse: function (raw) {
+            FieldDescriptors.customSlots = raw.value.customSlots;
+            FieldDescriptors.autoPopulateValues = raw.value.autoPopulateValues;
+            return raw.value.nodes;
+        },
+        getSecondaryNodes: function() {
+            return this.models.filter(function(model){
+                var transValues = model.get('TransientValues');
+                return transValues && !transValues['registry-identity-node'] && transValues['registry-local-node'];
+            });
+        },
+        getIdentityNode: function(){
+            var array = this.models.filter(function(model){
+                return model.get('TransientValues') && model.get('TransientValues')['registry-identity-node'];
+            });
+            if(array.length === 1){
+                array[0].set('identityNode',true);
+                return array[0];
+            }
+            return undefined;
+        },
+        deleteNodes: function (nodes) {
+            var mbean = 'org.codice.ddf.registry:type=FederationAdminMBean';
+            var operation = 'deleteLocalEntry';
+
+            var data = {
+                type: 'EXEC',
+                mbean: mbean,
+                operation: operation
+            };
+
+            data.arguments = [nodes];
+            data = JSON.stringify(data);
+
+            return $.ajax({
+                type: 'POST',
+                contentType: 'application/json',
+                data: data,
+                url: this.deleteUrl
+            }).success(function () {
+                wreqr.vent.trigger('nodeDeleted');
+            });
+        }
+
+    });
+
+    return Node;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Segment.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Segment.js
@@ -1,0 +1,464 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/*jshint -W024*/
+define([
+    'backbone',
+    'underscore',
+    'js/model/FieldDescriptors.js',
+    'js/model/Field.js',
+    'jquery',
+    'backboneassociation'
+
+
+], function (Backbone, _, FieldDescriptors, Field) {
+
+    var counter = 0;
+
+    function addValueFields(field, values) {
+        var properties = {};
+        properties.value = values;
+        if (_.isArray(values)) {
+            for (var i = 0; i < values.length; i++) {
+                properties['value' + i] = values[i];
+            }
+        } else if (values && field.get('type') === 'date') {
+            var normalizedDateTime = new Date(values).toISOString();
+            var dateTimeParts = normalizedDateTime.split('T');
+            properties.valueDate = dateTimeParts[0];
+            if (dateTimeParts.length === 2) {
+                properties.valueTime = dateTimeParts[1].substring(0, dateTimeParts[1].length - 1);
+            }
+        } else if (values && field.get('type') === 'point') {
+            properties.valueLat = values.coords[1];
+            properties.valueLon = values.coords[0];
+        }
+        field.set(properties);
+    }
+
+    function addSlotFields(array, backingData, descriptors, segId) {
+
+        var addedSlots = [];
+        _.each(_.keys(descriptors), function (name) {
+            var entry = descriptors[name];
+            if (entry.isSlot) {
+                var field = new Field.FormField({
+                    key: name,
+                    name: entry.displayName,
+                    desc: entry.description,
+                    type: entry.type,
+                    isSlot: true,
+                    required: entry.required ? entry.required : false,
+                    multiValued: entry.multiValued ? entry.multiValued : false,
+                    min: entry.min,
+                    max: entry.max,
+                    regex: entry.regex,
+                    regexMessage: entry.regexMessage,
+                    possibleValues: entry.possibleValues,
+                    editable: entry.editable,
+                    parentId: segId
+                });
+                var slotFound = false;
+                _.each(backingData.Slot, function (slot) {
+                    if (slot.name === name) {
+                        slotFound = true;
+                        var values = getSlotValue(slot, entry.type, entry.multiValued);
+                        if(!values || (_.isArray(values) && values.length === 0)) {
+                            if(entry.values){
+                                if(_.isArray(entry.values)){
+                                    values = entry.values.slice(0);
+                                } else {
+                                    values = entry.values;
+                                }
+                            }
+                        }
+                        addValueFields(field, values);
+                        addedSlots.push(name);
+                    }
+                });
+                if(!slotFound && entry.values){
+                    var values = [];
+                    if(_.isArray(entry.values)){
+                        values = entry.values.slice(0);
+                    } else {
+                        values = entry.values;
+                    }
+                    addValueFields(field, values);
+                }
+                field.on('change', field.validate, field);
+                array.push(field);
+            }
+        });
+
+        //add custom slots
+        _.each(backingData.Slot, function (slot) {
+            if (!_.contains(addedSlots, slot.name)) {
+                var type = FieldDescriptors.getFieldType(slot.slotType);
+                if (!type) {
+                    type = slot.slotType;
+                }
+                var field = new Field.FormField({
+                    key: slot.name,
+                    name: slot.name,
+                    type: type,
+                    custom: true,
+                    isSlot: true,
+                    multiValued: type === 'string',
+                    parentId: segId
+                });
+                addValueFields(field, getSlotValue(slot, type, field.get('multiValued')));
+                field.on('change', field.validate, field);
+                array.push(field);
+            }
+        });
+    }
+
+    function getSlotValue(slot, type, multiValued) {
+        if (_.isArray(slot.value)) { //ebrim value list
+            if (multiValued) {
+                return slot.value.slice(0);
+            }if (type === 'boolean') {
+                return slot.value[0] === 'true' ? true : false;
+            }
+            return slot.value[0];
+        } else {
+            if (type === 'boolean') {
+                return slot.value === 'true' ? true : false;
+            } else if (type === 'point') {
+                return {coords: slot.value.Point.pos.split(/[ ]+/)};
+            } else {
+                return slot.value;
+            }
+        }
+    }
+
+    function generateId() {
+        counter++;
+        return 'urn:segment:id:' + new Date().getTime() + "-" + counter;
+
+    }
+
+    function getSegment(data, key) {
+        var backingData = data;
+        if (!_.isArray(data)) {
+            backingData = [data];
+        }
+        for (var index = 0; index < backingData.length; index++) {
+            var foundModel;
+
+            if (backingData[index].id === key) {
+                return backingData[index];
+            }
+
+            for (var prop in backingData[index]) {
+                if (backingData[index].hasOwnProperty(prop) && typeof backingData[index][prop] === 'object') {
+                    foundModel = getSegment(backingData[index][prop], key);
+                    if (foundModel) {
+                        return foundModel;
+                    }
+                }
+            }
+        }
+    }
+
+    var Segment = {};
+
+    Segment.Segment = Backbone.AssociatedModel.extend({
+        relations: [
+            {
+                type: Backbone.Many,
+                key: 'segments',
+                collectionType: function () {
+                    return Segment.Segments;
+                },
+                relatedModel: function () {
+                    return Segment.Segment;
+                }
+            },
+            {
+                type: Backbone.Many,
+                key: 'fields',
+                collectionType: function () {
+                    return Field.FormFields;
+                },
+                relatedModel: function () {
+                    return Field.FormField;
+                }
+            }
+        ],
+        defaults: {
+            parentId: undefined,
+            simpleId: undefined,
+            segmentId: undefined,
+            segmentName: undefined,
+            segmentType: undefined,
+            containerOnly: false,
+            multiValued: false,
+            editableSegment: true,
+            nestedLevel: 0,
+            fields: [],
+            segments: [],
+            associationModel: undefined
+        },
+        populateFromModel: function (backingData, descriptors) {
+            var model = this;
+            var segs = [];
+            var seg;
+            var segType = model.get('segmentType');
+            var properties = {
+                backingData: backingData,
+                descriptors: descriptors
+            };
+
+            if (_.isArray(backingData)) {
+                properties.segmentId = generateId();
+                properties.simpleId = properties.segmentId.split(':').join('-');
+
+                for (var index = 0; index < backingData.length; index++) {
+                    seg = new Segment.Segment({
+                        segmentName: segType,
+                        multiValued: false,
+                        parentId: properties.segmentId,
+                        segmentType: segType,
+                        nestedLevel: model.get('nestedLevel') + 1,
+                        associationModel: model.get('associationModel')
+                    });
+                    seg.constructTitle = model.constructTitle;
+                    seg.populateFromModel(backingData[index] ? backingData[index] : {}, descriptors);
+                    segs.push(seg);
+                }
+                properties.segments = segs;
+            } else if (backingData) {
+                if (backingData.id) {
+                    properties.segmentId = backingData.id;
+                } else {
+                    properties.segmentId = generateId();
+                    backingData.id = properties.segmentId;
+                }
+                properties.simpleId = properties.segmentId.split(':').join('-');
+
+                var fieldList = [];
+                var prop;
+
+                for (prop in descriptors[segType]) {
+                    if (descriptors[segType].hasOwnProperty(prop)) {
+                        var obj = descriptors[segType][prop];
+                        if (obj.isGroup) {
+                            seg = new Segment.Segment({
+                                segmentName: obj.displayName,
+                                multiValued: obj.multiValued,
+                                parentId: properties.segmentId,
+                                segmentType: prop,
+                                containerOnly: FieldDescriptors.isContainerOnly(prop),
+                                nestedLevel: model.get('nestedLevel') + 1,
+                                associationModel: model.get('associationModel'),
+                                autoPopulateFunction: obj.autoPopulateFunction,
+                                autoPopulateId: obj.autoPopulateId,
+                                autoPopulateName: obj.autoPopulateName
+                            });
+                            seg.constructTitle = obj.constructTitle;
+                            var passedModel = backingData[prop];
+                            if (!passedModel) {
+                                passedModel = seg.get('containerOnly') || obj.multiValued ? [] : {};
+                                backingData[prop] = passedModel;
+                            }
+                            seg.populateFromModel(passedModel, descriptors);
+                            segs.push(seg);
+                        } else if (!obj.isSlot) {
+                            var field =new Field.FormField({
+                                key: prop,
+                                name: obj.displayName,
+                                desc: obj.description,
+                                type: obj.type,
+                                isSlot: false,
+                                multiValued: obj.multiValued,
+                                value: backingData[prop] ? backingData[prop] : obj.values,
+                                required: obj.required ? obj.required : false,
+                                min: obj.min,
+                                max: obj.max,
+                                regex: obj.regex,
+                                regexMessage: obj.regexMessage,
+                                possibleValues: obj.possibleValues,
+                                editable: obj.editable,
+                                parentId: properties.segmentId
+                            });
+                            field.on('change', field.validate, field);
+                            fieldList.push(field);
+
+                        }
+                    }
+                }
+                addSlotFields(fieldList, backingData, descriptors[segType], properties.segmentId);
+                properties.segments = segs;
+                properties.fields = fieldList;
+            } else {
+                properties.segmentId = generateId();
+                properties.simpleId = properties.segmentId.split(':').join('-');
+            }
+            model.set(properties);
+        },
+        addField: function (key, type, value) {
+            var model = this;
+            if(this.getField(key)){
+                //field with that name already exists return
+                return;
+            }
+            var newField = new Field.FormField({
+                key: key,
+                name: key,
+                type: type,
+                custom: true,
+                isSlot: true,
+                multiValued: type === 'string',
+                value: [],
+                parentId: model.get('segmentId')
+            });
+            if (value) {
+                this.setFieldValue(newField, value);
+            }
+            newField.on('change', newField.validate, newField);
+            this.get('fields').add(newField);
+            return newField;
+        },
+        removeField: function (key) {
+            var removedField = _.find(this.get('fields').models, function (field) {
+                return field.get('key') === key;
+            });
+            this.get('fields').remove(removedField);
+            return removedField;
+        },
+        addSegment: function (prePopulateId) {
+            var seg = new Segment.Segment({
+                segmentName: this.get('segmentName'),
+                multiValued: false,
+                segmentType: this.get('segmentType'),
+                parentId: this.get('segmentId'),
+                nestedLevel: this.get('nestedLevel') + 1,
+                associationModel: this.get('associationModel')
+            });
+            seg.constructTitle = this.constructTitle;
+            seg.populateFromModel({}, this.get('descriptors'));
+            if (this.get('autoPopulateFunction') && prePopulateId) {
+                this.get('autoPopulateFunction')(seg, this.getAutoPopulationValues(prePopulateId));
+            }
+            this.get('segments').add(seg);
+            var segTitle = seg.constructTitle ? seg.constructTitle() : seg.getField('Name').get('value');
+            this.get('associationModel').addAssociationSegment(seg.get('segmentId'), seg.get('segmentType'), segTitle);
+
+            return seg;
+        },
+        removeSegment: function (id) {
+            var seg = _.find(this.get('segments').models, function (seg) {
+                return seg.get('segmentId') === id;
+            });
+            this.get('segments').remove(seg);
+            this.get('associationModel').removeSegment(seg);
+            return seg;
+        },
+        setFieldValue: function (field, value) {
+            addValueFields(field, value);
+        },
+        getField: function (key) {
+            var fields = this.get("fields").models;
+            var foundField;
+            _.each(fields, function (field) {
+                if (field.get('key') === key) {
+                    foundField = field;
+                }
+            });
+            return foundField;
+        },
+        getAutoPopulationValues: function (prePopulateId) {
+            var autoPopId = this.get('autoPopulateId');
+            var autoPopObj = FieldDescriptors.autoPopulateValues[this.get('segmentType')];
+            return _.find(autoPopObj, function (obj) {
+                return obj[autoPopId] === prePopulateId;
+            });
+        },
+        validate: function(){
+            var errors = [];
+            var fields = this.get("fields").models;
+            var segments = this.get('segments').models;
+            this.validationError = undefined;
+            _.each(fields, function (field) {
+                var error = field.validate();
+                if(error){
+                    errors = errors.concat(error);
+                }
+            });
+
+            _.each(segments, function (segment) {
+                var error = segment.validate();
+                if(error){
+                    errors = errors.concat(error);
+                }
+            });
+            if(errors.length > 0){
+                this.validationError = errors;
+                return errors;
+            }
+        },
+        saveData: function () {
+            var model = this;
+            var fields = this.get("fields").models;
+            var segments = this.get('segments').models;
+            var ebrimTypes = FieldDescriptors.getSlotTypes();
+            var backingData = model.get('backingData');
+            if (!backingData.Slot) {
+                backingData.Slot = [];
+            }
+            //update and add values
+            _.each(fields, function (field) {
+                field.saveData(backingData,ebrimTypes);
+            });
+
+            //remove slots
+            if (backingData.Slot) {
+                var slots = [];
+                for (var index = 0; index <backingData.Slot.length; index++) {
+                    if (model.getField(backingData.Slot[index].name)) {
+                        slots.push(backingData.Slot[index]);
+                    }
+                }
+                backingData.Slot = slots;
+            }
+
+            //now handle the segments
+            _.each(segments, function (segment) {
+                if (!segment.get('containerOnly') && !segment.get('multiValued')) {
+                    var segObj = getSegment(backingData, segment.get('segmentId'));
+                    if (!segObj) {
+                        if (!_.isArray(backingData)) {
+                            backingData[segment.get('segmentType')] = segment.get('backingData');
+                        }
+                    }
+                }
+                segment.saveData();
+            });
+            if (_.isArray(backingData)) {
+                backingData.length = 0;
+                _.each(segments, function (segment) {
+                    backingData.push(segment.get('backingData'));
+                });
+            }
+        }
+    });
+
+    Segment.Segments = Backbone.Collection.extend({
+        model: Segment.Segment
+    });
+
+    return Segment;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/module.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/module.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+/*global define*/
+define([
+        'wreqr',
+        'js/application',
+        'js/view/Registry.view.js',
+        'js/model/Node.js'
+    ],
+    function (wreqr, Application, RegistryView, Node) {
+
+        Application.App.module('Registry', function (RegistryModule, App, Backbone, Marionette) {
+
+            var nodeModels = new Node.Models();
+            nodeModels.fetch();
+
+            var registryPage = new RegistryView.RegistryPage({model: nodeModels});
+
+            var Controller = Marionette.Controller.extend({
+
+                initialize: function (options) {
+                    this.region = options.region;
+                },
+
+                show: function () {
+                    this.region.show(registryPage);
+                }
+
+            });
+
+            RegistryModule.addInitializer(function () {
+                RegistryModule.contentController = new Controller({
+                    region: App.mainRegion
+                });
+                RegistryModule.contentController.show();
+            });
+
+
+        });
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Association.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Association.view.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'marionette',
+        'backbone',
+        'wreqr',
+        'underscore',
+        'jquery',
+        'text!templates/associationList.handlebars',
+        'text!templates/associationRow.handlebars'
+
+    ],
+    function (ich, Marionette, Backbone, wreqr, _, $,  associationList, associationRow) {
+
+        ich.addTemplate('associationList', associationList);
+        ich.addTemplate('associationRow', associationRow);
+
+
+        var Association = {};
+
+        Association.AssociationView = Marionette.ItemView.extend({
+            template: 'associationRow',
+            tagName: 'tr',
+            events: {
+                "click .remove-association": 'removeAssociation'
+            },
+            removeAssociation: function () {
+                wreqr.vent.trigger('removeAssociation:' + this.model.get('sourceId'), this.model.get('id'));
+            }
+        });
+        Association.AssociationCollectionView = Marionette.CompositeView.extend({
+            template: 'associationList',
+            itemView: Association.AssociationView,
+            itemViewContainer: ".association-list",
+            events: {
+                "click .add-association": 'addAssociation'
+            },
+            initialize: function (options) {
+                this.parentId = options.parentId;
+                this.simpleId = this.parentId.split(':').join('-');
+                this.listenTo(wreqr.vent, 'removeAssociation:' + this.parentId, this.removeAssociation);
+                this.listenTo(wreqr.vent, 'associationSegmentRemoved', this.updateAssociations);
+                this.listenTo(wreqr.vent, 'associationSegmentAdded', this.updateAssociations);
+                this.listenTo(this.collection, 'add', this.render);
+                this.listenTo(this.collection, 'remove', this.render);
+            },
+            serializeData: function () {
+                var data = {};
+                data.availableAssociation = this.model.getAvailableAssociationSegments(this.parentId);
+                data.simpleId = this.simpleId;
+                return data;
+            },
+            removeAssociation: function (associationId) {
+                this.collection.remove(this.model.removeAssociation(associationId));
+            },
+            addAssociation: function () {
+                var selectedOption = this.$('.association-selector').find(':selected');
+                if (selectedOption.length === 1) {
+                    var addedItem = this.model.addAssociation(this.parentId, selectedOption.attr('name'), 'AssociatedWith');
+                    this.collection.add(addedItem);
+                    this.render();
+                }
+            },
+            updateAssociations: function (id) {
+                var seg = _.find(this.collection.models, function (model) {
+                    return model.get('sourceId') === id || model.get('targetId') === id;
+                });
+                if (seg) {
+                    this.collection.remove(seg);
+                }
+            }
+        });
+
+        return Association;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/CustomizableField.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/CustomizableField.view.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'marionette',
+        'backbone',
+        'wreqr',
+        'underscore',
+        'jquery',
+        'js/view/Field.view.js',
+        'text!templates/customFieldList.handlebars'
+    ],
+    function (ich, Marionette, Backbone, wreqr, _, $, Field, customList) {
+
+        ich.addTemplate('customList', customList);
+
+        var Customizable = {};
+
+        Customizable.CustomizableCollectionView = Marionette.Layout.extend({
+            template: 'customList',
+            regions: {
+                customFieldsRegion: '#custom-fields'
+            },
+            events: {
+                "click .add-custom-field": 'addField'
+            },
+            initialize: function () {
+                this.listenTo(wreqr.vent, 'removeField:' + this.model.get('segmentId'), this.removeField);
+            },
+            onRender: function () {
+                var customFields = this.model.get('fields').models
+                    .filter(function (field) {
+                        return field.get('custom');
+                    });
+                this.customFieldsRegion.show(new Field.FieldCollectionView({
+                    collection: new Backbone.Collection(customFields),
+                    parentId: this.model.get("segmentId")
+                }));
+            },
+            addField: function (event) {
+                event.stopImmediatePropagation();
+                var fieldName = this.$('.field-name').val();
+                if (!fieldName || fieldName.trim().length === 0) {
+                    return;
+                }
+                var fieldType = this.$('.field-type-selector').val();
+                var addedField = this.model.addField(fieldName, fieldType);
+                this.$('.field-name').val('');
+                if (addedField) {
+                    if (this.customFieldError) {
+                        this.clearCustomFieldError();
+                    } else {
+                        wreqr.vent.trigger('addedField:' + this.model.get("segmentId"), addedField);
+                    }
+                } else {
+                    this.showCustomFieldError(fieldName);
+                }
+            },
+            removeField: function (key) {
+                var removedField = this.model.removeField(key);
+                wreqr.vent.trigger('removedField:' + this.model.get("segmentId"), removedField);
+            },
+            showCustomFieldError: function (fieldName) {
+                this.customFieldError = 'Field \'' + fieldName + '\' already exists.';
+                this.render();
+            },
+            clearCustomFieldError: function () {
+                this.customFieldError = undefined;
+                this.render();
+            },
+            serializeData: function () {
+                var data = {};
+
+                if (this.model) {
+                    data = this.model.toJSON();
+                }
+                data.customFieldError = this.customFieldError;
+                return data;
+            }
+        });
+
+
+        return Customizable;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'marionette',
+        'backbone',
+        'wreqr',
+        'underscore',
+        'jquery',
+        'text!templates/field.handlebars'
+    ],
+    function (ich, Marionette, Backbone, wreqr, _, $,  field) {
+
+
+        ich.addTemplate('field', field);
+
+        var Field = {};
+
+        Field.FieldView = Marionette.ItemView.extend({
+            template: 'field',
+            events: {
+                "click .remove-field": 'removeField',
+                "click .add-value": 'addValue',
+                "click .remove-value": 'removeValue'
+            },
+            initialize: function () {
+                this.modelBinder = new Backbone.ModelBinder();
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.get('key'), this.showHideError);
+            },
+            onRender: function () {
+                var bindings = Backbone.ModelBinder.createDefaultBindings(this.el, 'name');
+                this.modelBinder.bind(this.model, this.$el, bindings);
+            },
+            addValue: function () {
+                this.model.addValue('');
+                this.render();
+                wreqr.vent.trigger('valueAdded:' + this.model.get('parentId'));
+            },
+            removeValue: function (event) {
+                this.model.removeValue(event.target.getAttribute('name'));
+                this.render();
+                wreqr.vent.trigger('valueRemoved:' + this.model.get('parentId'));
+            },
+            removeField: function () {
+                wreqr.vent.trigger('removeField:' + this.model.get('parentId'), this.model.get('key'));
+            },
+            showHideError: function () {
+                wreqr.vent.trigger('fieldErrorChange:' + this.model.get('parentId'));
+                this.render();
+            },
+            serializeData: function () {
+                var data = {};
+
+                if (this.model) {
+                    data = this.model.toJSON();
+                    data.validationError = this.model.hadError;
+                    data.errorIndices = this.model.errorIndices;
+                }
+                return data;
+            }
+        });
+
+        Field.FieldCollectionView = Marionette.CollectionView.extend({
+            itemView: Field.FieldView,
+            tagName: 'tr',
+            initialize: function (options) {
+                this.listenTo(wreqr.vent, 'addedField:' + options.parentId, this.addedField);
+                this.listenTo(wreqr.vent, 'removedField:' + options.parentId, this.removedField);
+
+            },
+            buildItemView: function (item, ItemViewType, itemViewOptions) {
+                var options = _.extend({
+                    model: item,
+                    parentId: this.options.parentId
+                }, itemViewOptions);
+                return new ItemViewType(options);
+            },
+            addedField: function (field) {
+                this.collection.add(field);
+                this.render();
+            },
+            removedField: function (field) {
+                this.collection.remove(field);
+                this.render();
+            }
+        });
+
+        return Field;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'marionette',
+        'backbone',
+        'wreqr',
+        'underscore',
+        'jquery',
+        'js/model/Node.js',
+        'js/model/FieldDescriptors.js',
+        'js/view/Segment.view.js',
+        'text!templates/nodeModal.handlebars'
+    ],
+    function (ich, Marionette, Backbone, wreqr, _, $, Node, FieldDescriptors, Segment, nodeModal) {
+
+        ich.addTemplate('modalNode', nodeModal);
+
+        var NodeModal = {};
+
+        NodeModal.View = Marionette.Layout.extend({
+            template: 'modalNode',
+            className: 'modal',
+            /**
+             * Button events, right now there's a submit button
+             * I do not know where to go with the cancel button.
+             */
+            events: {
+                "click .submit-button": "submitData",
+                "click .cancel-button": "cancel",
+                "click .close": "cancel"
+            },
+            regions: {
+                generalInfo: '#generalInfo',
+                organizationInfo: '#organizationInfo',
+                contactInfo: '#contactInfo',
+                serviceInfo: '#serviceInfo',
+                contentInfo: '#contentInfo'
+            },
+
+            saveErrors: undefined,
+            /**
+             * Initialize  the binder with the ManagedServiceFactory model.
+             * @param options
+             */
+            initialize: function (options) {
+                this.mode = options.mode;
+                this.descriptors = FieldDescriptors.retrieveFieldDescriptors();
+                this.model.refreshData();
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.generalInfo.get('segmentId'), this.updateGeneralTabError);
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.organizationInfo.get('segmentId'), this.updateOrgTabError);
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.contactInfo.get('segmentId'), this.updateContactTabError);
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.serviceInfo.get('segmentId'), this.updateServiceTabError);
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.contentInfo.get('segmentId'), this.updateContentTabError);
+
+            },
+            serializeData: function () {
+                var data = {};
+
+                if (this.model) {
+                    data = this.model.toJSON();
+                }
+                data.generalErrors = this.model.generalInfo.validationError;
+                data.serviceErrors = this.model.serviceInfo.validationError;
+                data.organizationErrors = this.model.organizationInfo.validationError;
+                data.contactErrors = this.model.contactInfo.validationError;
+                data.collectionErrors = this.model.contentInfo.validationError;
+                data.saveErrors = this.saveErrors;
+                data.validationErrors = this.model.validationError;
+                data.mode = this.mode;
+
+                return data;
+            },
+            onRender: function () {
+                this.$el.attr('role', "dialog");
+                this.$el.attr('aria-hidden', "true");
+
+                this.generalInfo.show(new Segment.SegmentCollectionView({
+                    model: this.model.generalInfo,
+                    collection: this.model.generalInfo.get('segments'),
+                    showHeader: true
+                }));
+                this.organizationInfo.show(new Segment.SegmentCollectionView({
+                    model: this.model.organizationInfo,
+                    collection: this.model.organizationInfo.get('segments'),
+                    showHeader: true
+                }));
+                this.contactInfo.show(new Segment.SegmentCollectionView({
+                    model: this.model.contactInfo,
+                    collection: this.model.contactInfo.get('segments'),
+                    showHeader: true
+                }));
+                this.serviceInfo.show(new Segment.SegmentCollectionView({
+                    model: this.model.serviceInfo,
+                    collection: this.model.serviceInfo.get('segments'),
+                    showHeader: true
+                }));
+                this.contentInfo.show(new Segment.SegmentCollectionView({
+                    model: this.model.contentInfo,
+                    collection: this.model.contentInfo.get('segments'),
+                    showHeader: true
+                }));
+            },
+            updateGeneralTabError: function () {
+               this.updateTabError("#generalTabLink", this.model.generalInfo);
+            },
+            updateServiceTabError: function () {
+                this.updateTabError("#serviceTabLink", this.model.serviceInfo);
+            },
+            updateOrgTabError: function () {
+                this.updateTabError("#organizationTabLink", this.model.organizationInfo);
+            },
+            updateContactTabError: function () {
+                this.updateTabError("#contactTabLink", this.model.contactInfo);
+            },
+            updateContentTabError: function () {
+                this.updateTabError("#collectionTabLink", this.model.contentInfo);
+            },
+            updateTabError: function(id, model){
+                var title = this.$(id);
+                if(model.validate()) {
+                    title.addClass('validation-error-text');
+                } else {
+                    title.removeClass('validation-error-text');
+                }
+            },
+            /**
+             * Submit to the backend.
+             */
+            submitData: function () {
+                wreqr.vent.trigger('beforesave');
+                var view = this;
+                var response = view.model.save();
+                if (response) {
+                    response.success(function () {
+                        view.closeAndUnbind();
+                        if (response.addOperation) {
+                            wreqr.vent.trigger('nodeAdded');
+                        } else {
+                            wreqr.vent.trigger('nodeUpdated');
+                        }
+                    });
+                    response.fail(function (val) {
+                        view.saveErrors = val;
+                        view.render();
+                    });
+                } else {
+                    view.render();
+                }
+
+            },
+            cancel: function () {
+                this.saveErrors = undefined;
+                this.model.validationError = undefined;
+                this.closeAndUnbind();
+            },
+            closeAndUnbind: function () {
+                this.$el.modal("hide");
+            }
+        });
+
+        return NodeModal;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'backbone',
+        'marionette',
+        'underscore',
+        'jquery',
+        'q',
+        'wreqr',
+        'js/model/Node.js',
+        'js/view/NodeModal.view.js',
+        'text!templates/registryPage.handlebars',
+        'text!templates/nodeList.handlebars',
+        'text!templates/nodeRow.handlebars'
+    ],
+    function (ich,Backbone,Marionette,_,$,Q,wreqr,Node,NodeModal,registryPage, nodeList, nodeRow) {
+
+        var RegistryView = {};
+
+        ich.addTemplate('registryPage', registryPage);
+        ich.addTemplate('nodeList', nodeList);
+        ich.addTemplate('nodeRow', nodeRow);
+
+        RegistryView.RegistryPage = Marionette.Layout.extend({
+            template: 'registryPage',
+            events: {
+                'click .add-node-link' : 'showAddNode',
+                'click .refresh-button' : 'addDeleteNode'
+            },
+            initialize: function () {
+                this.listenTo(wreqr.vent, 'editNode', this.showEditNode);
+                this.listenTo(wreqr.vent, "deleteNodes", this.deleteNodes);
+                this.listenTo(wreqr.vent, "nodeUpdated", this.onRender);
+                this.listenTo(wreqr.vent, "nodeAdded", this.addDeleteNode);
+                this.listenTo(wreqr.vent, "nodeDeleted", this.addDeleteNode);
+
+                new RegistryView.ModalController({
+                    application: this
+                });
+                this.listenTo(this.model, 'add', this.render);
+                this.listenTo(this.model, 'remove', this.render);
+            },
+            regions: {
+                identityRegion: '#localIdentityNodeRegion',
+                additionalRegion: '#localAdditionalNodeRegion',
+                modalRegion: '#registry-modal'
+            },
+            onRender: function() {
+                this.identityRegion.show(new RegistryView.NodeTable({collection: new Backbone.Collection(this.model.getIdentityNode())}));
+                this.additionalRegion.show(new RegistryView.NodeTable({collection: new Backbone.Collection(this.model.getSecondaryNodes()), multiValued: true}));
+            },
+            showEditNode: function(node) {
+                wreqr.vent.trigger("showModal",
+                    new NodeModal.View({
+                        model: node,
+                        mode: 'edit'
+                    })
+                );
+            },
+            showAddNode: function() {
+                if(this.model) {
+                    wreqr.vent.trigger("showModal",
+                        new NodeModal.View({
+                            model: new Node.Model(),
+                            mode: 'add'
+                        })
+                    );
+                }
+            },
+            addDeleteNode: function () {
+                var view = this;
+                var button = view.$('.refresh-button');
+                if(!button.hasClass('fa-spin')) {
+                    button.addClass('fa-spin');
+                }
+                this.model.fetch({
+                    reset: true,
+                    success: function () {
+                        view.fetchComplete(view);
+                    }
+                });
+            },
+            fetchComplete: function(view){
+                var button = view.$('.refresh-button');
+                button.removeClass('fa-spin');
+                view.render();
+            },
+            deleteNodes: function(nodeList) {
+                this.model.deleteNodes(nodeList);
+            }
+        });
+        RegistryView.ModalController = Marionette.Controller.extend({
+            initialize: function (options) {
+                this.application = options.application;
+                this.listenTo(wreqr.vent, "showModal", this.showModal);
+            },
+            showModal: function(modalView) {
+
+                var region = this.application.getRegion('modalRegion');
+                var iFrameModalDOM = $('#IframeModalDOM');
+                modalView.$el.on('hidden.bs.modal', function () {
+                    iFrameModalDOM.hide();
+                });
+                modalView.$el.on('shown.bs.modal', function () {
+                    var extraHeight = modalView.el.firstChild.clientHeight - $('#localNode').height();
+                    if(extraHeight > 0) {
+                        iFrameModalDOM.height(extraHeight);
+                        iFrameModalDOM.show();
+                    }
+                });
+                region.show(modalView);
+                region.currentView.$el.modal({
+                    backdrop: 'static',
+                    keyboard: false
+                });
+            }
+        });
+
+
+        RegistryView.NodeRow= Marionette.ItemView.extend({
+            template: "nodeRow",
+            tagName: "tr",
+            className: "highlight-on-hover",
+            events: {
+                'click td' : 'editNode',
+                'click .remove-node-link': 'removeNode'
+            },
+            editNode: function(evt) {
+                evt.stopPropagation();
+                var node = this.model;
+                wreqr.vent.trigger('editNode', node);
+            },
+            removeNode: function(evt) {
+                evt.stopPropagation();
+                wreqr.vent.trigger('deleteNodes', [this.model.get('id')]);
+            },
+            serializeData: function(){
+                var data = {};
+
+                if(this.model) {
+                    data = this.model.toJSON();
+                }
+
+                var extrinsicData = this.model.getObjectOfType('urn:registry:federation:node');
+                if(extrinsicData.length === 1) {
+                    data.name = extrinsicData[0].Name;
+                    data.slots = extrinsicData[0].Slot;
+                }
+                return data;
+            }
+        });
+
+        RegistryView.NodeTable = Marionette.CompositeView.extend({
+            template: 'nodeList',
+            itemView: RegistryView.NodeRow,
+            itemViewContainer: 'tbody',
+            serializeData: function(){
+                var data = {};
+
+                if(this.model) {
+                    data = this.model.toJSON();
+                }
+                data.multiValued = this.options.multiValued;
+
+                return data;
+            }
+        });
+
+
+        return RegistryView;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Segment.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Segment.view.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz',
+        'marionette',
+        'backbone',
+        'wreqr',
+        'underscore',
+        'jquery',
+        'js/view/Field.view.js',
+        'js/view/CustomizableField.view.js',
+        'js/view/Association.view.js',
+        'js/model/FieldDescriptors.js',
+        'text!templates/segmentRow.handlebars',
+        'text!templates/segmentList.handlebars'
+
+    ],
+    function (ich, Marionette, Backbone, wreqr, _, $, Field, Customizable, Association, FieldDescriptors,  segmentRow, segmentList) {
+        
+        ich.addTemplate('segmentRow', segmentRow);
+        ich.addTemplate('segmentList', segmentList);
+
+        var Segment = {};
+
+        Segment.SegmentView = Marionette.Layout.extend({
+            template: 'segmentRow',
+            regions: {
+                formFields: '.form-fields',
+                formSegments: '.form-segments'
+            },
+            events: {
+                "click .remove-segment": 'removeSegment',
+                "click .add-segment": 'addSegment'
+            },
+            initialize: function () {
+                this.listenTo(wreqr.vent, 'fieldChanged:' + this.model.get('segmentId'), this.updateTitle);
+                this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.get('segmentId'), this.updateTitleError);
+                this.listenTo(wreqr.vent, 'valueAdded:' + this.model.get('segmentId'), this.setupPopOvers);
+                this.listenTo(wreqr.vent, 'valueRemoved:' + this.model.get('segmentId'), this.setupPopOvers);
+                this.addRegions({
+                    associations: '#associations-' + this.model.get('simpleId'),
+                    customizable: '#customizable-' + this.model.get('simpleId')
+                });
+                this.events['click .'+this.model.get('simpleId')] = this.toggleCheveron;
+                this.delegateEvents();
+            },
+            onRender: function () {
+                var knownFields = [];
+                var allFields = this.model.get('fields').models;
+                _.each(allFields, function (field) {
+                    if (!field.get('custom')) {
+                        knownFields.push(field);
+                    }
+                });
+                this.formFields.show(new Field.FieldCollectionView({collection: new Backbone.Collection(knownFields)}));
+                this.formSegments.show(new Segment.SegmentCollectionView({
+                    model: this.model,
+                    collection: this.model.get('segments'),
+                    showHeader: knownFields.length > 0 ? false : true
+                }));
+                if (FieldDescriptors.isCustomizableSegment(this.model.get('segmentType'))) {
+                    this.customizable.show(new Customizable.CustomizableCollectionView({
+                        model: this.model
+                    }));
+                    if (this.model.get('fields').models.length > 0) {
+                        var associationModel = this.model.get('associationModel');
+                        this.associations.show(new Association.AssociationCollectionView({
+                            parentId: this.model.get("segmentId"),
+                            model: associationModel,
+                            collection: new Backbone.Collection(associationModel.getAssociationsForId(this.model.get('segmentId')))
+                        }));
+                    }
+                }
+                this.setupPopOvers();
+            },
+            removeSegment: function () {
+                wreqr.vent.trigger('removeSegment:' + this.model.get('parentId'), this.model.get('segmentId'));
+            },
+            addSegment: function () {
+                this.model.addSegment();
+                this.render();
+            },
+            updateTitle: function () {
+                if (!this.model.get('multiValued') && this.model.constructTitle) {
+                    var title = this.$('.segment-title-'+this.model.get('simpleId'));
+                    title.html(this.model.constructTitle());
+                }
+            },
+            updateTitleError: function () {
+                var title = this.$('.segment-title-error-'+this.model.get('simpleId'));
+                if(this.model.validate()){
+                    title.show();
+                } else {
+                    title.hide();
+                }
+                wreqr.vent.trigger('fieldErrorChange:' + this.model.get('parentId'));
+            },
+            serializeData: function () {
+                var data = this.model.toJSON();
+                if (!this.model.get('multiValued') && this.model.constructTitle) {
+                    data.title = this.model.constructTitle();
+                } else {
+                    data.title = this.model.get('segmentName');
+                }
+                data.errors = this.model.validationError;
+                data.customizable = FieldDescriptors.isCustomizableSegment(this.model.get('segmentType')) && !this.model.get('multiValued');
+                data.showFields = this.model.get('fields').models.length > 0;
+                data.showAssociations = FieldDescriptors.isCustomizableSegment(this.model.get('segmentType')) && this.model.get('fields').models.length > 0;
+                return data;
+            },
+            toggleCheveron: function() {
+                this.$el.find(".chevron-"+this.model.get('simpleId')).toggleClass('fa-chevron-down fa-chevron-right');
+            },
+            /**
+             * Set up the popovers based on if the selector has a description.
+             */
+            setupPopOvers: function () {
+                var view = this;
+                this.model.get('fields').each(function (each) {
+                    if (!_.isUndefined(each.get("desc"))) {
+                        var options,
+                            selector = ".description[data-title='" + each.get('key') + "']";
+                        options = {
+                            title: each.get("name"),
+                            content: each.get("desc"),
+                            trigger: 'hover'
+                        };
+                        view.$(selector).popover(options);
+                    }
+                });
+            }
+        });
+
+        Segment.SegmentCollectionView = Marionette.CompositeView.extend({
+            template: 'segmentList',
+            itemView: Segment.SegmentView,
+            events: {
+                "click .add-segment": 'addSegment'
+            },
+            modelEvents: {
+                "change:segments": "render"
+            },
+            initialize: function () {
+                this.listenTo(wreqr.vent, 'removeSegment:' + this.model.get('segmentId'), this.removeSegment);
+            },
+            buildItemView: function (item, ItemViewType, itemViewOptions) {
+                item.set('editableSegment', this.model.get('multiValued'));
+                var options = _.extend({
+                    model: item
+                }, itemViewOptions);
+                return new ItemViewType(options);
+            },
+            addSegment: function () {
+                var selector = this.$('.auto-populate-selector');
+                var prePopulateId;
+                if (selector) {
+                    var selected = selector.find(':selected');
+                    if (selected.attr('id') !== 'empty') {
+                        prePopulateId = selected.attr('id');
+                    }
+                }
+                this.model.addSegment(prePopulateId);
+                this.render();
+            },
+            removeSegment: function (id) {
+                this.model.removeSegment(id);
+            },
+            serializeData: function () {
+                var data = {};
+
+                if (this.model) {
+                    data = this.model.toJSON();
+                }
+                var autoValues = FieldDescriptors.autoPopulateValues[this.model.get('segmentType')];
+                data.autoValues = autoValues;
+                data.showHeader = this.options.showHeader;
+                data.segmentName = this.model.get('segmentName');
+                return data;
+            }
+        });
+
+        return Segment;
+
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
@@ -1,0 +1,255 @@
+@activeColor: #18BC9C;
+@highlightColor : lighten(@activeColor, 35);
+
+
+table.align-middle{
+  td {
+    vertical-align: middle !important;
+  }
+}
+
+#localIdentityNodeRegion,#localAdditionalNodeRegion {
+  a {
+    padding-left: 5px;
+    text-decoration: none;
+  }
+  table {
+    thead {
+      th:last-child{
+        text-align: right;
+      }
+      th {
+        width: 25%;
+      }
+    }
+  }
+  label {
+    color: black;
+  }
+  .table-striped > tbody {
+    tr.highlight-on-hover:hover td {
+      background-color: @highlightColor;
+    }
+
+    tr:nth-child(odd) > td{
+      .configurationSelect {
+        border: none;
+        background-color: #f9f9f9;
+      }
+    }
+
+    tr:nth-child(even) > td{
+      .configurationSelect {
+        border: none;
+        background-color: white;
+      }
+    }
+    td {
+      width: 25%;
+    }
+  }
+  .add-segment{
+    text-align: right;
+  }
+
+}
+
+.button-icon {
+   padding-left: 5px;
+   padding-right: 5px;
+   text-decoration: none!important;
+ }
+.button-icon:hover {
+  text-decoration: underline!important;
+}
+
+.tab-header {
+  display: block;
+  height: 50px;
+  h3 {
+   // float: left;
+  }
+  a {
+   // float: right;
+    margin: 21px;
+  }
+}
+#registry-modal {
+  .nested-label0 {
+    font-size: 28px;
+  }
+  .nested-label1 {
+    font-size: 22px;
+    font-style: oblique;
+    vertical-align: middle;
+  }
+  .nested-label2 {
+    font-size: 18px;
+    vertical-align: middle;
+  }
+  .nested-label3 {
+    font-style: oblique;
+    vertical-align: middle;
+    margin-bottom: 2px;
+  }
+  .clickable {
+    background-color: lightgrey;
+    margin-bottom: 2px;
+    border-radius: 5px;
+    padding: 0px 10px;
+  }
+  .segment-header-table {
+    width: 100%;
+    table
+    td:first-child {
+      width: 95%;
+    };
+    td:last-child {
+      width: 5%;
+    };
+  }
+  .disabled-link{
+    color: grey;
+    pointer-events: none;
+  }
+  .segment-content {
+    border-radius: 5px;
+    border: black 1px;
+  }
+  .add-segment {
+    padding-left: 10px;
+    margin-bottom: 5px;
+  }
+  .add-value {
+    padding-left: 10px;
+  }
+  .remove-field {
+    padding-left: 10px;
+  }
+  .node-field {
+    margin-top: 10px;
+  }
+  .coords {
+    padding-left: 10px;
+    label {
+      font-weight: normal;
+    }
+  }
+  input {
+    line-height : normal;
+  }
+
+  .segment-associations {
+    font-weight: bold;
+  }
+
+  .customizable-header,.association-header {
+    padding-bottom: 1px;
+    border-bottom: 1px solid lightgray;
+  }
+  tbody {
+    tr {
+      .custom-fields {
+        padding-left: 10px;
+      }
+    }
+  }
+
+  .validation-error {
+    border-color: red;
+  }
+
+  .validation-error-text {
+    color: red;
+  }
+
+  .validation-error-icon {
+    color: red;
+    padding-right: 5px;
+    vertical-align: middle;
+  }
+
+  .error-list {
+    text-align: left;
+  }
+  .string-input{
+    width: 80%;
+  }
+  .multi-value-field{
+    width:88.5%;
+  }
+  .string-table-input {
+    width: 100%;
+  }
+  .remove-value {
+    padding-left: 10px;
+  }
+  .lat-lon-input {
+    width: 35%;
+    margin-right: 10px;
+  }
+  .association-table {
+    margin-left: 10px;
+    width: 75%;
+
+    tr:nth-child(odd) > td{
+        border: none;
+        background-color: #f9f9f9;
+
+    }
+    tr:nth-child(even) > td{
+        border: none;
+        background-color: white;
+    }
+    td {
+      padding: 0px;
+    }
+    td:last-child{
+      text-align: right;
+    }
+  }
+  .segment-header-table {
+    width: 100%;
+    td:last-child{
+      text-align: right;
+    }
+  }
+}
+
+.IframeModalDOM {
+  padding-top: 30px;
+  padding-bottom: 30px
+}
+
+.newLink {
+  text-decoration: none!important;
+  width: 100%;
+  font-weight: 700;
+}
+
+.node-table-label {
+  font-weight: bold;
+}
+
+.card-style-toggle .btn {
+  color: #fff;
+  background-color: #95a5a6;
+  border-color: #95a5a6;
+  padding: 7px 6px 4px;
+}
+
+.delete-modal-body {
+  min-height: 400px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.no-results {
+  height: 100px;
+  display: table;
+  .message {
+    display: table-cell;
+    vertical-align: middle;
+  }
+}
+

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require, window */
+/*jslint nomen:false, -W064 */
+
+(function () {
+    'use strict';
+
+    require.config({
+
+        paths: {
+
+            bootstrap: '../../../admin/lib/components-bootstrap/js/bootstrap.min',
+            spin: '../../../admin/lib/spin.js/spin',
+            q: '../../../admin/lib/q/q',
+
+            // backbone
+            backbone: '../../../admin/lib/components-backbone/backbone',
+            backboneassociation: '../../../admin/lib/backbone-associations/backbone-associations',
+            underscore: '../../../admin/lib/lodash/dist/lodash.underscore',
+            marionette: '../../../admin/lib/marionette/lib/backbone.marionette',
+            modelbinder: '../../../admin/lib/backbone.modelbinder/Backbone.ModelBinder',
+            collectionbinder: '../../../admin/lib/backbone.modelbinder/Backbone.CollectionBinder',
+            poller: '../../../admin/lib/backbone-poller/backbone.poller',
+            iframeresizer: '../../../admin/lib/iframe-resizer/js/iframeResizer.min',
+
+            // ddf
+            spinnerConfig: 'js/spinnerConfig',
+
+            // jquery
+            jquery: '../../../admin/lib/jquery/jquery.min',
+            jqueryui: '../../../admin/lib/jquery-ui/ui/minified/jquery-ui.min',
+            'jquery.ui.widget': '../../../admin/lib/jquery-ui/ui/minified/jquery.ui.widget.min',
+            multiselect: '../../../admin/lib/bootstrap-multiselect/js/bootstrap-multiselect',
+            perfectscrollbar: '../../../admin/lib/perfect-scrollbar/min/perfect-scrollbar-0.4.8.with-mousewheel.min',
+
+            // handlebars
+            handlebars: '../../../admin/lib/handlebars/handlebars.min',
+            icanhaz: '../../../admin/lib/icanhandlebarz/ICanHandlebarz',
+
+            // require plugins
+            text: '../../../admin/lib/requirejs-plugins/lib/text',
+            css: '../../../admin/lib/require-css/css',
+
+            // default admin ui
+            app: '../../../admin/js/application',
+
+            // datatables
+            datatables: '../../../admin/lib/datatables/media/js/jquery.dataTables'
+        },
+
+
+        shim: {
+
+            backbone: {
+                deps: ['underscore', 'jquery'],
+                exports: 'Backbone'
+            },
+            modelbinder: {
+                deps: ['underscore', 'jquery', 'backbone']
+            },
+            collectionbinder: {
+                deps: ['modelbinder']
+            },
+            poller: {
+                deps: ['underscore', 'backbone']
+            },
+            backboneassociation: ['backbone'],
+            marionette: {
+                deps: ['jquery', 'underscore', 'backbone'],
+                exports: 'Marionette'
+            },
+            underscore: {
+                exports: '_'
+            },
+            handlebars: {
+                exports: 'Handlebars'
+            },
+            icanhaz: {
+                deps: ['handlebars', 'jquery'],
+                exports: 'ich'
+            },
+
+            perfectscrollbar: ['jquery'],
+
+            multiselect: ['jquery'],
+
+            jqueryui: ['jquery'],
+            bootstrap: ['jqueryui']
+
+        },
+
+        waitSeconds: 200
+    });
+
+
+    require([
+        'jquery',
+        'backbone',
+        'marionette',
+        'icanhaz',
+        'js/application',
+        'js/HandlebarsHelpers',
+        'modelbinder',
+        'bootstrap'
+    ], function ($, Backbone, Marionette, ich, Application) {
+
+
+        var app = Application.App;
+        // Once the application has been initialized (i.e. all initializers have completed), start up
+        // Backbone.history.
+        app.on('initialize:after', function () {
+            Backbone.history.start();
+            //bootstrap call for tabs
+            $('tabs').tab();
+        });
+
+        if (window) {
+            // make ddf object available on window.  Makes debugging in chrome console much easier
+            window.app = app;
+            if (!window.console) {
+                window.console = {
+                    log: function () {
+                        // no op
+                    }
+                };
+            }
+        }
+
+        // Actually start up the application.
+        app.start();
+
+        require(['js/module'], function () {
+
+        });
+
+    });
+}());

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationList.handlebars
@@ -1,0 +1,32 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="segment-associations">
+    <div class="association-header">
+        <lable class="nested-label2">Associations</lable>
+        <select class="association-selector" {{#lt availableAssociation.length 1}}disabled{{/lt}}>
+            {{#each availableAssociation}}
+                <option name="{{this.segmentId}}"
+                        value="{{this.segmentName}}">{{this.segmentName}}</option>
+            {{/each}}
+        </select>
+        <a href="#" class="add-association fa fa-plus-square fa-lg plus-button {{#lt availableAssociation.length 1}}disabled-link{{/lt}}"></a>
+    </div>
+    <label>The following entities are associated with this entity:</label>
+    <table class='association-table table align-middle'>
+        <tbody class="association-list">
+
+        </tbody>
+    </table>
+
+</div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationRow.handlebars
@@ -1,0 +1,24 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<td>
+    <label class="association-name">{{targetName}}</label>
+</td>
+<td>
+    <label class="association-name">{{targetType}}</label>
+</td>
+<td>
+    <a href="#" name="{{id}}"
+       class="remove-association fa fa-minus-square fa-lg minus-button"></a>
+</td>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/customFieldList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/customFieldList.handlebars
@@ -1,0 +1,39 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<div class="customizable-fields">
+    <div class="customizable-header">
+        <label class="nested-label2">Custom Fields</label>
+        <input type="text" class="field-name" name="customName"
+               placeholder="Field Name">
+        <select class="field-type-selector">
+            <option value="string">string</option>
+            <option value="boolean">boolean</option>
+            <option value="number">number</option>
+            <option value="date">date</option>
+            <option value="point">point</option>
+        </select>
+        <a href="#" class="add-custom-field fa fa-plus-square fa-lg plus-button"></a>
+    </div>
+    {{#if customFieldError}}
+        <div>
+            <label class="validation-error-text">{{customFieldError}}</label>
+        </div>
+    {{/if}}
+    <table class='table align-middle'>
+        <tbody id="custom-fields" class="custom-fields">
+
+        </tbody>
+    </table>
+</div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/deleteNode.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/deleteNode.handlebars
@@ -1,0 +1,17 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="delete-node-name">
+    <input id="{{id}}" class="deleteNode" type="checkbox" value="{{Name}}"> {{Name}}</input>
+</div>
+

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
@@ -1,0 +1,89 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="node-field">
+    <label>{{name}}{{#if required}}*{{/if}}</label>
+    {{#unless custom}}
+        <a href='#' class='description' data-title='{{key}}'>
+            <i class='fa fa-question-circle fa-lg'></i>
+        </a>
+    {{/unless}}
+    {{#if multiValued}}
+        <a href="#" class="add-value fa fa-plus-square fa-lg plus-button"></a>
+    {{/if}}
+    {{#if custom}}
+        <a href="#" class="remove-field fa fa-minus-square fa-lg minus-button"></a>
+
+    {{/if}}
+    <div class="input-area">
+        {{#is type "string"}}
+            {{#if multiValued}}
+                <table class="multi-value-field">
+                    {{#each value}}
+                        <tr>
+                            <td>
+                                <input type="text" class="string-table-input {{../key}}
+                                    {{#if ../validationError}}
+                                        {{#each ../../errorIndices}}
+                                            {{#is @../index this}}validation-error{{/is}}
+                                        {{/each}}
+                                    {{/if}}"
+                                       name="value{{@index}}" value="{{this}}" {{#unless ../../editable}}readonly{{/unless}}/>
+                            </td>
+                            <td>
+                                <a href="#" name="{{@index}}"
+                                   class="remove-value fa fa-minus-square fa-lg minus-button"></a>
+                            </td>
+                        </tr>
+                    {{/each}}
+                </table>
+            {{else}}
+                {{#if possibleValues}}
+                    <select name="value">
+                        {{#each possibleValues}}
+                            <option {{#is this ../value}}selected{{/is}}>{{this}}</option>
+                        {{/each}}
+                    </select>
+                {{else}}
+                    <input type="text" class="string-input {{key}}  {{#if validationError}}validation-error{{/if}}" name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
+                {{/if}}
+            {{/if}}
+        {{/is}}
+        {{#is type "number"}}
+            <input type="number" class="{{#if validationError}}validation-error{{/if}}" name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
+        {{/is}}
+        {{#is type "boolean"}}
+            <input type="checkbox" name="value" value="{{value}}"/>
+        {{/is}}
+        {{#is type "date"}}
+            <input type="date" name="valueDate" value="{{valueDate}}" {{#unless editable}}readonly{{/unless}}/>
+            <input type="time" name="valueTime" value="{{valueTime}}" {{#unless editable}}readonly{{/unless}}/>
+        {{/is}}
+        {{#is type "time"}}
+            <input type="datetime" name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
+        {{/is}}
+        {{#is type "point"}}
+            <div class="coords">
+                <label>Lat:</label><input class="lat-lon-input" type="number" min="-90" max="90" name="valueLat" class="{{#if validationError}} validation-error{{/if}}"
+                                          value="{{valueLat}}"/>
+                <label>Lon:</label><input class="lat-lon-input" type="number" min="-180" max="180" name="valueLon" class="{{#if validationError}} validation-error{{/if}}"
+                                          value="{{valueLon}}"/>
+            </div>
+        {{/is}}
+        {{#if validationError}}
+            <div class="error-div">
+                <label class="validation-error-text">{{validationError}}</label>
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
@@ -1,0 +1,29 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<table class='table table-striped align-middle'>
+    <thead>
+    <th class="name">Name</th>
+    <th class="created">Created On</th>
+    <th class="modified">Last Modified</th>
+    <th>
+        {{#if multiValued}}
+            <a href="#" class="button-icon add-node-link fa fa-plus"></a>
+            <a href="#" class="button-icon refresh-button fa fa-refresh"></a>
+        {{/if}}
+    </th>
+    </thead>
+    <tbody>
+
+    </tbody>
+</table>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
@@ -1,0 +1,89 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal"
+                    aria-hidden="true">&times;</button>
+            <h4 class="modal-title">
+                {{#is mode 'edit'}}
+                    Edit {{name}}
+                {{else}}
+                    Add Local Node
+                {{/is}}
+            </h4>
+        </div>
+        <div class="modal-body">
+            <ul class="nav nav-tabs">
+                <li class="active"><a class="{{#if generalErrors}}validation-error-text{{/if}}"
+                                      id="generalTabLink" data-toggle="tab"
+                                      href="#general">General</a></li>
+                <li><a class="{{#if serviceErrors}}validation-error-text{{/if}}" id="serviceTabLink"
+                       data-toggle="tab" href="#service">Services</a></li>
+                <li><a class="{{#if organizationErrors}}validation-error-text{{/if}}"
+                       id="organizationTabLink" data-toggle="tab" href="#organizations">Organizations</a>
+                </li>
+                <li><a class="{{#if contactErrors}}validation-error-text{{/if}}" id="contactTabLink"
+                       data-toggle="tab" href="#contacts">Contacts</a></li>
+                <li><a class="{{#if collectionErrors}}validation-error-text{{/if}}"
+                       id="collectionTabLink" data-toggle="tab" href="#collections">Collections</a>
+                </li>
+            </ul>
+            <form class="form-horizontal add-federated-source container-fluid">
+                <div class="tab-content">
+                    <div id="general" class="tab-pane fade in active">
+                        <div id="generalInfo"></div>
+                    </div>
+                    <div id="service" class="tab-pane fade">
+                        <div id="serviceInfo"></div>
+                    </div>
+                    <div id="organizations" class="tab-pane fade">
+                        <div id="organizationInfo"></div>
+                    </div>
+                    <div id="contacts" class="tab-pane fade">
+                        <div id="contactInfo"></div>
+                    </div>
+                    <div id="collections" class="tab-pane fade">
+                        <div id="contentInfo"></div>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <div class="modal-footer">
+            {{#if validationErrors}}
+                <div class="error-list">
+                    <label class="validation-error-text">Input validation errors. Please correct
+                        before saving.</label>
+                </div>
+            {{/if}}
+            {{#if saveErrors}}
+                <div class="error-list">
+                    <label class="validation-error-text">Saving data to server failed.</label>
+                </div>
+            {{/if}}
+            <div class="btn-group">
+                {{#is mode 'edit'}}
+                    <button type="button" class="btn btn-primary submit-button">Save</button>
+                {{else}}
+                    <button type="button" class="btn btn-primary submit-button">Add</button>
+                {{/is}}
+                <button type="button" class="btn btn-default cancel-button" data-dismiss="modal">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div><!-- /.modal-content -->
+</div><!-- /.modal-dialog -->

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeRow.handlebars
@@ -1,0 +1,48 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<td>
+    <a href='#{{id}}' class='newLink' data-toggle="modal">
+        {{#if name}}
+            {{name}}
+        {{else}}
+            <span class='label label-danger'>[No Title]</span>
+        {{/if}}
+    </a>
+
+    <div class="modal-container">
+
+    </div>
+</td>
+<td>
+    {{#each slots}}
+        {{#is name "liveDate"}}
+            <label class="label">{{value}}</label>
+        {{/is}}
+    {{/each}}
+</td>
+<td>
+    {{#each slots}}
+        {{#is name "lastUpdated"}}
+            <label class="label">{{value}}</label>
+        {{/is}}
+    {{/each}}
+</td>
+<td/>
+<td>
+    {{#unless identityNode}}
+        <a href="#" class="button-icon remove-node-link fa fa-trash-o"></a>
+    {{/unless}}
+
+</td>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/registryPage.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/registryPage.handlebars
@@ -1,0 +1,24 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div id="registry-modal"></div>
+<div id="localNode">
+    <div>
+        <h4 class="node-table-label">Local Identity Node</h4>
+        <div id="localIdentityNodeRegion"></div>
+
+        <h4 class="node-table-label">Additional Local Nodes</h4>
+        <div id="localAdditionalNodeRegion"></div>
+    </div>
+</div>
+<div id="IframeModalDOM" class="IframeModalDOM"></div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentList.handlebars
@@ -1,0 +1,24 @@
+{{#if showHeader}}
+<div class="segment-header">
+    <table>
+        <tr>
+            <td>
+                <label class="nested-label{{nestedLevel}}">{{segmentName}}</label>
+            </td>
+            {{#if multiValued}}
+                <td>
+                    {{#if autoValues}}
+                        <select class="auto-populate-selector">
+                            <option id="empty" >Empty</option>
+                            {{#each autoValues}}
+                                <option id="{{this.id}}" value="{{this.name}}">{{this.name}}</option>
+                            {{/each}}
+                        </select>
+                    {{/if}}
+                    <a href="#" class="button-icon add-segment fa fa-lg fa-plus-square" aria-hidden="true"></a>
+                </td>
+            {{/if}}
+        </tr>
+    </table>
+</div>
+{{/if}}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentRow.handlebars
@@ -1,0 +1,63 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="segment">
+    {{#if editableSegment}}
+        <table class="segment-header-table">
+            <tr>
+                <td>
+                    <div data-toggle="collapse" data-target="#{{simpleId}}"
+                         class="clickable segment-title {{simpleId}}">
+                        <table class="segment-header-table">
+                            <tr>
+                                <td>
+                                    {{#if errors}}<i class="segment-title-error-{{simpleId}} validation-error-icon fa fa-exclamation-triangle" aria-hidden="true"></i>{{/if}}
+                                    <label class="segment-title-{{simpleId}} nested-label{{nestedLevel}}">{{title}}</label>
+                                </td>
+                                <td>
+                                    <span class="chevron-{{simpleId}} fa fa-chevron-right pull-right"></span>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </td>
+                <td>
+                    <div class="segment-delete">
+                        <a href="#"
+                           class="button-icon remove-segment minus-button fa fa-lg fa-trash-o"></a>
+                    </div>
+                </td>
+        </table>
+    {{/if}}
+    <div id="{{simpleId}}" class="segment-content {{#if editableSegment}}collapse{{/if}}">
+        {{#if showFields}}
+            <table class='table align-middle'>
+                <tbody class="form-fields">
+
+                </tbody>
+            </table>
+        {{/if}}
+        <table class='table align-middle'>
+            <tbody class="form-segments">
+            </tbody>
+        </table>
+
+        {{#if customizable}}
+            <div id="customizable-{{simpleId}}"/>
+        {{/if}}
+
+        {{#if showAssociations}}
+            <div id="associations-{{simpleId}}"/>
+        {{/if}}
+    </div>
+</div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/wreqr.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/wreqr.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+
+define(['backbone', 'marionette'], function (Backbone) {
+    'use strict';
+    var wreqr = {};
+
+    wreqr.vent = new Backbone.Wreqr.EventAggregator();
+    wreqr.commands = new Backbone.Wreqr.Commands();
+    wreqr.reqres = new Backbone.Wreqr.RequestResponse();
+
+    return wreqr;
+});

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -69,6 +69,10 @@
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-admin-local-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-schema-bindings</artifactId>
         </dependency>
         <dependency>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -46,6 +46,7 @@
     <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-action-provider/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-viewer/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-admin-local-ui/${project.version}</bundle>
 </feature>
 
 <feature name="registry-app" install="auto" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
Adds admin ui for adding/editing local registry node information. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@djblue @andrewkfiedler @harrison-tarr 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris

#### How should this be tested?
Start up ddf and then start the DDF Registry app. Once the app is started you can open up the app and see a new 'Local Node Information' tab. You can play around with setting/adding/removing nodes/fields and saving them.
#### Any background context you want to provide?
This was pulled from the ddf-registry repo.
#### What are the relevant tickets?
DDF-1886
#### Screenshots (if appropriate)
Main table view
![screen shot 2016-06-06 at 4 08 54 pm](https://cloud.githubusercontent.com/assets/5248090/15840775/0fd42654-2c01-11e6-9587-a961fdc7a014.png)

Edit dialog
![screen shot 2016-06-06 at 4 01 43 pm](https://cloud.githubusercontent.com/assets/5248090/15840776/14d93446-2c01-11e6-88ba-53e6630d65f3.png)

Validation error
![screen shot 2016-06-07 at 4 11 57 pm](https://cloud.githubusercontent.com/assets/5248090/15882626/472dcb2e-2cf5-11e6-954a-f7f1ff5a1361.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
