### PR TITLE
DDF-2136 Added metacard peer folder to dump/ingest include content zip

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -97,6 +97,8 @@ public class IngestCommand extends CatalogCommands {
 
     private static final String ZIP_DECOMPRESSION = "zipDecompression";
 
+    private static final String METACARD_PATH = "metacards" + File.separator;
+
     private final PeriodFormatter timeFormatter = new PeriodFormatterBuilder().printZeroRarelyLast()
             .appendDays()
             .appendSuffix(" day", " days")
@@ -432,8 +434,7 @@ public class IngestCommand extends CatalogCommands {
 
     private void makeFailedIngestDirectory() {
         if (!failedIngestDirectory.mkdirs()) {
-            printErrorMessage(
-                    "Unable to create directory [" + failedIngestDirectory.getAbsolutePath()
+            printErrorMessage("Unable to create directory [" + failedIngestDirectory.getAbsolutePath()
                             + "].");
         }
     }
@@ -490,7 +491,7 @@ public class IngestCommand extends CatalogCommands {
                     List<Metacard> metacardList = zipDecompression.transform(inputStream,
                             arguments);
                     if (metacardList.size() != 0) {
-                        metacardFileMapping = generateFileMap(inputFile.getParentFile());
+                        metacardFileMapping = generateFileMap(new File(inputFile.getParent(), METACARD_PATH));
                         fileCount.set(metacardList.size());
                         metacardQueue.addAll(metacardList);
                     }

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -61,6 +61,8 @@ public class ZipCompression implements QueryResponseTransformer {
 
     public CatalogFramework catalogFramework;
 
+    public static final String METACARD_PATH = "metacards" + File.separator;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipCompression.class);
 
     /**
@@ -103,7 +105,7 @@ public class ZipCompression implements QueryResponseTransformer {
                 .forEach(metacard -> {
                     ZipParameters zipParameters = new ZipParameters();
                     zipParameters.setSourceExternalStream(true);
-                    zipParameters.setFileNameInZip(metacard.getId());
+                    zipParameters.setFileNameInZip(METACARD_PATH + metacard.getId());
 
                     try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
                             ObjectOutputStream objectOutputStream = new ObjectOutputStream(

--- a/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/TestZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/TestZipCompression.java
@@ -146,7 +146,8 @@ public class TestZipCompression {
     public void testCompressionWithFilePath() throws Exception {
         BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
         assertThat(binaryContent, notNullValue());
-        assertZipContents(binaryContent, Arrays.asList("id1", "id2"));
+        assertZipContents(binaryContent, Arrays.asList(ZipCompression.METACARD_PATH + "id1",
+                ZipCompression.METACARD_PATH + "id2"));
         Files.deleteIfExists(file.toPath());
     }
 
@@ -157,8 +158,11 @@ public class TestZipCompression {
         BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
         assertThat(binaryContent, notNullValue());
 
-        ArrayList<String> assertionList = new ArrayList<>(idList);
-        assertionList.add("content/id3-localresource.txt");
+        List<String> assertionList = Arrays.asList(
+                ZipCompression.METACARD_PATH + "id1",
+                ZipCompression.METACARD_PATH + "id2",
+                ZipCompression.METACARD_PATH + "id3",
+                "content/id3-localresource.txt");
         assertZipContents(binaryContent, assertionList);
 
         Files.deleteIfExists(file.toPath());


### PR DESCRIPTION
#### What does this PR do?
This PR adds a `metacards` folder to the zip file generated from catalog:dump --include-content.  Also updated catalog:ingest --include-content to respect this change.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth 
@glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build DDF and run catalog:ingest and catalog:dump using --include-content, and verify that the metacards file exists and the commands still work.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2136
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
