### PR TITLE
DDF-2101 Created registry-federation-admin-impl to enable UI access to registry features

### DIFF
--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -73,6 +73,11 @@
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-federation-admin-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
                 <artifactId>registry-policy-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -149,6 +154,7 @@
         <module>registry-federation-admin-service</module>
         <module>registry-federation-admin-service-impl</module>
         <module>registry-federation-admin-api</module>
+        <module>registry-federation-admin-impl</module>
         <module>registry-app</module>
         <module>registry-admin-modules</module>
         <module>registry-publication-update-handler</module>

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-identification-plugin</artifactId>
         </dependency>
         <dependency>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -41,6 +41,7 @@
     <feature prerequisite="true">registry-app</feature>
     <bundle>mvn:org.codice.ddf.registry/registry-api-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-service-impl/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-impl/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-identification-plugin/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-action-provider/${project.version}</bundle>

--- a/catalog/spatial/registry/registry-federation-admin-api/src/main/java/org/codice/ddf/registry/federationadmin/FederationAdminMBean.java
+++ b/catalog/spatial/registry/registry-federation-admin-api/src/main/java/org/codice/ddf/registry/federationadmin/FederationAdminMBean.java
@@ -13,15 +13,10 @@
  */
 package org.codice.ddf.registry.federationadmin;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
-
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 
 /**
  * This is the external facing interface for the FederationAdminService. This is what should be used by the UI,
@@ -75,7 +70,9 @@ public interface FederationAdminMBean {
     void deleteLocalEntry(List<String> ids) throws FederationAdminException;
 
     /**
-     * Returns a Map of RegistryPackage objects as converted using {@code RegistryPackageWebConverter}
+     * Returns a Map of {@code RegistryPackageType} objects as converted using {@code RegistryPackageWebConverter}
+     * List of node maps representing local registry entries can be found in the returned map using
+     * the key 'nodes'. Additional information about the nodes/registry is also included in the map.
      *
      * @return Map<String, Object>
      * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
@@ -94,18 +91,12 @@ public interface FederationAdminMBean {
     List<Map<String, Object>> allRegistryInfo();
 
     /**
-     * @return the list of registry metacards as RegistryObjectWebMaps
+     * Returns a Map of {@code RegistryPackageType} objects as converted using {@code RegistryPackageWebConverter}
+     * List of node maps representing all registry entries can be found in the returned map using
+     * the key 'nodes'. Additional information about the nodes/registry is also included in the map.
+     *
+     * @return Map<String, Object>
      */
-    List<Map<String, Object>> allRegistryMetacards();
+    Map<String, Object> allRegistryMetacards();
 
-    /**
-     * @param source       - The id of the source that will be published to or unpublished
-     *                     from the following destinations
-     * @param destinations - List of ids of catalog stores that the source will be
-     *                     published to or unpublished from
-     * @return the list of currently published locations after attempting to perform
-     * the publish/unpublishes
-     */
-    List<Serializable> updatePublications(String source, List<String> destinations)
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException;
 }

--- a/catalog/spatial/registry/registry-federation-admin-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.ddf.registry</groupId>
+        <artifactId>registry</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>registry-federation-admin-impl</artifactId>
+    <name>DDF :: Registry :: Federation :: Admin :: Impl</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-ebrim-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-schema-bindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-parser-xml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Embed-Dependency>
+                            ddf-security-common,
+                            registry-common,
+                            catalog-core-api-impl;scope=!test,
+                            gson
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util.http,
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.62</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.81</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/AdminHelper.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/AdminHelper.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.federationadmin.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.ui.admin.api.ConfigurationAdminExt;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+import ddf.catalog.service.ConfiguredService;
+import ddf.catalog.source.Source;
+
+public class AdminHelper {
+    private static final String REGISTRY_FILTER = String.format(
+            "(|(%s=*Registry*Store*)(%s=*registry*store*))",
+            ConfigurationAdmin.SERVICE_FACTORYPID, ConfigurationAdmin.SERVICE_FACTORYPID);
+
+    private static final String MAP_ENTRY_ID = "id";
+
+    private static final String DISABLED = "_disabled";
+
+    private final ConfigurationAdmin configurationAdmin;
+
+    public AdminHelper(ConfigurationAdmin configurationAdmin) {
+        this.configurationAdmin = configurationAdmin;
+    }
+
+    private BundleContext getBundleContext() {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle != null) {
+            return bundle.getBundleContext();
+        }
+        return null;
+    }
+
+    public List<Source> getRegistrySources() throws org.osgi.framework.InvalidSyntaxException {
+        List<ServiceReference<? extends Source>> refs = new ArrayList<>();
+        refs.addAll(getBundleContext().getServiceReferences(RegistryStore.class, null));
+        return refs.stream()
+                .map(e -> getBundleContext().getService(e))
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, Object>> getMetatypes() {
+        ConfigurationAdminExt configAdminExt = new ConfigurationAdminExt(configurationAdmin);
+        return configAdminExt.addMetaTypeNamesToMap(configAdminExt.getFactoryPidObjectClasses(),
+                REGISTRY_FILTER,
+                ConfigurationAdmin.SERVICE_FACTORYPID);
+    }
+
+    public List getConfigurations(Map<String, Object> metatype)
+            throws InvalidSyntaxException, IOException {
+        return org.apache.shiro.util.CollectionUtils.asList(configurationAdmin.listConfigurations(
+                String.format("(|(%s=%s)(%s=%s%s))",
+                        ConfigurationAdmin.SERVICE_FACTORYPID,
+                        metatype.get(MAP_ENTRY_ID),
+                        ConfigurationAdmin.SERVICE_FACTORYPID,
+                        metatype.get(MAP_ENTRY_ID),
+                        DISABLED)));
+    }
+
+    public Configuration getConfiguration(ConfiguredService cs) throws IOException {
+        return configurationAdmin.getConfiguration(cs.getConfigurationPid());
+    }
+
+    public String getBundleName(Configuration config) {
+        ConfigurationAdminExt configAdminExt = new ConfigurationAdminExt(configurationAdmin);
+        return configAdminExt.getName(getBundleContext().getBundle(config.getBundleLocation()));
+    }
+
+    public long getBundleId(Configuration config) {
+        return getBundleContext().getBundle(config.getBundleLocation())
+                .getBundleId();
+    }
+
+    public String getName(Configuration config) {
+        ConfigurationAdminExt configAdminExt = new ConfigurationAdminExt(configurationAdmin);
+        return ((ObjectClassDefinition) configAdminExt.getFactoryPidObjectClasses()
+                .get(config.getFactoryPid())).getName();
+    }
+}

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
@@ -1,0 +1,688 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.federationadmin.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.DatatypeConstants;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.tika.io.IOUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.FederationAdminMBean;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.schemabindings.EbrimConstants;
+import org.codice.ddf.registry.schemabindings.converter.type.RegistryPackageTypeConverter;
+import org.codice.ddf.registry.schemabindings.converter.web.RegistryPackageWebConverter;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.endpoint.CatalogEndpoint;
+import ddf.catalog.service.ConfiguredService;
+import ddf.catalog.source.Source;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ValueListType;
+
+public class FederationAdmin implements FederationAdminMBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FederationAdmin.class);
+
+    private static final String MAP_ENTRY_ID = "id";
+
+    private static final String MAP_ENTRY_ENABLED = "enabled";
+
+    private static final String MAP_ENTRY_FPID = "fpid";
+
+    private static final String MAP_ENTRY_NAME = "name";
+
+    private static final String MAP_ENTRY_BUNDLE_NAME = "bundle_name";
+
+    private static final String MAP_ENTRY_BUNDLE_LOCATION = "bundle_location";
+
+    private static final String MAP_ENTRY_BUNDLE = "bundle";
+
+    private static final String MAP_ENTRY_PROPERTIES = "properties";
+
+    private static final String MAP_ENTRY_CONFIGURATIONS = "configurations";
+
+    private static final String DISABLED = "_disabled";
+
+    private static final String TRANSIENT_VALUES_KEY = "TransientValues";
+
+    private static final String AUTO_POPULATE_VALUES_KEY = "autoPopulateValues";
+
+    private static final String SERVICE_BINDINGS_KEY = "ServiceBinding";
+
+    private static final String CUSTOM_SLOTS_KEY = "customSlots";
+
+    private static final String NODES_KEY = "nodes";
+
+    private static final String KARAF_ETC = "karaf.etc";
+
+    private static final String REGISTRY_CONFIG_DIR = "registry";
+
+    private static final String REGISTRY_FIELDS_FILE = "registry-custom-slots.json";
+
+    private final AdminHelper helper;
+
+    private MBeanServer mbeanServer;
+
+    private ObjectName objectName;
+
+    private FederationAdminService federationAdminService;
+
+    private InputTransformer registryTransformer;
+
+    private Parser parser;
+
+    private ParserConfigurator marshalConfigurator;
+
+    private Map<String, Object> customSlots;
+
+    private Map<String, Map<String, String>> endpointMap = new HashMap<>();
+
+    private RegistryPackageTypeConverter registryTypeConverter;
+
+    private RegistryPackageWebConverter registryMapConverter;
+
+    private SlotTypeHelper slotHelper;
+
+    public FederationAdmin(AdminHelper helper) {
+        configureMBean();
+        this.helper = helper;
+    }
+
+    @Override
+    public String createLocalEntry(Map<String, Object> registryMap)
+            throws FederationAdminException {
+
+        Optional<RegistryPackageType> registryPackageOptional = registryTypeConverter.convert(
+                registryMap);
+        RegistryPackageType registryPackage =
+                registryPackageOptional.orElseThrow(() -> new FederationAdminException(
+                        "Error creating local registry entry. Couldn't convert registry map to a registry package."));
+
+        if (!registryPackage.isSetHome()) {
+            registryPackage.setHome(SystemBaseUrl.getBaseUrl());
+        }
+
+        if (!registryPackage.isSetObjectType()) {
+            registryPackage.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+        }
+
+        if (!registryPackage.isSetId()) {
+            String registryPackageId = RegistryConstants.GUID_PREFIX + UUID.randomUUID()
+                    .toString()
+                    .replaceAll("-", "");
+            registryPackage.setId(registryPackageId);
+        }
+
+        updateDateFields(registryPackage);
+
+        Metacard metacard = getRegistryMetacardFromRegistryPackage(registryPackage);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                true));
+        return federationAdminService.addRegistryEntry(metacard);
+    }
+
+    @Override
+    public String createLocalEntry(String base64EncodedXmlData) throws FederationAdminException {
+        if (StringUtils.isBlank(base64EncodedXmlData)) {
+            throw new FederationAdminException(
+                    "Error creating local entry. String provided was blank.");
+        }
+
+        String metacardId;
+        try (InputStream xmlStream = new ByteArrayInputStream(Base64.getDecoder()
+                .decode(base64EncodedXmlData))) {
+            Metacard metacard = getRegistryMetacardFromInputStream(xmlStream);
+            metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                    true));
+            metacardId = federationAdminService.addRegistryEntry(metacard);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new FederationAdminException("Error creating local entry. Couldn't decode string.",
+                    e);
+        }
+        return metacardId;
+    }
+
+    @Override
+    public void updateLocalEntry(Map<String, Object> registryObjectMap)
+            throws FederationAdminException {
+
+        Optional<RegistryPackageType> registryPackageOptional = registryTypeConverter.convert(
+                registryObjectMap);
+        RegistryPackageType registryPackage =
+                registryPackageOptional.orElseThrow(() -> new FederationAdminException(
+                        "Error updating local registry entry. Couldn't convert registry map to a registry package."));
+
+        updateDateFields(registryPackage);
+
+        List<Metacard> existingMetacards =
+                federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                        registryPackage.getId()));
+
+        if (CollectionUtils.isEmpty(existingMetacards)) {
+            String message = "Error updating local registry entry. Registry metacard not found.";
+            LOGGER.error("{} Registry ID: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message);
+        }
+
+        if (existingMetacards.size() > 1) {
+            throw new FederationAdminException(
+                    "Error updating local registry entry. Multiple registry metacards found.");
+        }
+        Metacard existingMetacard = existingMetacards.get(0);
+
+        Metacard updateMetacard = getRegistryMetacardFromRegistryPackage(registryPackage);
+        updateMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacard.getId()));
+
+        federationAdminService.updateRegistryEntry(updateMetacard);
+    }
+
+    @Override
+    public void deleteLocalEntry(List<String> ids) throws FederationAdminException {
+        if (CollectionUtils.isEmpty(ids)) {
+            throw new FederationAdminException(
+                    "Error deleting local registry entries. No ids provided.");
+        }
+
+        List<Metacard> localMetacards =
+                federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids);
+        List<String> metacardIds = new ArrayList<>();
+
+        metacardIds.addAll(localMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+        if (ids.size() != metacardIds.size()) {
+            String message = "Error deleting local registry entries. ";
+            LOGGER.error("{} Registry Ids provided: {}. Registry metacard ids found: {}",
+                    message,
+                    ids,
+                    metacardIds);
+            throw new FederationAdminException(message);
+        }
+
+        federationAdminService.deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Override
+    public Map<String, Object> getLocalNodes() throws FederationAdminException {
+        Map<String, Object> localNodes = new HashMap<>();
+        List<Map<String, Object>> registryWebMaps;
+
+        List<RegistryPackageType> registryPackages =
+                federationAdminService.getLocalRegistryObjects();
+
+        List<Metacard> metacards = federationAdminService.getLocalRegistryMetacards();
+        Map<String, Metacard> metacardByRegistryIdMap = getRegistryIdMetacardMap(metacards);
+
+        registryWebMaps = getWebMapsFromRegistryPackages(registryPackages, metacardByRegistryIdMap);
+
+        if (customSlots != null) {
+            localNodes.put(CUSTOM_SLOTS_KEY, customSlots);
+        }
+
+        Map<String, Object> autoPopulateMap = new HashMap<>();
+        autoPopulateMap.put(SERVICE_BINDINGS_KEY, endpointMap.values());
+        localNodes.put(AUTO_POPULATE_VALUES_KEY, autoPopulateMap);
+
+        localNodes.put(NODES_KEY, registryWebMaps);
+
+        return localNodes;
+    }
+
+    @Override
+    public boolean registryStatus(String servicePID) {
+        try {
+            List<Source> sources = helper.getRegistrySources();
+            for (Source source : sources) {
+                if (source instanceof ConfiguredService) {
+                    ConfiguredService cs = (ConfiguredService) source;
+                    try {
+                        Configuration config = helper.getConfiguration(cs);
+                        if (config != null && config.getProperties()
+                                .get(Constants.SERVICE_PID)
+                                .equals(servicePID)) {
+                            try {
+                                return source.isAvailable();
+                            } catch (Exception e) {
+                                LOGGER.warn("Couldn't get availability on registry {}: {}",
+                                        servicePID,
+                                        e);
+                            }
+                        }
+                    } catch (IOException e) {
+                        LOGGER.warn("Couldn't find configuration for source '{}'", source.getId());
+                    }
+                } else {
+                    LOGGER.warn("Source '{}' not a configured service", source.getId());
+                }
+            }
+        } catch (InvalidSyntaxException e) {
+            LOGGER.error("Could not get service reference list");
+        }
+
+        return false;
+    }
+
+    @Override
+    public List<Map<String, Object>> allRegistryInfo() {
+
+        List<Map<String, Object>> metatypes = helper.getMetatypes();
+
+        for (Map metatype : metatypes) {
+            try {
+                List<Configuration> configs = helper.getConfigurations(metatype);
+
+                ArrayList<Map<String, Object>> configurations = new ArrayList<>();
+                if (configs != null) {
+                    for (Configuration config : configs) {
+                        Map<String, Object> registry = new HashMap<>();
+
+                        boolean disabled = config.getPid()
+                                .endsWith(DISABLED);
+                        registry.put(MAP_ENTRY_ID, config.getPid());
+                        registry.put(MAP_ENTRY_ENABLED, !disabled);
+                        registry.put(MAP_ENTRY_FPID, config.getFactoryPid());
+
+                        if (!disabled) {
+                            registry.put(MAP_ENTRY_NAME, helper.getName(config));
+                            registry.put(MAP_ENTRY_BUNDLE_NAME, helper.getBundleName(config));
+                            registry.put(MAP_ENTRY_BUNDLE_LOCATION, config.getBundleLocation());
+                            registry.put(MAP_ENTRY_BUNDLE, helper.getBundleId(config));
+                        } else {
+                            registry.put(MAP_ENTRY_NAME, config.getPid());
+                        }
+
+                        Dictionary<String, Object> properties = config.getProperties();
+                        Map<String, Object> plist = new HashMap<>();
+                        for (String key : Collections.list(properties.keys())) {
+                            plist.put(key, properties.get(key));
+                        }
+                        registry.put(MAP_ENTRY_PROPERTIES, plist);
+
+                        configurations.add(registry);
+                    }
+                    metatype.put(MAP_ENTRY_CONFIGURATIONS, configurations);
+                }
+            } catch (InvalidSyntaxException | IOException e) {
+                LOGGER.warn("Error getting registry info: {}", e.getMessage());
+            }
+        }
+
+        Collections.sort(metatypes,
+                (o1, o2) -> ((String) o1.get("id")).compareToIgnoreCase((String) o2.get("id")));
+        return metatypes;
+    }
+
+    @Override
+    public Map<String, Object> allRegistryMetacards() {
+        Map<String, Object> nodes = new HashMap<>();
+        List<Map<String, Object>> registryMetacardInfo = new ArrayList<>();
+
+        try {
+            List<RegistryPackageType> registryMetacardObjects =
+                    federationAdminService.getRegistryObjects();
+
+            List<Metacard> metacards = federationAdminService.getRegistryMetacards();
+            Map<String, Metacard> metacardByRegistryIdMap = getRegistryIdMetacardMap(metacards);
+
+            registryMetacardInfo = getWebMapsFromRegistryPackages(registryMetacardObjects,
+                    metacardByRegistryIdMap);
+
+        } catch (FederationAdminException e) {
+            LOGGER.warn("Couldn't get remote registry metacards '{}'", e);
+        }
+
+        if (customSlots != null) {
+            nodes.put(CUSTOM_SLOTS_KEY, customSlots);
+        }
+
+        Map<String, Object> autoPopulateMap = new HashMap<>();
+        autoPopulateMap.put(SERVICE_BINDINGS_KEY, endpointMap.values());
+        nodes.put(AUTO_POPULATE_VALUES_KEY, autoPopulateMap);
+
+        nodes.put(NODES_KEY, registryMetacardInfo);
+
+        return nodes;
+    }
+
+    private List<Map<String, Object>> getWebMapsFromRegistryPackages(
+            List<RegistryPackageType> packages, Map<String, Metacard> metacardByRegistryIdMap) {
+        List<Map<String, Object>> registryMaps = new ArrayList<>();
+        for (RegistryPackageType registryPackage : packages) {
+            Map<String, Object> registryWebMap = registryMapConverter.convert(registryPackage);
+
+            Metacard metacard = metacardByRegistryIdMap.get(registryPackage.getId());
+            Map<String, Object> transientValues = getTransientValuesMap(metacard);
+            if (MapUtils.isNotEmpty(transientValues)) {
+                registryWebMap.put(TRANSIENT_VALUES_KEY, transientValues);
+            }
+
+            if (MapUtils.isNotEmpty(registryWebMap)) {
+                registryMaps.add(registryWebMap);
+            }
+        }
+        return registryMaps;
+    }
+
+    private Metacard getRegistryMetacardFromRegistryPackage(RegistryPackageType registryPackage)
+            throws FederationAdminException {
+        if (registryPackage == null) {
+            throw new FederationAdminException(
+                    "Error creating metacard from registry package. Null package was received.");
+        }
+        Metacard metacard;
+
+        try {
+            JAXBElement<RegistryPackageType> jaxbRegistryObjectType =
+                    EbrimConstants.RIM_FACTORY.createRegistryPackage(registryPackage);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            parser.marshal(marshalConfigurator, jaxbRegistryObjectType, baos);
+            InputStream xmlInputStream = new ByteArrayInputStream(baos.toByteArray());
+            metacard = registryTransformer.transform(xmlInputStream);
+
+            IOUtils.closeQuietly(baos);
+            IOUtils.closeQuietly(xmlInputStream);
+
+        } catch (IOException | CatalogTransformerException | ParserException e) {
+            String message = "Error creating metacard from registry package.";
+            LOGGER.error("{} Registry id: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message, e);
+        }
+
+        return metacard;
+    }
+
+    private Metacard getRegistryMetacardFromInputStream(InputStream inputStream)
+            throws FederationAdminException {
+        if (inputStream == null) {
+            throw new FederationAdminException(
+                    "Error converting input stream to a metacard. Null input stream provided.");
+        }
+
+        Metacard metacard;
+        try {
+            metacard = registryTransformer.transform(inputStream);
+        } catch (IOException | CatalogTransformerException e) {
+            throw new FederationAdminException(
+                    "Error getting metacard. RegistryTransformer couldn't convert the input stream.",
+                    e);
+        }
+
+        return metacard;
+    }
+
+    private Map<String, Metacard> getRegistryIdMetacardMap(List<Metacard> metacards) {
+        Map<String, Metacard> registryIdMetacardMap = new HashMap<>();
+
+        for (Metacard metacard : metacards) {
+            String registryId = metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                    .getValue()
+                    .toString();
+
+            registryIdMetacardMap.put(registryId, metacard);
+        }
+
+        return registryIdMetacardMap;
+    }
+
+    private Map<String, Object> getTransientValuesMap(Metacard metacard) {
+        Map<String, Object> transientValuesMap = new HashMap<>();
+        if (metacard != null) {
+            for (String transientAttributeKey : RegistryObjectMetacardType.TRANSIENT_ATTRIBUTES) {
+                Attribute transientAttribute = metacard.getAttribute(transientAttributeKey);
+
+                if (transientAttribute != null) {
+                    transientValuesMap.put(transientAttributeKey, transientAttribute.getValues());
+                }
+            }
+        }
+        return transientValuesMap;
+    }
+
+    private void updateDateFields(RegistryPackageType rpt) {
+
+        ExtrinsicObjectType nodeInfo = null;
+        for (JAXBElement identifiable : rpt.getRegistryObjectList()
+                .getIdentifiable()) {
+            RegistryObjectType registryObject = (RegistryObjectType) identifiable.getValue();
+
+            if (registryObject instanceof ExtrinsicObjectType
+                    && RegistryConstants.REGISTRY_NODE_OBJECT_TYPE.equals(registryObject.getObjectType())) {
+                nodeInfo = (ExtrinsicObjectType) registryObject;
+                break;
+            }
+        }
+        if (nodeInfo != null) {
+            boolean liveDateFound = false;
+            boolean lastUpdatedFound = false;
+
+            OffsetDateTime now = OffsetDateTime.now(ZoneId.of(ZoneOffset.UTC.toString()));
+            String rightNow = now.toString();
+
+            for (SlotType1 slot : nodeInfo.getSlot()) {
+                if (slot.getName()
+                        .equals(RegistryConstants.XML_LIVE_DATE_NAME)) {
+                    liveDateFound = true;
+                } else if (slot.getName()
+                        .equals(RegistryConstants.XML_LAST_UPDATED_NAME)) {
+                    ValueListType valueList = EbrimConstants.RIM_FACTORY.createValueListType();
+                    valueList.getValue()
+                            .add(rightNow);
+                    slot.setValueList(EbrimConstants.RIM_FACTORY.createValueList(valueList));
+                    lastUpdatedFound = true;
+                }
+            }
+
+            if (!liveDateFound) {
+                SlotType1 liveDate = slotHelper.create(RegistryConstants.XML_LIVE_DATE_NAME,
+                        rightNow,
+                        DatatypeConstants.DATETIME.toString());
+
+                nodeInfo.getSlot()
+                        .add(liveDate);
+            }
+
+            if (!lastUpdatedFound) {
+                SlotType1 lastUpdated = slotHelper.create(RegistryConstants.XML_LAST_UPDATED_NAME,
+                        rightNow,
+                        DatatypeConstants.DATETIME.toString());
+
+                nodeInfo.getSlot()
+                        .add(lastUpdated);
+            }
+        }
+    }
+
+    private void configureMBean() {
+        mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        try {
+            objectName = new ObjectName(FederationAdminMBean.OBJECT_NAME);
+        } catch (MalformedObjectNameException e) {
+            LOGGER.warn("Exception while creating object name: " + FederationAdminMBean.OBJECT_NAME,
+                    e);
+        }
+
+        try {
+            try {
+                mbeanServer.registerMBean(new StandardMBean(this, FederationAdminMBean.class),
+                        objectName);
+            } catch (InstanceAlreadyExistsException e) {
+                mbeanServer.unregisterMBean(objectName);
+                mbeanServer.registerMBean(new StandardMBean(this, FederationAdminMBean.class),
+                        objectName);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Could not register mbean.", e);
+        }
+    }
+
+    public void destroy() {
+        try {
+            if (objectName != null && mbeanServer != null) {
+                mbeanServer.unregisterMBean(objectName);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Exception un registering mbean: ", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void init() {
+
+        Path path = Paths.get(System.getProperty(KARAF_ETC),
+                REGISTRY_CONFIG_DIR,
+                REGISTRY_FIELDS_FILE);
+        if (Files.exists(path)) {
+            try {
+                String registryFieldsJsonString = new String(Files.readAllBytes(path),
+                        StandardCharsets.UTF_8);
+                Gson gson = new Gson();
+                customSlots = new HashMap<>();
+                customSlots = (Map<String, Object>) gson.fromJson(registryFieldsJsonString,
+                        customSlots.getClass());
+            } catch (IOException e) {
+                LOGGER.error(
+                        "Error reading {}. This will result in no custom fields being shown for registry node editing",
+                        path.toString(),
+                        e);
+            }
+        }
+    }
+
+    public void bindEndpoint(ServiceReference reference) {
+        BundleContext context = getContext();
+        if (reference != null && context != null) {
+            CatalogEndpoint endpoint = (CatalogEndpoint) context.getService(reference);
+            Map<String, String> properties = endpoint.getEndpointProperties();
+            endpointMap.put(properties.get(CatalogEndpoint.ID_KEY), properties);
+        }
+    }
+
+    public void unbindEndpoint(ServiceReference reference) {
+        BundleContext context = getContext();
+        if (reference != null && context != null) {
+            CatalogEndpoint endpoint = (CatalogEndpoint) context.getService(reference);
+            Map<String, String> properties = endpoint.getEndpointProperties();
+            endpointMap.remove(properties.get(CatalogEndpoint.ID_KEY));
+        }
+    }
+
+    protected BundleContext getContext() {
+        Bundle bundle = FrameworkUtil.getBundle(FederationAdmin.class);
+        if (bundle != null) {
+            return bundle.getBundleContext();
+        }
+        return null;
+    }
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+
+    public void setParser(Parser parser) {
+        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                EbrimConstants.OGC_FACTORY.getClass()
+                        .getPackage()
+                        .getName(),
+                EbrimConstants.GML_FACTORY.getClass()
+                        .getPackage()
+                        .getName());
+
+        ClassLoader classLoader = this.getClass()
+                .getClassLoader();
+
+        this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
+
+        this.parser = parser;
+    }
+
+    public void setRegistryTransformer(InputTransformer inputTransformer) {
+        this.registryTransformer = inputTransformer;
+    }
+
+    public void setRegistryTypeConverter(RegistryPackageTypeConverter registryTypeConverter) {
+        this.registryTypeConverter = registryTypeConverter;
+    }
+
+    public void setRegistryMapConverter(RegistryPackageWebConverter registryMapConverter) {
+        this.registryMapConverter = registryMapConverter;
+    }
+
+    public void setSlotHelper(SlotTypeHelper slotHelper) {
+        this.slotHelper = slotHelper;
+    }
+
+}

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,49 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="federationAdmin" class="org.codice.ddf.registry.federationadmin.impl.FederationAdmin"
+          destroy-method="destroy" init-method="init">
+        <argument ref="adminHelper"/>
+        <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="parser" ref="xmlParser"/>
+        <property name="registryTransformer" ref="inputTransformer"/>
+        <property name="registryTypeConverter" ref="registryTypeConverter"/>
+        <property name="registryMapConverter" ref="registryMapConverter"/>
+        <property name="slotHelper" ref="slotHelper"/>
+    </bean>
+
+    <bean id="registryTypeConverter" class="org.codice.ddf.registry.schemabindings.converter.type.RegistryPackageTypeConverter"/>
+    <bean id="registryMapConverter" class="org.codice.ddf.registry.schemabindings.converter.web.RegistryPackageWebConverter"/>
+    <bean id="slotHelper" class="org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper"/>
+
+    <bean id="adminHelper" class="org.codice.ddf.registry.federationadmin.impl.AdminHelper">
+        <argument ref="configurationAdmin"/>
+    </bean>
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+    <reference id="federationAdminService"
+               interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+    <reference id="inputTransformer" interface="ddf.catalog.transform.InputTransformer"
+               filter="(id=rim:RegistryPackage)"/>
+    <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"/>
+
+    <reference-list id="catalogEndpoints" interface="ddf.catalog.endpoint.CatalogEndpoint"
+                    availability="optional">
+        <reference-listener bind-method="bindEndpoint"
+                            unbind-method="unbindEndpoint" ref="federationAdmin"/>
+    </reference-list>
+</blueprint>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
@@ -1,0 +1,827 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.federationadmin.impl;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBElement;
+
+import org.apache.commons.io.IOUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.schemabindings.EbrimConstants;
+import org.codice.ddf.registry.schemabindings.converter.type.RegistryPackageTypeConverter;
+import org.codice.ddf.registry.schemabindings.converter.web.RegistryPackageWebConverter;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
+import org.codice.ddf.registry.transformer.RegistryTransformer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.endpoint.CatalogEndpoint;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.service.ConfiguredService;
+import ddf.catalog.source.CatalogStore;
+import ddf.catalog.source.Source;
+import ddf.catalog.transform.CatalogTransformerException;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FederationAdminTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Mock
+    private FederationAdminService federationAdminService;
+
+    @Mock
+    private RegistryTransformer registryTransformer;
+
+    @Mock
+    private AdminHelper helper;
+
+    @Mock
+    private CatalogFramework catalogFramework;
+
+    @Mock
+    private BundleContext context;
+
+    @Mock
+    private QueryResponse queryResponse;
+
+    @Mock
+    private CatalogStore store;
+
+    private Parser parser;
+
+    private ParserConfigurator configurator;
+
+    private FederationAdmin federationAdmin;
+
+    private Map<String, CatalogStore> catalogStoreMap = new HashMap<>();
+
+    private MetacardImpl mcard;
+
+    private RegistryPackageTypeConverter typeConverter = new RegistryPackageTypeConverter();
+
+    private RegistryPackageWebConverter mapConverter = new RegistryPackageWebConverter();
+
+    private static final String LOCAL_NODE_KEY = "nodes";
+
+    @Before
+    public void setup() throws Exception {
+        parser = new XmlParser();
+        configurator = parser.configureParser(Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                EbrimConstants.OGC_FACTORY.getClass()
+                        .getPackage()
+                        .getName(),
+                EbrimConstants.GML_FACTORY.getClass()
+                        .getPackage()
+                        .getName()),
+                this.getClass()
+                        .getClassLoader());
+        federationAdmin = new FederationAdmin(helper) {
+            @Override
+            public BundleContext getContext() {
+                return context;
+            }
+        };
+        federationAdmin.setFederationAdminService(federationAdminService);
+        federationAdmin.setRegistryTransformer(registryTransformer);
+        federationAdmin.setParser(parser);
+        federationAdmin.setSlotHelper(new SlotTypeHelper());
+        federationAdmin.setRegistryMapConverter(new RegistryPackageWebConverter());
+        federationAdmin.setRegistryTypeConverter(new RegistryPackageTypeConverter());
+
+        mcard = new MetacardImpl(new RegistryObjectMetacardType());
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, "myId");
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, new ArrayList<>());
+        mcard.setId("someUUID");
+
+        when(queryResponse.getResults()).thenReturn(Collections.singletonList(new ResultImpl(mcard)));
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(queryResponse);
+        catalogStoreMap.put("myDest", store);
+    }
+
+    @Test
+    public void testCreateLocalEntry() throws Exception {
+        String metacardId = "metacardId";
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+
+        Metacard metacard = getTestMetacard();
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenReturn(metacardId);
+
+        String createdMetacardId = federationAdmin.createLocalEntry(registryMap);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testCreateLocalEntryMissingAttributes() throws Exception {
+        String metacardId = "metacardId";
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        registryMap.remove("id");
+        registryMap.remove("home");
+        registryMap.remove("objectType");
+        Metacard metacard = getTestMetacard();
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenReturn(metacardId);
+
+        federationAdmin.createLocalEntry(registryMap);
+        ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
+        verify(registryTransformer).transform(captor.capture());
+        String ebrim = IOUtils.toString(captor.getValue());
+        IOUtils.closeQuietly(captor.getValue());
+        assertXpathEvaluatesTo(SystemBaseUrl.getBaseUrl(),
+                "/*[local-name() = 'RegistryPackage']/@home",
+                ebrim);
+        assertXpathEvaluatesTo(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE,
+                "/*[local-name() = 'RegistryPackage']/@objectType",
+                ebrim);
+        assertXpathExists("/*[local-name() = 'RegistryPackage']/@id", ebrim);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithEmptyMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        federationAdmin.createLocalEntry(registryMap);
+
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithBadMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        registryMap.put("BadKey", "BadValue");
+
+        federationAdmin.createLocalEntry(registryMap);
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithFederationAdminException() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+
+        Metacard metacard = getTestMetacard();
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenThrow(
+                FederationAdminException.class);
+
+        federationAdmin.createLocalEntry(registryMap);
+
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testCreateLocalEntryString() throws Exception {
+        String encodeThisString = "aPretendXmlRegistryPackage";
+        String metacardId = "createdMetacardId";
+        String base64EncodedString = Base64.getEncoder()
+                .encodeToString(encodeThisString.getBytes());
+
+        Metacard metacard = getTestMetacard();
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(metacard)).thenReturn(metacardId);
+
+        String createdMetacardId = federationAdmin.createLocalEntry(base64EncodedString);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithBlankString() throws Exception {
+        String base64EncodedString = "";
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithTransformerException() throws Exception {
+        String encodeThisString = "aPretendXmlRegistryPackage";
+        String base64EncodedString = Base64.getEncoder()
+                .encodeToString(encodeThisString.getBytes());
+
+        when(registryTransformer.transform(any(InputStream.class))).thenThrow(
+                CatalogTransformerException.class);
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithDecodeError() throws Exception {
+        // This is has an illegal base64 character
+        String base64EncodedString = "[B@6499375d";
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test
+    public void testUpdateLocalEntry() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-registry-package-smaller.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        String existingMetacardId = "someUpdateMetacardId";
+
+        Metacard existingMetacard = getTestMetacard();
+        existingMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacardId));
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(existingMetacard);
+        Metacard updateMetacard = getTestMetacard();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(updateMetacard);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).updateRegistryEntry(updateMetacard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithEmptyMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(any(String.class)));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithBadMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        registryMap.put("BadKey", "BadValue");
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(any(String.class)));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithEmptyExistingList() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        List<Metacard> existingMetacards = new ArrayList<>();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithMultipleExistingMetacards() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(getTestMetacard());
+        existingMetacards.add(getTestMetacard());
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithFederationAdminServiceException() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        String existingMetacardId = "someUpdateMetacardId";
+
+        Metacard existingMetacard = getTestMetacard();
+        existingMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacardId));
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(existingMetacard);
+        Metacard updateMetacard = getTestMetacard();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(updateMetacard);
+        doThrow(FederationAdminException.class).when(federationAdminService)
+                .updateRegistryEntry(updateMetacard);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).updateRegistryEntry(updateMetacard);
+    }
+
+    @Test
+    public void testDeleteLocalEntry() throws Exception {
+        String firstRegistryId = "firstRegistryId";
+        String secondRegistryId = "secondRegistryId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstRegistryId);
+        ids.add(secondRegistryId);
+
+        String firstMetacardId = "firstMetacardId";
+        String secondMetacardId = "secondMetacardId";
+
+        Metacard firstMetacard = getTestMetacard();
+        firstMetacard.setAttribute(new AttributeImpl(Metacard.ID, firstMetacardId));
+        Metacard secondMetacard = getTestMetacard();
+        secondMetacard.setAttribute(new AttributeImpl(Metacard.ID, secondMetacardId));
+
+        List<Metacard> matchingMetacards = new ArrayList<>();
+        matchingMetacards.add(firstMetacard);
+        matchingMetacards.add(secondMetacard);
+
+        List<String> metacardIds = new ArrayList<>();
+        metacardIds.addAll(matchingMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenReturn(
+                matchingMetacards);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService).deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService, never()).getLocalRegistryMetacardsByRegistryIds(anyList());
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(anyList());
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithExceptionGettingLocalMetacards() throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("whatever");
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenThrow(
+                FederationAdminException.class);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(anyList());
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithNonMatchingLists() throws Exception {
+        String firstRegistryId = "firstRegistryId";
+        String secondRegistryId = "secondRegistryId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstRegistryId);
+        ids.add(secondRegistryId);
+
+        String firstMetacardId = "firstMetacardId";
+
+        Metacard firstMetacard = getTestMetacard();
+        firstMetacard.setAttribute(new AttributeImpl(Metacard.ID, firstMetacardId));
+
+        List<Metacard> matchingMetacards = new ArrayList<>();
+        matchingMetacards.add(firstMetacard);
+
+        List<String> metacardIds = new ArrayList<>();
+        metacardIds.addAll(matchingMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenReturn(
+                matchingMetacards);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithExceptionDeletingEntries() throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("firstId");
+
+        doThrow(FederationAdminException.class).when(federationAdminService)
+                .deleteRegistryEntriesByRegistryIds(ids);
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).deleteRegistryEntriesByRegistryIds(ids);
+    }
+
+    @Test
+    public void testGetLocalNodes() throws Exception {
+        RegistryPackageType registryObject = getRegistryObjectFromResource(
+                "/csw-registry-package-smaller.xml");
+        Map<String, Object> registryObjectMap = new RegistryPackageWebConverter().convert(
+                registryObject);
+        List<RegistryPackageType> registryPackages = new ArrayList<>();
+        registryPackages.add((RegistryPackageType) registryObject);
+
+        when(federationAdminService.getLocalRegistryObjects()).thenReturn(registryPackages);
+        Map<String, Object> localNodes = federationAdmin.getLocalNodes();
+
+        Map<String, Object> localNode =
+                ((List<Map<String, Object>>) localNodes.get(LOCAL_NODE_KEY)).get(0);
+        verify(federationAdminService).getLocalRegistryObjects();
+        assertThat(localNode, is(equalTo(registryObjectMap)));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalNodesWithFederationAdminException() throws Exception {
+        when(federationAdminService.getLocalRegistryObjects()).thenThrow(FederationAdminException.class);
+
+        federationAdmin.getLocalNodes();
+
+        verify(federationAdminService).getLocalRegistryObjects();
+    }
+
+    @Test
+    public void testAllRegistryInfoNoMetatypes() throws Exception {
+        List<Map<String, Object>> metatypes = new ArrayList<>();
+        when(helper.getMetatypes()).thenReturn(metatypes);
+        assertThat(federationAdmin.allRegistryInfo()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testAllRegistryInfo() throws Exception {
+        List<Map<String, Object>> metatypes = new ArrayList<>();
+        List<Configuration> configurations = new ArrayList<>();
+        Dictionary<String, Object> props = new Hashtable<>();
+        Dictionary<String, Object> propsDisabled = new Hashtable<>();
+
+        metatypes.add(new HashMap<>());
+
+        props.put("key1", "value1");
+        propsDisabled.put("key2", "value2");
+
+        Configuration config = mock(Configuration.class);
+        configurations.add(config);
+        when(config.getPid()).thenReturn("myPid");
+        when(config.getFactoryPid()).thenReturn("myFpid");
+        when(config.getProperties()).thenReturn(props);
+
+        Configuration configDisabled = mock(Configuration.class);
+        configurations.add(configDisabled);
+        when(configDisabled.getPid()).thenReturn("myPid_disabled");
+        when(configDisabled.getFactoryPid()).thenReturn("myFpid_disabled");
+        when(configDisabled.getProperties()).thenReturn(propsDisabled);
+
+        when(helper.getMetatypes()).thenReturn(metatypes);
+        when(helper.getConfigurations(any(Map.class))).thenReturn(configurations);
+        when(helper.getName(any(Configuration.class))).thenReturn("name");
+        when(helper.getBundleName(any(Configuration.class))).thenReturn("bundleName");
+        when(helper.getBundleId(any(Configuration.class))).thenReturn(1234L);
+
+        List<Map<String, Object>> updatedMetatypes = federationAdmin.allRegistryInfo();
+        assertThat(updatedMetatypes.size(), is(1));
+        ArrayList<Map<String, Object>> configs =
+                (ArrayList<Map<String, Object>>) updatedMetatypes.get(0)
+                        .get("configurations");
+        assertThat(configs.size(), is(2));
+        Map<String, Object> activeConfig = configs.get(0);
+        Map<String, Object> disabledConfig = configs.get(1);
+        assertThat(activeConfig.get("name"), equalTo("name"));
+        assertThat(activeConfig.get("id"), equalTo("myPid"));
+        assertThat(activeConfig.get("fpid"), equalTo("myFpid"));
+        assertThat(activeConfig.get("enabled"), equalTo(true));
+        assertThat(((Map<String, Object>) activeConfig.get("properties")).get("key1"),
+                equalTo("value1"));
+
+        assertThat(disabledConfig.get("name"), equalTo("myPid_disabled"));
+        assertThat(disabledConfig.get("id"), equalTo("myPid_disabled"));
+        assertThat(disabledConfig.get("fpid"), equalTo("myFpid_disabled"));
+        assertThat(disabledConfig.get("enabled"), equalTo(false));
+        assertThat(((Map<String, Object>) disabledConfig.get("properties")).get("key2"),
+                equalTo("value2"));
+    }
+
+    @Test
+    public void testAllRegistryMetacards() throws Exception {
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "location1");
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        List<Map<String, Object>> result =
+                (List<Map<String, Object>>) federationAdmin.allRegistryMetacards()
+                        .get("nodes");
+        assertThat(result.size(), is(1));
+        Map<String, Object> mcardMap = result.get(0);
+        assertThat(mcardMap.get("TransientValues"), notNullValue());
+        Map<String, Object> transValues = (Map<String, Object>) mcardMap.get("TransientValues");
+        assertThat(((List) transValues.get(RegistryObjectMetacardType.PUBLISHED_LOCATIONS)).get(0),
+                equalTo("location1"));
+    }
+
+    @Test
+    public void testRegistryStatusNotConfiguredService() throws Exception {
+        Source source = mock(Source.class);
+        when(helper.getRegistrySources()).thenReturn(Collections.singletonList(source));
+        assertThat(federationAdmin.registryStatus("servicePid"), is(false));
+    }
+
+    @Test
+    public void testRegistryStatusNoMatchingConfig() throws Exception {
+        RegistryStore source = mock(RegistryStore.class);
+        Configuration config = mock(Configuration.class);
+        Dictionary<String, Object> props = new Hashtable<>();
+        props.put("service.pid", "servicePid2");
+        when(config.getProperties()).thenReturn(props);
+        when(source.isAvailable()).thenReturn(true);
+        when(helper.getRegistrySources()).thenReturn(Collections.singletonList(source));
+        when(helper.getConfiguration(any(ConfiguredService.class))).thenReturn(config);
+        assertThat(federationAdmin.registryStatus("servicePid"), is(false));
+    }
+
+    @Test
+    public void testRegistryStatusNoConfig() throws Exception {
+        RegistryStore source = mock(RegistryStore.class);
+        when(source.isAvailable()).thenReturn(true);
+        when(helper.getRegistrySources()).thenReturn(Collections.singletonList(source));
+        when(helper.getConfiguration(any(ConfiguredService.class))).thenReturn(null);
+        assertThat(federationAdmin.registryStatus("servicePid"), is(false));
+    }
+
+    @Test
+    public void testRegistryStatus() throws Exception {
+        RegistryStore source = mock(RegistryStore.class);
+        Configuration config = mock(Configuration.class);
+        Dictionary<String, Object> props = new Hashtable<>();
+        props.put("service.pid", "servicePid");
+        when(config.getProperties()).thenReturn(props);
+        when(source.isAvailable()).thenReturn(true);
+        when(helper.getRegistrySources()).thenReturn(Collections.singletonList(source));
+        when(helper.getConfiguration(any(ConfiguredService.class))).thenReturn(config);
+        assertThat(federationAdmin.registryStatus("servicePid"), is(true));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+
+        copyJsonFileToKarafDir();
+
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "location1");
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        federationAdmin.init();
+        Map<String, Object> nodes = federationAdmin.getLocalNodes();
+        Map<String, Object> customSlots = (Map<String, Object>) nodes.get("customSlots");
+        assertThat(customSlots.size(), is(6));
+    }
+
+    @Test
+    public void testInitNoFile() throws Exception {
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "location1");
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        federationAdmin.init();
+        Map<String, Object> nodes = federationAdmin.getLocalNodes();
+        Map<String, Object> customSlots = (Map<String, Object>) nodes.get("customSlots");
+        assertThat(customSlots, nullValue());
+    }
+
+    @Test
+    public void testBindEndpointNullReference() throws Exception {
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        federationAdmin.bindEndpoint(null);
+        Map<String, Object> autoValues = (Map<String, Object>) federationAdmin.getLocalNodes()
+                .get("autoPopulateValues");
+        assertThat(autoValues.size(), is(1));
+        Collection bindingValues = (Collection) autoValues.get("ServiceBinding");
+        assertThat(bindingValues.size(), is(0));
+    }
+
+    @Test
+    public void testBindEndpoint() throws Exception {
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        ServiceReference reference = mock(ServiceReference.class);
+        CatalogEndpoint endpoint = mock(CatalogEndpoint.class);
+        Map<String, String> props = new HashMap<>();
+        props.put(CatalogEndpoint.ID_KEY, "myId");
+        when(endpoint.getEndpointProperties()).thenReturn(props);
+        when(context.getService(reference)).thenReturn(endpoint);
+        federationAdmin.bindEndpoint(reference);
+        Map<String, Object> autoValues = (Map<String, Object>) federationAdmin.getLocalNodes()
+                .get("autoPopulateValues");
+        assertThat(autoValues.size(), is(1));
+        Collection bindingValues = (Collection) autoValues.get("ServiceBinding");
+        assertThat(bindingValues.size(), is(1));
+        Map<String, String> bindings = (Map<String, String>) bindingValues.iterator()
+                .next();
+        assertThat(bindings.get(CatalogEndpoint.ID_KEY), equalTo("myId"));
+
+    }
+
+    @Test
+    public void testUnbindEndpoint() throws Exception {
+        List<RegistryPackageType> regObjects =
+                Collections.singletonList((RegistryPackageType) getRegistryObjectFromResource(
+                        "/csw-full-registry-package.xml"));
+        when(federationAdminService.getRegistryObjects()).thenReturn(regObjects);
+
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
+
+        when(federationAdminService.getRegistryMetacards()).thenReturn(Collections.singletonList(
+                mcard));
+        ServiceReference reference = mock(ServiceReference.class);
+        CatalogEndpoint endpoint = mock(CatalogEndpoint.class);
+        Map<String, String> props = new HashMap<>();
+        props.put(CatalogEndpoint.ID_KEY, "myId");
+        when(endpoint.getEndpointProperties()).thenReturn(props);
+        when(context.getService(reference)).thenReturn(endpoint);
+        federationAdmin.bindEndpoint(reference);
+
+        federationAdmin.unbindEndpoint(reference);
+        Map<String, Object> autoValues = (Map<String, Object>) federationAdmin.getLocalNodes()
+                .get("autoPopulateValues");
+        assertThat(autoValues.size(), is(1));
+        Collection bindingValues = (Collection) autoValues.get("ServiceBinding");
+        assertThat(bindingValues.size(), is(0));
+    }
+
+    private void copyJsonFileToKarafDir() throws Exception {
+        File etc = folder.getRoot();
+        File registry = folder.newFolder("registry");
+        File jsonFile = new File(registry, "registry-custom-slots.json");
+        FileOutputStream outputStream = new FileOutputStream(jsonFile);
+        InputStream inputStream = this.getClass()
+                .getResourceAsStream("/etc/registry/registry-custom-slots.json");
+        IOUtils.copy(inputStream, outputStream);
+        inputStream.close();
+        outputStream.close();
+        System.setProperty("karaf.etc", etc.getCanonicalPath());
+    }
+
+    private RegistryPackageType getRegistryObjectFromResource(String path) throws ParserException {
+        RegistryObjectType registryObject = null;
+        JAXBElement<RegistryObjectType> jaxbRegistryObject = parser.unmarshal(configurator,
+                JAXBElement.class,
+                getClass().getResourceAsStream(path));
+
+        if (jaxbRegistryObject != null) {
+            registryObject = jaxbRegistryObject.getValue();
+        }
+
+        return (RegistryPackageType) registryObject;
+    }
+
+    private Map<String, Object> getMapFromRegistryObject(RegistryPackageType registryObject) {
+        return mapConverter.convert(registryObject);
+    }
+
+    private RegistryPackageType getRegistryObjectFromMap(Map<String, Object> registryMap) {
+        return typeConverter.convert(registryMap)
+                .get();
+    }
+
+    private Metacard getTestMetacard() {
+        return new MetacardImpl(new RegistryObjectMetacardType());
+    }
+}

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/csw-full-registry-package.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/csw-full-registry-package.xml
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!-- This example csw-ebrim message represents a single node in a system. The ddf registry is not a ebrim registry but uses the csw ebrim format to hold and transmit registry information. In
+     a sense each node contains its own ebrim registry less the canonical classifications. The full registry package and all its RegistryObjects are stored in one metacard. In places where
+     you might reference a pre existing ClassificationNode or ClassificationSchema as defined in a standard ebrim registry we have opted to just use string identifiers that are consistent
+     with the canonical classification nodes. Associations are used to associate the various object. Primarily associations are ued to associate organizations and people with content collections,
+     services and the general node description. Each of the user defined id's (not the framework generated ones) are arbitrary and are only required to be unique in the document. The top level
+     objects id should be a uuid that is globally unique-->
+<!-- top level registry object id is turned into the regsitry-id internally. metacard content type will be set using the lid.-->
+<!-- home attribute should be set by the framework to the base url of the originating instance -->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <!-- external identifiers are set by the framework to track the local metacard id and the origin-id. origin-id is the metacard id of the registry entry on the originating instance-->
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+
+    <!-- RegistryObjectList holds all the actual registry content-->
+    <rim:RegistryObjectList>
+        <!-- defines the general node information -->
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <!--Optional: Date indicating when this instance when live or operational-->
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T06:15:30-07:00</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating the earliest data sets available in this instance-->
+            <rim:Slot name="dataStartDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this instance-->
+            <rim:Slot name="dataEndDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T23:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!-- Date this entries data was last updated/created by its originator -->
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Any links that might be associated with this instance like wiki pages -->
+            <rim:Slot name="links" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>https://some/link/to/my/repo</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Geographic location of this instance described by a gml:Point-->
+            <rim:Slot name="location" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Point">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Point srsDimension="2" srsName="urn:ogc:def:crs:EPSG::4326">
+                            <gml:pos>112.267472 33.467944</gml:pos>
+                        </gml:Point>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: Region of this instance described by a UNSD region. The location should be within this region -->
+            <rim:Slot name="region" slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>USA</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Sorces of information that contribute to this instances data-->
+            <rim:Slot name="inputDataSources" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>youtube</rim:Value>
+                    <rim:Value>myCamera</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Types of data that this instance contains-->
+            <rim:Slot name="dataTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: String representing the security level of this instance-->
+            <rim:Slot name="securityLevel" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>role=guest</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!-- Name used primarily for display in UI interfaces to uniquely identify this node -->
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId"/>
+        </rim:ExtrinsicObject>
+
+        <!-- all extrinsic objects with lid=urn:registry:content:collection will be used to create content collections -->
+        <rim:ExtrinsicObject id="urn:content:collection:id0" objectType="urn:registry:content:collection">
+
+            <rim:Slot name="types" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="mimeTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>application/pdf</rim:Value>
+                    <rim:Value>application/msword</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="recordCount" slotType="xs:long">
+                <rim:ValueList>
+                    <rim:Value>1234</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Date indicating the earliest data sets available in this collection-->
+            <rim:Slot name="startDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this collection-->
+            <rim:Slot name="endDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T23:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: A gml feature describing the geographic bounds of the data contained in this collection-->
+            <rim:Slot name="bounds" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Envelope">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Envelope srsName="urn:ogc:def:crs:EPSG:4326">
+                            <gml:lowerCorner>60.042 13.754</gml:lowerCorner>
+                            <gml:upperCorner>68.410 17.920</gml:upperCorner>
+                        </gml:Envelope>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: A UNSD region  describing the geographic bounds of the data contained in this collection-->
+            <rim:Slot name="region"
+                      slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>Arizona</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Name>
+                <rim:LocalizedString value="Collection Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+            </rim:Description>
+        </rim:ExtrinsicObject>
+
+        <rim:ExtrinsicObject id="urn:content:collection:id1" objectType="urn:registry:content:collection">
+            <rim:Slot name="types" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="mimeTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video/mpeg4-generic</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="recordCount" slotType="xs:long">
+                <rim:ValueList>
+                    <rim:Value>1234</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating the earliest data sets available in this collection-->
+            <rim:Slot name="startDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this collection-->
+            <rim:Slot name="endDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T22:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Name>
+                <rim:LocalizedString value="Collection Name2"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+            </rim:Description>
+        </rim:ExtrinsicObject>
+
+        <rim:ExtrinsicObject id="urn:service:params:id0" mimeType="application/octet-stream" isOpaque="false">
+            <rim:ContentVersionInfo comment="someComment" versionName="versionName"/>
+            <rim:Slot name="parameters">
+                <rim:ValueList>
+                    <rim:Value>param1</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+        </rim:ExtrinsicObject>
+
+        <!-- There should be only one service defined with lid=urn:registry:federation:service. Multiple service bindings can be added to this one service -->
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <!--
+            Zero or more repetitions: Service bindings represent a way to query data
+            from this instance. Each binding can have one or more slots that define URLs or other properties.
+            For more complex properties such as query parameters use specification links to point to an
+            ExtrinsicObject that contains the required information. For federation source creation all the
+            serviceBinding slots and name will be used as properties for creating the source. Which source is
+            created will be based on the bindingType attribute which should be the factory pid of a managed service factory
+            -->
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
+                <!--Slot defining the query url for this particular method of communicating with this instance-->
+                <rim:Slot name="cswUrl" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <!-- bindingType identifies communication message type for this binding-->
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>Csw_Federated_Source</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>REST</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+
+                <!-- SpecificationLinks are also RegistryObjects so if needed slots can be added directly to them. If possible use an ExtrinsicObject instead.-->
+                <rim:SpecificationLink id="urn:request:parameters" serviceBinding="urn:registry:federation:method:csw" specificationObject="urn:service:params:id0"/>
+            </rim:ServiceBinding>
+            <rim:ServiceBinding id="urn:registry:federation:method:soap13"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="some:access:URI:any:URI" targetBinding="some:target:binding:reference:URI">
+                <rim:Slot name="queryAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="ingestAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="eventAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>soap13</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>SOAP</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="Soap Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the Soap federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="1.3"/>
+                <rim:SpecificationLink id="notARealId" serviceBinding="notARealServiceBinding"
+                                       specificationObject="notARealSpecificationObject">
+                    <rim:UsageDescription>
+                        <rim:LocalizedString value="This is some usage description"/>
+                    </rim:UsageDescription>
+                    <rim:UsageParameter>
+                        "someUsageParameter"
+                    </rim:UsageParameter>
+                </rim:SpecificationLink>
+            </rim:ServiceBinding>
+        </rim:Service>
+
+        <rim:Organization id="urn:organization:id0"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                          primaryContact="somePrimaryContact"
+                          lid="someLid"
+                          status="someStatus">
+            <rim:Name>
+                <rim:LocalizedString value="Codice"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId" classificationScheme="classificationScheme" classificationNode="classificationNode" nodeRepresentation="nodeRepresentation"/>
+        </rim:Organization>
+
+        <rim:Organization id="urn:organization:id1"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276">
+            <rim:Name>
+                <rim:LocalizedString value="MyOrg"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com" type="SomeEmailAddressType"/>
+        </rim:Organization>
+
+        <rim:Person id="urn:contact:id0" >
+            <rim:PersonName firstName="john" middleName="middleName" lastName="doe"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234" countryCode="country" phoneType="cell phone"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street" streetNumber="1234"/>
+        </rim:Person>
+
+        <rim:Person id="urn:contact:id1">
+            <rim:PersonName firstName="john1" lastName="doe1"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+        </rim:Person>
+
+        <rim:Person id="urn:contact:id2">
+            <rim:PersonName firstName="john2" lastName="doe2"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+        </rim:Person>
+
+        <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
+        with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
+        <rim:Association id="urn:assoication:1" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
+        <rim:Association id="urn:assoication:2" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:assoication:3" associationType="RelatedTo" sourceObject="urn:contact:person1" targetObject="urn:content:collection:id0"/>
+        <rim:Association id="urn:assoication:4" associationType="RelatedTo" sourceObject="urn:contact:person2" targetObject="urn:content:collection:id1"/>
+        <rim:Association id="urn:assoication:5" associationType="RelatedTo" sourceObject="urn:organization:id1" targetObject="urn:service:id0"/>
+        <rim:Association id="urn:assoication:6" associationType="RelatedTo" sourceObject="urn:organization:id0" targetObject="urn:content:collection:id0"/>
+
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/csw-registry-package-smaller.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/csw-registry-package-smaller.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!-- This example csw-ebrim message represents a single node in a system. The ddf registry is not a ebrim registry but uses the csw ebrim format to hold and transmit registry information. In
+     a sense each node contains its own ebrim registry less the canonical classifications. The full registry package and all its RegistryObjects are stored in one metacard. In places where
+     you might reference a pre existing ClassificationNode or ClassificationSchema as defined in a standard ebrim registry we have opted to just use string identifiers that are consistent
+     with the canonical classification nodes. Associations are used to associate the various object. Primarily associations are ued to associate organizations and people with content collections,
+     services and the general node description. Each of the user defined id's (not the framework generated ones) are arbitrary and are only required to be unique in the document. The top level
+     objects id should be a uuid that is globally unique-->
+<!-- top level registry object id is turned into the regsitry-id internally. metacard content type will be set using the lid.-->
+<!-- home attribute should be set by the framework to the base url of the originating instance -->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <!-- external identifiers are set by the framework to track the local metacard id and the origin-id. origin-id is the metacard id of the registry entry on the originating instance-->
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+
+    <!-- RegistryObjectList holds all the actual registry content-->
+    <rim:RegistryObjectList>
+        <!-- defines the general node information -->
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <!--Optional: Any links that might be associated with this instance like wiki pages -->
+            <rim:Slot name="links" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>https://some/link/to/my/repo</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Geographic location of this instance described by a gml:Point-->
+            <rim:Slot name="location" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Point">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Point srsDimension="2" srsName="urn:ogc:def:crs:EPSG::4326">
+                            <gml:pos>112.267472 33.467944</gml:pos>
+                        </gml:Point>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: Region of this instance described by a UNSD region. The location should be within this region -->
+            <rim:Slot name="region" slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>USA</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Sorces of information that contribute to this instances data-->
+            <rim:Slot name="inputDataSources" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>youtube</rim:Value>
+                    <rim:Value>myCamera</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Types of data that this instance contains-->
+            <rim:Slot name="dataTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: String representing the security level of this instance-->
+            <rim:Slot name="securityLevel" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>role=guest</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!-- Name used primarily for display in UI interfaces to uniquely identify this node -->
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId"/>
+        </rim:ExtrinsicObject>
+
+        <!-- There should be only one service defined with lid=urn:registry:federation:service. Multiple service bindings can be added to this one service -->
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <!--
+            Zero or more repetitions: Service bindings represent a way to query data
+            from this instance. Each binding can have one or more slots that define URLs or other properties.
+            For more complex properties such as query parameters use specification links to point to an
+            ExtrinsicObject that contains the required information. For federation source creation all the
+            serviceBinding slots and name will be used as properties for creating the source. Which source is
+            created will be based on the bindingType attribute which should be the factory pid of a managed service factory
+            -->
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
+                <!--Slot defining the query url for this particular method of communicating with this instance-->
+                <rim:Slot name="cswUrl" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <!-- bindingType identifies communication message type for this binding-->
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>Csw_Federated_Source</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>REST</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+
+                <!-- SpecificationLinks are also RegistryObjects so if needed slots can be added directly to them. If possible use an ExtrinsicObject instead.-->
+                <rim:SpecificationLink id="urn:request:parameters" serviceBinding="urn:registry:federation:method:csw" specificationObject="urn:service:params:id0"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+
+        <rim:Organization id="urn:organization:id0"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                          primaryContact="somePrimaryContact"
+                          lid="someLid"
+                          status="someStatus">
+            <rim:Name>
+                <rim:LocalizedString value="Codice"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId" classificationScheme="classificationScheme" classificationNode="classificationNode" nodeRepresentation="nodeRepresentation"/>
+        </rim:Organization>
+
+        <rim:Person id="urn:contact:id0" >
+            <rim:PersonName firstName="john" middleName="middleName" lastName="doe"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234" countryCode="country" phoneType="cell phone"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street" streetNumber="1234"/>
+        </rim:Person>
+
+        <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
+        with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
+        <rim:Association id="urn:assoication:1" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
+
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/etc/registry/registry-custom-slots.json
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/resources/etc/registry/registry-custom-slots.json
@@ -1,0 +1,45 @@
+{
+  "General": {
+    "liveDate": {
+      "displayName": "Live Date",
+      "description": "Date indicating when this node went live or operational",
+      "values": [],
+      "type": "date"
+    },
+    "lastUpdated": {
+      "displayName": "Last Updated",
+      "description": "Date this entry's data was last updated",
+      "values": [],
+      "type": "date",
+      "editable": false
+    },
+    "securityLevel": {
+      "displayName": "Security Attributes",
+      "description": "Security attributes associated with this node. Format \"attribute=val1,val2\"",
+      "values": [],
+      "type": "string",
+      "multiValued": true,
+      "regex": "/^(\\w|\\d|_|-|\\/|:|\\.)+[=](\\w|\\d|_|-|\\/|:|\\.|,)+$/",
+      "regexMessage": "Security attributes must be in the format of attribute=value1,value2"
+    }
+  },
+  "Organization": {},
+  "Person": {},
+  "Service": {},
+  "ServiceBinding": {
+    "urlBindingName": {
+      "displayName": "Url Property Key",
+      "description": "Property that the accessURI value should be put in for source creation",
+      "values": [],
+      "type": "string"
+    },
+    "bindingType": {
+      "displayName": "Service Binding Type",
+      "description": "The binding type for the service.",
+      "values": [],
+      "type": "string"
+    }
+  },
+  "Content": {
+  }
+}

--- a/catalog/spatial/registry/registry-schema-bindings/pom.xml
+++ b/catalog/spatial/registry/registry-schema-bindings/pom.xml
@@ -165,6 +165,8 @@
                             net.opengis.ogc,
                             net.opengis.cat.wrs.v_1_0_2,
                             org.codice.ddf.registry.schemabindings,
+                            org.codice.ddf.registry.schemabindings.converter.type,
+                            org.codice.ddf.registry.schemabindings.converter.web,
                             org.codice.ddf.registry.schemabindings.helper
                         </Export-Package>
                         <Private-Package>

--- a/distribution/ddf-common/src/main/resources/etc/registry/registry-custom-slots.json
+++ b/distribution/ddf-common/src/main/resources/etc/registry/registry-custom-slots.json
@@ -1,0 +1,45 @@
+{
+  "General": {
+    "liveDate": {
+      "displayName": "Live Date",
+      "description": "Date indicating when this node went live or operational",
+      "values": [],
+      "type": "date"
+    },
+    "lastUpdated": {
+      "displayName": "Last Updated",
+      "description": "Date this entry's data was last updated",
+      "values": [],
+      "type": "date",
+      "editable": false
+    },
+    "securityLevel": {
+      "displayName": "Security Attributes",
+      "description": "Security attributes associated with this node. Format \"attribute=val1,val2\"",
+      "values": [],
+      "type": "string",
+      "multiValued": true,
+      "regex": "/^(\\w|\\d|_|-|\\/|:|\\.)+[=](\\w|\\d|_|-|\\/|:|\\.|,)+$/",
+      "regexMessage": "Security attributes must be in the format of attribute=value1,value2"
+    }
+  },
+  "Organization": {},
+  "Person": {},
+  "Service": {},
+  "ServiceBinding": {
+    "urlBindingName": {
+      "displayName": "Url Property Key",
+      "description": "Property that the accessURI value should be put in for source creation",
+      "values": [],
+      "type": "string"
+    },
+    "bindingType": {
+      "displayName": "Service Binding Type",
+      "description": "The binding type for the service.",
+      "values": [],
+      "type": "string"
+    }
+  },
+  "Content": {
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds the registry-federation-admin-impl module which provides an mbean for accessing/update registry information. This is an initial PR and can't be heroed or built until other peer PRs are merged.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@AzGoalie @spearskw 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold 
@stustison
#### How should this be tested?
Outside of unit/itests 
1) Bring up an instance of DDF and start the DDF Registry app
2) Hit the endpoint https://localhost:8993/admin/jolokia/read/org.codice.ddf.registry:type=FederationAdminMBean/LocalNodes
3) Verify that you get a response back that has the following
 - one identity node in the 'nodes' array
 - six entries in the custom slots
 - two entries in the auto populate service bindings

#### Any background context you want to provide?
This module is coming over from the ddf-registry repo.
#### What are the relevant tickets?
DDF-2101
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests