### PR TITLE
DDF-2113 Move subject role check for admin into getSystemSubject()

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -88,7 +88,10 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
             LOGGER.debug("No routes to remove before configuring a new route");
         }
 
-        configureCamelRoute();
+        org.codice.ddf.security.common.Security.runAsAdmin(() -> {
+            configureCamelRoute();
+            return null;
+        });
     }
 
     /**
@@ -174,8 +177,8 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
                     String attributeOverrideString = attributeOverrides.stream()
                             .map(String::trim)
                             .collect(Collectors.joining(","));
-                    routeDefinition.setHeader(Constants.ATTRIBUTE_OVERRIDES_KEY, simple(
-                            attributeOverrideString));
+                    routeDefinition.setHeader(Constants.ATTRIBUTE_OVERRIDES_KEY,
+                            simple(attributeOverrideString));
                 }
 
                 routeDefinition.process(systemSubjectBinder)

--- a/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
+++ b/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
@@ -63,8 +63,8 @@ public class FilterPlugin implements AccessPlugin {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterPlugin.class);
 
-    private Map<ServiceReference, FilterStrategy> filterStrategies = Collections.synchronizedMap(
-            new TreeMap<>(new ServiceComparator()));
+    private Map<ServiceReference, FilterStrategy> filterStrategies =
+            Collections.synchronizedMap(new TreeMap<>(new ServiceComparator()));
 
     public void addStrategy(ServiceReference<FilterStrategy> filterStrategyRef) {
         Bundle bundle = FrameworkUtil.getBundle(FilterPlugin.class);
@@ -80,7 +80,7 @@ public class FilterPlugin implements AccessPlugin {
     }
 
     protected Subject getSystemSubject() {
-        return Security.getSystemSubject();
+        return org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
     }
 
     @Override
@@ -94,11 +94,15 @@ public class FilterPlugin implements AccessPlugin {
         List<String> systemNotPermittedIds = new ArrayList<>();
         for (Metacard metacard : metacards) {
             Attribute attr = metacard.getAttribute(Metacard.SECURITY);
-            if (!checkPermissions(attr, securityPermission, subject,
+            if (!checkPermissions(attr,
+                    securityPermission,
+                    subject,
                     CollectionPermission.CREATE_ACTION)) {
                 userNotPermittedIds.add(metacard.getId());
             }
-            if (!checkPermissions(attr, securityPermission, systemSubject,
+            if (!checkPermissions(attr,
+                    securityPermission,
+                    systemSubject,
                     CollectionPermission.CREATE_ACTION)) {
                 systemNotPermittedIds.add(metacard.getId());
             }
@@ -144,12 +148,18 @@ public class FilterPlugin implements AccessPlugin {
                 unknownIds.add(id);
             } else {
                 Attribute oldAttr = oldMetacard.getAttribute(Metacard.SECURITY);
-                if (!checkPermissions(attr, securityPermission, subject,
+                if (!checkPermissions(attr,
+                        securityPermission,
+                        subject,
                         CollectionPermission.UPDATE_ACTION) || !checkPermissions(oldAttr,
-                        securityPermission, subject, CollectionPermission.UPDATE_ACTION)) {
+                        securityPermission,
+                        subject,
+                        CollectionPermission.UPDATE_ACTION)) {
                     userNotPermittedIds.add(newMetacard.getId());
                 }
-                if (!checkPermissions(attr, securityPermission, systemSubject,
+                if (!checkPermissions(attr,
+                        securityPermission,
+                        systemSubject,
                         CollectionPermission.UPDATE_ACTION)) {
                     systemNotPermittedIds.add(newMetacard.getId());
                 }
@@ -190,7 +200,9 @@ public class FilterPlugin implements AccessPlugin {
         int filteredMetacards = 0;
         for (Metacard metacard : results) {
             Attribute attr = metacard.getAttribute(Metacard.SECURITY);
-            if (!checkPermissions(attr, securityPermission, subject,
+            if (!checkPermissions(attr,
+                    securityPermission,
+                    subject,
                     CollectionPermission.READ_ACTION)) {
                 for (FilterStrategy filterStrategy : filterStrategies.values()) {
                     FilterResult filterResult = filterStrategy.process(input, metacard);
@@ -210,7 +222,8 @@ public class FilterPlugin implements AccessPlugin {
 
         if (filteredMetacards > 0) {
             SecurityLogger.audit(
-                    "Filtered " + filteredMetacards + " metacards, returned " + newResults.size(), subject);
+                    "Filtered " + filteredMetacards + " metacards, returned " + newResults.size(),
+                    subject);
         }
 
         input.getDeletedMetacards()
@@ -244,7 +257,9 @@ public class FilterPlugin implements AccessPlugin {
         for (Result result : results) {
             metacard = result.getMetacard();
             Attribute attr = metacard.getAttribute(Metacard.SECURITY);
-            if (!checkPermissions(attr, securityPermission, subject,
+            if (!checkPermissions(attr,
+                    securityPermission,
+                    subject,
                     CollectionPermission.READ_ACTION)) {
                 for (FilterStrategy filterStrategy : filterStrategies.values()) {
                     FilterResult filterResult = filterStrategy.process(input, metacard);
@@ -264,7 +279,8 @@ public class FilterPlugin implements AccessPlugin {
 
         if (filteredMetacards > 0) {
             SecurityLogger.audit(
-                    "Filtered " + filteredMetacards + " metacards, returned " + newResults.size(), subject);
+                    "Filtered " + filteredMetacards + " metacards, returned " + newResults.size(),
+                    subject);
         }
 
         input.getResults()
@@ -293,7 +309,9 @@ public class FilterPlugin implements AccessPlugin {
                 CollectionPermission.READ_ACTION);
         Subject subject = getSubject(input);
         Attribute attr = metacard.getAttribute(Metacard.SECURITY);
-        if (!checkPermissions(attr, securityPermission, subject,
+        if (!checkPermissions(attr,
+                securityPermission,
+                subject,
                 CollectionPermission.READ_ACTION)) {
             for (FilterStrategy filterStrategy : filterStrategies.values()) {
                 FilterResult filterResult = filterStrategy.process(input, metacard);

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -1766,7 +1766,7 @@ public abstract class AbstractCswSource extends MaskableImpl
     }
 
     protected Subject getSystemSubject() {
-        return Security.getSystemSubject();
+        return org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
     }
 
     private GetRecordsType createSubscriptionGetRecordsRequest() {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -49,6 +49,8 @@ public class TestRegistry extends AbstractIntegrationTest {
 
     private static final String REGISTRY_CATALOG_STORE_ID = "cswRegistryCatalogStore";
 
+    private static final String ADMIN = "admin";
+
     @BeforeExam
     public void beforeExam() throws Exception {
         try {
@@ -82,11 +84,14 @@ public class TestRegistry extends AbstractIntegrationTest {
     public void testCswRegistryUpdate() throws Exception {
         String id = createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51280");
 
-        Response response = given().body(Library.getCswRegistryUpdate()
-                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                        "urn:uuid:2014ca7f59ac46f495e32b4a67a51280")
-                .replace("Node Name", "New Node Name")
-                .replaceAll("someUUID", id))
+        Response response = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(Library.getCswRegistryUpdate()
+                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
+                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51280")
+                        .replace("Node Name", "New Node Name")
+                        .replaceAll("someUUID", id))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -108,9 +113,12 @@ public class TestRegistry extends AbstractIntegrationTest {
     public void testCswRegistryDelete() throws Exception {
         createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51281");
 
-        Response response = given().body(Library.getCswRegistryDelete()
-                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                        "urn:uuid:2014ca7f59ac46f495e32b4a67a51281"))
+        Response response = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(Library.getCswRegistryDelete()
+                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
+                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51281"))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -132,9 +140,12 @@ public class TestRegistry extends AbstractIntegrationTest {
     public void testCswRegistryCreateDup() throws Exception {
         createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51282");
 
-        given().body(Library.getCswRegistryInsert()
-                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                        "urn:uuid:2014ca7f59ac46f495e32b4a67a51282"))
+        given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(Library.getCswRegistryInsert()
+                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
+                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51282"))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -169,8 +180,11 @@ public class TestRegistry extends AbstractIntegrationTest {
     }
 
     private String createRegistryEntry(String id) throws Exception {
-        Response response = given().body(Library.getCswRegistryInsert()
-                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276", id))
+        Response response = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(Library.getCswRegistryInsert()
+                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276", id))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
@@ -119,7 +119,7 @@ public class CommandJob implements Job {
     }
 
     public Subject getSystemSubject() {
-        return Security.getSystemSubject();
+        return org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
     }
 
     private CommandProcessor getCommandProcessor() {


### PR DESCRIPTION
#### What does this PR do? 
Moves the subject role check from runWithSubjectOrElevate() into getSystemSubject() within the Security class. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @coyotesqrl @bcwaters @tbatie @jckilmer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
PRBS.
#### Any background context you want to provide?
There are some operations that require the system subject, but are not associated with a user. These operations cannot retrieve the system subject due to not having a java subject containing an admin role. In order to fix this, I have added a method that creates a java subject with an admin role and can run an action using that subject.
#### What are the relevant tickets?
DDF-2113
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests

