### PR TITLE
DDF-2138 Fix tmpdir with comment in name

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.apache.felix.fileinstall-definitions.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.felix.fileinstall-definitions.cfg
@@ -12,12 +12,7 @@
 # */
 
 felix.fileinstall.dir = ${karaf.base}/etc/definitions
-felix.fileinstall.tmpdir  = ${karaf.data}/generated-bundles #do we need
+felix.fileinstall.tmpdir  = ${karaf.data}/generated-bundles
 felix.fileinstall.poll    = 997
-felix.fileinstall.bundles.new.start = true              #do we need
 felix.fileinstall.filter = .*\\.json
-felix.fileinstall.bundles.startTransient = false        #do we need
-felix.fileinstall.bundles.startActivationPolicy = true  #do we need
 felix.fileinstall.log.level = 0
-felix.fileinstall.noInitialDelay = false
-felix.fileinstall.start.level = 0


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where a comment was getting included in a directory name, as well as cleaning up some other unneeded properties.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth 
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef
#### How should this be tested?
 - Double-check against the documentation [here](http://felix.apache.org/documentation/subprojects/apache-felix-file-install.html)
 - Build, run, verify there's only one `generated-bundles` directory

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2138](https://codice.atlassian.net/browse/DDF-2138)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests