### PR TITLE
DDF-2134 Moves /cometd context beneath the /search context, to /search/cometd

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
@@ -110,7 +110,7 @@ public class CometdEndpoint {
 
     public void init() throws ServletException {
         Dictionary<String, String> properties = new Hashtable<>();
-        properties.put("alias", "/cometd");
+        properties.put("alias", "/search/cometd");
         properties.put("org.eclipse.jetty.servlet.SessionIdPathParameterName", "none");
         properties.put("org.eclipse.jetty.servlet.SessionPath", "/");
         properties.put("load-on-startup", "1");

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/cometd.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/cometd.js
@@ -18,7 +18,7 @@ define(['jquery', 'jquerycometd'], function ($) {
 
     Cometd.Comet = $.cometd;
     Cometd.Comet.websocketEnabled = false;
-    var path = location.protocol + '//' + location.hostname+(location.port ? ':' + location.port : '') + '/cometd';
+    var path = location.protocol + '//' + location.hostname+(location.port ? ':' + location.port : '') + '/search/cometd';
     Cometd.Comet.configure({
         url: path,
         maxNetworkDelay: 30000

--- a/catalog/ui/search-ui/standard/test.js
+++ b/catalog/ui/search-ui/standard/test.js
@@ -37,7 +37,7 @@ app.all('/services/store/config', server.mockRequest);
 app.all('/services/platform/config/ui', server.mockRequest);
 app.all('/services/user', server.mockRequest);
 
-var bayeux = new faye.NodeAdapter({mount: '/cometd', timeout: 60});
+var bayeux = new faye.NodeAdapter({mount: '/search/cometd', timeout: 60});
 app.listen = function() {
     var server = http.createServer(this);
     bayeux.attach(server);

--- a/distribution/docs/src/main/resources/_contents/extending-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/extending-contents.adoc
@@ -1,4 +1,3 @@
-
 This section discusses the several extension points and components permitted by the ${branding} APIs.
 Using code examples, diagrams, and references to specific instances of each API, this guide provides details on how to develop and extend various ${branding} components.
 
@@ -899,7 +898,7 @@ CometD offers both Dojo and jQuery bindings that allow CometD to be easily used 
 For more information on the individual bindings, refer to the http://docs.cometd.org/2/reference/javascript.html[JavaScript Library page] in the CometD reference manual.
 The UI application uses the jQuery library.
 To initialize the CometD connection, an instance of CometD must be created and configured to point to the server and call the handshake, which creates the network connection.
-The CometD endpoint is exposed at `/cometd`, and it is recommended to not use websockets when connecting.
+The CometD endpoint is exposed at `/search/cometd`, and it is recommended to not use websockets when connecting.
 
 .Example Initialization with JQuery
 [source,javascript,linenums]
@@ -912,7 +911,7 @@ Cometd.Comet.websocketEnabled = false;
 
 // configure the location of the cometd endpoint on the server
 Cometd.Comet.configure({
-	url: 'http://server:8181/cometd'
+	url: 'http://server:8181/search/cometd'
 });
 
 // create network connection to server

--- a/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
@@ -1,4 +1,3 @@
-
 This section supports integrating ${branding} with existing applications or frameworks.
 
 === Understanding Metadata and Metacards
@@ -306,7 +305,7 @@ If caching is enabled, a progress bar is displayed in the Activity (Product Retr
 
 The following section shows examples of integration.
 The channels are used for clients to subscribe, followed by examples of request and responses.
-There is only one endpoint hosted at `<${branding}_IP>:<${branding}_PORT_NUMBER>/cometd`
+There is only one endpoint hosted at `<${branding}_IP>:<${branding}_PORT_NUMBER>/search/cometd`
 
 ===== Subscribing to Notifications
 

--- a/distribution/sdk/sample-cometd/cometd-java-example/src/main/java/org/codice/ddf/sdk/cometd/AsyncClient.java
+++ b/distribution/sdk/sample-cometd/cometd-java-example/src/main/java/org/codice/ddf/sdk/cometd/AsyncClient.java
@@ -56,7 +56,7 @@ public class AsyncClient {
 
     private static final String DOWNLOADS_CHANNEL = NOTIFICATIONS_CHANNEL + "/downloads";
 
-    private static final String COMETD_CONTEXT = "/cometd";
+    private static final String COMETD_CONTEXT = "/search/cometd";
 
     private static final String DOWNLOAD_CONTEXT = "/services/catalog/sources/";
 

--- a/distribution/sdk/sample-cometd/cometd-web-example/README.md
+++ b/distribution/sdk/sample-cometd/cometd-web-example/README.md
@@ -2,7 +2,7 @@
 Example of how to interact with the DDF Asynchronous API in the Browser
 
 ## Usage
-This example assumes that the CometD endpoint is available at `https://localhost:8993/cometd`, if another url is required change the `cometURL` variable in `src/main/webapp/js/application.js`
+This example assumes that the CometD endpoint is available at `https://localhost:8993/search/cometd`, if another url is required change the `cometURL` variable in `src/main/webapp/js/application.js`
 
 ### DDF
 To use in DDF run `mvn install` and `cp target/sample-cometd.jar $DDF_HOME/deploy` then go to `https://localhost:8993/sample/cometd`

--- a/distribution/sdk/sample-cometd/cometd-web-example/src/main/webapp/js/application.js
+++ b/distribution/sdk/sample-cometd/cometd-web-example/src/main/webapp/js/application.js
@@ -20,7 +20,7 @@
     cometd.websocketEnabled=false;
     
     // CometD endpoint is assumed to be at localhost, change if otherwise
-    var cometURL = "https://localhost:8993/cometd";
+    var cometURL = "https://localhost:8993/search/cometd";
 
     $(document).ready(function() {
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -71,7 +71,7 @@ import ddf.test.itests.AbstractIntegrationTest;
 public class TestSingleSignOn extends AbstractIntegrationTest {
 
     private static final String IDP_AUTH_TYPES =
-            "/=SAML|GUEST,/search=IDP,/cometd=IDP,/solr=SAML|PKI|basic,/services/whoami=IDP|GUEST";
+            "/=SAML|GUEST,/search=IDP,/solr=SAML|PKI|basic,/services/whoami=IDP|GUEST";
 
     private static final String KEY_STORE_PATH = System.getProperty("javax.net.ssl.keyStore");
 

--- a/platform/security/policy/security-policy-context/src/test/java/org/codice/security/policy/context/PolicyManagerTest.java
+++ b/platform/security/policy/security-policy-context/src/test/java/org/codice/security/policy/context/PolicyManagerTest.java
@@ -97,8 +97,8 @@ public class PolicyManagerTest {
                 new Policy("/admin", null, new ArrayList<String>(), null));
         manager.setContextPolicy("/search/standard",
                 new Policy("/search/standard", null, new ArrayList<String>(), null));
-        manager.setContextPolicy("/cometd",
-                new Policy("/cometd", null, new ArrayList<String>(), null));
+        manager.setContextPolicy("/search/cometd",
+                new Policy("/search/cometd", null, new ArrayList<String>(), null));
         manager.setContextPolicy("/search/simple",
                 new Policy("/search/simple", null, new ArrayList<String>(), null));
         manager.setContextPolicy("/aaaaaa",


### PR DESCRIPTION
#### What does this PR do?
Moves the `/cometd` context.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @ryeats 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested?
Full build and itests; install and ingest; ensure that search UI works correctly.

#### Any background context you want to provide?
Currently, the webcontext policy for the `/search` and `/cometd` contexts must be kept in lockstep. As there is no reason for the `/cometd` context to be directly beneath the root, this move will simplify security configuration for our users.

#### What are the relevant tickets?
DDF-2134

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests
