### PR TITLE
DDF-2107 Created registry-source-configuration-handler module to handle source creation from registry entries.

### DIFF
--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -50,7 +50,7 @@
         <property name="name" value="Open Search Endpoint"/>
         <property name="version" value="1.0.0"/>
         <property name="description" value="The endpoint used for open search."/>
-        <property name="bindingType" value="OpenSearchSource"/>
+        <property name="bindingType" value="OpenSearch_1.0.0"/>
     </bean>
     <service ref="ddf.catalog.endpoint.opensearch"
              interface="ddf.catalog.endpoint.CatalogEndpoint"/>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -154,7 +154,7 @@
         <property name="name" value="CSW Endpoint"/>
         <property name="version" value="2.0.2"/>
         <property name="description" value="The endpoint used for csw."/>
-        <property name="bindingType" value="Csw_Federated_Source"/>
+        <property name="bindingType" value="CSW_2.0.2"/>
     </bean>
 
     <bean id="validator"

--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -88,6 +88,11 @@
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-source-configuration-handler</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
                 <artifactId>registry-publication-update-handler</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -165,5 +170,6 @@
         <module>registry-publication-update-handler</module>
         <module>registry-report-action-provider</module>
         <module>registry-report-viewer</module>
+        <module>registry-source-configuration-handler</module>
     </modules>
 </project>

--- a/catalog/spatial/registry/registry-api-impl/pom.xml
+++ b/catalog/spatial/registry/registry-api-impl/pom.xml
@@ -241,7 +241,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -256,7 +256,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,6 +34,10 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
+    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+        <argument ref="xmlParser"/>
+    </bean>
+
     <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
         <reference-listener ref="metacardTypes" bind-method="bindPlugin"
@@ -102,7 +106,7 @@
             <property name="eventServiceAddress" value=""/>
             <property name="registerForEvents" value="false"/>
             <property name="schemaTransformerManager" ref="metacardTransformerManager"/>
-            <property name="parser" ref="xmlParser"/>
+            <property name="metacardMarshaller" ref="metacardMarshaller"/>
             <property name="pullAllowed" value="true"/>
             <property name="pushAllowed" value="true"/>
             <argument ref="encryptionService"/>

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
@@ -34,6 +34,7 @@ import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.xml.XmlParser;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.Csw;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
@@ -107,7 +108,7 @@ public class TestRegistryStore {
                 provider,
                 factory,
                 encryptionService);
-        registryStore.setParser(parser);
+        registryStore.setMetacardMarshaller(new MetacardMarshaller(parser));
         registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
         registryStore.setSchemaTransformerManager(transformer);
         configAdmin = mock(ConfigurationAdmin.class);
@@ -136,7 +137,7 @@ public class TestRegistryStore {
 
             }
         };
-        registryStore.setParser(parser);
+        registryStore.setMetacardMarshaller(new MetacardMarshaller(parser));
         registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
         registryStore.setSchemaTransformerManager(transformer);
 

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -83,6 +83,10 @@
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-report-viewer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-source-configuration-handler</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -43,6 +43,7 @@
     <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-source-configuration-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-action-provider/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-viewer/${project.version}</bundle>

--- a/catalog/spatial/registry/registry-federation-admin-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/pom.xml
@@ -118,7 +118,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -133,7 +133,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,11 +19,15 @@
           destroy-method="destroy" init-method="init">
         <argument ref="adminHelper"/>
         <property name="federationAdminService" ref="federationAdminService"/>
-        <property name="parser" ref="xmlParser"/>
+        <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryTransformer" ref="inputTransformer"/>
         <property name="registryTypeConverter" ref="registryTypeConverter"/>
         <property name="registryMapConverter" ref="registryMapConverter"/>
         <property name="slotHelper" ref="slotHelper"/>
+    </bean>
+
+    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+        <argument ref="xmlParser"/>
     </bean>
 
     <bean id="registryTypeConverter" class="org.codice.ddf.registry.schemabindings.converter.type.RegistryPackageTypeConverter"/>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
@@ -59,6 +59,7 @@ import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
 import org.codice.ddf.registry.schemabindings.EbrimConstants;
 import org.codice.ddf.registry.schemabindings.converter.type.RegistryPackageTypeConverter;
 import org.codice.ddf.registry.schemabindings.converter.web.RegistryPackageWebConverter;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
 import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.junit.Before;
@@ -152,7 +153,7 @@ public class FederationAdminTest {
         };
         federationAdmin.setFederationAdminService(federationAdminService);
         federationAdmin.setRegistryTransformer(registryTransformer);
-        federationAdmin.setParser(parser);
+        federationAdmin.setMetacardMarshaller(new MetacardMarshaller(parser));
         federationAdmin.setSlotHelper(new SlotTypeHelper());
         federationAdmin.setRegistryMapConverter(new RegistryPackageWebConverter());
         federationAdmin.setRegistryTypeConverter(new RegistryPackageTypeConverter());

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
@@ -125,7 +125,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -15,10 +15,7 @@ package org.codice.ddf.registry.federationadmin.service.impl;
 
 import static org.codice.ddf.registry.schemabindings.EbrimConstants.RIM_FACTORY;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
@@ -26,7 +23,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,8 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.Marshaller;
 import javax.xml.datatype.DatatypeConstants;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -45,15 +39,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
-import org.codice.ddf.parser.Parser;
-import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
-import org.codice.ddf.registry.schemabindings.EbrimConstants;
 import org.codice.ddf.registry.schemabindings.helper.InternationalStringTypeHelper;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
 import org.codice.ddf.security.common.Security;
 import org.geotools.filter.SortByImpl;
@@ -91,7 +83,6 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.security.service.SecurityServiceException;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.VersionInfoType;
@@ -107,11 +98,7 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
     private InputTransformer registryTransformer;
 
-    private Parser parser;
-
-    private ParserConfigurator marshalConfigurator;
-
-    private ParserConfigurator unmarshalConfigurator;
+    private MetacardMarshaller metacardMarshaller;
 
     private FilterBuilder filterBuilder;
 
@@ -442,8 +429,7 @@ public class FederationAdminServiceImpl implements FederationAdminService {
         List<RegistryPackageType> registryEntries = new ArrayList<>();
 
         for (Metacard metacard : getLocalRegistryMetacards()) {
-            String xml = metacard.getMetadata();
-            registryEntries.add(getRegistryPackageFromString(xml));
+            registryEntries.add(getRegistryPackageFromMetacard(metacard));
         }
         return registryEntries;
     }
@@ -452,8 +438,7 @@ public class FederationAdminServiceImpl implements FederationAdminService {
     public List<RegistryPackageType> getRegistryObjects() throws FederationAdminException {
         List<RegistryPackageType> registryEntries = new ArrayList<>();
         for (Metacard metacard : getRegistryMetacards()) {
-            String xml = metacard.getMetadata();
-            registryEntries.add(getRegistryPackageFromString(xml));
+            registryEntries.add(getRegistryPackageFromMetacard(metacard));
         }
         return registryEntries;
     }
@@ -499,10 +484,7 @@ public class FederationAdminServiceImpl implements FederationAdminService {
                     sourceIds);
             throw new FederationAdminException(message);
         }
-
-        String xml = metacards.get(0)
-                .getMetadata();
-        return getRegistryPackageFromString(xml);
+        return getRegistryPackageFromMetacard(metacards.get(0));
     }
 
     public void init() {
@@ -516,6 +498,15 @@ public class FederationAdminServiceImpl implements FederationAdminService {
             }
             return null;
         });
+    }
+
+    private RegistryPackageType getRegistryPackageFromMetacard(Metacard metacard)
+            throws FederationAdminException {
+        try {
+            return metacardMarshaller.getRegistryPackageFromMetacard(metacard);
+        } catch (ParserException e) {
+            throw new FederationAdminException("Error parsing ebrim xml from metacard", e);
+        }
     }
 
     private void createIdentityNode() throws FederationAdminException {
@@ -681,13 +672,9 @@ public class FederationAdminServiceImpl implements FederationAdminService {
         Metacard metacard;
 
         try {
-            JAXBElement<RegistryPackageType> jaxbRegistryObjectType =
-                    RIM_FACTORY.createRegistryPackage(registryPackage);
-
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            parser.marshal(marshalConfigurator, jaxbRegistryObjectType, baos);
-            InputStream xmlInputStream = new ByteArrayInputStream(baos.toByteArray());
-            metacard = registryTransformer.transform(xmlInputStream);
+            metacard =
+                    registryTransformer.transform(metacardMarshaller.getRegistryPackageAsInputStream(
+                            registryPackage));
 
         } catch (IOException | CatalogTransformerException | ParserException e) {
             String message = "Error creating metacard from registry package.";
@@ -696,32 +683,6 @@ public class FederationAdminServiceImpl implements FederationAdminService {
         }
 
         return metacard;
-    }
-
-    private RegistryPackageType getRegistryPackageFromString(String xml)
-            throws FederationAdminException {
-        if (StringUtils.isBlank(xml)) {
-            throw new FederationAdminException(
-                    "Error unmarshalling xml string to RegistryPackage. Empty string was provided.");
-        }
-
-        RegistryPackageType registryPackage = null;
-
-        try {
-            JAXBElement<RegistryPackageType> jaxbRegistryPackage = parser.unmarshal(
-                    unmarshalConfigurator,
-                    JAXBElement.class,
-                    IOUtils.toInputStream(xml));
-            if (jaxbRegistryPackage != null && jaxbRegistryPackage.getValue() != null) {
-                registryPackage = jaxbRegistryPackage.getValue();
-            }
-        } catch (ParserException e) {
-            String message = "Error getting local registry objects. Couldn't unmarshal the string.";
-            LOGGER.error("{} String: {}", message, xml);
-            throw new FederationAdminException(message, e);
-        }
-
-        return registryPackage;
     }
 
     private Metacard getRegistryMetacardFromString(String xml) throws FederationAdminException {
@@ -773,25 +734,8 @@ public class FederationAdminServiceImpl implements FederationAdminService {
         this.filterBuilder = filterBuilder;
     }
 
-    public void setParser(Parser parser) {
-        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
-                        .getName(),
-                EbrimConstants.OGC_FACTORY.getClass()
-                        .getPackage()
-                        .getName(),
-                EbrimConstants.GML_FACTORY.getClass()
-                        .getPackage()
-                        .getName());
-
-        ClassLoader classLoader = this.getClass()
-                .getClassLoader();
-
-        this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
-        this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
-
-        this.unmarshalConfigurator = parser.configureParser(contextPath, classLoader);
-
-        this.parser = parser;
+    public void setMetacardMarshaller(MetacardMarshaller helper) {
+        this.metacardMarshaller = helper;
     }
 
     public void setRegistryTransformer(InputTransformer inputTransformer) {

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,13 +21,17 @@
           init-method="init">
         <property name="catalogFramework" ref="catalogFramework"/>
         <property name="filterBuilder" ref="filterBuilder"/>
-        <property name="parser" ref="xmlParser"/>
+        <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryTransformer" ref="inputTransformer"/>
     </bean>
 
     <bean id="refreshRegistrySubscriptions"
           class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistrySubscriptions">
         <property name="federationAdminService" ref="federationAdminService"/>
+    </bean>
+
+    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+        <argument ref="xmlParser"/>
     </bean>
 
 

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -56,6 +56,7 @@ import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.schemabindings.EbrimConstants;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.codice.ddf.security.common.Security;
 import org.geotools.filter.FilterFactoryImpl;
@@ -177,7 +178,7 @@ public class FederationAdminServiceImplTest {
         federationAdminServiceImpl = spy(new FederationAdminServiceImpl(security));
         federationAdminServiceImpl.setRegistryTransformer(registryTransformer);
         federationAdminServiceImpl.setCatalogFramework(catalogFramework);
-        federationAdminServiceImpl.setParser(parser);
+        federationAdminServiceImpl.setMetacardMarshaller(new MetacardMarshaller(parser));
         federationAdminServiceImpl.setFilterBuilder(filterBuilder);
         System.setProperty(SystemInfo.SITE_NAME, TEST_SITE_NAME);
         System.setProperty(SystemInfo.VERSION, TEST_VERSION);

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistrySubscriptionsTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistrySubscriptionsTest.java
@@ -32,6 +32,7 @@ import org.codice.ddf.registry.api.RegistryStore;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.codice.ddf.security.common.Security;
 import org.geotools.filter.FilterFactoryImpl;
@@ -137,7 +138,7 @@ public class RefreshRegistrySubscriptionsTest {
         refreshRegistrySubscriptions = spy(new RefreshRegistrySubscriptions());
         federationAdminService.setRegistryTransformer(registryTransformer);
         federationAdminService.setCatalogFramework(catalogFramework);
-        federationAdminService.setParser(parser);
+        federationAdminService.setMetacardMarshaller(new MetacardMarshaller(parser));
         federationAdminService.setFilterBuilder(filterBuilder);
         refreshRegistrySubscriptions.setFederationAdminService(federationAdminService);
         System.setProperty(SystemInfo.SITE_NAME, TEST_SITE_NAME);

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,9 +20,13 @@
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
 
+    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+        <argument ref="xmlParser"/>
+    </bean>
+
     <bean id="identificationPlugin"
           class="org.codice.ddf.registry.identification.IdentificationPlugin" init-method="init">
-        <property name="parser" ref="xmlParser"/>
+        <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="catalogFramework" ref="catalogFramework"/>
         <property name="filterBuilder" ref="filterBuilder"/>
     </bean>

--- a/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
@@ -43,6 +43,7 @@ import org.codice.ddf.parser.xml.XmlParser;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.EbrimConstants;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -79,7 +80,7 @@ public class IdentificationPluginTest {
     public void setUp() {
         parser = new XmlParser();
         identificationPlugin = new IdentificationPlugin();
-        identificationPlugin.setParser(parser);
+        identificationPlugin.setMetacardMarshaller(new MetacardMarshaller(parser));
         setParser(parser);
         sampleData = new MetacardImpl();
         sampleData.setId("testNewMetacardId");

--- a/catalog/spatial/registry/registry-schema-bindings/pom.xml
+++ b/catalog/spatial/registry/registry-schema-bindings/pom.xml
@@ -77,7 +77,14 @@
             <groupId>ddf.platform</groupId>
             <artifactId>platform-parser-api</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>ddf.platform</groupId>
@@ -156,7 +163,9 @@
                 <configuration>
                     <instructions>
                         <Embed-Dependency>
-                            jaxb2-basics-runtime
+                            jaxb2-basics-runtime,
+                            registry-common,
+                            catalog-core-api-impl;scope=!test
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>
@@ -169,6 +178,11 @@
                             org.codice.ddf.registry.schemabindings.converter.web,
                             org.codice.ddf.registry.schemabindings.helper
                         </Export-Package>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util.http,
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
                         <Private-Package>
                             net.opengis.filter.v_1_1_0,
                             org.w3._1999.xlink

--- a/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/MetacardMarshaller.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/MetacardMarshaller.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.schemabindings.helper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.registry.schemabindings.EbrimConstants;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+public class MetacardMarshaller {
+    private Parser parser;
+
+    private ParserConfigurator unmarshalConfigurator;
+
+    private ParserConfigurator marshalConfigurator;
+
+    public MetacardMarshaller(Parser parser) {
+        setParser(parser);
+    }
+
+    /**
+     * Converts the metacards metadata into a RegistryPackageType object
+     *
+     * @param mcard A metacard with ebrim metadata
+     * @return A RegistryPackageType object created from the ebrim metadata
+     * @throws ParserException
+     */
+    public RegistryPackageType getRegistryPackageFromMetacard(Metacard mcard)
+            throws ParserException {
+
+        JAXBElement<RegistryObjectType> registryObjectTypeJAXBElement;
+        String metadata = mcard.getMetadata();
+        try (InputStream inputStream = new ByteArrayInputStream(metadata.getBytes(StandardCharsets.UTF_8))) {
+            registryObjectTypeJAXBElement = parser.unmarshal(unmarshalConfigurator,
+                    JAXBElement.class,
+                    inputStream);
+        } catch (IOException e) {
+            throw new ParserException("Error parsing metacards xml as ebrim", e);
+        }
+
+        if (registryObjectTypeJAXBElement == null) {
+            throw new ParserException("Error parsing metacards xml as ebrim");
+        }
+        RegistryPackageType registryPackage =
+                (RegistryPackageType) registryObjectTypeJAXBElement.getValue();
+        if (registryPackage == null) {
+            throw new ParserException("Error parsing metacards xml as ebrim. No value");
+        }
+        return registryPackage;
+    }
+
+    /**
+     * Converts the RegistryPackageType into an xml string
+     *
+     * @param registryPackage Registry package to convert
+     * @return Ebrim xml string
+     * @throws ParserException
+     */
+    public String getRegistryPackageAsXml(RegistryPackageType registryPackage)
+            throws ParserException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            JAXBElement<RegistryPackageType> registryObjectTypeJAXBElement =
+                    EbrimConstants.RIM_FACTORY.createRegistryPackage(registryPackage);
+
+            parser.marshal(marshalConfigurator, registryObjectTypeJAXBElement, outputStream);
+            return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new ParserException("Error parsing registry package to ebrim xml", e);
+        }
+    }
+
+    /**
+     * Turns the passed in registryPackage into an InputStream of xml
+     * @param registryPackage RegistryPackageType to create the input stream from
+     * @return An InputStream with the xml content of the RegistryPackageTypes
+     * @throws ParserException
+     */
+    public InputStream getRegistryPackageAsInputStream(RegistryPackageType registryPackage)
+            throws ParserException {
+        return new ByteArrayInputStream(getRegistryPackageAsXml(registryPackage).getBytes(
+                StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Converts the registryPackage into xml and puts it in the metacards metadata field
+     *
+     * @param metacard        Metacards to put ebrim xml into
+     * @param registryPackage RegistryPackage to put into metacard
+     * @throws ParserException
+     */
+    public void setMetacardRegistryPackage(Metacard metacard, RegistryPackageType registryPackage)
+            throws ParserException {
+        metacard.setAttribute(new AttributeImpl(Metacard.METADATA,
+                getRegistryPackageAsXml(registryPackage)));
+    }
+
+    private void setParser(Parser parser) {
+        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                EbrimConstants.OGC_FACTORY.getClass()
+                        .getPackage()
+                        .getName(),
+                EbrimConstants.GML_FACTORY.getClass()
+                        .getPackage()
+                        .getName());
+        ClassLoader classLoader = this.getClass()
+                .getClassLoader();
+
+        this.unmarshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
+        this.parser = parser;
+    }
+}

--- a/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
@@ -14,54 +14,57 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.codice.ddf.registry</groupId>
         <artifactId>registry</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
         <version>2.10.0-SNAPSHOT</version>
     </parent>
-    <artifactId>registry-identification-plugin</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>registry-source-configuration-handler</artifactId>
+    <name>DDF :: Registry :: Source :: Configuration :: Handler</name>
     <packaging>bundle</packaging>
-    <name>DDF :: Registry :: Identification Plugin</name>
+
     <dependencies>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
-            <artifactId>registry-api</artifactId>
-            <version>${project.version}</version>
+            <artifactId>registry-federation-admin-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-ebrim-transformer</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-schema-bindings</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-parser-api</artifactId>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
         </dependency>
         <dependency>
             <groupId>ddf.platform</groupId>
             <artifactId>platform-parser-xml</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -73,10 +76,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
                         <Embed-Dependency>
-                            registry-common,
-                            ddf-security-common,
-                            catalog-core-api-impl;scope=!test
+                            catalog-core-api-impl;scope=!test,
+                            ddf-security-common
                         </Embed-Dependency>
                         <Import-Package>
                             !org.codice.ddf.platform.util.http,
@@ -103,24 +106,24 @@
                                     <element>BUNDLE</element>
                                     <limits>
                                         <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.92</minimum>
+                                        </limit>
+                                        <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>INSTRUCTION</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -131,4 +134,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -1,0 +1,718 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.source.configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.registry.schemabindings.helper.RegistryPackageTypeHelper;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.MetaTypeInformation;
+import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceBindingType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
+
+/**
+ * This handler class is responsible for the create/update/delete of source configurations that
+ * come from registry nodes. It listens to the create/update/delete events to trigger its logic.
+ */
+@SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
+public class SourceConfigurationHandler implements EventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceConfigurationHandler.class);
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String BINDING_TYPE = "bindingType";
+
+    private static final String DISABLED_CONFIGURATION_SUFFIX = "_disabled";
+
+    private static final String ID = "id";
+
+    private static final String SHORTNAME = "shortname";
+
+    private static final String CONFIGURATION_FILTER =
+            "(&(%s=%s)(|(service.factoryPid=*source*)(service.factoryPid=*Source*)(service.factoryPid=*service*)(service.factoryPid=*Service*)))";
+
+    private static final String CREATED_TOPIC = "ddf/catalog/event/CREATED";
+
+    private static final String UPDATED_TOPIC = "ddf/catalog/event/UPDATED";
+
+    private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private ConfigurationAdmin configurationAdmin;
+
+    private FederationAdminService federationAdminService;
+
+    private MetaTypeService metaTypeService;
+
+    private MetacardMarshaller metacardMarshaller;
+
+    private ExecutorService executor;
+
+    private String urlBindingName;
+
+    private Map<String, String> bindingTypeToFactoryPidMap = new ConcurrentHashMap<>();
+
+    private List<String> sourceActivationPriorityOrder = new CopyOnWriteArrayList<>();
+
+    private boolean activateConfigurations;
+
+    private boolean preserveActiveConfigurations;
+
+    private boolean cleanUpOnDelete;
+
+    private SlotTypeHelper slotHelper;
+
+    private RegistryPackageTypeHelper registryTypeHelper;
+
+    public SourceConfigurationHandler(FederationAdminService federationAdminService,
+            ExecutorService executor) {
+        this.federationAdminService = federationAdminService;
+        this.executor = executor;
+    }
+
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.error("Thread pool didn't terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        if (mcard == null || !mcard.getTags()
+                .contains(RegistryConstants.REGISTRY_TAG)) {
+            return;
+        }
+
+        executor.execute(() -> {
+            if (event.getTopic()
+                    .equals(CREATED_TOPIC)) {
+                processCreate(mcard);
+            } else if (event.getTopic()
+                    .equals(UPDATED_TOPIC)) {
+                processUpdate(mcard);
+            } else if (event.getTopic()
+                    .equals(DELETED_TOPIC)) {
+                processDelete(mcard);
+            }
+        });
+
+    }
+
+    private void processCreate(Metacard metacard) {
+        try {
+            updateRegistryConfigurations(metacard, true);
+        } catch (IOException | InvalidSyntaxException | ParserException | RuntimeException e) {
+            LOGGER.error("Unable to update registry configurations, metacard still ingested");
+        }
+    }
+
+    private void processUpdate(Metacard metacard) {
+        try {
+            updateRegistryConfigurations(metacard, false);
+        } catch (IOException | InvalidSyntaxException | ParserException | RuntimeException e) {
+            LOGGER.error("Unable to update registry configurations, metacard still updated");
+        }
+    }
+
+    private void processDelete(Metacard metacard) {
+        try {
+            if (cleanUpOnDelete) {
+                deleteRegistryConfigurations(metacard);
+            }
+        } catch (IOException | InvalidSyntaxException e) {
+            LOGGER.error("Unable to delete registry configurations, metacard still deleted");
+        }
+    }
+
+    /**
+     * Finds all source configurations associated with the registry metacard creates/updates them
+     * with the information in the metacards service bindings. This method will enable/disable
+     * configurations if the right conditions are met but will never delete a configuration other
+     * than for switching a configuration from enabled to disabled or vice-versa
+     *
+     * @param metacard    Registry metacard with new service binding info
+     * @param createEvent Flag indicating if this was a metacard create or update event
+     * @throws IOException
+     * @throws InvalidSyntaxException
+     * @throws ParserException
+     */
+    private synchronized void updateRegistryConfigurations(Metacard metacard, boolean createEvent)
+            throws IOException, InvalidSyntaxException, ParserException {
+        boolean identityNode =
+                metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE) != null;
+
+        boolean autoActivateConfigurations = activateConfigurations && !identityNode && (createEvent
+                || !preserveActiveConfigurations);
+
+        List<ServiceBindingType> bindingTypes = registryTypeHelper.getBindingTypes(
+                metacardMarshaller.getRegistryPackageFromMetacard(metacard));
+
+        String registryId = metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                .getValue()
+                .toString();
+
+        String configId = getDeconflictedConfigId(metacard.getTitle(), registryId);
+
+        Map<String, Configuration> fpidToConfigurationMap = getCurrentConfigurations(registryId);
+
+        String bindingTypeToActivate = getBindingTypeToActivate(bindingTypes);
+        String fPidToActivate = bindingTypeToFactoryPidMap.get(bindingTypeToActivate);
+
+        if (autoActivateConfigurations) {
+            activateDeactivateExistingConfiguration(fPidToActivate, fpidToConfigurationMap);
+        }
+
+        for (ServiceBindingType bindingType : bindingTypes) {
+            Map<String, Object> slotMap = this.getServiceBindingProperties(bindingType);
+
+            String factoryPidMask = slotMap.get(BINDING_TYPE)
+                    .toString();
+            if (factoryPidMask == null) {
+                continue;
+            }
+            String factoryPid = bindingTypeToFactoryPidMap.get(factoryPidMask);
+
+            if (StringUtils.isBlank(factoryPid)) {
+                continue;
+            }
+            Configuration curConfig = findOrCreateConfig(factoryPid,
+                    fpidToConfigurationMap,
+                    (autoActivateConfigurations && factoryPidMask.equals(bindingTypeToActivate)));
+
+            Hashtable<String, Object> serviceConfigurationProperties = new Hashtable<>();
+            if (fpidToConfigurationMap.containsKey(curConfig.getFactoryPid())) {
+                serviceConfigurationProperties.putAll(getConfigurationsFromDictionary(curConfig.getProperties()));
+            } else {
+                serviceConfigurationProperties.putAll(getMetatypeDefaults(factoryPid));
+            }
+
+            serviceConfigurationProperties.putAll(slotMap);
+            serviceConfigurationProperties.put(ID, configId);
+            serviceConfigurationProperties.put(SHORTNAME, configId);
+            serviceConfigurationProperties.put(RegistryObjectMetacardType.REGISTRY_ID, registryId);
+
+            curConfig.update(serviceConfigurationProperties);
+        }
+
+    }
+
+    /**
+     * Finds a configuration in the map of current configurations or creates a new one if one doesn't
+     * exist yet.
+     *
+     * @param factoryPid             The factory pid to lookup/create
+     * @param fpidToConfigurationMap Map containing current configurations
+     * @param createActiveConfig     If a configuration needs to be created, indicates if it should
+     *                               be created as an active or disable configuration.
+     * @return
+     * @throws IOException
+     */
+    private Configuration findOrCreateConfig(String factoryPid,
+            Map<String, Configuration> fpidToConfigurationMap, boolean createActiveConfig)
+            throws IOException {
+        String factoryPidDisabled = factoryPid.concat(DISABLED_CONFIGURATION_SUFFIX);
+
+        Configuration curConfig = fpidToConfigurationMap.get(factoryPid);
+        if (curConfig == null) {
+            curConfig = fpidToConfigurationMap.get(factoryPidDisabled);
+        }
+        if (curConfig == null) {
+            String pid = factoryPidDisabled;
+            if (createActiveConfig) {
+                pid = factoryPid;
+            }
+            curConfig = configurationAdmin.createFactoryConfiguration(pid, null);
+        }
+        return curConfig;
+    }
+
+    /**
+     * Activates an existing configuration if it isn't active and has the fpid matching the fPidToActivate.
+     * If there is an acticve configuration that isn't the fPidToActivate it will deactivate it.
+     *
+     * @param fPidToActivate         Factory PID that should be active
+     * @param fpidToConfigurationMap Map of existing fpid -> configuration mappings
+     * @throws IOException
+     */
+    private void activateDeactivateExistingConfiguration(String fPidToActivate,
+            Map<String, Configuration> fpidToConfigurationMap) throws IOException {
+        String fpid;
+        Configuration configToEnable = null;
+        Configuration configToDisable = null;
+        for (Map.Entry<String, Configuration> entry : fpidToConfigurationMap.entrySet()) {
+            fpid = entry.getKey();
+            if (!fpid.contains(DISABLED_CONFIGURATION_SUFFIX) && !fpid.equals(fPidToActivate)) {
+                configToDisable = entry.getValue();
+            } else if (fpid.equals(fPidToActivate.concat(DISABLED_CONFIGURATION_SUFFIX))) {
+                configToEnable = entry.getValue();
+            }
+            if (configToDisable != null && configToEnable != null) {
+                break;
+            }
+        }
+        //Order of disable/enable important. Can't have two enabled configurations with the same
+        //id so if there is one to disable, disable it before enabling another one.
+        if (configToDisable != null) {
+            fpidToConfigurationMap.remove(configToDisable.getFactoryPid());
+            Configuration config = toggleConfiguration(configToDisable);
+            fpidToConfigurationMap.put(config.getFactoryPid(), config);
+        }
+        if (configToEnable != null) {
+            fpidToConfigurationMap.remove(configToEnable.getFactoryPid());
+            Configuration config = toggleConfiguration(configToEnable);
+            fpidToConfigurationMap.put(config.getFactoryPid(), config);
+        }
+    }
+
+    private void deleteRegistryConfigurations(Metacard metacard)
+            throws IOException, InvalidSyntaxException {
+        String registryId = null;
+        Attribute registryIdAttribute =
+                metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID);
+        if (registryIdAttribute != null) {
+            registryId = registryIdAttribute.getValue()
+                    .toString();
+        }
+
+        //This case shouldn't ever happen but we check to make sure
+        if (registryId == null) {
+            return;
+        }
+
+        Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
+                CONFIGURATION_FILTER,
+                RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        if (configurations != null) {
+            for (Configuration configuration : configurations) {
+                configuration.delete();
+            }
+        }
+    }
+
+    /**
+     * Toggles a configuration between enabled and disabled.
+     *
+     * @param config The configuration to enable/disable
+     * @return The new enabled/disabled configuration
+     * @throws IOException
+     */
+    private Configuration toggleConfiguration(Configuration config) throws IOException {
+        String newFpid;
+        if (config.getFactoryPid()
+                .contains(DISABLED_CONFIGURATION_SUFFIX)) {
+            newFpid = config.getFactoryPid()
+                    .replace(DISABLED_CONFIGURATION_SUFFIX, "");
+        } else {
+            newFpid = config.getFactoryPid()
+                    .concat(DISABLED_CONFIGURATION_SUFFIX);
+        }
+        Dictionary<String, Object> properties = config.getProperties();
+        config.delete();
+        Configuration newConfig = configurationAdmin.createFactoryConfiguration(newFpid, null);
+        newConfig.update(properties);
+        return newConfig;
+    }
+
+    /**
+     * Returns the service binding slots as a map of string properties with the slot name as the key
+     *
+     * @param binding ServiceBindingType to generate the map from
+     * @return A map of service binding slots
+     */
+    private Map<String, Object> getServiceBindingProperties(ServiceBindingType binding) {
+        Map<String, Object> properties = new HashMap<>();
+        for (SlotType1 slot : binding.getSlot()) {
+            List<String> slotValues = slotHelper.getStringValues(slot);
+            if (CollectionUtils.isEmpty(slotValues)) {
+                continue;
+            }
+            properties.put(slot.getName(), slotValues.size() == 1 ? slotValues.get(0) : slotValues);
+        }
+        if (binding.isSetAccessURI() && properties.get(urlBindingName) != null) {
+            properties.put(properties.get(urlBindingName)
+                    .toString(), binding.getAccessURI());
+        }
+        return properties;
+    }
+
+    /**
+     * Gets all the configurations that have a matching registry id
+     *
+     * @param registryId The registry id to match
+     * @return A map of configurations with factory pids as keys
+     * @throws IOException
+     * @throws InvalidSyntaxException
+     */
+    private Map<String, Configuration> getCurrentConfigurations(String registryId)
+            throws IOException, InvalidSyntaxException {
+        Map<String, Configuration> configurationMap = new HashMap<>();
+        Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
+                CONFIGURATION_FILTER,
+                RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        if (configurations == null) {
+            return configurationMap;
+        }
+
+        //we have found a set of source configurations with a matching registry-id
+        //now we need to search again with the id of one of the matching configs because
+        //all source configurations for an id might not all have a registry id if they
+        //were manually added but we want to make sure we include them here.
+        configurations = configurationAdmin.listConfigurations(String.format(CONFIGURATION_FILTER,
+                "id",
+                configurations[0].getProperties()
+                        .get("id")));
+
+        for (Configuration config : configurations) {
+            configurationMap.put(config.getFactoryPid(), config);
+        }
+
+        return configurationMap;
+    }
+
+    /**
+     * Gets the deconflicted configuration id. Checks for current configurations with the same ID
+     * and if present makes sure they belong to this registry entry. If configuration not present or
+     * present with the same registryId then the id passed in will be returned. If configuration is
+     * present and does not have the same registry id then return a new id that is a combination of
+     * the id and registry id which is guaranteed to be unique.
+     *
+     * @param id         Initial configuration ID
+     * @param registryId Associated registry ID
+     * @return A unique valid configuration ID
+     * @throws IOException
+     * @throws InvalidSyntaxException
+     */
+    private String getDeconflictedConfigId(String id, String registryId)
+            throws IOException, InvalidSyntaxException {
+        String configId = id;
+        if (StringUtils.isEmpty(configId)) {
+            configId = registryId;
+        }
+
+        Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
+                "(id=%s)",
+                configId));
+
+        if (configurations == null) {
+            return configId;
+        }
+
+        String configRegistryId = null;
+        for (Configuration config : configurations) {
+            configRegistryId = (String) config.getProperties()
+                    .get(RegistryObjectMetacardType.REGISTRY_ID);
+            if (configRegistryId != null) {
+                break;
+            }
+        }
+
+        if (configRegistryId == null || !configRegistryId.equals(registryId)) {
+            configId = String.format("%s - %s", configId, registryId);
+        }
+        return configId;
+    }
+
+    private String getBindingTypeToActivate(List<ServiceBindingType> bindingTypes) {
+
+        String bindingTypeToActivate = null;
+        String topPriority = sourceActivationPriorityOrder.get(0);
+        List<String> bindingTypesNames = new ArrayList<>();
+
+        for (ServiceBindingType bindingType : bindingTypes) {
+            Map<String, Object> slotMap = this.getServiceBindingProperties(bindingType);
+
+            if (slotMap.get(BINDING_TYPE) == null) {
+                continue;
+            }
+
+            String factoryPidMask = slotMap.get(BINDING_TYPE)
+                    .toString();
+
+            if (StringUtils.isNotBlank(factoryPidMask)) {
+                if (factoryPidMask.equals(topPriority)) {
+                    return factoryPidMask;
+                }
+
+                bindingTypesNames.add(factoryPidMask);
+            }
+        }
+
+        for (String prioritySource : sourceActivationPriorityOrder.subList(1,
+                sourceActivationPriorityOrder.size())) {
+            if (bindingTypesNames.contains(prioritySource)) {
+                return prioritySource;
+            }
+        }
+
+        return bindingTypeToActivate;
+
+    }
+
+    private Hashtable<String, Object> getConfigurationsFromDictionary(
+            Dictionary<String, Object> properties) {
+        Hashtable<String, Object> configProperties = new Hashtable<>();
+
+        Enumeration<String> enumeration = properties.keys();
+        while (enumeration.hasMoreElements()) {
+            String key = enumeration.nextElement();
+            configProperties.put(key, properties.get(key));
+        }
+
+        return configProperties;
+    }
+
+    private Map<String, Object> getMetatypeDefaults(String factoryPid) {
+        Map<String, Object> properties = new HashMap<>();
+        ObjectClassDefinition bundleMetatype = getObjectClassDefinition(factoryPid);
+        if (bundleMetatype != null) {
+            for (AttributeDefinition attributeDef : bundleMetatype.getAttributeDefinitions(
+                    ObjectClassDefinition.ALL)) {
+                if (attributeDef.getID() != null) {
+                    if (attributeDef.getDefaultValue() != null) {
+                        if (attributeDef.getCardinality() == 0) {
+                            properties.put(attributeDef.getID(),
+                                    getAttributeValue(attributeDef.getDefaultValue()[0],
+                                            attributeDef.getType()));
+                        } else {
+                            properties.put(attributeDef.getID(), attributeDef.getDefaultValue());
+                        }
+                    } else if (attributeDef.getCardinality() != 0) {
+                        properties.put(attributeDef.getID(), new String[0]);
+                    }
+                }
+            }
+        }
+
+        return properties;
+    }
+
+    private ObjectClassDefinition getObjectClassDefinition(String pid) {
+        Bundle[] bundles = this.getBundleContext()
+                .getBundles();
+        for (int i = 0; i < bundles.length; i++) {
+            try {
+                ObjectClassDefinition ocd = this.getObjectClassDefinition(bundles[i], pid);
+                if (ocd != null) {
+                    return ocd;
+                }
+            } catch (IllegalArgumentException iae) {
+                // don't care
+            }
+        }
+        return null;
+    }
+
+    private ObjectClassDefinition getObjectClassDefinition(Bundle bundle, String pid) {
+        Locale locale = Locale.getDefault();
+        if (bundle != null) {
+            if (metaTypeService != null) {
+                MetaTypeInformation mti = metaTypeService.getMetaTypeInformation(bundle);
+                if (mti != null) {
+                    try {
+                        return mti.getObjectClassDefinition(pid, locale.toString());
+                    } catch (IllegalArgumentException e) {
+                        // MetaTypeProvider.getObjectClassDefinition might throw illegal
+                        // argument exception. So we must catch it here, otherwise the
+                        // other configurations will not be shown
+                        // See https://issues.apache.org/jira/browse/FELIX-2390
+                        // https://issues.apache.org/jira/browse/FELIX-3694
+                    }
+                }
+            }
+        }
+
+        // fallback to nothing found
+        return null;
+    }
+
+    private Object getAttributeValue(String value, int type) {
+        switch (type) {
+        case AttributeDefinition.BOOLEAN:
+            return Boolean.valueOf(value);
+        case AttributeDefinition.BYTE:
+            return Byte.valueOf(value);
+        case AttributeDefinition.DOUBLE:
+            return Double.valueOf(value);
+        case AttributeDefinition.CHARACTER:
+            return value.toCharArray()[0];
+        case AttributeDefinition.FLOAT:
+            return Float.valueOf(value);
+        case AttributeDefinition.INTEGER:
+            return Integer.valueOf(value);
+        case AttributeDefinition.LONG:
+            return Long.valueOf(value);
+        case AttributeDefinition.SHORT:
+            return Short.valueOf(value);
+        case AttributeDefinition.PASSWORD:
+        case AttributeDefinition.STRING:
+        default:
+            return value;
+        }
+    }
+
+    protected BundleContext getBundleContext() {
+        return FrameworkUtil.getBundle(this.getClass())
+                .getBundleContext();
+    }
+
+    private void updateRegistrySourceConfigurations() {
+        try {
+            List<Metacard> metacards = federationAdminService.getRegistryMetacards();
+
+            for (Metacard metacard : metacards) {
+                try {
+                    updateRegistryConfigurations(metacard, false);
+                } catch (InvalidSyntaxException | ParserException | IOException e) {
+                    LOGGER.error(
+                            "Unable to update registry configurations. Registry source configurations won't be updated for metacard id: {}",
+                            metacard.getId());
+                }
+            }
+
+        } catch (FederationAdminException e) {
+            LOGGER.error(
+                    "Error getting registry metacards. Registry source configurations won't be updated.");
+        }
+    }
+
+    public void setActivateConfigurations(boolean activateConfigurations) {
+        if (!(activateConfigurations == this.activateConfigurations)) {
+            this.activateConfigurations = activateConfigurations;
+
+            if (!activateConfigurations || preserveActiveConfigurations) {
+                return;
+            }
+
+            updateRegistrySourceConfigurations();
+        }
+    }
+
+    public void setPreserveActiveConfigurations(boolean preserveActiveConfigurations) {
+        if (!(preserveActiveConfigurations == this.preserveActiveConfigurations)) {
+            this.preserveActiveConfigurations = preserveActiveConfigurations;
+
+            if (preserveActiveConfigurations || !activateConfigurations) {
+                return;
+            }
+
+            updateRegistrySourceConfigurations();
+        }
+    }
+
+    public void setCleanUpOnDelete(boolean cleanUpOnDelete) {
+        this.cleanUpOnDelete = cleanUpOnDelete;
+    }
+
+    public synchronized void setBindingTypeFactoryPid(List<String> bindingTypeFactoryPid) {
+        bindingTypeToFactoryPidMap.clear();
+
+        for (String mapping : bindingTypeFactoryPid) {
+            String bindingType = StringUtils.substringBefore(mapping, "=");
+            String factoryPid = StringUtils.substringAfter(mapping, "=");
+
+            if (StringUtils.isNotBlank(bindingType) && StringUtils.isNotBlank(factoryPid)) {
+                bindingTypeToFactoryPidMap.put(bindingType, factoryPid);
+            }
+        }
+    }
+
+    public synchronized void setSourceActivationPriorityOrder(
+            List<String> sourceActivationPriorityOrder) {
+        if (!sourceActivationPriorityOrder.equals(this.sourceActivationPriorityOrder)) {
+            this.sourceActivationPriorityOrder.clear();
+            this.sourceActivationPriorityOrder.addAll(sourceActivationPriorityOrder);
+
+            if (!activateConfigurations && preserveActiveConfigurations) {
+                return;
+            }
+
+            updateRegistrySourceConfigurations();
+        }
+    }
+
+    public void setUrlBindingName(String urlBindingName) {
+        this.urlBindingName = urlBindingName;
+    }
+
+    public void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
+        this.configurationAdmin = configurationAdmin;
+    }
+
+    public void setMetaTypeService(MetaTypeService metaTypeService) {
+        this.metaTypeService = metaTypeService;
+    }
+
+    public void setRegistryTypeHelper(RegistryPackageTypeHelper registryTypeHelper) {
+        this.registryTypeHelper = registryTypeHelper;
+    }
+
+    public void setSlotHelper(SlotTypeHelper slotHelper) {
+        this.slotHelper = slotHelper;
+    }
+
+    public void setMetacardMarshaller(MetacardMarshaller helper) {
+        this.metacardMarshaller = helper;
+    }
+}

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+    <reference id="eventAdmin" interface="org.codice.ddf.parser.Parser" availability="mandatory"/>
+    <reference id="federationAdminService" interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+    <reference id="metaTypeService" interface="org.osgi.service.metatype.MetaTypeService" />
+    <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)" availability="mandatory"/>
+
+    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+        <argument ref="xmlParser"/>
+    </bean>
+
+    <bean id="executor" class="java.util.concurrent.Executors" factory-method="newFixedThreadPool">
+        <argument value="1"/>
+    </bean>
+
+    <bean id="slotHelper" class="org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper"/>
+
+    <bean id="registryTypeHelper" class="org.codice.ddf.registry.schemabindings.helper.RegistryPackageTypeHelper"/>
+
+    <bean id="sourceConfigurationHandler" class="org.codice.ddf.registry.source.configuration.SourceConfigurationHandler" destroy-method="destroy">
+        <cm:managed-properties persistent-id="Registry_Configuration_Event_Handler" update-strategy="container-managed"/>
+        <argument ref="federationAdminService"/>
+        <argument ref="executor"/>
+        <property name="configurationAdmin" ref="configurationAdmin"/>
+        <property name="metaTypeService" ref="metaTypeService"/>
+        <property name="metacardMarshaller" ref="metacardMarshaller"/>
+        <property name="slotHelper" ref="slotHelper"/>
+        <property name="registryTypeHelper" ref="registryTypeHelper"/>
+        <property name="urlBindingName" value="urlBindingName"/>
+        <property name="bindingTypeFactoryPid">
+            <list value-type="java.lang.String">
+                <value>CSW_2.0.2=Csw_Federated_Source</value>
+                <value>WFS_1.0.0=Wfs_v1_0_0_Federated_Source</value>
+                <value>OpenSearch_1.0.0=OpenSearchSource</value>
+            </list>
+        </property>
+        <property name="preserveActiveConfigurations" value="true"/>
+        <property name="activateConfigurations" value="false"/>
+        <property name="cleanUpOnDelete" value="false"/>
+        <property name="sourceActivationPriorityOrder">
+            <list value-type="java.lang.String">
+                <value>CSW_2.0.2</value>
+                <value>WFS_1.0.0</value>
+                <value>OpenSearch_1.0.0</value>
+            </list>
+        </property>
+    </bean>
+
+    <service ref="sourceConfigurationHandler" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>ddf/catalog/event/CREATED</value>
+                    <value>ddf/catalog/event/UPDATED</value>
+                    <value>ddf/catalog/event/DELETED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+</blueprint>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="Configurable values for the registry source configuration handler"
+         name="Registry Source Configuration Handler"
+         id="Registry_Configuration_Event_Handler">
+
+        <AD name="Url Binding Name" id="urlBindingName" required="true"
+            type="String" default="urlBindingName"
+            description="The url name for communicating with the specific instance."/>
+
+        <AD name="BindingType to Factory PID" id="bindingTypeFactoryPid" required="true"
+            type="String" cardinality="100"
+            default="CSW_2.0.2=Csw_Federated_Source,WFS_1.0.0=Wfs_v1_0_0_Federated_Source,OpenSearch_1.0.0=OpenSearchSource"
+            description="Key/Value mappings of binding type to factory PID"/>
+
+        <AD name="Remove Configurations on Metacard Delete" id="cleanUpOnDelete" required="true"
+            type="Boolean" default="false"
+            description="Flag used to determine if configurations should be deleted when the metacard is deleted."/>
+
+        <AD name="Activate Configurations" id="activateConfigurations" required="true"
+            type="Boolean" default="false"
+            description="Flag used to determine if a configuration should be activated on creation"/>
+
+        <AD name="Preserve Active Configuration" id="preserveActiveConfigurations" required="true"
+            type="Boolean" default="true"
+            description="Flag used to determine if configurations should be preserved. If true will only allow auto activation on creation. If false auto activation will happen on updates as well. Only applicable if activateConfigurations is true."/>
+
+        <AD name="Source Activation Priority Order" id="sourceActivationPriorityOrder" required="true" type="String" cardinality="100"
+            default="CSW_2.0.2,WFS_1.0.0,OpenSearch_1.0.0" description="This is the priority list used to determine which source should be activated on creation"/>
+
+    </OCD>
+    <Designate pid="Registry_Configuration_Event_Handler">
+        <Object ocdref="Registry_Configuration_Event_Handler"/>
+    </Designate>
+</metatype:MetaData>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
@@ -1,0 +1,850 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.source.configuration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.registry.schemabindings.helper.RegistryPackageTypeHelper;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.Event;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.MetaTypeInformation;
+import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class SourceConfigurationHandlerTest {
+    private Parser parser;
+
+    private FederationAdminService adminService;
+
+    private ExecutorService executorService;
+
+    private ConfigurationAdmin configAdmin;
+
+    private MetaTypeService metaTypeService;
+
+    private BundleContext bundleContext;
+
+    private MetaTypeInformation mti;
+
+    private ObjectClassDefinition ocd;
+
+    private SourceConfigurationHandler sch;
+
+    private Configuration config;
+
+    private MetacardImpl mcard;
+
+    private Event createEvent;
+
+    private Event updateEvent;
+
+    private Event deleteEvent;
+
+    @Before
+    public void setUp() throws Exception {
+        parser = new XmlParser();
+        adminService = mock(FederationAdminService.class);
+        configAdmin = mock(ConfigurationAdmin.class);
+        metaTypeService = mock(MetaTypeService.class);
+        bundleContext = mock(BundleContext.class);
+        executorService = mock(ExecutorService.class);
+
+        sch = new SourceConfigurationHandler(adminService, executorService) {
+            @Override
+            protected BundleContext getBundleContext() {
+                return bundleContext;
+            }
+        };
+        sch.setMetacardMarshaller(new MetacardMarshaller(parser));
+        sch.setConfigurationAdmin(configAdmin);
+        sch.setMetaTypeService(metaTypeService);
+        sch.setSlotHelper(new SlotTypeHelper());
+        sch.setRegistryTypeHelper(new RegistryPackageTypeHelper());
+        sch.setActivateConfigurations(false);
+        sch.setPreserveActiveConfigurations(true);
+        sch.setUrlBindingName("urlBindingName");
+        sch.setBindingTypeFactoryPid(Collections.singletonList("CSW_2.0.2=Csw_Federated_Source"));
+        sch.setSourceActivationPriorityOrder(Collections.singletonList("CSW_2.0.2"));
+        sch.setCleanUpOnDelete(false);
+
+        Bundle bundle = mock(Bundle.class);
+        mti = mock(MetaTypeInformation.class);
+        ocd = mock(ObjectClassDefinition.class);
+        config = mock(Configuration.class);
+
+        AttributeDefinition adi = new AttributeDefinitionImpl("attId",
+                "attName",
+                "attDesc",
+                "attValue");
+
+        when(adminService.getRegistryMetacards()).thenReturn(new ArrayList());
+
+        when(bundleContext.getBundles()).thenReturn(new Bundle[] {bundle});
+        when(configAdmin.listConfigurations("(id=TestRegNode")).thenReturn(null);
+        when(configAdmin.listConfigurations("(registry-id=urn:uuid:2014ca7f59ac46f495e32b4a67a51276")).thenReturn(
+                null);
+        when(metaTypeService.getMetaTypeInformation(any(Bundle.class))).thenReturn(mti);
+        when(mti.getObjectClassDefinition(anyString(), anyString())).thenReturn(ocd);
+        when(ocd.getAttributeDefinitions(anyInt())).thenReturn(new AttributeDefinition[] {adi});
+        when(configAdmin.createFactoryConfiguration(anyString(), anyString())).thenReturn(config);
+
+        mcard = new MetacardImpl(new RegistryObjectMetacardType());
+        mcard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG));
+        mcard.setId("2014ca7f59ac46f495e32b4a67a51276");
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true);
+        mcard.setMetadata(getMetadata("/csw-rim-node-csw-binding.xml"));
+        mcard.setTitle("TestRegNode");
+
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put("ddf.catalog.event.metacard", mcard);
+        createEvent = new Event("ddf/catalog/event/CREATED", eventProperties);
+        updateEvent = new Event("ddf/catalog/event/UPDATED", eventProperties);
+        deleteEvent = new Event("ddf/catalog/event/DELETED", eventProperties);
+
+    }
+
+    @Test
+    public void testNullMetacard() {
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Event event = new Event("ddf/catalog/event/CREATED", eventProperties);
+        sch.handleEvent(event);
+        verify(executorService, never()).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testNonRegistryMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setAttribute(Metacard.TAGS, Metacard.DEFAULT_TAG);
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put("ddf.catalog.event.metacard", metacard);
+        Event event = new Event("ddf/catalog/event/CREATED", eventProperties);
+        sch.handleEvent(event);
+        verify(executorService, never()).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testRegistryMetacardExecutorCall() {
+        MetacardImpl mcard = new MetacardImpl();
+        mcard.setAttribute(Metacard.TAGS, RegistryConstants.REGISTRY_TAG);
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put("ddf.catalog.event.metacard", mcard);
+        Event event = new Event("ddf/catalog/event/CREATED", eventProperties);
+        sch.handleEvent(event);
+        event = new Event("ddf/catalog/event/UPDATED", eventProperties);
+        sch.handleEvent(event);
+        event = new Event("ddf/catalog/event/DELETED", eventProperties);
+        sch.handleEvent(event);
+        verify(executorService, times(3)).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testDefaultConfigurationLocalNodeCreate() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertThat(passedValues.get("attId"), equalTo("attValue"));
+        assertCswProperties(passedValues);
+
+    }
+
+    @Test
+    public void testDefaultConfigurationLocalNodeCreateNoTitle() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(Metacard.TITLE, null);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertThat(passedValues.get("attId"), equalTo("attValue"));
+        assertThat(passedValues.get("urlBindingName"), equalTo("cswUrl"));
+        assertThat(passedValues.get("id"), equalTo("urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
+        assertThat(passedValues.get("cswUrl"), equalTo("https://localhost:1234/mycsw/endpoint"));
+        assertThat(passedValues.get("bindingType"), equalTo("CSW_2.0.2"));
+        assertThat(passedValues.get("customSlot"), equalTo("customValue"));
+
+    }
+
+    @Test
+    public void testDefaultConfigurationLocalNodeCreateNoBindingType() throws Exception {
+
+        mcard.setMetadata(this.getMetadata("/csw-rim-node-missing-type-binding.xml"));
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+
+        verify(configAdmin, never()).createFactoryConfiguration(anyString(), anyString());
+    }
+
+    @Test
+    public void testDefaultConfigurationRemoteNodeCreate() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertThat(passedValues.get("attId"), equalTo("attValue"));
+        assertCswProperties(passedValues);
+
+    }
+
+    @Test
+    public void testConfigurationCreateActivateConfig() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertThat(passedValues.get("attId"), equalTo("attValue"));
+        assertCswProperties(passedValues);
+
+    }
+
+    @Test
+    public void testConfigurationCreateActivateConfigWithExistingDisabledConfig() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Csw_Federated_Source_disabled");
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config, times(2)).update(captor.capture());
+        Dictionary passedValues = captor.getAllValues()
+                .get(1);
+        assertCswProperties(passedValues);
+        assertThat(passedValues.get("origConfig"), equalTo("origConfigValue"));
+    }
+
+    @Test
+    public void testConfigurationCreateActivateConfigWithExistingMatchingActiveConfig()
+            throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Csw_Federated_Source");
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(config, never()).delete();
+        verify(configAdmin, never()).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertCswProperties(passedValues);
+        assertThat(passedValues.get("origConfig"), equalTo("origConfigValue"));
+    }
+
+    @Test
+    public void testConfigurationCreateActivateConfigWithExistingDifferentActiveConfig()
+            throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        Configuration newConfig = mock(Configuration.class);
+        when(newConfig.getFactoryPid()).thenReturn("Some_Other_Source_disabled");
+        when(configAdmin.createFactoryConfiguration("Some_Other_Source_disabled", null)).thenReturn(
+                newConfig);
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Some_Other_Source");
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config).update(captor.capture());
+        List<Dictionary> values = captor.getAllValues();
+        assertThat(values.size(), equalTo(1));
+        Dictionary passedValues = values.get(0);
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testConfigurationCreateNoBindingType() throws Exception {
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        mcard.setMetadata(getMetadata("/csw-rim-node-no-binding.xml"));
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(config, never()).delete();
+        verify(configAdmin, never()).createFactoryConfiguration(anyString(), anyString());
+    }
+
+    @Test
+    public void testConfigurationUpdateActivateConfigWithExistingDifferentActiveConfig()
+            throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Some_Other_Source");
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+        verify(config).update(captor.capture());
+        List<Dictionary> values = captor.getAllValues();
+        assertThat(values.size(), equalTo(1));
+        Dictionary passedValues = values.get(0);
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testConfigurationUpdateActivateConfigWithExistingDifferentActiveConfigPreserveActiveFalse()
+            throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        Configuration newConfig = mock(Configuration.class);
+        when(newConfig.getFactoryPid()).thenReturn("Some_Other_Source_disabled");
+        when(configAdmin.createFactoryConfiguration("Some_Other_Source_disabled", null)).thenReturn(
+                newConfig);
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Some_Other_Source");
+        sch.setPreserveActiveConfigurations(false);
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config).update(captor.capture());
+        List<Dictionary> values = captor.getAllValues();
+        assertThat(values.size(), equalTo(1));
+        Dictionary passedValues = values.get(0);
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testConfigurationUpdateActivateConfigNotFirstPriority() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Some_Other_Source");
+        Configuration newConfig = mock(Configuration.class);
+        when(newConfig.getFactoryPid()).thenReturn("Some_Other_Source_disabled");
+        when(configAdmin.createFactoryConfiguration("Some_Other_Source_disabled", null)).thenReturn(
+                newConfig);
+        List<String> priority = new ArrayList();
+        priority.add("Top_Priority_Source");
+        priority.add("CSW_2.0.2");
+        sch.setSourceActivationPriorityOrder(priority);
+        sch.setPreserveActiveConfigurations(false);
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(configAdmin, times(1)).createFactoryConfiguration("Some_Other_Source_disabled",
+                null);
+        verify(config).update(captor.capture());
+        List<Dictionary> values = captor.getAllValues();
+        assertThat(values.size(), equalTo(1));
+        Dictionary passedValues = values.get(0);
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testConfigurationUpdateActivateConfigActivePriorityNotAvailable() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put("origConfig", "origConfigValue");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        Configuration newConfig = mock(Configuration.class);
+        when(newConfig.getFactoryPid()).thenReturn("Some_Other_Source_disabled");
+        when(configAdmin.createFactoryConfiguration("Some_Other_Source_disabled", null)).thenReturn(
+                newConfig);
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Some_Other_Source");
+        List<String> priority = new ArrayList<>();
+        priority.add("Top_Priority_Source");
+        priority.add("CSW_2.0.2");
+        List<String> bindings = new ArrayList<>();
+        bindings.add("Top_Priority_Source=Some_Other_Source");
+        bindings.add("CSW_2.0.2=Csw_Federated_Source");
+        sch.setBindingTypeFactoryPid(bindings);
+        sch.setSourceActivationPriorityOrder(priority);
+        sch.setPreserveActiveConfigurations(false);
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(config).update(captor.capture());
+        List<Dictionary> values = captor.getAllValues();
+        assertThat(values.size(), equalTo(1));
+        Dictionary passedValues = values.get(0);
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testDefaultConfigurationUpdateMatchingConfig() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Csw_Federated_Source_disabled");
+
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+
+        verify(config).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertCswProperties(passedValues);
+    }
+
+    @Test
+    public void testConfigurationUpdateMatchingConfigAndActiveAndPrioritySwitchWithMultipleBindings()
+            throws Exception {
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        mcard.setMetadata(getMetadata("/csw-rim-node-multi-binding.xml"));
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Csw_Federated_Source2");
+
+        List<String> priority = new ArrayList<>();
+        priority.add("CSW_2.0.2");
+        priority.add("CSW2_2.0.2");
+        List<String> bindings = new ArrayList<>();
+        bindings.add("CSW2_2.0.2=Csw_Federated_Source2");
+        bindings.add("CSW_2.0.2=Csw_Federated_Source");
+        sch.setBindingTypeFactoryPid(bindings);
+        sch.setSourceActivationPriorityOrder(priority);
+
+        sch.setPreserveActiveConfigurations(false);
+        sch.setActivateConfigurations(true);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+
+        verify(config, times(1)).delete();
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source", null);
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source2_disabled",
+                null);
+
+    }
+
+    @Test
+    public void testDefaultConfigurationUpdateNoMatchingConfig() throws Exception {
+
+        ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config}, null);
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put("id", "TestRegNode");
+        when(config.getProperties()).thenReturn(props);
+        when(config.getFactoryPid()).thenReturn("Csw_Federated_Source");
+        Configuration newConfig = mock(Configuration.class);
+        when(configAdmin.createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null)).thenReturn(newConfig);
+        setupSerialExecutor();
+        sch.handleEvent(updateEvent);
+
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+        verify(newConfig).update(captor.capture());
+        Dictionary passedValues = captor.getValue();
+        assertThat(passedValues.get(RegistryObjectMetacardType.REGISTRY_ID),
+                equalTo("urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
+        assertThat(passedValues.get("attId"), equalTo("attValue"));
+        assertThat(passedValues.get("urlBindingName"), equalTo("cswUrl"));
+        assertThat(passedValues.get("id"),
+                equalTo("TestRegNode - urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
+        assertThat(passedValues.get("cswUrl"), equalTo("https://localhost:1234/mycsw/endpoint"));
+        assertThat(passedValues.get("bindingType"), equalTo("CSW_2.0.2"));
+        assertThat(passedValues.get("customSlot"), equalTo("customValue"));
+
+    }
+
+    @Test
+    public void testDeleteConfiguration() throws Exception {
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        sch.setCleanUpOnDelete(true);
+        setupSerialExecutor();
+        sch.handleEvent(deleteEvent);
+        verify(config).delete();
+    }
+
+    @Test
+    public void testDeleteConfigurationNoCleanup() throws Exception {
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
+        setupSerialExecutor();
+        sch.handleEvent(deleteEvent);
+        verify(config, never()).delete();
+    }
+
+    @Test
+    public void testMultipleAttributes() throws Exception {
+        ArrayList<AttributeDefinition> attributeDefinitions = new ArrayList<>();
+        attributeDefinitions.add(new AttributeDefinitionImpl("att1",
+                "att1",
+                "",
+                AttributeDefinition.BOOLEAN,
+                new String[] {"true"},
+                0,
+                new String[] {"att1Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att2",
+                "att2",
+                "",
+                AttributeDefinition.BYTE,
+                new String[] {"0"},
+                0,
+                new String[] {"att2Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att3",
+                "att3",
+                "",
+                AttributeDefinition.DOUBLE,
+                new String[] {"1.234"},
+                0,
+                new String[] {"att3Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att4",
+                "att4",
+                "",
+                AttributeDefinition.FLOAT,
+                new String[] {"1.234"},
+                0,
+                new String[] {"att4Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att5",
+                "att5",
+                "",
+                AttributeDefinition.INTEGER,
+                new String[] {"1"},
+                0,
+                new String[] {"att5Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att6",
+                "att6",
+                "",
+                AttributeDefinition.LONG,
+                new String[] {"1234"},
+                0,
+                new String[] {"att6Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att7",
+                "att7",
+                "",
+                AttributeDefinition.SHORT,
+                new String[] {"123"},
+                0,
+                new String[] {"att7Value"},
+                null));
+        attributeDefinitions.add(new AttributeDefinitionImpl("att8",
+                "att8",
+                "",
+                AttributeDefinition.CHARACTER,
+                null,
+                0,
+                new String[] {"a"},
+                null));
+
+        when(ocd.getAttributeDefinitions(-1)).thenReturn(attributeDefinitions.toArray(new AttributeDefinition[attributeDefinitions.size()]));
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, null);
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(configAdmin, times(1)).createFactoryConfiguration("Csw_Federated_Source_disabled",
+                null);
+    }
+
+    @Test
+    public void testActivationSetter() throws Exception {
+        sch.setActivateConfigurations(false);
+        verify(adminService, never()).getRegistryMetacards();
+        sch.setActivateConfigurations(true);
+        verify(adminService, never()).getRegistryMetacards();
+        sch.setActivateConfigurations(false);
+        sch.setPreserveActiveConfigurations(false);
+        sch.setActivateConfigurations(true);
+        verify(adminService, times(1)).getRegistryMetacards();
+    }
+
+    @Test
+    public void testPreserveActivationSetter() throws Exception {
+        sch.setPreserveActiveConfigurations(true);
+        verify(adminService, never()).getRegistryMetacards();
+        sch.setPreserveActiveConfigurations(false);
+        verify(adminService, never()).getRegistryMetacards();
+        sch.setPreserveActiveConfigurations(true);
+        sch.setActivateConfigurations(true);
+        sch.setPreserveActiveConfigurations(false);
+        verify(adminService, times(1)).getRegistryMetacards();
+    }
+
+    @Test
+    public void testSourceActivationPriorityOrderSetter() throws Exception {
+        List<String> order1 = Arrays.asList(new String[] {"one", "two"});
+        List<String> order2 = Arrays.asList(new String[] {"two", "one"});
+        sch.setSourceActivationPriorityOrder(order1);
+        verify(adminService, never()).getRegistryMetacards();
+        sch.setActivateConfigurations(true);
+        sch.setPreserveActiveConfigurations(false);
+        sch.setSourceActivationPriorityOrder(order1);
+        verify(adminService, times(1)).getRegistryMetacards();
+        sch.setSourceActivationPriorityOrder(order2);
+        verify(adminService, times(2)).getRegistryMetacards();
+    }
+
+    @Test
+    public void testEmptyMetadata() throws Exception {
+        mcard.setMetadata("");
+        setupSerialExecutor();
+        sch.handleEvent(createEvent);
+        verify(configAdmin, never()).listConfigurations(anyString());
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        sch.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyTerminateTasks() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        sch.destroy();
+        verify(executorService, times(2)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterupt() throws Exception {
+        when(executorService.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException("interrupt"));
+        sch.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    private String getMetadata(String path) throws Exception {
+        InputStream inputStream = getClass().getResourceAsStream(path);
+        BufferedReader buffer = new BufferedReader(new InputStreamReader(inputStream));
+        return buffer.lines()
+                .collect(Collectors.joining("\n"));
+    }
+
+    //taken from org.apache.felix.webconsole.internal.servlet.ConfigurationMetatypeSupport
+    private static class AttributeDefinitionImpl implements AttributeDefinition {
+
+        private final String id;
+
+        private final String name;
+
+        private final String description;
+
+        private final int type;
+
+        private final String[] defaultValues;
+
+        private final int cardinality;
+
+        private final String[] optionLabels;
+
+        private final String[] optionValues;
+
+        AttributeDefinitionImpl(final String id, final String name, final String description,
+                final String defaultValue) {
+            this(id, name, description, STRING, new String[] {defaultValue}, 0, null, null);
+        }
+
+        AttributeDefinitionImpl(final String id, final String name, final String description,
+                final int type, final String[] defaultValues, final int cardinality,
+                final String[] optionLabels, final String[] optionValues) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+            this.type = type;
+            this.defaultValues = defaultValues;
+            this.cardinality = cardinality;
+            this.optionLabels = optionLabels;
+            this.optionValues = optionValues;
+        }
+
+        public int getCardinality() {
+            return cardinality;
+        }
+
+        public String[] getDefaultValue() {
+            return defaultValues;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getID() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String[] getOptionLabels() {
+            return optionLabels;
+        }
+
+        public String[] getOptionValues() {
+            return optionValues;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public String validate(String arg0) {
+            return null;
+        }
+    }
+
+    private void setupSerialExecutor() {
+        doAnswer((args) -> {
+            ((Runnable) args.getArguments()[0]).run();
+            return null;
+        }).when(executorService)
+                .execute(any());
+    }
+
+    private void assertCswProperties(Dictionary passedValues) {
+        assertThat(passedValues.get(RegistryObjectMetacardType.REGISTRY_ID),
+                equalTo("urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
+        assertThat(passedValues.get("urlBindingName"), equalTo("cswUrl"));
+        assertThat(passedValues.get("id"), equalTo("TestRegNode"));
+        assertThat(passedValues.get("cswUrl"), equalTo("https://localhost:1234/mycsw/endpoint"));
+        assertThat(passedValues.get("bindingType"), equalTo("CSW_2.0.2"));
+        assertThat(passedValues.get("customSlot"), equalTo("customValue"));
+    }
+}

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-csw-binding.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-csw-binding.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+
+    <rim:RegistryObjectList>
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-06-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+        </rim:ExtrinsicObject>
+
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="https://localhost:1234/mycsw/endpoint">
+                <rim:Slot name="urlBindingName" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>cswUrl</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>CSW_2.0.2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-missing-type-binding.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-missing-type-binding.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+
+    <rim:RegistryObjectList>
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-06-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+        </rim:ExtrinsicObject>
+
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="https://localhost:1234/mycsw/endpoint">
+                <rim:Slot name="urlBindingName" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>cswUrl</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-multi-binding.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-multi-binding.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+
+    <rim:RegistryObjectList>
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-06-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+        </rim:ExtrinsicObject>
+
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="https://localhost:1234/mycsw/endpoint">
+                <rim:Slot name="urlBindingName" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>cswUrl</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>CSW_2.0.2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+            </rim:ServiceBinding>
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="https://localhost:1234/mycsw/endpoint">
+                <rim:Slot name="urlBindingName" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>cswUrl2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>CSW2_2.0.2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method2"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method2."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+            </rim:ServiceBinding>
+            <rim:ServiceBinding id="urn:registry:custom:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
+                <rim:Slot name="urlBindingName" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>cswUrl2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>CustomType</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="customSlot2" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue1</rim:Value>
+                        <rim:Value>customValue2</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="Custom Binding"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="Custom non-federation binding"/>
+                </rim:Description>
+                <rim:VersionInfo versionName="0.1"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-no-binding.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/resources/csw-rim-node-no-binding.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="2014ca7f59ac46f495e32b4a67a51276"/>
+
+    <rim:RegistryObjectList>
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-06-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+        </rim:ExtrinsicObject>
+
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="https://localhost:1234/mycsw/endpoint">
+                <rim:Slot name="customSlot" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>customValue</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Name>
+                    <rim:LocalizedString value="Some non source binding"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="Some binding for something we don't work with"/>
+                </rim:Description>
+                <rim:VersionInfo versionName="1.2.3"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -82,7 +82,7 @@
         <property name="name" value="WFS Endpoint"/>
         <property name="version" value="1.0.0"/>
         <property name="description" value="The endpoint used for wfs."/>
-        <property name="bindingType" value="Wfs_v1_0_0_Federated_Source"/>
+        <property name="bindingType" value="WFS_1.0.0"/>
     </bean>
     <service ref="ddf.catalog.endpoint.wfs" interface="ddf.catalog.endpoint.CatalogEndpoint"/>
 


### PR DESCRIPTION
#### What does this PR do?
Adds an event handler module for registry metacards that creates source configurations from service bindings. This is an initial pr and cannot be heroed or build right now because it requires https://github.com/codice/ddf/pull/778 to be merged first
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@stustison
#### How should this be tested?
No testing at this time
#### Any background context you want to provide?
This is coming over from the ddf-registry repo
#### What are the relevant tickets?
DDF-2107
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

