### PR TITLE
DDF-2109 Merge RegistryStoreImpl from ddf-registry to ddf

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -1698,11 +1698,11 @@ public abstract class AbstractCswSource extends MaskableImpl
             // Simple "ping" to ensure the source is responding
             newAvailability = (getCapabilities() != null);
             if (oldAvailability != newAvailability) {
-                availabilityChanged(newAvailability);
                 // If the source becomes available, configure it.
                 if (newAvailability) {
                     configureCswSource();
                 }
+                availabilityChanged(newAvailability);
             }
             return newAvailability;
         }
@@ -1812,5 +1812,9 @@ public abstract class AbstractCswSource extends MaskableImpl
     public void setEventServiceAddress(String eventServiceAddress) {
         this.cswSourceConfiguration.setEventServiceAddress(eventServiceAddress);
 
+    }
+
+    protected void addSourceMonitor(SourceMonitor sourceMonitor) {
+        sourceMonitors.add(sourceMonitor);
     }
 }

--- a/catalog/spatial/registry/registry-api-impl/pom.xml
+++ b/catalog/spatial/registry/registry-api-impl/pom.xml
@@ -241,22 +241,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.82</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
@@ -15,9 +15,12 @@ package org.codice.ddf.registry.api.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +37,15 @@ import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.registry.api.RegistryStore;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.schemabindings.EbrimConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.source.AbstractCswStore;
+import org.opengis.filter.Filter;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 import com.thoughtworks.xstream.converters.Converter;
@@ -44,15 +53,20 @@ import com.thoughtworks.xstream.converters.Converter;
 import ddf.catalog.Constants;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.filter.delegate.TagsFilterDelegate;
 import ddf.catalog.operation.OperationTransaction;
+import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceMonitor;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.encryption.EncryptionService;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
@@ -60,19 +74,29 @@ import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
 
 public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryStoreImpl.class);
+
     public static final String PUSH_ALLOWED_PROPERTY = "pushAllowed";
 
     public static final String PULL_ALLOWED_PROPERTY = "pullAllowed";
 
+    public static final String REMOTE_NAME = "remoteName";
+
     private boolean pushAllowed = true;
 
     private boolean pullAllowed = true;
+
+    private String registryId = "";
+
+    private String remoteName = "";
 
     private Parser parser;
 
     private ParserConfigurator marshalConfigurator;
 
     private ParserConfigurator unmarshalConfigurator;
+
+    private ConfigurationAdmin configAdmin;
 
     public RegistryStoreImpl(BundleContext context, CswSourceConfiguration cswSourceConfiguration,
             Converter provider, SecureCxfClientFactory factory,
@@ -89,6 +113,7 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
         Map<String, Consumer<Object>> map = new HashMap<>();
         map.put(PUSH_ALLOWED_PROPERTY, value -> setPushAllowed((Boolean) value));
         map.put(PULL_ALLOWED_PROPERTY, value -> setPullAllowed((Boolean) value));
+        map.put(RegistryObjectMetacardType.REGISTRY_ID, value -> setRegistryId((String) value));
         return map;
     }
 
@@ -138,6 +163,31 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
             return new SourceResponseImpl(request, Collections.emptyList());
         }
 
+        SourceResponse registryQueryResponse = queryResponse(request);
+        for (Result singleResult : registryQueryResponse.getResults()) {
+            if (singleResult.getMetacard()
+                    .getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                    .getValue()
+                    .toString()
+                    .equals(registryId)) {
+                String metacardTitle = singleResult.getMetacard().getTitle();
+                if (metacardTitle != null && !remoteName.equals(metacardTitle)) {
+                    remoteName = metacardTitle;
+                    updateConfiguration();
+                }
+                break;
+            }
+        }
+        return registryQueryResponse;
+    }
+
+    /*
+    * After reviewing the various ways to test the query method above, it was decided
+    * that moving the super.query method call into its own method was the least offensive option.
+    * This is due to the inability to mock or spy an abstract super class method that is being
+    * overwritten without resorting to... Power Mock.
+    */
+    SourceResponse queryResponse(QueryRequest request) throws UnsupportedQueryException {
         return super.query(request);
     }
 
@@ -147,6 +197,14 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
 
     public void setPullAllowed(boolean pullAllowed) {
         this.pullAllowed = pullAllowed;
+    }
+
+    public void setRegistryId(String registryId) {
+        this.registryId = registryId;
+    }
+
+    public void setRemoteName(String remoteName) {
+        this.remoteName = remoteName;
     }
 
     private String getRegistryId(Metacard mcard) {
@@ -192,9 +250,11 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
     public void setParser(Parser parser) {
         List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
                         .getName(),
-                net.opengis.ogc.ObjectFactory.class.getPackage()
+                EbrimConstants.OGC_FACTORY.getClass()
+                        .getPackage()
                         .getName(),
-                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                EbrimConstants.GML_FACTORY.getClass()
+                        .getPackage()
                         .getName());
         ClassLoader classLoader = this.getClass()
                 .getClassLoader();
@@ -202,5 +262,81 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
         this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
         this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
         this.parser = parser;
+    }
+
+    public void init() {
+
+        SourceMonitor registrySourceMonitor = new SourceMonitor() {
+            @Override
+            public void setAvailable() {
+                try {
+                    registryInfoQuery();
+                } catch (UnsupportedQueryException e) {
+                    LOGGER.error("Unable to query registry configurations, ", e);
+                }
+            }
+
+            @Override
+            public void setUnavailable() {
+            }
+        };
+
+        addSourceMonitor(registrySourceMonitor);
+        super.init();
+        isAvailable();
+    }
+
+    void registryInfoQuery() throws UnsupportedQueryException {
+        List<Filter> filters = new ArrayList<>();
+        filters.add(filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .like()
+                .text(RegistryConstants.REGISTRY_TAG));
+        filters.add(filterBuilder.not(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
+                .empty()));
+        Filter filter = filterBuilder.allOf(filters);
+        Query newQuery = new QueryImpl(filter);
+        QueryRequest queryRequest = new QueryRequestImpl(newQuery);
+        SourceResponse identityMetacard = query(queryRequest);
+        if (identityMetacard.getResults()
+                .size() > 0) {
+            remoteName = identityMetacard.getResults()
+                    .get(0)
+                    .getMetacard()
+                    .getTitle();
+            registryId = identityMetacard.getResults()
+                    .get(0)
+                    .getMetacard()
+                    .getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                    .getValue()
+                    .toString();
+        }
+        updateConfiguration();
+    }
+
+    private void updateConfiguration() {
+        String currentPid = getConfigurationPid();
+        try {
+            Configuration currentConfig = configAdmin.getConfiguration(currentPid);
+            Dictionary<String, Object> currentProperties = currentConfig.getProperties();
+            currentProperties.put(REMOTE_NAME, remoteName);
+            currentProperties.put(RegistryObjectMetacardType.REGISTRY_ID, registryId);
+            currentConfig.update(currentProperties);
+        } catch (IOException e) {
+            LOGGER.error("Unable to update registry configurations, ", e);
+        }
+    }
+
+    public void setConfigAdmin(ConfigurationAdmin config) {
+        this.configAdmin = config;
+    }
+
+    @Override
+    public String getRegistryId() {
+        return registryId;
+    }
+
+    public String getRemoteName() {
+        return remoteName;
     }
 }

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,6 +32,8 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+
     <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
         <reference-listener ref="metacardTypes" bind-method="bindPlugin"
@@ -104,6 +106,8 @@
             <property name="pullAllowed" value="true"/>
             <property name="pushAllowed" value="true"/>
             <argument ref="encryptionService"/>
+            <property name="configAdmin" ref="configurationAdmin"/>
+            <property name="registryId" value=""/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,8 +19,8 @@
         <AD description="The unique name of the store" name="Registry ID" id="id" required="true"
             type="String"/>
 
-        <AD description="URL to the endpoint implementing CSW spec capable of returning ebrim formatted records"
-            name="CSW URL" id="cswUrl" required="true" type="String"/>
+        <AD description="URL to the endpoint implementing CSW spec capable of returning ebrim formatted records, e.g. https://hostname.here:port#/services/csw"
+            name="Registry Service URL" id="cswUrl" required="true" type="String"/>
 
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.registry.api;
+package org.codice.ddf.registry.api.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -25,13 +25,13 @@ import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.xml.XmlParser;
-import org.codice.ddf.registry.api.impl.RegistryStoreImpl;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.Csw;
@@ -39,7 +39,10 @@ import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.opengis.filter.Filter;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 import com.thoughtworks.xstream.converters.Converter;
 
@@ -47,11 +50,14 @@ import ddf.catalog.Constants;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
@@ -62,6 +68,8 @@ import net.opengis.cat.csw.v_2_0_2.TransactionSummaryType;
 public class TestRegistryStore {
 
     private RegistryStoreImpl registryStore;
+
+    private RegistryStoreImplTest registryStoreImplTest;
 
     private Parser parser;
 
@@ -76,6 +84,14 @@ public class TestRegistryStore {
     private TransformerManager transformer;
 
     private EncryptionService encryptionService;
+
+    private ConfigurationAdmin configAdmin;
+
+    private FilterAdapter filterAdapter;
+
+    private Configuration config;
+
+    private Filter filter;
 
     @Before
     public void setup() {
@@ -94,7 +110,10 @@ public class TestRegistryStore {
         registryStore.setParser(parser);
         registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
         registryStore.setSchemaTransformerManager(transformer);
-
+        configAdmin = mock(ConfigurationAdmin.class);
+        filterAdapter = mock(FilterAdapter.class);
+        config = mock(Configuration.class);
+        filter = mock(Filter.class);
     }
 
     @Test
@@ -156,6 +175,58 @@ public class TestRegistryStore {
         mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, "registryId");
         mcard.setContentTypeName(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME);
         mcard.setMetadata(xml);
+        mcard.setTitle("testRegistryMetacard");
         return mcard;
+    }
+
+    @Test
+    public void testSetAvailable() throws Exception {
+        setupRegistryStoreImplTest();
+
+        registryStoreImplTest.registryInfoQuery();
+
+        assertThat(registryStoreImplTest.getRegistryId(), is("registryId"));
+        assertThat(registryStoreImplTest.getRemoteName(), is("testRegistryMetacard"));
+    }
+
+    @Test
+    public void testQuery() throws Exception {
+        setupRegistryStoreImplTest();
+
+        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
+        SourceResponse answer = registryStoreImplTest.query(testRequest);
+        List<Result> testResults = answer.getResults();
+
+        assertThat(testResults.size(), is(1));
+        assertThat(testResults.get(0)
+                .getMetacard()
+                .getTitle(), is("testRegistryMetacard"));
+    }
+
+    private void setupRegistryStoreImplTest() throws Exception{
+        registryStoreImplTest = new RegistryStoreImplTest();
+
+        registryStoreImplTest.setFilterBuilder(new GeotoolsFilterBuilder());
+        registryStoreImplTest.setFilterAdapter(filterAdapter);
+        registryStoreImplTest.setConfigAdmin(configAdmin);
+        registryStoreImplTest.setRegistryId("registryId");
+
+        when(filterAdapter.adapt(any(), any())).thenReturn(true);
+        when(configAdmin.getConfiguration(any())).thenReturn(config);
+        when(config.getProperties()).thenReturn(new Hashtable<>());
+    }
+
+    private class RegistryStoreImplTest extends RegistryStoreImpl {
+
+        RegistryStoreImplTest() {
+            super(encryptionService);
+        }
+
+        @Override
+        public SourceResponse queryResponse(QueryRequest request) {
+            List<Result> results = new ArrayList<>();
+            results.add(new ResultImpl(getDefaultMetacard()));
+            return new SourceResponseImpl(request, results);
+        }
     }
 }

--- a/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
+++ b/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
@@ -32,4 +32,10 @@ public interface RegistryStore extends CatalogStore, ConfiguredService {
      * @return true if allowed otherwise false
      */
     boolean isPullAllowed();
+
+    /**
+     * Indicates the Id associated with this registry
+     * @return registry id in a string
+     */
+    String getRegistryId();
 }


### PR DESCRIPTION
#### What does this PR do?
This PR merges the changes made to the RegistryStoreImpl from ddf-registry to ddf. The logic has been updated since RegistryStoreImpl and the IdentityPlugin both were performing similar operations to update metacard ids within the ebrim method. This functionality was also improved with other minor changes and extra unit tests were added. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@spearskw @harrison-tarr 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris

#### How should this be tested?

Please review the code, build and run the tests.

#### What are the relevant tickets?
DDF-2057 Update RegistryStoreImpl to gather remote name for Remote Registry UI
DDF-2099 Improve test coverage in registry-api-impl
DDF-2109 Refactor Logic

#### Screenshots (if appropriate)
Backend functionality - once the ui is merged a Remote Name field should be populated on the Remote Registries tab after the registry becomes available. 
![screen shot 2016-05-24 at 7 41 48 am](https://cloud.githubusercontent.com/assets/11355332/15508102/03049414-2183-11e6-8175-0b4b4e80c018.png)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

