### PR TITLE
DDF-2147: Fixed guest user cross-notifications

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.security.SecurityConstants;
+import ddf.security.SubjectUtils;
 import ddf.security.assertion.SecurityAssertion;
 
 /**
@@ -220,6 +221,11 @@ public abstract class AbstractEventController implements EventHandler {
 
         if (null == userId) {
             throw new IllegalArgumentException("User ID is null");
+        }
+
+        // check if user is a guest. Register with sessionId to avoid cross-notifications
+        if (userId.startsWith(SubjectUtils.GUEST_DISPLAY_NAME + "@")) {
+            userId = serverSession.getId();
         }
 
         userSessionMap.put(userId, serverSession);


### PR DESCRIPTION
#### What does this PR do?
Registers Guests by their sessionId so that multiple Guest usrs from the same IP address will have notifications delivered properly.
#### Choose 2 committers to review/merge the PR
@lessarderic
@pklinef
#### Any background context you want to provide?
Update to original DDF-2147 PR.