### PR TITLE
Ddf 2143 - SchematronValidationService should sanitze it's metadata

### DIFF
--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.ErrorListener;
@@ -242,8 +243,14 @@ public class SchematronValidationService implements MetacardValidator, Describab
             schematronReport = generateReport(metadata, validator);
             if (!schematronReport.isValid(suppressWarnings)) {
                 throw new SchematronValidationException("Schematron validation failed.",
-                        schematronReport.getErrors(),
-                        schematronReport.getWarnings());
+                        schematronReport.getErrors()
+                                .stream()
+                                .map(SchematronValidationService::sanitize)
+                                .collect(Collectors.toList()),
+                        schematronReport.getWarnings()
+                                .stream()
+                                .map(SchematronValidationService::sanitize)
+                                .collect(Collectors.toList()));
             }
         }
     }
@@ -264,6 +271,15 @@ public class SchematronValidationService implements MetacardValidator, Describab
                     e);
         }
         return report;
+    }
+
+    /**
+     * Replace tabs, literal carriage returns, and newlines with a single whitespace
+     * @param input
+     * @return
+     */
+    static String sanitize(final String input) {
+        return input.replaceAll("[\t \r\n]+", " ").trim();
     }
 
     @Override


### PR DESCRIPTION
#### What does this PR do?
Currently, the messages produced by SchematronValidationService contain all the whitespace and literal newlines from the raw schematron xml. These should be stripped out so that exact queries don't need to include all those extra characters and so they will display better in UI's.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@spearskw @harrison-tarr 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 
@pklinef

#### How should this be tested?
 - There is a unit test included. 
 - It can be manually verified by ingesting valid metacards and then looking in `/solr/admin` to verify that there are no longer `/n` and extra whitespace characters in the validation warning / error string

#### Any background context you want to provide?
This change was desired due to **burgeoning** changes to the UI.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2143
#### Screenshots (if appropriate)

 - Before sanitization
![validation_warnings_no_sanitization](https://cloud.githubusercontent.com/assets/5597089/15512277/e705323a-2193-11e6-9f7a-4490070f60e4.png)

 - After sanitization
![validation_warnings_sanitization](https://cloud.githubusercontent.com/assets/5597089/15523399/fd693202-21ce-11e6-97a5-b0e8e05f52c5.png)


#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests