### PR TITLE
DDF-2082 Fix MetacardValidityMarkerPlugin so it runs on update requests

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
@@ -22,7 +22,6 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>ddf.catalog.plugin</groupId>
     <artifactId>catalog-plugin-metacard-validation</artifactId>
     <packaging>bundle</packaging>
     <name>DDF :: Catalog :: Plugin :: Metacard Validation</name>
@@ -36,26 +35,25 @@
             <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>antlr</groupId>
-            <artifactId>antlr</artifactId>
-            <version>2.7.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>filter-proxy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
-    </dependencies>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -66,7 +64,10 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package/>
-                        <Embed-Dependency>catalog-core-api-impl, commons-lang3,platform-util</Embed-Dependency>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>
@@ -88,22 +89,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.87</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
@@ -13,8 +13,8 @@
  */
 package ddf.catalog.metacard.validation;
 
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_ERRORS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_WARNINGS;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -46,9 +46,9 @@ public class MetacardValidityFilterPlugin implements PolicyPlugin {
     }
 
     public void setAttributeMap(List<String> attributeMappings) {
-        if (CollectionUtils.isEmpty(attributeMappings)|| (
-                attributeMappings.size() == 1 && attributeMappings.get(0)
-                        .isEmpty())) {
+        if (CollectionUtils.isEmpty(attributeMappings) || (attributeMappings.size() == 1
+                && attributeMappings.get(0)
+                .isEmpty())) {
             attributeMap = new HashMap<>();
             return;
         }

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityFilterPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityFilterPluginTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_ERRORS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_WARNINGS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,13 +148,15 @@ public class MetacardValidityFilterPluginTest {
     @Test
     public void testResetAttributeMappingEmptyList() {
         metacardValidityFilterPlugin.setAttributeMap(new ArrayList<String>());
-        assertThat(metacardValidityFilterPlugin.getAttributeMap(), is(new HashMap<String, List<String>>()));
+        assertThat(metacardValidityFilterPlugin.getAttributeMap(),
+                is(new HashMap<String, List<String>>()));
     }
 
     @Test
     public void testResetAttributeMappingEmptyString() {
         metacardValidityFilterPlugin.setAttributeMap(Arrays.asList(""));
-        assertThat(metacardValidityFilterPlugin.getAttributeMap(), is(new HashMap<String, List<String>>()));
+        assertThat(metacardValidityFilterPlugin.getAttributeMap(),
+                is(new HashMap<String, List<String>>()));
     }
 }
 

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
@@ -11,31 +11,49 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-
 package ddf.catalog.metacard.validation;
 
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.theInstance;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_ERRORS;
-import static ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin.VALIDATION_WARNINGS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_ERRORS;
+import static ddf.catalog.data.impl.BasicTypes.VALIDATION_WARNINGS;
 
+import java.io.Serializable;
+import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.Request;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.impl.CreateRequestImpl;
 import ddf.catalog.operation.impl.DeleteRequestImpl;
@@ -47,257 +65,327 @@ import ddf.catalog.validation.MetacardValidator;
 import ddf.catalog.validation.ValidationException;
 
 public class MetacardValidityMarkerPluginTest {
-
     private static final String ID = "ID";
 
-    private static final String SAMPLE = "sample";
+    private static final String SAMPLE_WARNING = "sample warning";
+
+    private static final String SAMPLE_ERROR = "sample error";
+
+    private static final String FIRST = "first";
+
+    private static final String SECOND = "second";
+
+    private static final Map<String, Serializable> PROPERTIES = Collections.singletonMap("foo",
+            "bar");
+
+    private static final Set<String> DESTINATIONS = Sets.newHashSet("source 1", "source 2");
+
+    private final Consumer<Attribute> expectNone = attribute -> assertThat(attribute,
+            is(nullValue()));
+
+    private final Consumer<Attribute> expectError = attribute -> {
+        assertThat(attribute.getValues(), hasSize(1));
+        assertThat(attribute.getValues(), contains(SAMPLE_ERROR));
+    };
+
+    private final Consumer<Attribute> expectWarning = attribute -> {
+        assertThat(attribute.getValues(), hasSize(1));
+        assertThat(attribute.getValues(), contains(SAMPLE_WARNING));
+    };
+
+    private MetacardValidityMarkerPlugin plugin;
+
+    private List<MetacardValidator> metacardValidators;
+
+    private List<String> enforcedMetacardValidators;
+
+    @Before
+    public void setUp() {
+        metacardValidators = new ArrayList<>();
+        enforcedMetacardValidators = new ArrayList<>();
+        plugin = new MetacardValidityMarkerPlugin();
+        plugin.setMetacardValidators(metacardValidators);
+        plugin.setEnforcedMetacardValidators(enforcedMetacardValidators);
+    }
+
+    private List<Metacard> getUpdatedMetacards(UpdateRequest updateRequest) {
+        return updateRequest.getUpdates()
+                .stream()
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private void verifyCreate(CreateRequest originalRequest, Consumer<Attribute> errorExpectation,
+            Consumer<Attribute> warningExpectation)
+            throws PluginExecutionException, StopProcessingException {
+        CreateRequest filteredRequest = plugin.process(originalRequest);
+        List<Metacard> filteredMetacards = filteredRequest.getMetacards();
+
+        verifyMetacardErrorsAndWarnings(filteredMetacards, errorExpectation, warningExpectation);
+        verifyRequestPropertiesUnchanged(originalRequest, filteredRequest);
+    }
+
+    private void verifyUpdate(UpdateRequest originalRequest, Consumer<Attribute> errorExpectation,
+            Consumer<Attribute> warningExpectation)
+            throws PluginExecutionException, StopProcessingException {
+        UpdateRequest filteredRequest = plugin.process(originalRequest);
+        List<Metacard> filteredMetacards = getUpdatedMetacards(filteredRequest);
+
+        verifyMetacardErrorsAndWarnings(filteredMetacards, errorExpectation, warningExpectation);
+        verifyRequestPropertiesUnchanged(originalRequest, filteredRequest);
+    }
+
+    private void verifyMetacardErrorsAndWarnings(List<Metacard> filteredMetacards,
+            Consumer<Attribute> errorExpectation, Consumer<Attribute> warningExpectation) {
+        assertThat(filteredMetacards, hasSize(2));
+
+        filteredMetacards.forEach(metacard -> {
+            errorExpectation.accept(metacard.getAttribute(VALIDATION_ERRORS));
+            warningExpectation.accept(metacard.getAttribute(VALIDATION_WARNINGS));
+        });
+    }
+
+    private void verifyRequestPropertiesUnchanged(Request original, Request processed) {
+        assertThat(processed.getProperties(), is(original.getProperties()));
+        assertThat(processed.getStoreIds(), is(original.getStoreIds()));
+    }
 
     @Test
-    public void testMarkMetacardValid()
-            throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
+    public void testMarkMetacardValid() throws StopProcessingException, PluginExecutionException {
         metacardValidators.add(getMockPassingValidator());
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS), is(nullValue(null)));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS), is(nullValue(null)));
+        verifyCreate(getMockCreateRequest(), expectNone, expectNone);
+        verifyUpdate(getMockUpdateRequest(), expectNone, expectNone);
     }
 
     @Test
     public void testMarkMetacardInvalidErrors()
             throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockFailingValidatorWithErrors(ID));
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_ERRORS)
-                .getValues()
-                .contains(SAMPLE), is(true));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_ERRORS)
-                .getValues()
-                .size(), is(1));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS), is(nullValue(null)));
+        metacardValidators.add(getMockFailingValidatorWithErrors());
+        verifyCreate(getMockCreateRequest(), expectError, expectNone);
+        verifyUpdate(getMockUpdateRequest(), expectError, expectNone);
     }
 
     @Test
     public void testMarkMetacardInvalidWarnings()
             throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockFailingValidatorWithWarnings(ID));
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_ERRORS), is(nullValue(null)));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS)
-                .getValues()
-                .contains(SAMPLE), is(true));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS)
-                .getValues()
-                .size(), is(1));
+        metacardValidators.add(getMockFailingValidatorWithWarnings());
+        verifyCreate(getMockCreateRequest(), expectNone, expectWarning);
+        verifyUpdate(getMockUpdateRequest(), expectNone, expectWarning);
     }
 
     @Test
     public void testMarkMetacardInvalidErrorsAndWarnings()
             throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings(ID));
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_ERRORS)
-                .getValues()
-                .contains(SAMPLE), is(true));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_ERRORS)
-                .getValues()
-                .size(), is(1));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS)
-                .getValues()
-                .contains(SAMPLE), is(true));
-        assertThat(filteredRequest.getMetacards()
-                .get(0)
-                .getAttribute(VALIDATION_WARNINGS)
-                .getValues()
-                .size(), is(1));
+        metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings());
+        verifyCreate(getMockCreateRequest(), expectError, expectWarning);
+        verifyUpdate(getMockUpdateRequest(), expectError, expectWarning);
     }
 
     @Test
-    public void testUpdateProcess() throws StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        UpdateRequestImpl updateRequest = mock(UpdateRequestImpl.class);
-        UpdateRequest returnedUpdateRequest = plugin.process(updateRequest);
-        assertThat(returnedUpdateRequest, is(equalTo(updateRequest)));
-
-    }
-
-    @Test
-    public void testDeleteProcess() throws StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
+    public void testProcessDelete() throws StopProcessingException, PluginExecutionException {
         DeleteRequestImpl deleteRequest = mock(DeleteRequestImpl.class);
         DeleteRequest returnedDeleteRequest = plugin.process(deleteRequest);
-        assertThat(returnedDeleteRequest, is(equalTo(deleteRequest)));
+        assertThat(returnedDeleteRequest, is(theInstance(deleteRequest)));
+    }
+
+    private void verifyEnforcedCreate(CreateRequest originalRequest,
+            List<Metacard> expectedAllowedMetacards)
+            throws PluginExecutionException, StopProcessingException {
+        CreateRequest filteredRequest = plugin.process(originalRequest);
+
+        List<Metacard> filteredMetacards = filteredRequest.getMetacards();
+        verifyAllowedMetacards(filteredMetacards, expectedAllowedMetacards);
+
+        verifyRequestPropertiesUnchanged(originalRequest, filteredRequest);
+    }
+
+    private void verifyEnforcedUpdate(UpdateRequest originalRequest,
+            List<Metacard> expectedAllowedMetacards)
+            throws PluginExecutionException, StopProcessingException {
+        UpdateRequest filteredRequest = plugin.process(originalRequest);
+
+        List<Metacard> filteredMetacards = getUpdatedMetacards(filteredRequest);
+        verifyAllowedMetacards(filteredMetacards, expectedAllowedMetacards);
+
+        verifyRequestPropertiesUnchanged(originalRequest, filteredRequest);
+    }
+
+    private void verifyAllowedMetacards(List<Metacard> filteredMetacards,
+            List<Metacard> expectedAllowedMetacards) {
+        Matcher[] metacardMatchers = expectedAllowedMetacards.stream()
+                .map(Matchers::theInstance)
+                .toArray(Matcher[]::new);
+        assertThat(filteredMetacards, contains(metacardMatchers));
     }
 
     @Test
-    public void testAllowMetacardEnforcedValidation()
-            throws ValidationException, StopProcessingException, PluginExecutionException {
-        String id = ID + "1";
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockPassingValidatorWithId(id));
-        plugin.setMetacardValidators(metacardValidators);
-        List<String> enforcedMetacardValidators = new ArrayList<>();
-        enforcedMetacardValidators.add(id);
-        plugin.setEnforcedMetacardValidators(enforcedMetacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .isEmpty(), is(false));
+    public void testMetacardPassesEnforcedValidators()
+            throws StopProcessingException, PluginExecutionException {
+        metacardValidators.add(getMockEnforcedPassingValidatorWithId(ID));
+        enforcedMetacardValidators.add(ID);
+
+        CreateRequest createRequest = getMockCreateRequest();
+        List<Metacard> createdMetacards = createRequest.getMetacards();
+        verifyEnforcedCreate(createRequest, createdMetacards);
+
+        UpdateRequest updateRequest = getMockUpdateRequest();
+        List<Metacard> updatedMetacards = getUpdatedMetacards(updateRequest);
+        verifyEnforcedUpdate(updateRequest, updatedMetacards);
     }
 
     @Test
-    public void testRemoveMetacardEnforcedValidation()
+    public void testMetacardFailsEnforcedValidator()
             throws ValidationException, StopProcessingException, PluginExecutionException {
-        String id = ID + "1";
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockFailingValidatorWithId(id));
-        plugin.setMetacardValidators(metacardValidators);
-        List<String> enforcedMetacardValidators = new ArrayList<>();
-        enforcedMetacardValidators.add(id);
-        plugin.setEnforcedMetacardValidators(enforcedMetacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .isEmpty(), is(true));
+        metacardValidators.add(getMockEnforcedFailingValidatorWithId(ID));
+        enforcedMetacardValidators.add(ID);
+
+        CreateRequest createRequest = getMockCreateRequest();
+        List<Metacard> createdMetacards = createRequest.getMetacards();
+        verifyEnforcedCreate(createRequest, createdMetacards.subList(1, createdMetacards.size()));
+
+        UpdateRequest updateRequest = getMockUpdateRequest();
+        List<Metacard> updatedMetacards = getUpdatedMetacards(updateRequest);
+        verifyEnforcedUpdate(updateRequest, updatedMetacards.subList(1, updatedMetacards.size()));
     }
 
     @Test
-    public void testAllowMetacardNoDescribable()
-            throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockPassingValidatorNoDescribable());
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .isEmpty(), is(false));
+    public void testMetacardPassesEnforcedValidatorsNoDescribable()
+            throws StopProcessingException, PluginExecutionException {
+        MetacardValidator mockValidator = getMockPassingValidatorNoDescribable();
+        metacardValidators.add(mockValidator);
+        enforcedMetacardValidators.add(mockValidator.getClass()
+                .getCanonicalName());
+
+        CreateRequest createRequest = getMockCreateRequest();
+        List<Metacard> createdMetacards = createRequest.getMetacards();
+        verifyEnforcedCreate(createRequest, createdMetacards);
+
+        UpdateRequest updateRequest = getMockUpdateRequest();
+        List<Metacard> updatedMetacards = getUpdatedMetacards(updateRequest);
+        verifyEnforcedUpdate(updateRequest, updatedMetacards);
     }
 
     @Test
-    public void testRemoveMetacardNoDescribable()
+    public void testMetacardFailsEnforcedValidatorNoDescribable()
             throws ValidationException, StopProcessingException, PluginExecutionException {
-        MetacardValidityMarkerPlugin plugin = new MetacardValidityMarkerPlugin();
-        List<MetacardValidator> metacardValidators = new ArrayList<>();
-        metacardValidators.add(getMockFailingValidatorNoDescribable());
-        plugin.setMetacardValidators(metacardValidators);
-        CreateRequest filteredRequest = plugin.process(getMockCreateRequest());
-        assertThat(filteredRequest.getMetacards()
-                .isEmpty(), is(false));
+        MetacardValidator mockValidator = getMockFailingValidatorNoDescribable();
+        metacardValidators.add(mockValidator);
+        enforcedMetacardValidators.add(mockValidator.getClass()
+                .getCanonicalName());
 
+        CreateRequest createRequest = getMockCreateRequest();
+        List<Metacard> createdMetacards = createRequest.getMetacards();
+        verifyEnforcedCreate(createRequest, createdMetacards.subList(1, createdMetacards.size()));
+
+        UpdateRequest updateRequest = getMockUpdateRequest();
+        List<Metacard> updatedMetacards = getUpdatedMetacards(updateRequest);
+        verifyEnforcedUpdate(updateRequest, updatedMetacards.subList(1, updatedMetacards.size()));
     }
 
     @Test
     public void testGetters() {
-        assertThat(new MetacardValidityMarkerPlugin().getMetacardValidators(), is(nullValue(null)));
-        assertThat(new MetacardValidityMarkerPlugin().getEnforcedMetacardValidators(),
-                is(nullValue(null)));
+        assertThat(plugin.getMetacardValidators(), is(empty()));
+        assertThat(plugin.getEnforcedMetacardValidators(), is(empty()));
+    }
+
+    private Metacard metacardWithTitle(String title) {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle(title);
+        return metacard;
     }
 
     private CreateRequest getMockCreateRequest() {
-        List<Metacard> listMetacards = new ArrayList<>();
-        listMetacards.add(new MetacardImpl());
-        return new CreateRequestImpl(listMetacards);
+        List<Metacard> listMetacards = Lists.newArrayList(metacardWithTitle(FIRST),
+                metacardWithTitle(SECOND));
+        return new CreateRequestImpl(listMetacards, PROPERTIES, DESTINATIONS);
     }
 
-    private MetacardValidator getMockPassingValidator() throws ValidationException {
+    private UpdateRequest getMockUpdateRequest() {
+        List<Map.Entry<Serializable, Metacard>> updates = new ArrayList<>();
+        updates.add(new AbstractMap.SimpleEntry<>(FIRST, metacardWithTitle(FIRST)));
+        updates.add(new AbstractMap.SimpleEntry<>(SECOND, metacardWithTitle(SECOND)));
+        return new UpdateRequestImpl(updates, Metacard.TITLE, PROPERTIES, DESTINATIONS);
+    }
+
+    private MetacardValidator getMockPassingValidator() {
         return mock(MetacardValidator.class, withSettings().extraInterfaces(Describable.class));
     }
 
-    private MetacardValidator getMockFailingValidatorWithErrors(String id)
-            throws ValidationException {
+    private MetacardValidator getMockFailingValidatorWithErrors() throws ValidationException {
         ValidationException validationException = mock(ValidationException.class);
-        when(validationException.getErrors()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        when(validationException.getErrors()).thenReturn(Collections.singletonList(SAMPLE_ERROR));
         MetacardValidator metacardValidator = mock(MetacardValidator.class,
                 withSettings().extraInterfaces(Describable.class));
-        when(((Describable) metacardValidator).getId()).thenReturn(id);
         doThrow(validationException).when(metacardValidator)
                 .validate(any(Metacard.class));
         return metacardValidator;
     }
 
-    private MetacardValidator getMockFailingValidatorWithWarnings(String id)
-            throws ValidationException {
+    private MetacardValidator getMockFailingValidatorWithWarnings() throws ValidationException {
         ValidationException validationException = mock(ValidationException.class);
-        when(validationException.getWarnings()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        when(validationException.getWarnings()).thenReturn(Collections.singletonList(SAMPLE_WARNING));
         MetacardValidator metacardValidator = mock(MetacardValidator.class,
                 withSettings().extraInterfaces(Describable.class));
-        when(((Describable) metacardValidator).getId()).thenReturn(id);
         doThrow(validationException).when(metacardValidator)
                 .validate(any(Metacard.class));
         return metacardValidator;
     }
 
-    private MetacardValidator getMockFailingValidatorWithErrorsAndWarnings(String id)
+    private MetacardValidator getMockFailingValidatorWithErrorsAndWarnings()
             throws ValidationException {
         ValidationException validationException = mock(ValidationException.class);
-        when(validationException.getErrors()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
-        when(validationException.getWarnings()).thenReturn(new ArrayList<>(Arrays.asList(SAMPLE)));
+        when(validationException.getErrors()).thenReturn(Collections.singletonList(SAMPLE_ERROR));
+        when(validationException.getWarnings()).thenReturn(Collections.singletonList(SAMPLE_WARNING));
         MetacardValidator metacardValidator = mock(MetacardValidator.class,
                 withSettings().extraInterfaces(Describable.class));
-        when(((Describable) metacardValidator).getId()).thenReturn(id);
         doThrow(validationException).when(metacardValidator)
                 .validate(any(Metacard.class));
         return metacardValidator;
     }
 
-    private MetacardValidator getMockPassingValidatorWithId(String id) throws ValidationException {
+    private MetacardValidator getMockEnforcedPassingValidatorWithId(String id) {
         MetacardValidator metacardValidator = mock(MetacardValidator.class,
                 withSettings().extraInterfaces(Describable.class));
         when(((Describable) metacardValidator).getId()).thenReturn(id);
         return metacardValidator;
-
     }
 
-    private MetacardValidator getMockFailingValidatorWithId(String id) throws ValidationException {
+    private MetacardValidator getMockEnforcedFailingValidatorWithId(String id)
+            throws ValidationException {
         MetacardValidator metacardValidator = mock(MetacardValidator.class,
                 withSettings().extraInterfaces(Describable.class));
         doThrow(mock(ValidationException.class)).when(metacardValidator)
-                .validate(any(Metacard.class));
+                .validate(argThat(isMetacardWithTitle(FIRST)));
         when(((Describable) metacardValidator).getId()).thenReturn(id);
         return metacardValidator;
     }
 
-    private MetacardValidator getMockPassingValidatorNoDescribable() throws ValidationException {
-        MetacardValidator metacardValidator = mock(MetacardValidator.class);
-        return metacardValidator;
+    private class IsMetacardWithTitle extends ArgumentMatcher<Metacard> {
+        private final String title;
+
+        private IsMetacardWithTitle(String title) {
+            this.title = title;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            return ((Metacard) o).getTitle()
+                    .equals(title);
+        }
+    }
+
+    private IsMetacardWithTitle isMetacardWithTitle(String title) {
+        return new IsMetacardWithTitle(title);
+    }
+
+    private MetacardValidator getMockPassingValidatorNoDescribable() {
+        return mock(MetacardValidator.class);
     }
 
     private MetacardValidator getMockFailingValidatorNoDescribable() throws ValidationException {
         MetacardValidator metacardValidator = mock(MetacardValidator.class);
         doThrow(mock(ValidationException.class)).when(metacardValidator)
-                .validate(any(Metacard.class));
+                .validate(argThat(isMetacardWithTitle(FIRST)));
         return metacardValidator;
     }
 }

--- a/distribution/sdk/sample-metacard-validator/pom.xml
+++ b/distribution/sdk/sample-metacard-validator/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>platform-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
+++ b/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
@@ -14,10 +14,10 @@
 
 package org.codice.ddf.sdk.validation.metacard;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.util.Describable;
@@ -26,8 +26,7 @@ import ddf.catalog.validation.ValidationException;
 import ddf.catalog.validation.impl.ValidationExceptionImpl;
 
 public class SampleMetacardValidator implements MetacardValidator, Describable {
-
-    private static String[] validWords = new String[] {"test", "default", "sample"};
+    private Set<String> validWords = Sets.newHashSet("test", "default", "sample");
 
     private String id = "sample-validator";
 
@@ -62,32 +61,27 @@ public class SampleMetacardValidator implements MetacardValidator, Describable {
 
     @Override
     public void validate(Metacard metacard) throws ValidationException {
-        if (!checkMetacard(metacard.getTitle(), new ArrayList<>(Arrays.asList(validWords)))) {
+        if (!checkMetacard(metacard.getTitle())) {
             ValidationExceptionImpl validationException = new ValidationExceptionImpl(
-                    "Metacard title does not contain any of: " + Arrays.toString(validWords));
-            validationException.setErrors(new ArrayList<String>(Arrays.asList("sampleError")));
-            validationException.setWarnings(new ArrayList<String>(Arrays.asList("sampleWarnings")));
+                    "Metacard title does not contain any of: " + validWords);
+            validationException.setErrors(Collections.singletonList("sampleError"));
+            validationException.setWarnings(Collections.singletonList("sampleWarnings"));
             throw validationException;
         }
-
     }
 
-    private Boolean checkMetacard(String metacardAttribute, ArrayList<String> toCheck) {
-        List<String> result = toCheck.stream()
-                .filter(metacardAttribute::contains)
-                .collect(Collectors.toList());
-        return !result.isEmpty();
+    private boolean checkMetacard(String title) {
+        return validWords.stream()
+                .anyMatch(title::contains);
     }
 
-    public void setValidWords(String... validWords) {
-        SampleMetacardValidator.validWords = validWords;
-    }
-
-    public String[] getValidWords() {
-        String[] resultValidWords = null;
+    public void setValidWords(Set<String> validWords) {
         if (validWords != null) {
-            resultValidWords = Arrays.copyOf(validWords, validWords.length);
+            this.validWords = validWords;
         }
-        return resultValidWords;
+    }
+
+    public Set<String> getValidWords() {
+        return validWords;
     }
 }

--- a/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,34 +11,15 @@
  *
  **/
 -->
-<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <!-- Register in the OSGi Service Registry -->
     <service interface="ddf.catalog.validation.MetacardValidator" >
         <bean class="org.codice.ddf.sdk.validation.metacard.SampleMetacardValidator">
-            <!--<cm:managed-properties persistent-id="SampleMetacardValidator"-->
-                                   <!--update-strategy="container-managed"/>-->
             <property name="validWords">
-                <array value-type="java.lang.String">
+                <set value-type="java.lang.String">
                     <value>Metacard-1</value>
-                </array>
-            </property>
-        </bean>
-    </service>
-
-    <service interface="ddf.catalog.validation.MetacardValidator" >
-        <bean class="org.codice.ddf.sdk.validation.metacard.SampleMetacardValidator">
-            <!--<cm:managed-properties persistent-id="SampleMetacardValidator"-->
-            <!--update-strategy="container-managed"/>-->
-            <property name="validWords">
-                <array value-type="java.lang.String">
-                    <value>Metacard-1</value>
-                </array>
-            </property>
-            <property name="id">
-                <value>sample-validator2</value>
+                </set>
             </property>
         </bean>
     </service>


### PR DESCRIPTION
#### What does this PR do?
Updates `MetacardValidityMarkerPlugin` so it runs on update requests.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr 
@bdeining 
@glenhein 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Create a validator using a validation JSON file. Ingest a metacard that your validator will fail. Verify that the proper errors and warnings are present on the metacard. Submit an update request for the metacard that will allow your validator to pass it and verify that the updated metacard has no warnings or errors.

Ingest a metacard that your validator will pass. Submit an update request for the metacard that will cause your validator to fail it and verify that the updated metacard has the proper warnings and errors.

Also verify that enforced metacard validators still work (i.e. if you have an enforced metacard validator and it fails your metacard, that metacard is dropped from the create/update operation).

#### What are the relevant tickets?
[DDF-2082](https://codice.atlassian.net/browse/DDF-2082)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
