### PR TITLE
DDF-2008 Merge registry report action provider from ddf-registry into ddf

### DIFF
--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -87,6 +87,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-report-action-provider</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codice.ddf.spatial</groupId>
                 <artifactId>spatial-ogc-common</artifactId>
                 <version>${project.version}</version>
@@ -147,5 +152,6 @@
         <module>registry-app</module>
         <module>registry-admin-modules</module>
         <module>registry-publication-update-handler</module>
+        <module>registry-report-action-provider</module>
     </modules>
 </project>

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-publication-update-handler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-report-action-provider</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -43,6 +43,7 @@
     <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-report-action-provider/${project.version}</bundle>
 </feature>
 
 <feature name="registry-app" install="auto" version="${project.version}"

--- a/catalog/spatial/registry/registry-report-action-provider/pom.xml
+++ b/catalog/spatial/registry/registry-report-action-provider/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.ddf.registry</groupId>
+        <artifactId>registry</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>registry-report-action-provider</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Registry :: Action Provider</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.72</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.78</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.68</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryMetacardActionProvider.java
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryMetacardActionProvider.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.report.action.provider;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.action.Action;
+import ddf.action.ActionProvider;
+import ddf.action.impl.ActionImpl;
+import ddf.catalog.data.Metacard;
+
+public class RegistryMetacardActionProvider implements ActionProvider {
+
+    public static final String TITLE = "Export Registry Metacard Information";
+
+    public static final String DESCRIPTION = "Provides a URL to the metacard";
+
+    private static final String UNKNOWN_TARGET = "0.0.0.0";
+
+    private static final String REGISTRY_PATH = "/registries";
+
+    private static final String REPORT_PATH = "/report";
+
+    private static final String FORMAT = ".html";
+
+    private static final String SOURCE_ID_QUERY_PARAM = "?sourceId=";
+
+    private final String actionProviderId;
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RegistryMetacardActionProvider.class);
+
+    public RegistryMetacardActionProvider(String id) {
+        this.actionProviderId = id;
+    }
+
+    public <T> List<Action> getActions(T subject) {
+
+        if (canHandle(subject)) {
+            Metacard metacard = (Metacard) subject;
+
+            if (StringUtils.isBlank(metacard.getId())) {
+                LOGGER.debug("No id given. No action to provide.");
+                return Collections.emptyList();
+            }
+
+            if (isHostUnset(SystemBaseUrl.getHost())) {
+                LOGGER.info("Host name/ip not set. Cannot create link for metacard.");
+                return Collections.emptyList();
+            }
+
+            String metacardId;
+            String sourceId;
+
+            try {
+                metacardId = URLEncoder.encode(metacard.getId(),
+                        (StandardCharsets.UTF_8).toString());
+                sourceId = URLEncoder.encode(getSource(metacard),
+                        (StandardCharsets.UTF_8).toString());
+            } catch (UnsupportedEncodingException e) {
+                LOGGER.warn("Unsupported Encoding exception", e);
+                return Collections.emptyList();
+            }
+
+            Action action = getAction(metacardId, sourceId);
+            if (action == null) {
+                return Collections.emptyList();
+            }
+            return Arrays.asList(action);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private Action getAction(String metacardId, String sourceId) {
+
+        String sourceIdValue = "";
+
+        if (StringUtils.isNotBlank(sourceId)) {
+            sourceIdValue = SOURCE_ID_QUERY_PARAM + sourceId;
+        }
+
+        URL url;
+        try {
+
+            URI uri = new URI(SystemBaseUrl.constructUrl(String.format("%s/%s%s%s%s",
+                    REGISTRY_PATH,
+                    metacardId,
+                    REPORT_PATH,
+                    FORMAT,
+                    sourceIdValue), true));
+            url = uri.toURL();
+
+        } catch (MalformedURLException e) {
+            LOGGER.debug("Malformed URL exception", e);
+            return null;
+        } catch (URISyntaxException e) {
+            LOGGER.debug("URI Syntax exception", e);
+            return null;
+        }
+
+        return new ActionImpl(getId(), TITLE, DESCRIPTION, url);
+    }
+
+    private boolean isHostUnset(String host) {
+        return (host == null || host.isEmpty() || host.trim()
+                .equals(UNKNOWN_TARGET));
+    }
+
+    public String getId() {
+        return this.actionProviderId;
+    }
+
+    public <T> boolean canHandle(T subject) {
+
+        return subject instanceof Metacard && ((Metacard) subject).getTags()
+                .contains(RegistryConstants.REGISTRY_TAG);
+
+    }
+
+    protected String getSource(Metacard metacard) {
+
+        if (StringUtils.isNotBlank(metacard.getSourceId())) {
+            return metacard.getSourceId();
+        }
+
+        return "";
+    }
+}

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="registryActionProvider"
+          class="org.codice.ddf.registry.report.action.provider.RegistryMetacardActionProvider">
+        <argument value="catalog.data.metacard.registry.view"/>
+    </bean>
+
+    <service ref="registryActionProvider" interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.metacard.registry.view"/>
+        </service-properties>
+    </service>
+
+</blueprint>


### PR DESCRIPTION
#### What does this PR do?
Create ActionProvider for registry metacards to provide an action (url). Currently this ActionProvider link is accessible when searching for metacards with the registry tag in the search UI and then checking the available actions. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@rzwiefel @kcwire @coyotesqrl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested?
Build, Confirm ActionProvider link in Search UI

This can be tested by following these steps:
1. Installing the registry app
2. Ingesting a registry metacard `ingest -t rim:RegistryPackage /Users/PathToYourDDF/ddf/catalog/spatial/registry/registry-ebrim-transformer/src/test/resources/csw-full-registry-package.xml`
3. Ingesting a second non-registry metacard
4. Open the search UI and do a wildcard search, the use the Details option to search for a **metacard-tags** contains **registry** search
5. Select the registry metacard returned by this second search and select the Action tab
6. Observe the URL generated when selecting **Export Registry Metacard Information** -> Display in new tab/window

#### Any background context you want to provide?
The code to generate the resulting report at the link provided is in another module. 
#### What are the relevant tickets?
DDF-2008
DDF-2059
#### Screenshots
![ddf2008_1](https://cloud.githubusercontent.com/assets/11355332/15477688/de3f7ed6-20ca-11e6-8d9a-bad259b7f6db.png)
![ddf2008_2](https://cloud.githubusercontent.com/assets/11355332/15477694/e2d44170-20ca-11e6-8502-1d5f03aecd14.png)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
