### PR TITLE
DDF-2148 Force immediate re-poll of CSW source on configuration change.

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
@@ -894,6 +894,7 @@ public class TestCswSource extends TestCswSourceBase {
         HashMap<String, Object> configuration = new HashMap<>();
         configuration.put("connectionTimeout", 10000);
         configuration.put("receiveTimeout", 10000);
+        configuration.put("pollInterval", 5);
         cswSource.refresh(configuration);
 
         assertEquals(cswSource.getConnectionTimeout()


### PR DESCRIPTION
#### What does this PR do?
Forces an immediate re-poll of CSW sources when their configuration changes. This will recheck availability when the configuration is updated rather than waiting until the CSW polling interval has passed.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @adimka @bcwaters 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire

#### How should this be tested?
Ensure that all tests pass; install; create a CSW Federated source with incorrect credentials and see that it does not connect. Edit the source and update with correct credentials and confirm that it reconnects.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2148

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests