### PR TITLE
DDF-2119: As an Integrator, I want to be able to trigger the caching of selected products in order to allow users to download them from the cache at a later time

### DIFF
--- a/catalog/core/catalog-core-actions/pom.xml
+++ b/catalog/core/catalog-core-actions/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>core</artifactId>
+        <groupId>ddf.catalog.core</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog-core-actions</artifactId>
+    <packaging>jar</packaging>
+    <name>DDF :: Catalog :: Core :: Actions</name>
+    <description>Common Catalog actions</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
+++ b/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.actions;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.action.Action;
+import ddf.action.ActionProvider;
+import ddf.catalog.data.Metacard;
+
+/**
+ * Abstract base class for {@link ActionProvider}s that can handle {@link Metacard} source objects.
+ */
+public abstract class AbstractMetacardActionProvider implements ActionProvider {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(AbstractMetacardActionProvider.class);
+
+    private static final String UNKNOWN_TARGET = "0.0.0.0";
+
+    private final String actionProviderId;
+
+    private final String title;
+
+    private final String description;
+
+    /**
+     * Constructor that accepts the values to be used when a new {@link Action} is created by this
+     * {@link ActionProvider}.
+     *
+     * @param actionProviderId ID that will be assigned to the {@link Action} that will be
+     *                         created. Cannot be empty or blank.
+     * @param title            title that will be used when this {@link ActionProvider} creates a
+     *                         new {@link Action}
+     * @param description      description that will be used when this {@link ActionProvider}
+     *                         creates a new {@link Action}
+     */
+    protected AbstractMetacardActionProvider(String actionProviderId, String title,
+            String description) {
+        Validate.notBlank(actionProviderId.trim(),
+                "Action provider ID cannot be null, empty or blank");
+        Validate.notNull(title, "Title cannot be null");
+        Validate.notNull(description, "Description cannot be null");
+
+        this.actionProviderId = actionProviderId;
+        this.title = title;
+        this.description = description;
+    }
+
+    /**
+     * Default implementation that ensures the {@code subject} provided is a {@link Metacard}
+     * with a valid ID before delegating to {@link #getMetacardAction(String, Metacard)}.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> List<Action> getActions(T subject) {
+
+        if (!canHandle(subject)) {
+            return Collections.emptyList();
+        }
+
+        Metacard metacard = (Metacard) subject;
+
+        if (StringUtils.isBlank(metacard.getId())) {
+            LOGGER.warn("Cannot create Action: No metacard ID.");
+            return Collections.emptyList();
+        }
+
+        if (isHostUnset(SystemBaseUrl.getHost())) {
+            LOGGER.warn("Cannot create Action URL for metacard {}: Host name/IP not set.",
+                    metacard.getId());
+            return Collections.emptyList();
+        }
+
+        try {
+            return Collections.singletonList(getMetacardAction(getSource(metacard), metacard));
+        } catch (Exception e) {
+            LOGGER.warn("Cannot create Action URL for metacard {}.", metacard.getId(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public String getId() {
+        return this.actionProviderId;
+    }
+
+    /**
+     * Default implementation that ensures the {@code subject} provided is a {@link Metacard}
+     * before delegating to {@link #canHandleMetacard(Metacard)}.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> boolean canHandle(T subject) {
+        return (subject instanceof Metacard) && (canHandleMetacard((Metacard) subject));
+    }
+
+    /**
+     * Determines if this {@link ActionProvider} can handle this {@link Metacard}. Returns
+     * {@code true} by default. Should be overwritten if more complex verification is needed.
+     *
+     * @param metacard metacard to which this {@link ActionProvider} could apply
+     * @return {@code true} if this {@link ActionProvider} applies to the {@link Metacard}
+     */
+    protected boolean canHandleMetacard(Metacard metacard) {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s [%s], Impl=%s",
+                ActionProvider.class.getName(),
+                getId(),
+                getClass().getName());
+    }
+
+    /**
+     * Creates a new {@link Action} given a {@link Metacard}. This method delegates to
+     * {@link #getMetacardActionUrl(String, Metacard)} and {@link #createMetacardAction(String, String, String, URL)}.
+     *
+     * @param metacardSource source ID of the {@link Metacard}
+     * @param metacard       {@link Metacard} to create an {@link Action} from
+     * @return new {@link Action} object. Cannot be {@code null}.
+     * @throws Exception thrown if an error occurred while creating the {@link Action}
+     */
+    protected Action getMetacardAction(String metacardSource, Metacard metacard) throws Exception {
+        URL url = getMetacardActionUrl(metacardSource, metacard);
+        return createMetacardAction(actionProviderId, title, description, url);
+    }
+
+    /**
+     * Factory method that creates the proper {@link Action} object from the information provided.
+     * Must be implemented by sub-classes.
+     *
+     * @param actionProviderId {@link Action} ID
+     * @param title            {@link Action} title
+     * @param description      {@link Action} description
+     * @param url              {@link Action} url
+     * @return new {@link Action} object. Cannot be {@code null}.
+     */
+    protected abstract Action createMetacardAction(String actionProviderId, String title,
+            String description, URL url);
+
+    /**
+     * Gets the {@link URL} that will be used when the {@link Action} is created.
+     *
+     * @param metacardSource source ID of the {@link Metacard}
+     * @param metacard       {@link Metacard} for which a {@link URL} needs to be created
+     * @return {@link URL} that will be used to create the {@link Action}
+     * @throws Exception thrown if the {@link URL} couldn't be created
+     */
+    protected abstract URL getMetacardActionUrl(String metacardSource, Metacard metacard)
+            throws Exception;
+
+    private boolean isHostUnset(String host) {
+        return (host == null || host.trim()
+                .equals(UNKNOWN_TARGET));
+    }
+
+    private String getSource(Metacard metacard) {
+
+        if (StringUtils.isNotBlank(metacard.getSourceId())) {
+            return metacard.getSourceId();
+        }
+
+        return SystemInfo.getSiteName();
+    }
+}

--- a/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
+++ b/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.actions;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.action.Action;
+import ddf.catalog.data.Metacard;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractMetacardActionProviderTest {
+
+    private static final String ACTION_ID = "id";
+
+    private static final String TITLE = "title";
+
+    private static final String DESCRIPTION = "description";
+
+    private static final String METACARD_ID = "metacard_id";
+
+    private static final String SOURCE_ID = "source_id";
+
+    private static URL url;
+
+    @Mock
+    private Metacard metacard;
+
+    @Mock
+    private Action action;
+
+    @BeforeClass
+    public static void setupClass() throws MalformedURLException {
+        url = new URL("https://localhost/action");
+    }
+
+    @Before
+    public void setup() {
+        when(metacard.getId()).thenReturn(METACARD_ID);
+        when(metacard.getSourceId()).thenReturn(SOURCE_ID);
+    }
+
+    private class MetacardActionProvider extends AbstractMetacardActionProvider {
+
+        MetacardActionProvider(String actionProviderId, String title, String description) {
+            super(actionProviderId, title, description);
+        }
+
+        @Override
+        protected boolean canHandleMetacard(Metacard metacard) {
+            return super.canHandleMetacard(metacard);
+        }
+
+        @Override
+        protected Action createMetacardAction(String actionProviderId, String title,
+                String description, URL url) {
+            return null;
+        }
+
+        @Override
+        protected URL getMetacardActionUrl(String metacardSource, Metacard metacard)
+                throws Exception {
+            return new URL("https://localhost/action");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorWithNullActionProviderId() {
+        new MetacardActionProvider(null, TITLE, DESCRIPTION);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWithBlankActionProviderId() {
+        new MetacardActionProvider("  ", TITLE, DESCRIPTION);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorWithNullTitle() {
+        new MetacardActionProvider(ACTION_ID, null, DESCRIPTION);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorWithNullDescription() {
+        new MetacardActionProvider(ACTION_ID, TITLE, null);
+    }
+
+    @Test
+    public void canHandleWithNull() {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        assertThat(actionProvider.canHandle(null), is(false));
+        verify(actionProvider, never()).canHandleMetacard(any());
+    }
+
+    @Test
+    public void canHandleWithNonMetacard() {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        assertThat(actionProvider.canHandle("blah"), is(false));
+        verify(actionProvider, never()).canHandleMetacard(any());
+    }
+
+    @Test
+    public void canHandleDelegatesToCanHandleMetacard() {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(actionProvider.canHandleMetacard(metacard)).thenReturn(true);
+
+        assertThat(actionProvider.canHandle(metacard), is(true));
+        verify(actionProvider).canHandleMetacard(metacard);
+    }
+
+    @Test
+    public void getActionsWithNull() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+
+        List<Action> actions = actionProvider.getActions(null);
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActionsWithNonMetacard() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+
+        List<Action> actions = actionProvider.getActions("blah");
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActionsWithMetacardThatHasNullId() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(metacard.getId()).thenReturn(null);
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActionsWithMetacardThatHasBlankId() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(metacard.getId()).thenReturn(" ");
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActionsWhenHostNotSet() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(actionProvider.canHandleMetacard(metacard)).thenReturn(true);
+        when(actionProvider.createMetacardAction(eq(ACTION_ID),
+                eq(TITLE),
+                eq(DESCRIPTION),
+                any())).thenReturn(action);
+        when(actionProvider.getMetacardActionUrl(SOURCE_ID, metacard)).thenReturn(url);
+        System.clearProperty(SystemBaseUrl.HOST);
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, hasItem(action));
+        verify(actionProvider).createMetacardAction(ACTION_ID, TITLE, DESCRIPTION, url);
+    }
+
+    @Test
+    public void getActionsWhenHostUnknown() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(actionProvider.canHandleMetacard(metacard)).thenReturn(true);
+        when(actionProvider.createMetacardAction(eq(ACTION_ID),
+                eq(TITLE),
+                eq(DESCRIPTION),
+                any())).thenReturn(action);
+        when(actionProvider.getMetacardActionUrl(SOURCE_ID, metacard)).thenReturn(url);
+        System.setProperty(SystemBaseUrl.HOST, "0.0.0.0");
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActionsWhenSubclassCannotHandleMetacard() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(actionProvider.canHandleMetacard(metacard)).thenReturn(false);
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, is(empty()));
+        verify(actionProvider, never()).getMetacardAction(any(), any());
+    }
+
+    @Test
+    public void getActions() {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(actionProvider.createMetacardAction(eq(ACTION_ID),
+                eq(TITLE),
+                eq(DESCRIPTION),
+                any())).thenReturn(action);
+        System.setProperty(SystemBaseUrl.HOST, "codice.org");
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, hasItem(action));
+    }
+
+    @Test
+    public void getActionsWhenGetMetacardActionFails() {
+        MetacardActionProvider actionProvider = new MetacardActionProvider(ACTION_ID,
+                TITLE,
+                DESCRIPTION) {
+
+            @Override
+            protected URL getMetacardActionUrl(String metacardSource, Metacard metacard)
+                    throws IOException {
+                throw new IOException();
+            }
+        };
+
+        System.setProperty(SystemBaseUrl.HOST, "codice.org");
+        List<Action> actions = actionProvider.getActions(metacard);
+        assertThat(actions, is(empty()));
+    }
+
+    @Test
+    public void getActionsWhenMetacardSourceIdIsNull() throws Exception {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(metacard.getSourceId()).thenReturn(null);
+        System.setProperty(SystemBaseUrl.HOST, "codice.org");
+        System.setProperty(SystemInfo.SITE_NAME, "ddf");
+        when(actionProvider.createMetacardAction(eq(ACTION_ID),
+                eq(TITLE),
+                eq(DESCRIPTION),
+                any())).thenReturn(action);
+
+        List<Action> actions = actionProvider.getActions(metacard);
+
+        assertThat(actions, hasItem(action));
+        verify(actionProvider).getMetacardAction("ddf", metacard);
+    }
+
+    private MetacardActionProvider createMetacardActionProvider() {
+        return spy(new MetacardActionProvider(ACTION_ID, TITLE, DESCRIPTION));
+    }
+}

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -46,6 +46,15 @@
             <artifactId>action-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-actions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-metricsplugin</artifactId>
             <version>${project.version}</version>
@@ -213,6 +222,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-defaultvalues</artifactId>
             <version>${project.version}</version>
@@ -228,11 +242,13 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
+                            catalog-core-actions,
                             catalog-core-solr,
                             notifications,
                             activities,
                             hazelcast;scope=runtime|compile,
                             commons-collections,
+                            commons-lang3,
                             platform-util
                         </Embed-Dependency>
                         <Private-Package>
@@ -246,6 +262,7 @@
                             ddf.catalog.federation.base,
                             ddf.catalog.filter.impl,
                             ddf.catalog.source.impl,
+                            ddf.catalog.resource.actions,
                             ddf.catalog.resource.download,
                             ddf.catalog.resource.impl,
                             ddf.catalog.resourceretriever,
@@ -270,6 +287,7 @@
                             com.vividsolutions.jts.simplify,
                             com.vividsolutions.jts.util,
                             ddf.action;version="1.0",
+                            ddf.action.impl,
                             ddf.catalog;version="2.0",
                             ddf.catalog.event;version="2.0",
                             ddf.catalog.filter.delegate;version=${project.version},
@@ -314,6 +332,7 @@
                             javax.security.sasl,
                             javax.ws.rs,
                             javax.ws.rs.core,
+                            javax.ws.rs.ext,
                             javax.xml.bind,
                             javax.xml.datatype,
                             javax.xml.namespace,
@@ -406,7 +425,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.48</minimum>
+                                            <minimum>0.49</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
@@ -416,7 +435,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadToCacheOnlyException.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadToCacheOnlyException.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import javax.ws.rs.core.Response.Status;
+
+public class DownloadToCacheOnlyException extends Exception {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private final Status status;
+
+    public DownloadToCacheOnlyException(Status status) {
+        super();
+        this.status = status;
+    }
+
+    public DownloadToCacheOnlyException(Status status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public DownloadToCacheOnlyException(Status status, String message, Throwable throwable) {
+        super(message, throwable);
+        this.status = status;
+    }
+
+    public DownloadToCacheOnlyException(Status status, Throwable throwable) {
+        super(throwable);
+        this.status = status;
+    }
+    
+    public Status getStatus() {
+        return status;
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadToCacheOnlyExceptionMapper.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadToCacheOnlyExceptionMapper.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class DownloadToCacheOnlyExceptionMapper implements ExceptionMapper<DownloadToCacheOnlyException> {
+
+    @Override
+    public Response toResponse(DownloadToCacheOnlyException e) {
+        return Response.status(e.getStatus()).entity(e.getMessage())
+        .type(MediaType.TEXT_PLAIN_TYPE).build();
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -205,4 +205,8 @@ public class ReliableResourceDownloadManager {
     public void setChunkSize(int chunkSize) {
         downloaderConfig.setChunkSize(chunkSize);
     }
+
+    public boolean isCacheEnabled() {
+        return downloaderConfig.isCacheEnabled();
+    }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadEndpoint.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadEndpoint.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.impl.ResourceRequestById;
+import ddf.catalog.resource.ResourceNotFoundException;
+import ddf.catalog.resource.ResourceNotSupportedException;
+
+@Path("/")
+public class ResourceDownloadEndpoint {
+
+    public static final String CONTEXT_PATH = "/catalog/downloads";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceDownloadEndpoint.class);
+
+    private static final String ERROR_MESSAGE_TEMPLATE =
+            "Unable to download the product associated with metacard [%s] from source [%s] to the product cache.";
+
+    private final CatalogFramework catalogFramework;
+
+    private final ReliableResourceDownloadManager downloadManager;
+
+    public ResourceDownloadEndpoint(CatalogFramework catalogFramework,
+            ReliableResourceDownloadManager downloadManager) {
+        this.catalogFramework = catalogFramework;
+        this.downloadManager = downloadManager;
+    }
+
+    @GET
+    @Path("/{sourceId}/{metacardId}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response startDownloadToCacheOnly(@PathParam("sourceId") String sourceId,
+            @PathParam("metacardId") String metacardId) throws DownloadToCacheOnlyException {
+
+        ResourceRequest resourceRequest = new ResourceRequestById(metacardId);
+
+        if (!downloadManager.isCacheEnabled()) {
+            String message = "Caching of products is not enabled.";
+            LOGGER.error(message);
+            throw new DownloadToCacheOnlyException(Status.BAD_REQUEST, message);
+        }
+
+        try {
+            LOGGER.debug(
+                    "Attempting to download the product associated with metacard [{}] from source [{}] to the product cache.",
+                    metacardId,
+                    sourceId);
+            ResourceResponse resourceResponse = catalogFramework.getResource(resourceRequest,
+                    sourceId);
+            if (resourceResponse == null) {
+                String message = String.format(ERROR_MESSAGE_TEMPLATE, metacardId, sourceId);
+                LOGGER.error(message);
+                throw new DownloadToCacheOnlyException(Status.INTERNAL_SERVER_ERROR, message);
+            }
+        } catch (IOException | ResourceNotSupportedException e) {
+            String message = String.format(ERROR_MESSAGE_TEMPLATE,
+                    metacardId,
+                    sourceId);
+            LOGGER.error(message, e);
+            throw new DownloadToCacheOnlyException(Status.INTERNAL_SERVER_ERROR, message);
+        } catch (ResourceNotFoundException e) {
+            String message = String.format(
+                    ERROR_MESSAGE_TEMPLATE + " The product could not be found.",
+                    metacardId,
+                    sourceId);
+            LOGGER.error(message, e);
+            throw new DownloadToCacheOnlyException(Status.NOT_FOUND, message);
+        }
+
+        String message = String.format(
+                "The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.",
+                metacardId,
+                sourceId);
+        return Response.ok(message, MediaType.TEXT_PLAIN_TYPE)
+                .build();
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -332,7 +332,7 @@
     <bean id="downloadResourceActionProvider"
           class="ddf.catalog.resource.actions.DownloadResourceActionProvider">
         <argument value="catalog.data.metacard.resource.download"/>
-        <argument ref="productCache"/>
+        <argument ref="deprecatedProductCache"/>
         <argument ref="reliableResourceDownloadManager"/>
     </bean>
 

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,9 +14,10 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xsi:schemaLocation="
 	    http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-        ">
+	    http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
 
     <!-- According to the schema the type-converters element must be above all other elements except 'description' -->
     <type-converters>
@@ -328,6 +329,19 @@
         <argument ref="downloadThreadPool"/>
     </bean>
 
+    <bean id="downloadResourceActionProvider"
+          class="ddf.catalog.resource.actions.DownloadResourceActionProvider">
+        <argument value="catalog.data.metacard.resource.download"/>
+        <argument ref="productCache"/>
+        <argument ref="reliableResourceDownloadManager"/>
+    </bean>
+
+    <service ref="downloadResourceActionProvider" interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.metacard.resource.download"/>
+        </service-properties>
+    </service>
+
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
 
     <reference id="defaultAttributeValueRegistry"
@@ -429,5 +443,19 @@
             </entry>
         </service-properties>
     </service>
+
+    <bean id="resourceDownloadBean" class="ddf.catalog.resource.download.ResourceDownloadEndpoint">
+        <argument ref="ddf"/>
+        <argument ref="reliableResourceDownloadManager"/>
+    </bean>
+
+    <jaxrs:server id="resourceDownloadEnpoint" address="/catalog/downloads">
+        <jaxrs:serviceBeans>
+            <ref component-id="resourceDownloadBean" />
+        </jaxrs:serviceBeans>
+        <jaxrs:providers>
+            <bean class="ddf.catalog.resource.download.DownloadToCacheOnlyExceptionMapper" />
+        </jaxrs:providers>
+    </jaxrs:server>
 
 </blueprint>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/CacheKeyTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/CacheKeyTest.java
@@ -38,166 +38,171 @@ import ddf.catalog.operation.ResourceRequest;
 public class CacheKeyTest {
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullMetacard() {
-
-        // given
-        CacheKey cacheKey = new CacheKey(null, mock(ResourceRequest.class));
-
-        // when
-        cacheKey.generateKey();
-
-        // then
-        // throws an exception
+    public void testNullMetacardValidResourceRequest() {
+        new CacheKey(null, mock(ResourceRequest.class));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullResourceRequest() {
+        new CacheKey(mock(Metacard.class), null);
+    }
 
-        // given
-        CacheKey cacheKey = new CacheKey(mock(Metacard.class), null);
-
-        // when
-        cacheKey.generateKey();
-
-        // then
-        // throws an exception
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullMetacard() {
+        new CacheKey(null);
     }
 
     @Test
-    public void testKeyGeneration() {
-
-        // given
+    public void testKeyGenerationFromMetacardAndResourceRequest() {
         CacheKey cacheKey = new CacheKey(getMetacardStub("sampleId"), getResourceRequestStub());
 
-        // when
         String key = cacheKey.generateKey();
 
-        // then
         assertNotNull("Key must not be null.", key);
         assertThat("Key must not be empty.", key, not(equalToIgnoringWhiteSpace("")));
-
     }
 
-    @Test()
-    public void testKeyUniquenessMetacardId() {
+    @Test
+    public void testKeyGenerationFromMetacardOnly() {
+        CacheKey cacheKey = new CacheKey(getMetacardStub("sampleId"));
 
-        // given
+        String key = cacheKey.generateKey();
+
+        assertNotNull("Key must not be null.", key);
+        assertThat("Key must not be empty.", key, not(equalToIgnoringWhiteSpace("")));
+    }
+
+    @Test
+    public void testKeyUniquenessMetacardId() {
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId"), getResourceRequestStub());
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampledI"), getResourceRequestStub());
 
-        // when
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("Keys must be different.", key1, not(equalTo(key2)));
-
     }
 
-    @Test()
+    @Test
     public void testKeyUniquenessFromSources() {
-
-        // given
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId", "source1"),
                 getResourceRequestStub());
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId", "source2"),
                 getResourceRequestStub());
 
-        // when
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("Keys must be different.", key1, not(equalTo(key2)));
-
     }
 
-    @Test()
-    public void testKeyUniquenessFromSourcesAndIds() {
+    @Test
+    public void testKeyUniquenessFromSourcesWithoutResourceRequest() {
+        CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId", "source1"));
+        CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId", "source2"));
 
-        // given
+        String key1 = cacheKey1.generateKey();
+        String key2 = cacheKey2.generateKey();
+
+        assertThat("Keys must be different.", key1, not(equalTo(key2)));
+    }
+
+    @Test
+    public void testKeyUniquenessFromSourcesAndIds() {
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub());
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId2", "source2"),
                 getResourceRequestStub());
 
-        // when
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("Keys must be different.", key1, not(equalTo(key2)));
+    }
 
+    @Test
+    public void testKeyUniquenessFromSourcesAndIdsWithoutResourceRequest() {
+        CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"));
+        CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId2", "source2"));
+        CacheKey cacheKey3 = new CacheKey(getMetacardStub("sampleId1", "source2"));
+        CacheKey cacheKey4 = new CacheKey(getMetacardStub("sampleId2", "source1"));
+
+        String key1 = cacheKey1.generateKey();
+        String key2 = cacheKey2.generateKey();
+        String key3 = cacheKey3.generateKey();
+        String key4 = cacheKey4.generateKey();
+
+        assertThat("Keys must be different.", key1, not(equalTo(key2)));
+        assertThat("Keys must be different.", key1, not(equalTo(key3)));
+        assertThat("Keys must be different.", key1, not(equalTo(key4)));
     }
 
     /**
      * Tests the key will be unique if given a different property in the ResourceRequest.
      */
-    @Test()
+    @Test
     public void testKeyUniquenessProperty() {
-
-        // given
-        Map<String, Serializable> propertyMap = new HashMap<String, Serializable>();
+        Map<String, Serializable> propertyMap = new HashMap<>();
         propertyMap.put(ResourceRequest.OPTION_ARGUMENT, "pdf");
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub(propertyMap));
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub());
 
-        // when
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("Keys must be different.", key1, not(equalTo(key2)));
-
     }
 
     /**
      * Tests keys will be unique if given different properties in the ResourceRequest.
      */
-    @Test()
+    @Test
     public void testKeyUniquenessProperties() {
-
-        // given
-        Map<String, Serializable> propertyMap1 = new HashMap<String, Serializable>();
+        Map<String, Serializable> propertyMap1 = new HashMap<>();
         propertyMap1.put(ResourceRequest.OPTION_ARGUMENT, "pdf");
-        Map<String, Serializable> propertyMap2 = new HashMap<String, Serializable>();
+        Map<String, Serializable> propertyMap2 = new HashMap<>();
         propertyMap2.put(ResourceRequest.OPTION_ARGUMENT, "html");
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub(propertyMap1));
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub(propertyMap2));
-
-        // when
+  
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("Keys must be different.", key1, not(equalTo(key2)));
-
     }
 
-    @Test()
-    public void testKeyConsistency() {
+    @Test
+    public void testKeyConsistencyWithoutResourceRequest() {
+        CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"));
+        CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId1", "source1"));
 
-        // given
-        Map<String, Serializable> propertyMap = new HashMap<String, Serializable>();
+        String key1 = cacheKey1.generateKey();
+        String key2 = cacheKey2.generateKey();
+
+        assertThat("The same input to cache key should generate the same output.",
+                key1,
+                equalTo(key2));
+    }
+
+    @Test
+    public void testKeyConsistency() {
+        Map<String, Serializable> propertyMap = new HashMap<>();
         propertyMap.put("pdf", "sample.pdf");
         CacheKey cacheKey1 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub(propertyMap));
         CacheKey cacheKey2 = new CacheKey(getMetacardStub("sampleId1", "source1"),
                 getResourceRequestStub(propertyMap));
 
-        // when
         String key1 = cacheKey1.generateKey();
         String key2 = cacheKey2.generateKey();
 
-        // then
         assertThat("The same input to cache key should generate the same output.",
                 key1,
                 equalTo(key2));
-
     }
 
     private ResourceRequest getResourceRequestStub(final Map<String, Serializable> properties) {

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
@@ -36,8 +36,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import ddf.action.Action;
+import ddf.catalog.cache.ResourceCacheInterface;
 import ddf.catalog.cache.impl.CacheKey;
-import ddf.catalog.cache.impl.ResourceCache;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.resource.download.ReliableResourceDownloadManager;
 
@@ -51,7 +51,7 @@ public class DownloadResourceActionProviderTest {
     private static final String REMOTE_SOURCE_ID = "remote";
 
     @Mock
-    private ResourceCache resourceCache;
+    private ResourceCacheInterface resourceCache;
 
     @Mock
     private ReliableResourceDownloadManager downloadManager;

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
@@ -11,21 +11,21 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package ddf.catalog.resource.actions;
 
-import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
-import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static ddf.catalog.resource.download.ResourceDownloadEndpoint.CONTEXT_PATH;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.List;
 
 import org.apache.commons.lang.CharEncoding;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -36,10 +36,13 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import ddf.action.Action;
+import ddf.catalog.cache.impl.CacheKey;
+import ddf.catalog.cache.impl.ResourceCache;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.resource.download.ReliableResourceDownloadManager;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
+public class DownloadResourceActionProviderTest {
 
     private static final String ACTION_PROVIDER_ID = "actionID";
 
@@ -48,46 +51,81 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
     private static final String REMOTE_SOURCE_ID = "remote";
 
     @Mock
+    private ResourceCache resourceCache;
+
+    @Mock
+    private ReliableResourceDownloadManager downloadManager;
+
+    @Mock
+    private CacheKey cacheKey;
+
+    @Mock
     private Metacard metacard;
 
-    private URL actionUrl;
-
-    private ViewMetacardActionProvider actionProvider;
+    private DownloadResourceActionProvider actionProvider;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         System.setProperty(SystemBaseUrl.HOST, "localhost");
 
+        when(resourceCache.containsValid(anyString(), same(metacard))).thenReturn(false);
+        when(resourceCache.isPending(anyString())).thenReturn(false);
+        when(downloadManager.isCacheEnabled()).thenReturn(true);
         when(metacard.getId()).thenReturn(METACARD_ID);
-        when(metacard.getSourceId()).thenReturn(REMOTE_SOURCE_ID);
 
-        actionUrl = getUrl(METACARD_ID);
-
-        actionProvider = new ViewMetacardActionProvider(ACTION_PROVIDER_ID);
+        actionProvider = new DownloadResourceActionProvider(ACTION_PROVIDER_ID,
+                resourceCache,
+                downloadManager);
     }
 
     @Test
     public void canHandle() {
-        assertThat(actionProvider.canHandle(metacard), is(true));
+        assertThat(actionProvider.canHandleMetacard(metacard), is(true));
+        verify(resourceCache).containsValid(anyString(), same(metacard));
+        verify(resourceCache).isPending(anyString());
+        verify(downloadManager).isCacheEnabled();
+    }
+
+    @Test
+    public void canHandleWhenCachingDisabled() {
+        when(downloadManager.isCacheEnabled()).thenReturn(false);
+        assertThat(actionProvider.canHandleMetacard(metacard), is(false));
+    }
+
+    @Test
+    public void canHandleWhenResourceCached() {
+        when(resourceCache.containsValid(anyString(), same(metacard))).thenReturn(true);
+        assertThat(actionProvider.canHandleMetacard(metacard), is(false));
+    }
+
+    @Test
+    public void canHandleWhenResourceBeingDownloaded() {
+        when(resourceCache.isPending(anyString())).thenReturn(true);
+        assertThat(actionProvider.canHandleMetacard(metacard), is(false));
     }
 
     @Test
     public void createMetacardAction() throws MalformedURLException {
-        List<Action> actions = actionProvider.getActions(metacard);
+        String title = "title";
+        String description = "description";
+        URL url = new URL("https://localhost/url");
 
-        assertThat(actions, hasSize(1));
-        Action action = actions.get(0);
+        Action action = actionProvider.createMetacardAction(ACTION_PROVIDER_ID,
+                title,
+                description,
+                url);
+
         assertThat(action.getId(), is(ACTION_PROVIDER_ID));
-        assertThat(action.getTitle(), is("Export Metacard XML"));
-        assertThat(action.getDescription(), is("Provides a URL to the metacard"));
-        assertThat(action.getUrl(), is(actionUrl));
+        assertThat(action.getTitle(), is(title));
+        assertThat(action.getDescription(), is(description));
+        assertThat(action.getUrl(), is(url));
     }
 
     @Test
     public void getMetacardActionUrl() throws Exception {
         URL url = actionProvider.getMetacardActionUrl(REMOTE_SOURCE_ID, metacard);
 
-        assertThat(url, is(actionUrl));
+        assertThat(url, is(getUrl(METACARD_ID)));
     }
 
     @Test
@@ -111,9 +149,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
     private URL getUrl(String metacardId)
             throws MalformedURLException, UnsupportedEncodingException {
         String encodedMetacardId = URLEncoder.encode(metacardId, CharEncoding.UTF_8);
-        String urlString = String.format("%s%s/%s/%s",
-                CONTEXT_ROOT,
-                SOURCES_PATH,
+        String urlString = String.format("%s/%s/%s",
+                CONTEXT_PATH,
                 REMOTE_SOURCE_ID,
                 encodedMetacardId);
         return new URL(SystemBaseUrl.constructUrl(urlString, true));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadEndpointTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadEndpointTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.resource.ResourceNotFoundException;
+import ddf.catalog.resource.ResourceNotSupportedException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceDownloadEndpointTest {
+
+    private static final String METACARD_ID = "57a4b894e13a455b8cccb87cec778b58";
+
+    private static final String SOURCE_ID = "ddf.distribution";
+
+    private static final String SUCCESSFUL_DOWNLOAD_TO_CACHE_MSG_TEMPLATE = "The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.";
+
+    @Mock
+    private CatalogFramework mockCatalogFramework;
+
+    @Mock
+    private ReliableResourceDownloadManager mockDownloadManager;
+
+    @Mock
+    private ResourceResponse mockResourceResponse;
+
+    @Test(expected = DownloadToCacheOnlyException.class)
+    public void testStartDownloadToCacheOnlyCacheDisabled() throws Exception {
+        // Setup
+        setupMockDownloadManager(false);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID, METACARD_ID);
+    }
+
+    @Test(expected = DownloadToCacheOnlyException.class)
+    public void testStartDownloadToCacheOnlyNullResourceResponse() throws Exception {
+        // Setup
+        setupMockDownloadManager(true);
+        setupMockCatalogFramework(null, null);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID, METACARD_ID);
+    }
+
+    @Test(expected = DownloadToCacheOnlyException.class)
+    public void testStartDownloadToCacheOnlyCatalogFrameworkThrowsIOException() throws Exception {
+        // Setup
+        setupMockDownloadManager(true);
+        setupMockCatalogFramework(mockResourceResponse, IOException.class);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID, METACARD_ID);
+    }
+
+    @Test(expected = DownloadToCacheOnlyException.class)
+    public void testStartDownloadToCacheOnlyCatalogFrameworkThrowsResourceNotSupportedException()
+        throws Exception {
+        // Setup
+        setupMockDownloadManager(true);
+        setupMockCatalogFramework(mockResourceResponse, ResourceNotSupportedException.class);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID, METACARD_ID);
+    }
+
+    @Test(expected = DownloadToCacheOnlyException.class)
+    public void testStartDownloadToCacheOnlyCatalogFrameworkThrowsResourceNotFoundException()
+        throws Exception {
+        // Setup
+        setupMockDownloadManager(true);
+        setupMockCatalogFramework(mockResourceResponse, ResourceNotFoundException.class);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID, METACARD_ID);
+    }
+
+    @Test
+    public void testStartDownloadToCacheOnly() throws Exception {
+        // Setup
+        setupMockDownloadManager(true);
+        setupMockCatalogFramework(mockResourceResponse, null);
+        ResourceDownloadEndpoint resourceDownloadEndpoint = new ResourceDownloadEndpoint(
+                mockCatalogFramework, mockDownloadManager);
+
+        // Perform Test
+        Response response = resourceDownloadEndpoint.startDownloadToCacheOnly(SOURCE_ID,
+                METACARD_ID);
+
+        assertThat(response.getEntity(), is(
+                String.format(SUCCESSFUL_DOWNLOAD_TO_CACHE_MSG_TEMPLATE, METACARD_ID, SOURCE_ID)));
+        assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+        assertThat(response.getMediaType().toString(), is(MediaType.TEXT_PLAIN));
+    }
+
+    private void setupMockDownloadManager(boolean isCacheEnabled) {
+        when(mockDownloadManager.isCacheEnabled()).thenReturn(isCacheEnabled);
+    }
+
+    private void setupMockCatalogFramework(ResourceResponse mockResourceResponse,
+            Class<? extends Throwable> exceptionClass)
+        throws Exception {
+        when(mockCatalogFramework.getResource(any(ResourceRequest.class), eq(SOURCE_ID)))
+                .thenReturn(mockResourceResponse);
+
+        if (exceptionClass != null) {
+            doThrow(exceptionClass).when(mockCatalogFramework)
+                    .getResource(any(ResourceRequest.class), eq(SOURCE_ID));
+        }
+    }
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -91,6 +91,7 @@
     <modules>
         <module>catalog-core-api</module>
         <module>catalog-core-api-impl</module>
+        <module>catalog-core-actions</module>
         <module>catalog-core-commons</module>
         <module>catalog-core-commands</module>
         <module>catalog-core-urlresourcereader</module>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>catalog-rest-pom</artifactId>
@@ -55,6 +57,11 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-actions</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -101,6 +108,11 @@
             <artifactId>catalog-transformer-attribute</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -110,7 +122,14 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>json-smart,catalog-core-api-impl,common-system,platform-util</Embed-Dependency>
+                        <Embed-Dependency>
+                            json-smart,
+                            catalog-core-api-impl,
+                            catalog-core-actions,
+                            common-system,
+                            platform-util,
+                            commons-lang3
+                        </Embed-Dependency>
                         <Import-Package>
                             javax.ws.rs.*,
                             *
@@ -121,6 +140,11 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/AbstractMetacardActionProvider*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-check</id>
@@ -141,17 +165,17 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.46</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.57</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -113,9 +113,9 @@ public class RESTEndpoint implements RESTService {
 
     static final String DEFAULT_METACARD_TRANSFORMER = "xml";
 
-    static final String DEFAULT_FILE_EXTENSION = "bin";
+    private static final String DEFAULT_FILE_EXTENSION = "bin";
 
-    static final String BYTES_TO_SKIP = "BytesToSkip";
+    private static final String BYTES_TO_SKIP = "BytesToSkip";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RESTEndpoint.class);
 
@@ -140,15 +140,15 @@ public class RESTEndpoint implements RESTService {
 
     private static final String JSON_MIME_TYPE_STRING = "application/json";
 
-    static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+    private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
 
-    static final String DEFAULT_FILE_NAME = "file";
+    private static final String DEFAULT_FILE_NAME = "file";
 
     /**
      * Basic mime types that will be attempted to refine to a more accurate mime type
      * based on the file extension of the filename specified in the create request.
      */
-    static final List<String> REFINEABLE_MIME_TYPES = Arrays.asList(DEFAULT_MIME_TYPE,
+    private static final List<String> REFINEABLE_MIME_TYPES = Arrays.asList(DEFAULT_MIME_TYPE,
             "text/plain");
 
     private static MimeType jsonMimeType = null;
@@ -362,7 +362,7 @@ public class RESTEndpoint implements RESTService {
      * @return
      */
     @GET
-    @Path("/sources")
+    @Path(SOURCES_PATH)
     public Response getDocument(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest) {
         BinaryContent content;
         ResponseBuilder responseBuilder;

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
@@ -36,6 +36,9 @@ import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 @Path("/")
 public interface RESTService {
 
+    String CONTEXT_ROOT = "catalog";
+    String SOURCES_PATH = "/sources";
+
     /**
      * REST Get. Retrieves the metadata entry specified by the id. Transformer argument is optional,
      * but is used to specify what format the data should be returned.
@@ -48,7 +51,7 @@ public interface RESTService {
      */
     @GET
     @Path("/{id}")
-    public Response getDocument(@PathParam("id") String id,
+    Response getDocument(@PathParam("id") String id,
             @QueryParam("transform") String transformerParam, @Context UriInfo uriInfo,
             @Context HttpServletRequest httpRequest);
 
@@ -60,8 +63,8 @@ public interface RESTService {
      * @return
      */
     @GET
-    @Path("/sources")
-    public Response getDocument(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest);
+    @Path(SOURCES_PATH)
+    Response getDocument(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest);
 
     /**
      * REST Get. Retrieves the metadata entry specified by the id from the federated source
@@ -75,8 +78,8 @@ public interface RESTService {
      * @return
      */
     @GET
-    @Path("/sources/{sourceid}/{id}")
-    public Response getDocument(@PathParam("sourceid") String sourceid, @PathParam("id") String id,
+    @Path(SOURCES_PATH + "/{sourceid}/{id}")
+    Response getDocument(@PathParam("sourceid") String sourceid, @PathParam("id") String id,
             @QueryParam("transform") String transformerParam, @Context UriInfo uriInfo,
             @Context HttpServletRequest httpRequest);
 
@@ -89,7 +92,7 @@ public interface RESTService {
      */
     @PUT
     @Path("/{id}")
-    public Response updateDocument(@PathParam("id") String id, @Context HttpHeaders headers,
+    Response updateDocument(@PathParam("id") String id, @Context HttpHeaders headers,
             @Context HttpServletRequest httpRequest, InputStream message);
 
     /**
@@ -101,7 +104,7 @@ public interface RESTService {
      */
     @PUT
     @Path("/{id}")
-    public Response updateDocument(@PathParam("id") String id, @Context HttpHeaders headers,
+    Response updateDocument(@PathParam("id") String id, @Context HttpHeaders headers,
             @Context HttpServletRequest httpRequest, MultipartBody multipartBody,
             InputStream message);
 
@@ -112,7 +115,7 @@ public interface RESTService {
      * @return
      */
     @POST
-    public Response addDocument(@Context HttpHeaders headers, @Context UriInfo requestUriInfo,
+    Response addDocument(@Context HttpHeaders headers, @Context UriInfo requestUriInfo,
             @Context HttpServletRequest httpRequest, InputStream message);
 
     /**
@@ -122,7 +125,7 @@ public interface RESTService {
      * @return
      */
     @POST
-    public Response addDocument(@Context HttpHeaders headers, @Context UriInfo requestUriInfo,
+    Response addDocument(@Context HttpHeaders headers, @Context UriInfo requestUriInfo,
             @Context HttpServletRequest httpRequest, MultipartBody multipartBody,
             InputStream message);
 
@@ -134,7 +137,6 @@ public interface RESTService {
      */
     @DELETE
     @Path("/{id}")
-    public Response deleteDocument(@PathParam("id") String id,
-            @Context HttpServletRequest httpRequest);
+    Response deleteDocument(@PathParam("id") String id, @Context HttpServletRequest httpRequest);
 
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
@@ -28,9 +28,12 @@ import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
 import ddf.action.ActionProvider;
-import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 
+/**
+ * @deprecated As of 2.10.0, replaced by {@link org.codice.ddf.catalog.actions.AbstractMetacardActionProvider}
+ */
+@Deprecated
 public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     static final String UNKNOWN_TARGET = "0.0.0.0";
@@ -108,14 +111,6 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
 
     @Override
     public <T> boolean canHandle(T subject) {
-        if (subject instanceof Metacard) {
-            if (StringUtils.isNotBlank(attributeName)) {
-                Attribute attr = ((Metacard) subject).getAttribute(attributeName);
-                return (attr != null && attr.getValue() != null);
-            }
-            return true;
-        }
-        return false;
+        return subject instanceof Metacard;
     }
-
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/MetacardTransformerActionProvider.java
@@ -13,18 +13,24 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
+import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
+import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
 
+import org.apache.commons.lang.CharEncoding;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.catalog.actions.AbstractMetacardActionProvider;
 import org.codice.ddf.configuration.SystemBaseUrl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
 import ddf.action.impl.ActionImpl;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
 
 public class MetacardTransformerActionProvider extends AbstractMetacardActionProvider {
 
@@ -35,13 +41,12 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
 
     static final String TITLE_PREFIX = "Export as ";
 
-    private static final Logger LOGGER =
-            LoggerFactory.getLogger(MetacardTransformerActionProvider.class);
-
     private String metacardTransformerId;
+    
+    private String attributeName;
 
     /**
-     * Constructor to instantiate this Metacard {@link ActionProvider}
+     * Constructor to instantiate this Metacard {@link ddf.action.ActionProvider}
      *
      * @param actionProviderId
      * @param metacardTransformerId
@@ -50,43 +55,50 @@ public class MetacardTransformerActionProvider extends AbstractMetacardActionPro
             String metacardTransformerId) {
         this(actionProviderId, metacardTransformerId, "");
     }
-
-    public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId, String attributeName) {
-        super();
-        this.actionProviderId = actionProviderId;
+    
+    /**
+     * Constructor to instantiate this Metacard {@link ddf.action.ActionProvider}
+     *
+     * @param actionProviderId
+     * @param metacardTransformerId
+     * @param attributeName
+     */
+    public MetacardTransformerActionProvider(String actionProviderId, String metacardTransformerId,
+            String attributeName) {
+        super(actionProviderId, TITLE_PREFIX + metacardTransformerId,
+                DESCRIPTION_PREFIX + metacardTransformerId + DESCRIPTION_SUFFIX);
         this.metacardTransformerId = metacardTransformerId;
         this.attributeName = attributeName;
     }
 
     @Override
-    protected Action getAction(String metacardId, String metacardSource) {
-
-        URL url = null;
-        try {
-
-            URI uri = new URI(SystemBaseUrl.constructUrl(
-                    PATH + "/" + metacardSource + "/" + metacardId + "?transform="
-                            + metacardTransformerId, true));
-            url = uri.toURL();
-
-        } catch (MalformedURLException e) {
-            LOGGER.info("Malformed URL exception", e);
-            return null;
-        } catch (URISyntaxException e) {
-            LOGGER.info("URI Syntax exception", e);
-            return null;
+    protected URL getMetacardActionUrl(String metacardSource, Metacard metacard) throws Exception {
+        String encodedMetacardId = URLEncoder.encode(metacard.getId(), CharEncoding.UTF_8);
+        String encodedMetacardSource = URLEncoder.encode(metacardSource, CharEncoding.UTF_8);
+        return getActionUrl(encodedMetacardSource, encodedMetacardId);
+    }
+    
+    @Override
+    protected boolean canHandleMetacard(Metacard metacard) {
+        if (StringUtils.isNotBlank(attributeName)) {
+            Attribute attr = metacard.getAttribute(attributeName);
+            return (attr != null && attr.getValue() != null);
         }
-
-        return new ActionImpl(getId(),
-                TITLE_PREFIX + metacardTransformerId,
-                DESCRIPTION_PREFIX + metacardTransformerId + DESCRIPTION_SUFFIX,
-                url);
-
+        return true;
     }
 
-    @Override
-    public String toString() {
+    protected Action createMetacardAction(String actionProviderId, String title, String description,
+            URL url) {
+        return new ActionImpl(actionProviderId, title, description, url);
+    }
 
-        return ActionProvider.class.getName() + " [" + getId() + "], Impl=" + getClass().getName();
+    private URL getActionUrl(String metacardSource, String metacardId)
+            throws MalformedURLException, URISyntaxException {
+        return new URI(SystemBaseUrl.constructUrl(String.format("%s%s/%s/%s?transform=%s",
+                CONTEXT_ROOT,
+                SOURCES_PATH,
+                metacardSource,
+                metacardId,
+                metacardTransformerId), true)).toURL();
     }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
@@ -80,7 +80,6 @@ import ddf.catalog.operation.impl.CreateResponseImpl;
 import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
 import ddf.catalog.operation.impl.SourceInfoResponseImpl;
 import ddf.catalog.resource.Resource;
-import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceDescriptor;
@@ -94,7 +93,6 @@ import ddf.mime.tika.TikaMimeTypeResolver;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
-import net.minidev.json.parser.ParseException;
 
 /**
  * Tests methods of the {@link RESTEndpoint}
@@ -219,18 +217,11 @@ public class TestRestEndpoint {
     /**
      * Tests local retrieve with a null QueryResponse
      *
-     * @throws URISyntaxException
-     * @throws SourceUnavailableException
-     * @throws IngestException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test(expected = ServerErrorException.class)
     public void testGetDocumentLocalNullQueryResponse()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
@@ -240,21 +231,11 @@ public class TestRestEndpoint {
     /**
      * Tests federated retrieve with a null QueryResponse
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test(expected = ServerErrorException.class)
     public void testGetDocumentFedNullQueryResponse()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
@@ -264,21 +245,11 @@ public class TestRestEndpoint {
     /**
      * Tests local retrieve with a null Metacard
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test(expected = ServerErrorException.class)
     public void testGetDocumentLocalNullMetacard()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
@@ -288,21 +259,11 @@ public class TestRestEndpoint {
     /**
      * Tests federated retrieve with a null Metacard
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test(expected = ServerErrorException.class)
     public void testGetDocumentFedNullMetacard()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
@@ -312,21 +273,11 @@ public class TestRestEndpoint {
     /**
      * Tests local retrieve with a successful response
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test
     public void testGetDocumentLocalSuccess()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
@@ -356,21 +307,11 @@ public class TestRestEndpoint {
     /**
      * Tests federated retrieve with a successful response
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test
     public void testGetDocumentFedSuccess()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
@@ -386,19 +327,11 @@ public class TestRestEndpoint {
     /**
      * Tests getting source information
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws UnsupportedEncodingException
-     * @throws ParseException
+     * @throws Exception
      */
     @Test
     public void testGetDocumentSourcesSuccess()
-            throws SourceUnavailableException, UnsupportedQueryException, FederationException,
-            CatalogTransformerException, URISyntaxException, ParseException, IOException {
+            throws Exception {
 
         final String localSourceId = "local";
         final String fed1SourceId = "fed1";
@@ -476,21 +409,11 @@ public class TestRestEndpoint {
     /**
      * Tests retrieving a local resource with a successful response
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test
     public void testGetDocumentResourceLocalSuccess()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
@@ -506,21 +429,11 @@ public class TestRestEndpoint {
     /**
      * Tests retrieving a federated resource with a successful response
      *
-     * @throws URISyntaxException
-     * @throws IngestException
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws ResourceNotSupportedException
-     * @throws ResourceNotFoundException
-     * @throws IOException
+     * @throws Exception
      */
     @Test
     public void testGetDocumentResourceFedSuccess()
-            throws URISyntaxException, IngestException, SourceUnavailableException,
-            UnsupportedQueryException, FederationException, CatalogTransformerException,
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
         String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
@@ -622,21 +535,11 @@ public class TestRestEndpoint {
      * Test using a Head request to find out if Range headers are supported and to get resource size of a local
      * resource for use when using Range headers.
      *
-     * @throws SourceUnavailableException
-     * @throws IngestException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws IOException
-     * @throws URISyntaxException
-     * @throws ResourceNotFoundException
-     * @throws ResourceNotSupportedException
+     * @throws Exception
      */
     @Test
     public void testHeadRequestLocal()
-            throws SourceUnavailableException, IngestException, UnsupportedQueryException,
-            FederationException, CatalogTransformerException, IOException, URISyntaxException,
-            ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         boolean isLocal = true;
 
@@ -652,21 +555,11 @@ public class TestRestEndpoint {
      * Test using a Head request to find out if Range headers are supported and to get resource size of a resource
      * at a federated site for use when using Range headers.
      *
-     * @throws SourceUnavailableException
-     * @throws IngestException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws IOException
-     * @throws URISyntaxException
-     * @throws ResourceNotFoundException
-     * @throws ResourceNotSupportedException
+     * @throws Exception
      */
     @Test
     public void testHeadRequestFederated()
-            throws SourceUnavailableException, IngestException, UnsupportedQueryException,
-            FederationException, CatalogTransformerException, IOException, URISyntaxException,
-            ResourceNotFoundException, ResourceNotSupportedException {
+            throws Exception {
 
         boolean isLocal = false;
 
@@ -754,17 +647,10 @@ public class TestRestEndpoint {
      * @param framework
      * @param testType
      * @return
-     * @throws SourceUnavailableException
-     * @throws UnsupportedQueryException
-     * @throws FederationException
-     * @throws CatalogTransformerException
-     * @throws IOException
-     * @throws ResourceNotFoundException
-     * @throws ResourceNotSupportedException
+     * @throws Exception
      */
     protected String mockTestSetup(CatalogFramework framework, TestType testType)
-            throws SourceUnavailableException, UnsupportedQueryException, FederationException,
-            CatalogTransformerException, IOException, ResourceNotFoundException,
+            throws Exception,
             ResourceNotSupportedException {
         String transformer = null;
         QueryResponse queryResponse = mock(QueryResponse.class);

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -13,180 +13,116 @@
  */
 package org.codice.ddf.endpoints.rest.action;
 
-import static org.hamcrest.Matchers.containsString;
+import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
+import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.List;
+
+import org.apache.commons.lang.CharEncoding;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.MetacardImpl;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TestMetacardTransformerActionProvider extends AbstractActionProviderTest {
 
     private static final String SAMPLE_TRANSFORMER_ID = "XML";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(
-            TestMetacardTransformerActionProvider.class);
+    private static final String ACTION_PROVIDER_ID = "actionID";
 
-    @Test
-    public void testMalformedUrlException() {
+    private static final String METACARD_ID = "metacardID";
 
-        String noSource = null;
-        Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
+    private static final String REMOTE_SOURCE_ID = "remote";
 
-        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
+    @Mock
+    private Metacard metacard;
+
+    private URL actionUrl;
+
+    private MetacardTransformerActionProvider actionProvider;
+
+    @Before
+    public void setup() throws Exception {
+        System.setProperty(SystemBaseUrl.HOST, "localhost");
+
+        when(metacard.getId()).thenReturn(METACARD_ID);
+        when(metacard.getSourceId()).thenReturn(REMOTE_SOURCE_ID);
+
+        actionUrl = getUrl(METACARD_ID);
+
+        actionProvider = new MetacardTransformerActionProvider(ACTION_PROVIDER_ID,
                 SAMPLE_TRANSFORMER_ID);
-
-        this.configureActionProvider("badProtocol",
-                SAMPLE_IP,
-                SAMPLE_PORT,
-                SAMPLE_SERVICES_ROOT,
-                SAMPLE_SOURCE_NAME);
-
-        assertThat("A bad url should have been caught and an empty list returned.",
-                actionProvider.getActions(metacard),
-                hasSize(0));
-
     }
 
     @Test
-    public void testUriSyntaxException() {
+    public void canHandle() {
+        assertThat(actionProvider.canHandle(metacard), is(true));
+    }
 
-        String noSource = null;
-        Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
+    @Test
+    public void createMetacardAction() throws MalformedURLException {
+        List<Action> actions = actionProvider.getActions(metacard);
 
-        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
+        assertThat(actions, hasSize(1));
+        Action action = actions.get(0);
+        assertThat(action.getId(), is(ACTION_PROVIDER_ID));
+        assertThat(action.getTitle(), is("Export as " + SAMPLE_TRANSFORMER_ID));
+        assertThat(action.getDescription(),
+                is("Provides a URL to the metacard that transforms the return value via the "
+                        + SAMPLE_TRANSFORMER_ID + " transformer"));
+        assertThat(action.getUrl(), is(actionUrl));
+    }
+
+    @Test
+    public void getMetacardActionUrl() throws Exception {
+        URL url = actionProvider.getMetacardActionUrl(REMOTE_SOURCE_ID, metacard);
+
+        assertThat(url, is(actionUrl));
+    }
+
+    @Test
+    public void getMetacardActionUrlEncodedAmpersand() throws Exception {
+        String metacardId = "abc&def";
+        when(metacard.getId()).thenReturn(metacardId);
+
+        URL url = actionProvider.getMetacardActionUrl(REMOTE_SOURCE_ID, metacard);
+
+        assertThat(url, is(getUrl(metacardId)));
+    }
+
+    @Test(expected = URISyntaxException.class)
+    public void getMetacardActionUrlWhenUrlIsMalformed() throws Exception {
+        String invalidHost = "23^&*#";
+        System.setProperty(SystemBaseUrl.HOST, invalidHost);
+
+        actionProvider.getMetacardActionUrl(REMOTE_SOURCE_ID, metacard);
+    }
+
+    private URL getUrl(String metacardId)
+            throws MalformedURLException, UnsupportedEncodingException {
+        String encodedMetacardId = URLEncoder.encode(metacardId, CharEncoding.UTF_8);
+        String urlString = String.format("%s%s/%s/%s?transform=%s",
+                CONTEXT_ROOT,
+                SOURCES_PATH,
+                REMOTE_SOURCE_ID,
+                encodedMetacardId,
                 SAMPLE_TRANSFORMER_ID);
-
-        this.configureActionProvider(SAMPLE_PROTOCOL,
-                "23^&*#",
-                SAMPLE_PORT,
-                SAMPLE_SERVICES_ROOT,
-                SAMPLE_SOURCE_NAME);
-
-        assertThat("A bad url should have been caught and an empty list returned.",
-                actionProvider.getActions(metacard),
-                hasSize(0));
-
-    }
-
-    @Test
-    public void testMetacard() {
-
-        // given
-
-        String noSource = null;
-        Metacard metacard = givenMetacard(SAMPLE_ID, noSource);
-
-        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID);
-        this.configureActionProvider();
-
-        // when
-        Action action = actionProvider.getActions(metacard)
-                .get(0);
-
-        // then
-        assertEquals(MetacardTransformerActionProvider.TITLE_PREFIX + SAMPLE_TRANSFORMER_ID,
-                action.getTitle());
-
-        assertEquals(MetacardTransformerActionProvider.DESCRIPTION_PREFIX + SAMPLE_TRANSFORMER_ID +
-                MetacardTransformerActionProvider.DESCRIPTION_SUFFIX, action.getDescription());
-
-        assertThat(action.getUrl()
-                        .toString(),
-                is(expectedDefaultAddressWith(metacard.getId(),
-                        SAMPLE_SOURCE_NAME,
-                        SAMPLE_TRANSFORMER_ID)));
-        assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
-
-    }
-
-    @Test
-    public void testToString() {
-        String toString = new MetacardTransformerActionProvider(ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID).toString();
-
-        LOGGER.info(toString);
-
-        assertThat(toString, containsString(ActionProvider.class.getName()));
-        assertThat(toString, containsString(ACTION_PROVIDER_ID));
-
-    }
-
-    private Metacard givenMetacard(String sampleId, String sourceName) {
-
-        Metacard metacard = mock(Metacard.class);
-
-        when(metacard.getId()).thenReturn(sampleId);
-        when(metacard.getSourceId()).thenReturn(sourceName);
-
-        return metacard;
-    }
-
-    @Test
-    public void testFederatedMetacard() {
-
-        // given
-        MetacardImpl metacard = new MetacardImpl();
-
-        metacard.setId(SAMPLE_ID);
-
-        String newSourceName = "newSource";
-
-        metacard.setSourceId(newSourceName);
-
-        AbstractMetacardActionProvider actionProvider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID);
-        this.configureActionProvider();
-
-        // when
-        Action action = actionProvider.getActions(metacard)
-                .get(0);
-
-        // then
-        assertThat(action.getUrl()
-                        .toString(),
-                is(expectedDefaultAddressWith(metacard.getId(),
-                        newSourceName,
-                        SAMPLE_TRANSFORMER_ID)));
-        assertEquals(ACTION_PROVIDER_ID, actionProvider.getId());
-
-    }
-
-    @Test
-    public void testEmptyAttributeName() {
-        AbstractMetacardActionProvider provider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID,
-                "");
-        assertThat(provider.canHandle(new MetacardImpl()), is(true));
-        assertThat(provider.canHandle(new String()), is(false));
-    }
-
-    @Test
-    public void testSpecificAttributeName() {
-        AbstractMetacardActionProvider provider = new MetacardTransformerActionProvider(
-                ACTION_PROVIDER_ID,
-                SAMPLE_TRANSFORMER_ID,
-                "thumbnail");
-        MetacardImpl metacard = new MetacardImpl();
-        assertThat(provider.canHandle(metacard), is(false));
-        metacard.setThumbnail(new byte[] {000});
-        assertThat(provider.canHandle(metacard), is(true));
+        return new URL(SystemBaseUrl.constructUrl(urlString, true));
     }
 
     private String expectedDefaultAddressWith(String id, String sourceName,

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
@@ -1128,6 +1128,42 @@ The FTP endpoint is implemented using the Apache FTP Server and Apache Mina. Apa
 
 None
 
+==== Resource Download Endpoint
+
+The Resource Download Endpoint provides a REST API to trigger downloading resources to the ${branding} cache only. The resource is not returned to the client.
+
+===== Configuring
+
+The Resource Download Endpoint has no configurable properties.
+
+===== Using the Resource Download Endpoint
+
+====== Using the endpoint
+
+The Resource Download Endpoint WADL is accessible from `http://<${ddf-branding}_HOST>:<${ddf-branding}_PORT>/services/catalog/downloads?_wadl`.
+
+[NOTE]
+====
+If resource caching is not enabled in ${ddf-branding}, the endpoint will return a `400 BAD REQUEST` response.
+====
+
+[cols="2,1,3,4", options="header"]
+|===
+|Operation
+|HTTP Request
+|Details
+|Example URL
+
+|`cache only`
+|HTTP GET
+|Resource caching must be enabled
+|\http://<${ddf-branding}_HOST>:<${ddf-branding}_PORT>/services/catalog/downloads/<sourceId>/<metacardId>
+
+|===
+====== Known Issues
+
+None
+
 === Developing a New Endpoint
 
 Complete the following procedure to create an endpoint. 
@@ -1440,7 +1476,7 @@ Metacard types, attribute types, global attribute validators, and default attrib
 
 Within a definition file you may define as many of the four types as you wish. This means that types can be defined across multiple files for grouping or clarity. 
 
-==== Deploying 
+==== Deploying
 The file must have a `.json` extension in order to be picked up by the deployer. Once the definition file is ready to be deployed, put the definition file `<filename>.json` into the `etc/definitions` folder.
 
 * * *
@@ -1524,7 +1560,7 @@ To define Metacard Types, your definition file must have a `metacardTypes` key i
 }
 ----
 
-The value of `metacardTypes` must be an array of Metacard Type Objects, which are composed of the `type` and `attributes` keys. 
+The value of `metacardTypes` must be an array of Metacard Type Objects, which are composed of the `type` and `attributes` keys.
 
 [source,json]
 ----

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -248,9 +248,11 @@ public abstract class AbstractIntegrationTest {
             HTTPS_PORT,
             "/admin/jolokia/exec/org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean:service=admin-source-poller-service/allSourceInfo");
 
-    public static final DynamicUrl ADMIN_STATUS_PATH = new DynamicUrl(SECURE_ROOT,
-            HTTPS_PORT,
+    public static final DynamicUrl ADMIN_STATUS_PATH = new DynamicUrl(SECURE_ROOT, HTTPS_PORT,
             "/admin/jolokia/exec/org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean:service=admin-source-poller-service/sourceStatus/");
+
+    public static final DynamicUrl RESOURCE_DOWNLOAD_ENDPOINT_ROOT = new DynamicUrl(SERVICE_ROOT,
+            "/catalog/downloads/");
 
     static {
         // Make Pax URL use the maven.repo.local setting if present

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
@@ -16,12 +16,14 @@ package ddf.test.itests;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,5 +155,23 @@ public class CatalogBundle {
         }
 
         serviceManager.startManagedService(CATALOG_FRAMEWORK_PID, properties);
+    }
+
+    public void setupCaching(boolean cachingEnabled) throws IOException {
+        Map<String, Object> existingProperties = adminConfig.getDdfConfigAdmin()
+                .getProperties(CATALOG_FRAMEWORK_PID);
+        if (existingProperties == null) {
+            existingProperties = new Hashtable<String, Object>();
+        }
+        Hashtable<String, Object> updatedProperties = new Hashtable<>();
+        updatedProperties.putAll(existingProperties);
+        if (cachingEnabled) {
+            updatedProperties.put("cacheEnabled", "True");
+        } else {
+            updatedProperties.put("cacheEnabled", "False");
+        }
+
+        Configuration configuration = adminConfig.getConfiguration(CATALOG_FRAMEWORK_PID, null);
+        configuration.update(updatedProperties);
     }
 }

--- a/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
+++ b/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
@@ -177,6 +177,12 @@ public final class SystemBaseUrl {
         return System.getProperty(HTTPS_PORT, DEFAULT_HTTPS_PORT);
     }
 
+    /**
+     * Gets the current host name or IP address from the system properties, or {@link #DEFAULT_HOST}
+     * if not set.
+     *
+     * @return host name, IP address or {@link #DEFAULT_HOST}
+     */
     public static String getHost() {
         return System.getProperty(HOST, DEFAULT_HOST);
     }

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -47,7 +47,7 @@
         <property name="whiteListContexts">
             <array value-type="java.lang.String">
                 <value>${org.codice.ddf.system.rootContext}/SecurityTokenService</value>
-                <value>${org.codice.ddf.system.rootContext}/internal</value>
+                <value>${org.codice.ddf.system.rootContext}/internal/metrics</value>
                 <value>/proxy</value>
                 <value>${org.codice.ddf.system.rootContext}/saml</value>
                 <value>${org.codice.ddf.system.rootContext}/idp</value>


### PR DESCRIPTION
#### What does this PR do?
This PR adds a new ResourceDownloadEndpoint and an associated ActionProvider. The ResourceDownloadEndpoint only downloads products to the local cache and does not return the product to the cllient.  The DownloadResourceActionProvider only returns an action if caching is enabled and the product is not currently in the cache.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@garrettfreibott 
@oconnormi 
@Lambeaux 
@bantillo 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested?
Run PRBS and do the following manual test:
1) Start DDF
2) Setup a federated source
3) Upload some images to use a products
4) Run a wildcard query from the Search UI
5) Select a metacard
6) On the Actions tab, select "Download Resource to local cache"
7) Run a wildcard query from the Search UI again
8) Select the same metacard that was selected on step 5
9) On the Actions tab, verify that the link (Action) "Download Resource to local cache" does NOT exist. It doesn't exist because the product is already in the cache.

#### Any background context you want to provide?

#### What are the relevant tickets?
DDF-2119
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
