### PR TITLE
DDF-2154 create a better wrapped version of FileBackedOutputStream

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -22,10 +22,9 @@ import javax.activation.MimeTypeParseException;
 
 import org.apache.camel.Message;
 import org.apache.commons.io.IOUtils;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.FileBackedOutputStream;
 
 import ddf.camel.component.catalog.CatalogEndpoint;
 import ddf.camel.component.catalog.transformer.TransformerProducer;
@@ -110,7 +109,7 @@ public class InputTransformerProducer extends TransformerProducer {
 
         Metacard generatedMetacard = null;
 
-        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(1000000)) {
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
 
             try {
                 IOUtils.copy(message, fileBackedOutputStream);

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/OpenSearchSource.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -44,6 +44,7 @@ import org.codehaus.stax2.XMLInputFactory2;
 import org.codice.ddf.configuration.PropertyResolver;
 import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.codice.ddf.endpoints.OpenSearch;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.geotools.filter.FilterTransformer;
 import org.jdom2.Element;
 import org.osgi.framework.Bundle;
@@ -54,7 +55,6 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.io.FileBackedOutputStream;
 import com.rometools.rome.feed.synd.SyndCategory;
 import com.rometools.rome.feed.synd.SyndContent;
 import com.rometools.rome.feed.synd.SyndEntry;
@@ -120,6 +120,8 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
     private final EncryptionService encryptionService;
 
+    protected SecureCxfClientFactory<OpenSearch> factory;
+
     private boolean isInitialized = false;
 
     // service properties
@@ -148,8 +150,6 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     private long receiveTimeout = 0;
 
     private XMLInputFactory xmlInputFactory;
-
-    protected SecureCxfClientFactory<OpenSearch> factory;
 
     private ResourceReader resourceReader;
 
@@ -283,8 +283,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
                 Metacard metacard = null;
                 List<Result> resultQueue = new ArrayList<Result>();
-                try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(
-                        1000000)) {
+                try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
                     if (responseStream != null) {
                         IOUtils.copyLarge(responseStream, fileBackedOutputStream);
                         InputTransformer inputTransformer = null;

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -58,6 +58,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,8 +154,6 @@ public class RESTEndpoint implements RESTService {
 
     private static MimeType jsonMimeType = null;
 
-    private MimeTypeMapper mimeTypeMapper;
-
     static {
         MimeType mime = null;
         try {
@@ -165,6 +164,8 @@ public class RESTEndpoint implements RESTService {
         jsonMimeType = mime;
 
     }
+
+    private MimeTypeMapper mimeTypeMapper;
 
     private FilterBuilder filterBuilder;
 
@@ -982,7 +983,7 @@ public class RESTEndpoint implements RESTService {
 
         Metacard generatedMetacard = null;
 
-        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(1000000)) {
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
 
             try {
                 if (null != message) {

--- a/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
@@ -30,6 +30,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/catalog/spatial/geocoding/spatial-geocoding-extract/src/main/java/org/codice/ddf/spatial/geocoding/extract/GeoNamesFileExtractor.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-extract/src/main/java/org/codice/ddf/spatial/geocoding/extract/GeoNamesFileExtractor.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.jaxrs.client.WebClient;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.codice.ddf.spatial.geocoding.GeoEntry;
 import org.codice.ddf.spatial.geocoding.GeoEntryCreator;
 import org.codice.ddf.spatial.geocoding.GeoEntryExtractionException;
@@ -42,12 +43,11 @@ import org.codice.ddf.spatial.geocoding.GeoNamesRemoteDownloadException;
 import org.codice.ddf.spatial.geocoding.ProgressCallback;
 
 import com.google.common.io.ByteSource;
-import com.google.common.io.FileBackedOutputStream;
 
 public class GeoNamesFileExtractor implements GeoEntryExtractor {
-    private GeoEntryCreator geoEntryCreator;
-
     private static final int BUFFER_SIZE = 4096;
+
+    private GeoEntryCreator geoEntryCreator;
 
     private WebClient webClient;
 
@@ -107,7 +107,7 @@ public class GeoNamesFileExtractor implements GeoEntryExtractor {
 
         try (InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream,
                 StandardCharsets.UTF_8);
-                BufferedReader reader = new BufferedReader(inputStreamReader);) {
+                BufferedReader reader = new BufferedReader(inputStreamReader)) {
 
             double bytesRead = 0.0;
 
@@ -198,7 +198,8 @@ public class GeoNamesFileExtractor implements GeoEntryExtractor {
             throws GeoNamesRemoteDownloadException {
         int responseCode = 0;
 
-        try (FileBackedOutputStream fileOutputStream = new FileBackedOutputStream(BUFFER_SIZE);) {
+        try (TemporaryFileBackedOutputStream fileOutputStream = new TemporaryFileBackedOutputStream(
+                BUFFER_SIZE)) {
 
             responseCode = response.getStatus();
 
@@ -289,8 +290,9 @@ public class GeoNamesFileExtractor implements GeoEntryExtractor {
      */
     private InputStream unZipInputStream(String resource, InputStream inputStream)
             throws GeoEntryExtractionException {
-        try (FileBackedOutputStream bufferedOutputStream = new FileBackedOutputStream(BUFFER_SIZE);
-                ZipInputStream zipInputStream = new ZipInputStream(inputStream);) {
+        try (TemporaryFileBackedOutputStream bufferedOutputStream = new TemporaryFileBackedOutputStream(
+                BUFFER_SIZE);
+                ZipInputStream zipInputStream = new ZipInputStream(inputStream)) {
 
             ZipEntry zipEntry;
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {

--- a/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
@@ -59,6 +59,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-common</artifactId>
             <version>${project.version}</version>
@@ -88,7 +93,8 @@
                             registry-common,
                             catalog-core-api-impl;scope=!test,
                             jaxb2-basics-runtime,
-                            ogc-tools-gml-jts
+                            ogc-tools-gml-jts,
+                            platform-util
                         </Embed-Dependency>
                         <Import-Package>
                             !org.codice.ddf.platform.util,

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/transformer/RegistryTransformer.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/transformer/RegistryTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -27,6 +27,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.converter.RegistryConversionException;
 import org.codice.ddf.registry.converter.RegistryPackageConverter;
@@ -34,7 +35,6 @@ import org.codice.ddf.registry.schemabindings.EbrimConstants;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import com.google.common.io.FileBackedOutputStream;
 
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
@@ -63,7 +63,7 @@ public class RegistryTransformer implements InputTransformer, MetacardTransforme
 
         MetacardImpl metacard;
 
-        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(1000000)) {
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
 
             try {
                 IOUtils.copy(inputStream, fileBackedOutputStream);

--- a/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
@@ -28,10 +28,9 @@ import org.apache.pdfbox.tools.imageio.ImageIOUtil;
 import org.apache.poi.sl.usermodel.SlideShow;
 import org.apache.poi.sl.usermodel.SlideShowFactory;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.FileBackedOutputStream;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -54,8 +53,6 @@ public class PptxInputTransformer implements InputTransformer {
     private static final float IMAGE_HEIGHTWIDTH = 128;
 
     private static final String FORMAT_NAME = "jpg";
-
-    private static final int FILE_BACKED_THRESHOLD = 1000000;
 
     private final InputTransformer inputTransformer;
 
@@ -104,8 +101,7 @@ public class PptxInputTransformer implements InputTransformer {
     private Metacard transformLogic(InputStream input, String id)
             throws IOException, CatalogTransformerException {
 
-        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(
-                FILE_BACKED_THRESHOLD)) {
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
             try {
                 int c = IOUtils.copy(input, fileBackedOutputStream);
                 LOGGER.debug("copied {} bytes from input stream to file backed output stream", c);

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -41,6 +41,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -95,7 +100,8 @@
                             jai-imageio-core,
                             jai-imageio-jpeg2000,
                             Saxon-HE,
-                            commons-io
+                            commons-io,
+                            platform-util
                         </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.transformer.input.tika,

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -47,6 +47,7 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.sax.ToXMLContentHandler;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.imgscalr.Scalr;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -55,7 +56,6 @@ import org.slf4j.LoggerFactory;
 
 import com.github.jaiimageio.impl.plugins.tiff.TIFFImageReaderSpi;
 import com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi;
-import com.google.common.io.FileBackedOutputStream;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -73,7 +73,8 @@ public class TikaInputTransformer implements InputTransformer {
         ClassLoader tccl = Thread.currentThread()
                 .getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            Thread.currentThread()
+                    .setContextClassLoader(getClass().getClassLoader());
             templates =
                     TransformerFactory.newInstance(net.sf.saxon.TransformerFactoryImpl.class.getName(),
                             net.sf.saxon.TransformerFactoryImpl.class.getClassLoader())
@@ -82,7 +83,8 @@ public class TikaInputTransformer implements InputTransformer {
         } catch (TransformerConfigurationException e) {
             LOGGER.warn("Couldn't create XML transformer", e);
         } finally {
-            Thread.currentThread().setContextClassLoader(tccl);
+            Thread.currentThread()
+                    .setContextClassLoader(tccl);
         }
 
         if (bundleContext == null) {
@@ -112,7 +114,7 @@ public class TikaInputTransformer implements InputTransformer {
             throw new CatalogTransformerException("Cannot transform null input.");
         }
 
-        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(1000000)) {
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
             try {
                 IOUtils.copy(input, fileBackedOutputStream);
             } catch (IOException e) {

--- a/distribution/docs/src/main/resources/_contents/_platform-contents/extending-platform-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_platform-contents/extending-platform-contents.adoc
@@ -160,3 +160,9 @@ to lookup all implementations of `org.codice.${ddf-branding-lowercase}.migration
 
 The abstract base class `org.codice.${ddf-branding-lowercase}.migration.AbstractMigratable` in the `platform-migratable-api` implements common boilerplate code required
 when implementing `org.codice.${ddf-branding-lowercase}.migration.Migratable` and should be extended when creating a `org.codice.${ddf-branding-lowercase}.migration.Migratable`.
+
+=== Do Not Use FileBackedOutputStream
+
+It is recommended to avoid using `com.google.common.io.FileBackedOutputStream` (FBOS). FBOS can create temporary files that are not automatically
+removed when FBOS is closed. Use `org.codice.ddf.platform.util.TemporaryFileBackedOutputStream` (TFBOS). TFBOS provides the same method calls as FBOS, but
+will remove temporary files when it is closed.

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -945,6 +945,7 @@
         <feature prerequisite="true" version="${project.version}">kernel</feature>
         <feature prerequisite="true">pax-http-jetty</feature>
         <feature prerequisite="true">pax-jetty</feature>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle start-level="30">mvn:ddf.platform/platform-filter-delegate/${project.version}</bundle>
     </feature>
 

--- a/platform/platform-filter-delegate/pom.xml
+++ b/platform/platform-filter-delegate/pom.xml
@@ -55,11 +55,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncy.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/TemporaryFileBackedOutputStream.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/TemporaryFileBackedOutputStream.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.google.common.io.ByteSource;
+import com.google.common.io.FileBackedOutputStream;
+
+/**
+ * TemporaryFileBackedOutputStream buffers the written data to memory of a temporary file, and
+ * makes the data available as a ByteSource. This class will make sure the temporary file is
+ * deleted when {@link #close()} is called. The method {@link #asByteSource()} should not be
+ * called after {@link #close()} is called.
+ */
+public class TemporaryFileBackedOutputStream extends OutputStream {
+
+    private static final int DEFAULT_THRESHOLD = 1000000;
+
+    private final FileBackedOutputStream fileBackedOutputStream;
+
+    private boolean isClosed = false;
+
+    /**
+     * @param fileThreshold the number of bytes before the stream should switch to buffering to a file
+     */
+    public TemporaryFileBackedOutputStream(int fileThreshold) {
+        this.fileBackedOutputStream = new FileBackedOutputStream(fileThreshold);
+    }
+
+    /**
+     * Use a file threshold size of {@link #DEFAULT_THRESHOLD}.
+     */
+    public TemporaryFileBackedOutputStream() {
+        this(DEFAULT_THRESHOLD);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        checkIsClosed();
+        fileBackedOutputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException("byte array must be non-null");
+        }
+        if (off < 0) {
+            throw new IndexOutOfBoundsException("off is negative");
+        }
+        if (len < 0) {
+            throw new IndexOutOfBoundsException("len is negative");
+        }
+        if (off + len > b.length) {
+            throw new IndexOutOfBoundsException("off+len is greater than array length");
+        }
+        checkIsClosed();
+        fileBackedOutputStream.write(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        try {
+            fileBackedOutputStream.close();
+            fileBackedOutputStream.reset();
+        } finally {
+            isClosed = true;
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        fileBackedOutputStream.flush();
+    }
+
+    /**
+     * Returns a readable {@link ByteSource} view of the data that has been written to this stream.
+     * Must not be called after {@link #close()} is called, otherwise an {@link IllegalStateException}
+     * will be thrown.
+     *
+     * @return ByteSource of the data
+     * @throws IOException throws an exception if the stream is closed
+     */
+    public ByteSource asByteSource() throws IOException {
+        checkIsClosed();
+        return fileBackedOutputStream.asByteSource();
+    }
+
+    /**
+     * Throw an exception if the stream is closed.
+     *
+     * @throws IOException
+     */
+    private void checkIsClosed() throws IOException {
+        if (isClosed) {
+            throw new IOException("stream closed");
+        }
+    }
+
+}

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/TestTemporaryFileBackedOutputStream.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/TestTemporaryFileBackedOutputStream.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.ByteSource;
+
+public class TestTemporaryFileBackedOutputStream {
+
+    private static final int TEST_BYTE = 1;
+
+    private static final byte[] TEST_BYTE_ARRAY = new byte[] {TEST_BYTE};
+
+    private TemporaryFileBackedOutputStream temporaryFileBackedOutputStream;
+
+    @Before
+    public void setup() {
+        temporaryFileBackedOutputStream = new TemporaryFileBackedOutputStream(1);
+    }
+
+    @After
+    public void teardown() throws IOException {
+        temporaryFileBackedOutputStream.close();
+    }
+
+    /**
+     * Make sure asByteSource() throws an IOException after close() is called.
+     *
+     * @throws IOException
+     */
+    @Test(expected = IOException.class)
+    public void testAsByteSourceAfterClose() throws IOException {
+
+        temporaryFileBackedOutputStream.close();
+
+        temporaryFileBackedOutputStream.asByteSource();
+
+    }
+
+    @Test
+    public void testWriteByte() throws IOException {
+
+        temporaryFileBackedOutputStream.write(TEST_BYTE);
+
+        ByteSource byteSource = temporaryFileBackedOutputStream.asByteSource();
+
+        assertThat(byteSource.read(), is(TEST_BYTE_ARRAY));
+
+    }
+
+    @Test
+    public void testWriteByteArray() throws IOException {
+
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY);
+
+        ByteSource byteSource = temporaryFileBackedOutputStream.asByteSource();
+
+        assertThat(byteSource.read(), is(TEST_BYTE_ARRAY));
+
+    }
+
+    @Test
+    public void testWriteByteArrayOffLen() throws IOException {
+
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY, 0, 1);
+
+        ByteSource byteSource = temporaryFileBackedOutputStream.asByteSource();
+
+        assertThat(byteSource.read(), is(TEST_BYTE_ARRAY));
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWriteNullArray() throws IOException {
+        temporaryFileBackedOutputStream.write(null, 0, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testWriteNegativeOffset() throws IOException {
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY, -1, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testWriteNegativeLength() throws IOException {
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY, 0, -1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testWriteBadOffsetLength() throws IOException {
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY, 1, 1);
+    }
+
+    /**
+     * Make sure that flush doesn't throw an exception.
+     */
+    @Test
+    public void testFlush() throws IOException {
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY);
+        temporaryFileBackedOutputStream.flush();
+    }
+
+    /**
+     * Make sure that flush doesn't throw an exception after close is called
+     */
+    @Test
+    public void testFlushAfterClose() throws IOException {
+        temporaryFileBackedOutputStream.write(TEST_BYTE_ARRAY);
+        temporaryFileBackedOutputStream.close();
+        temporaryFileBackedOutputStream.flush();
+    }
+
+}


### PR DESCRIPTION
#### What does this PR do?
Create a wrapper class around FileBackedOutputStream that automatically deletes the temporary backing file.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth @rzwiefel @kcwire @dcruver 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@kcwire
#### How should this be tested?
Run unit tests. 
#### Any background context you want to provide?
FileBackedOutputStream does not delete its temp file when close() is called. Must call reset() as well.
#### What are the relevant tickets?
DDF-2154
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

