### PR TITLE
DDF-2127: Update Tika from version 1.11.0 to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <mockito.version>1.10.19</mockito.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <junit.version>4.12</junit.version>
-        <tika.version>1.11</tika.version>
+        <tika.version>1.13</tika.version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <commons-lang.version>2.6</commons-lang.version>
         <handlebars.version>2.0.0</handlebars.version>


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where in some cases the ExternalParser class could not be found, and an error would be thrown. This affected the FTP when trying to ingest a file whose transformer may not have been installed. For example, a .ntf file being ingested without the Imagery app.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mweser @troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie 
@kcwire
#### How should this be tested?
Successful full build and itests.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2127](https://codice.atlassian.net/browse/DDF-2127)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests