### PR TITLE
DDF-2147: Fixed CometD registration and lookup for notifications

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
@@ -14,17 +14,18 @@
 package org.codice.ddf.ui.searchui.query.controller;
 
 import java.security.Principal;
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.shiro.SecurityUtils;
+import javax.inject.Inject;
+
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.codice.ddf.activities.ActivityEvent;
@@ -32,6 +33,7 @@ import org.codice.ddf.persistence.PersistentStore;
 import org.cometd.annotation.Listener;
 import org.cometd.annotation.Service;
 import org.cometd.annotation.Session;
+import org.cometd.bayeux.server.BayeuxServer;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.bayeux.server.ServerSession;
 import org.osgi.framework.BundleContext;
@@ -42,6 +44,7 @@ import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ddf.security.SecurityConstants;
 import ddf.security.assertion.SecurityAssertion;
 
 /**
@@ -55,22 +58,18 @@ public abstract class AbstractEventController implements EventHandler {
 
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
+    @Inject
+    private BayeuxServer bayeux;
+
     @Session
-    protected ServerSession controllerServerSession;
+    ServerSession controllerServerSession;
 
-    // Synchronize the map to protect against multiple clients triggering
-    // multiple Map operations at the same time
-    // Set the HashMap's initial capacity to allow for 30 users without
-    // resizing/rehashing the map
-    // ((30 users / .75 loadFactor) + 1) = 41 = initialCapacity.
-    // TODO: Should the initial size be larger? How many clients are we
-    // anticipating per DDF instance.
-    protected Map<String, ServerSession> userSessionMap =
-            Collections.synchronizedMap(new HashMap<String, ServerSession>(41));
+    PersistentStore persistentStore;
 
-    protected PersistentStore persistentStore;
+    EventAdmin eventAdmin;
 
-    protected EventAdmin eventAdmin;
+    ConcurrentHashMap<String, ServerSession> userSessionMap = new ConcurrentHashMap<>();
+
 
     /**
      * Establishes {@code AbstractEventController} as a listener to events published by the OSGi
@@ -101,6 +100,42 @@ public abstract class AbstractEventController implements EventHandler {
     }
 
     /**
+     * Obtains the {@link ServerSession} associated with a given sessionId. Retrieval using
+     * {@link #getSessionByUserId(String)} is the preferred method. This method is used when
+     * a userId is not available.
+     *
+     * @param sessionId The sessionId associated with the {@code ServerSession} to be retrieved.
+     * @return The {@code ServerSession} associated with the received sessionId or null if the session
+     * does not have an established {@code ServerSession}
+     */
+    public ServerSession getSessionBySessionId(String sessionId) {
+        return userSessionMap.searchValues(1, value -> {
+            if (value.getId().equals(sessionId)) {
+                return value;
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Obtains the {@link ServerSession} associated with a given userId or sessionId. It
+     *
+     * @param sessionId The sessionId associated with the {@code ServerSession} to be retrieved.
+     * @return The {@code ServerSession} associated with the received sessionId or null if the session
+     * does not have an established {@code ServerSession}
+     */
+    public ServerSession getSessionById(String userId, String sessionId) {
+        ServerSession session = null;
+        if (userId != null){
+            session = getSessionByUserId(userId);
+        }
+        if (session == null && sessionId != null) {
+            session = getSessionBySessionId(sessionId);
+        }
+        return session;
+    }
+
+    /**
      * Listens to the /meta/disconnect {@link org.cometd.bayeux.Channel} for clients disconnecting
      * and deregisters the user. This should be invoked in order to remove
      * {@code AbstractEventController} references to invalid {@link ServerSession}s.
@@ -117,9 +152,10 @@ public abstract class AbstractEventController implements EventHandler {
             throw new IllegalArgumentException("ServerSession is null");
         }
 
-        Subject subject = null;
+        ddf.security.Subject subject = null;
         try {
-            subject = SecurityUtils.getSubject();
+            subject = (ddf.security.Subject) bayeux.getContext()
+                    .getRequestAttribute(SecurityConstants.SECURITY_SUBJECT);
         } catch (Exception e) {
             LOGGER.debug("Couldn't grab user subject from Shiro.", e);
         }
@@ -130,11 +166,7 @@ public abstract class AbstractEventController implements EventHandler {
             throw new IllegalArgumentException("User ID is null");
         }
 
-        if (null != getSessionByUserId(userId)) {
-            userSessionMap.remove(userId);
-        } else {
-            LOGGER.debug("userSessionMap does not contain a user with the id \"{}\"", userId);
-        }
+        userSessionMap.remove(userId);
     }
 
     /**
@@ -176,9 +208,10 @@ public abstract class AbstractEventController implements EventHandler {
             throw new IllegalArgumentException("ServerSession is null");
         }
 
-        Subject subject = null;
+        ddf.security.Subject subject = null;
         try {
-            subject = SecurityUtils.getSubject();
+            subject = (ddf.security.Subject) bayeux.getContext()
+                    .getRequestAttribute(SecurityConstants.SECURITY_SUBJECT);
         } catch (Exception e) {
             LOGGER.debug("Couldn't grab user subject from Shiro.", e);
         }

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/ActivityController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/ActivityController.java
@@ -114,26 +114,15 @@ public class ActivityController extends AbstractEventController {
         }
 
         String sessionId = (String) event.getProperty(ActivityEvent.SESSION_ID_KEY);
-        if (StringUtils.isEmpty(sessionId)) {
-            throw new IllegalArgumentException("Activity Event \"" + ActivityEvent.SESSION_ID_KEY
-                    + "\" property is null or empty");
-        }
-
         String userId = (String) event.getProperty(ActivityEvent.USER_ID_KEY);
-        // Blank user ID is allowed as this indicates the guest user
-        if (null == userId) {
-            throw new IllegalArgumentException("Activity Event \"" + ActivityEvent.USER_ID_KEY
-                    + "\" property is null or empty");
+
+        if (StringUtils.isBlank(userId) && StringUtils.isBlank(sessionId)) {
+            throw new IllegalArgumentException("No user information was provided in the Event object. userId and sessionId properties were null");
         }
 
         ServerSession recipient = null;
-        if (StringUtils.isNotBlank(userId)) {
-            LOGGER.debug("Getting ServerSession for userId {}", userId);
-            recipient = getSessionByUserId(userId);
-        } else {
-            LOGGER.debug("Getting ServerSession for sessionId {}", sessionId);
-            recipient = getSessionByUserId(sessionId);
-        }
+        LOGGER.debug("Getting ServerSession for userId/sessionId {}", userId);
+        recipient = getSessionById(userId, sessionId);
 
         if (null != recipient) {
             Map<String, Object> propMap = new HashMap<>();

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/NotificationController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/NotificationController.java
@@ -108,26 +108,15 @@ public class NotificationController extends AbstractEventController {
         }
 
         String sessionId = (String) event.getProperty(Notification.NOTIFICATION_KEY_SESSION_ID);
-        if (StringUtils.isBlank(sessionId)) {
-            throw new IllegalArgumentException("Event \"" + Notification.NOTIFICATION_KEY_SESSION_ID
-                    + "\" property is null or empty");
-        }
-
         String userId = (String) event.getProperty(Notification.NOTIFICATION_KEY_USER_ID);
-        // Blank user ID is allowed as this indicates the guest user
-        if (null == userId) {
-            throw new IllegalArgumentException("Event \"" + Notification.NOTIFICATION_KEY_USER_ID
-                    + "\" property is null or empty");
+
+        if (StringUtils.isBlank(userId) && StringUtils.isBlank(sessionId)) {
+            throw new IllegalArgumentException("No user information was provided in the event object. userId and sessionId properties were null");
         }
 
         ServerSession recipient = null;
-        if (StringUtils.isNotBlank(userId)) {
-            LOGGER.debug("Getting ServerSession for userId {}", userId);
-            recipient = getSessionByUserId(userId);
-        } else {
-            LOGGER.debug("Getting ServerSession for sessionId {}", sessionId);
-            recipient = getSessionByUserId(sessionId);
-        }
+        LOGGER.debug("Getting ServerSession for userId/sessionId {}", userId);
+        recipient = getSessionById(userId, sessionId);
 
         if (null != recipient) {
             Map<String, Object> propMap = new HashMap<>();


### PR DESCRIPTION
#### What does this PR do?
DDF search ui notifications were not sending. This fixes the subject lookup and causes the user to be registered correctly so that notifications are passed to them. Logic was also added to allow for the upload notification to be sent as well, since they only provide sessionId.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@oconnormi 
@figliold 
#### Choose 2 committers to review/merge the PR
@lessarderic
@pklinef
#### How should this be tested?
Ingest a product form the search ui, make sure that a notification is delivered. Search and download that product with a clean Product_Cache, make sure that a notification is delivered.
#### Any background context you want to provide?
Previous to this, upload notifications would work because of the way that the subject registration was failing. The sessionId search backup is a way to keep the upload notifications working, as well as any other notifications that send a sessionId only. If the upload notifications are needed to persist, they should we reworked to send userIds instead of sessionIds.
#### What are the relevant tickets?
[DDF-2147](https://codice.atlassian.net/browse/DDF-2147)