### PR TITLE
DDF-2146 Update Registry itests

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -16,15 +16,22 @@ package ddf.test.itests.catalog;
 import static org.hamcrest.xml.HasXPath.hasXPath;
 import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.when;
 
 import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedActionException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.IOUtils;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.security.common.Security;
 import org.hamcrest.CoreMatchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -32,6 +39,7 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.xml.sax.InputSource;
 
+import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 
@@ -51,6 +59,8 @@ public class TestRegistry extends AbstractIntegrationTest {
 
     private static final String ADMIN = "admin";
 
+    private Set<String> destinations;
+
     @BeforeExam
     public void beforeExam() throws Exception {
         try {
@@ -68,11 +78,13 @@ public class TestRegistry extends AbstractIntegrationTest {
             getServiceManager().createManagedService(cswRegistryStoreProperties.FACTORY_PID,
                     cswRegistryStoreProperties);
             getCatalogBundle().waitForCatalogStore(REGISTRY_CATALOG_STORE_ID);
-
+            destinations = new HashSet<>();
+            destinations.add(REGISTRY_CATALOG_STORE_ID);
         } catch (Exception e) {
             LOGGER.error("Failed in @BeforeExam: ", e);
             fail("Failed in @BeforeExam: " + e.getMessage());
         }
+
     }
 
     @Test
@@ -81,37 +93,17 @@ public class TestRegistry extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testCswRegistryUpdateFailure() throws Exception {
-        String id = createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51280");
-
-        given().body(Library.getCswRegistryUpdate()
-                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                        "urn:uuid:2014ca7f59ac46f495e32b4a67a51280")
-                .replace("Node Name", "New Node Name")
-                .replace("2016-01-26T17:16:34.996Z", "2014-02-26T17:16:34.996Z")
-                .replaceAll("someUUID", id))
-                .header("Content-Type", "text/xml")
-                .expect()
-                .log()
-                .all()
-                .statusCode(400)
-                .when()
-                .post(CSW_PATH.getUrl());
-    }
-
-    @Test
     public void testCswRegistryUpdate() throws Exception {
-        String id = createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51285");
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51285";
+        String id = createRegistryEntry(regID);
 
         Response response = given().auth()
                 .preemptive()
                 .basic(ADMIN, ADMIN)
-                .body(Library.getCswRegistryUpdate()
-                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51285")
-                        .replace("Node Name", "New Node Name")
-                        .replace("2016-01-26T17:16:34.996Z", "2018-02-26T17:16:34.996Z")
-                        .replaceAll("someUUID", id))
+                .body(Library.getCswRegistryUpdate(regID,
+                        "New Node Name",
+                        "2018-02-26T17:16:34.996Z",
+                        id))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -119,6 +111,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                 .statusCode(200)
                 .when()
                 .post(CSW_PATH.getUrl());
+
         ValidatableResponse validatableResponse = response.then();
 
         validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalInserted",
@@ -130,15 +123,37 @@ public class TestRegistry extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testCswRegistryUpdateFailure() throws Exception {
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51280";
+        String id = createRegistryEntry(regID);
+        given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(Library.getCswRegistryUpdate(regID,
+                        "New Node Name",
+                        "2014-02-26T17:16:34.996Z",
+                        id))
+                .log()
+                .all()
+                .header("Content-Type", "text/xml")
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .statusCode(400);
+    }
+
+    @Test
     public void testCswRegistryDelete() throws Exception {
-        createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51281");
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51281";
+        createRegistryEntry(regID);
 
         Response response = given().auth()
                 .preemptive()
                 .basic(ADMIN, ADMIN)
-                .body(Library.getCswRegistryDelete()
-                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51281"))
+                .body(Library.getCswRegistryDelete(regID))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -146,6 +161,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                 .statusCode(200)
                 .when()
                 .post(CSW_PATH.getUrl());
+
         ValidatableResponse validatableResponse = response.then();
 
         validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalInserted",
@@ -158,53 +174,127 @@ public class TestRegistry extends AbstractIntegrationTest {
 
     @Test
     public void testCswRegistryCreateDup() throws Exception {
-        createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51282");
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51282";
+        createRegistryEntry(regID);
 
         given().auth()
                 .preemptive()
                 .basic(ADMIN, ADMIN)
-                .body(Library.getCswRegistryInsert()
-                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
-                                "urn:uuid:2014ca7f59ac46f495e32b4a67a51282"))
+                .body(Library.getCswRegistryInsert(regID))
                 .header("Content-Type", "text/xml")
-                .expect()
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
                 .log()
                 .all()
-                .statusCode(400)
-                .when()
-                .post(CSW_PATH.getUrl());
+                .assertThat()
+                .statusCode(400);
     }
 
-    @Ignore
     @Test
     public void testCswRegistryStoreCreate() throws Exception {
-        //Stub test, waiting for additional features/service before implementing
-        //Use federation admin to create a registry entry
-        //on a 'remote' (aka loopback) catalog store
+
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51277";
+        try {
+            Security.runAsAdminWithException(() -> {
+
+                createRegistryStoreEntry(regID);
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            String message = "There was an error bringing up the Federation Admin Service.";
+            LOGGER.error(message, e);
+            throw new Exception(message, e);
+        }
     }
 
-    @Ignore
     @Test
     public void testCswRegistryStoreUpdate() throws Exception {
-        //Stub test, waiting for additional features/service before implementing
-        //Use federation admin to update a registry entry
-        //on a 'remote' (aka loopback) catalog store
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51290";
+
+        try {
+            Security.runAsAdminWithException(() -> {
+
+                createRegistryStoreEntry(regID);
+                FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
+                        FederationAdminService.class);
+                federationAdminServiceImpl.updateRegistryEntry(Library.getRegistryNode(regID,
+                        "New Node Name",
+                        "2015-02-26T17:16:34.996Z"), destinations);
+
+                ValidatableResponse validatableResponse = getCswRegistryResponse("title",
+                        "New Node Name");
+
+                final String xPathRegistryName =
+                        "string(//GetRecordsResponse/SearchResults/RegistryPackage/RegistryObjectList/ExtrinsicObject/Name/LocalizedString/@value)";
+                validatableResponse.body(hasXPath(xPathRegistryName,
+                        CoreMatchers.is("New Node Name")));
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            String message = "There was an error bringing up the Federation Admin Service.";
+            LOGGER.error(message, e);
+            throw new Exception(message, e);
+        }
     }
 
-    @Ignore
     @Test
     public void testCswRegistryStoreDelete() throws Exception {
-        //Stub test, waiting for additional features/service before implementing
-        //Use federation admin to update a registry entry
-        //on a 'remote' (aka loopback) catalog store
+        String regID = "urn:uuid:2014ca7f59ac46f495e32b4a67a51291";
+        try {
+            Security.runAsAdminWithException(() -> {
+
+                createRegistryStoreEntry(regID);
+                FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
+                        FederationAdminService.class);
+
+                List<String> toBeDeletedIDs = new ArrayList<>();
+                toBeDeletedIDs.add(regID);
+
+                federationAdminServiceImpl.deleteRegistryEntriesByRegistryIds(toBeDeletedIDs,
+                        destinations);
+
+                ValidatableResponse validatableResponse = getCswRegistryResponse("registry-id",
+                        regID);
+
+                final String xPathNumRecords =
+                        "//GetRecordsResponse/SearchResults/@numberOfRecordsMatched";
+                validatableResponse.body(hasXPath(xPathNumRecords, CoreMatchers.is("0")));
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            String message = "There was an error bringing up the Federation Admin Service.";
+            LOGGER.error(message, e);
+            throw new Exception(message, e);
+        }
+
+    }
+
+    @Test
+    public void testRestEndpoint() throws Exception {
+        final String regId = "urn:uuid:2014ca7f59ac46f495e32b4a67a51292";
+        createRegistryEntry(regId);
+
+        final String restUrl = SERVICE_ROOT.getUrl() + "/registries/" + regId + "/report";
+
+        ValidatableResponse response = when().get(restUrl)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .contentType("text/html");
+
+        final String xPathServices = "//html/body/h4";
+
+        response.body(hasXPath(xPathServices, CoreMatchers.is("Csw_Federated_Source")),
+                hasXPath(xPathServices + "[2]", CoreMatchers.is("soap13")));
     }
 
     private String createRegistryEntry(String id) throws Exception {
         Response response = given().auth()
                 .preemptive()
                 .basic(ADMIN, ADMIN)
-                .body(Library.getCswRegistryInsert()
-                        .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276", id))
+                .body(Library.getCswRegistryInsert(id))
                 .header("Content-Type", "text/xml")
                 .expect()
                 .log()
@@ -228,6 +318,36 @@ public class TestRegistry extends AbstractIntegrationTest {
                 .asString(), StandardCharsets.UTF_8.name()));
         return xPath.compile(idPath)
                 .evaluate(xml);
+    }
+
+    private void createRegistryStoreEntry(String id) throws Exception {
+        FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
+                FederationAdminService.class);
+        federationAdminServiceImpl.addRegistryEntry(Library.getRegistryNode(id), destinations);
+
+        ValidatableResponse validatableResponse = getCswRegistryResponse("registry-id", id);
+
+        final String xPathRegistryID =
+                "string(//GetRecordsResponse/SearchResults/RegistryPackage/ExternalIdentifier/@registryObject)";
+        validatableResponse.body(hasXPath(xPathRegistryID, CoreMatchers.is(id)));
+    }
+
+    private ValidatableResponse getCswRegistryResponse(String attr, String value) {
+        String regQuery = Library.getCswQuery(attr,
+                value,
+                "application/xml",
+                "urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0");
+        LOGGER.error("##### {}", regQuery);
+        Response response = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .contentType(ContentType.XML)
+                .body(regQuery)
+                .when()
+                .post(CSW_PATH.getUrl());
+        ValidatableResponse validatableResponse = response.then();
+
+        return validatableResponse;
     }
 }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -81,7 +81,7 @@ public final class Library {
                 + getSimpleXmlNoDec(uri);
     }
 
-    public static String getCswQuery(String propertyName, String literalValue, String ouputFormat,
+    public static String getCswQuery(String propertyName, String literalValue, String outputFormat,
             String outputSchema) {
 
         String schema = "";
@@ -89,17 +89,15 @@ public final class Library {
             schema = "outputSchema=\"" + outputSchema + "\" ";
         }
 
-        return "<csw:GetRecords resultType=\"results\" outputFormat=\"" + ouputFormat + "\" "
-                + schema
-                + "startPosition=\"1\" maxRecords=\"10\" service=\"CSW\" version=\"2.0.2\" xmlns:ns2=\"http://www.opengis.net/ogc\" xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" xmlns:ns4=\"http://www.w3.org/1999/xlink\" xmlns:ns3=\"http://www.opengis.net/gml\" xmlns:ns9=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns5=\"http://www.opengis.net/ows\" xmlns:ns6=\"http://purl.org/dc/elements/1.1/\" xmlns:ns7=\"http://purl.org/dc/terms/\" xmlns:ns8=\"http://www.w3.org/2001/SMIL20/\">"
-                + "    <ns10:Query typeNames=\"csw:Record\" xmlns=\"\" xmlns:ns10=\"http://www.opengis.net/cat/csw/2.0.2\">"
-                + "        <ns10:ElementSetName>full</ns10:ElementSetName>"
-                + "        <ns10:Constraint version=\"1.1.0\">" + "            <ns2:Filter>"
-                + "                <ns2:PropertyIsLike wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\">"
-                + "                    <ns2:PropertyName>" + propertyName + "</ns2:PropertyName>"
-                + "                    <ns2:Literal>" + literalValue + "</ns2:Literal>"
-                + "                </ns2:PropertyIsLike>" + "            </ns2:Filter>"
-                + "        </ns10:Constraint>" + "    </ns10:Query>" + "</csw:GetRecords>";
+        return getFileContent("/csw-query.xml",
+                ImmutableMap.of("propertyName",
+                        propertyName,
+                        "literal",
+                        literalValue,
+                        "outputFormat",
+                        outputFormat,
+                        "outputSchema",
+                        schema));
     }
 
     public static String getCswSubscription(String propertyName, String literalValue,
@@ -182,23 +180,44 @@ public final class Library {
                 + "    </csw:Insert>\n" + "</csw:Transaction>";
     }
 
-    public static String getRegistryNode() throws IOException {
-        return IOUtils.toString(Library.class.getResourceAsStream("/csw-rim-node.xml"));
+    public static String getRegistryNode(String id) throws IOException {
+        return getRegistryNode(id, "Node Name", "2016-01-26T17:16:34.996Z", "someUUID");
     }
 
-    public static String getCswRegistryInsert() throws IOException {
-        return Library.getCswInsert("rim:RegistryPackage", getRegistryNode());
+    public static String getRegistryNode(String id, String nodeName, String date)
+            throws IOException {
+        return getRegistryNode(id, nodeName, date, "someUUID");
     }
 
-    public static String getCswRegistryUpdate() throws IOException {
+    public static String getRegistryNode(String id, String nodeName, String date, String uuid)
+            throws IOException {
+        return getFileContent("/csw-rim-node.xml",
+                ImmutableMap.of("id",
+                        id,
+                        "nodeName",
+                        nodeName,
+                        "lastUpdated",
+                        date,
+                        "someUUID",
+                        uuid));
+    }
+
+    public static String getCswRegistryInsert(String id) throws IOException {
+        return Library.getCswInsert("rim:RegistryPackage", getRegistryNode(id));
+    }
+
+    public static String getCswRegistryUpdate(String id, String nodeName, String date, String uuid)
+            throws IOException {
         return "<csw:Transaction\n" + "    service=\"CSW\"\n" + "    version=\"2.0.2\"\n"
                 + "    verboseResponse=\"true\"\n"
                 + "    xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\">\n"
-                + "    <csw:Update typeName=\"rim:RegistryPackage\">\n" + getRegistryNode() + "\n"
-                + "    </csw:Update>\n" + "</csw:Transaction>";
+                + "    <csw:Update typeName=\"rim:RegistryPackage\">\n" + getRegistryNode(id,
+                nodeName,
+                date,
+                uuid) + "\n" + "    </csw:Update>\n" + "</csw:Transaction>";
     }
 
-    public static String getCswRegistryDelete() throws IOException {
+    public static String getCswRegistryDelete(String id) throws IOException {
         return "<csw:Transaction service=\"CSW\"\n"
                 + "   version=\"2.0.2\" xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
                 + "   xmlns:ogc=\"http://www.opengis.net/ogc\">\n"
@@ -206,7 +225,7 @@ public final class Library {
                 + "    <csw:Constraint version=\"2.0.0\">\n" + "      <ogc:Filter>\n"
                 + "        <ogc:PropertyIsEqualTo>\n"
                 + "            <ogc:PropertyName>registry-id</ogc:PropertyName>\n"
-                + "            <ogc:Literal>urn:uuid:2014ca7f59ac46f495e32b4a67a51276</ogc:Literal>\n"
+                + "            <ogc:Literal>" + id + "</ogc:Literal>\n"
                 + "        </ogc:PropertyIsEqualTo>\n" + "      </ogc:Filter>\n"
                 + "    </csw:Constraint>\n" + "  </csw:Delete>\n" + "</csw:Transaction>";
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/csw-query.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/csw-query.xml
@@ -1,0 +1,32 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<csw:GetRecords resultType="results" outputFormat="$outputFormat$"
+        $outputSchema$ startPosition="1" maxRecords="10"
+        service="CSW" version="2.0.2" xmlns:ns2="http://www.opengis.net/ogc"
+        xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+        >
+<ns10:Query typeNames="csw:Record" xmlns="" xmlns:ns10="http://www.opengis.net/cat/csw/2.0.2">
+<ns10:ElementSetName>full</ns10:ElementSetName>
+<ns10:Constraint version="1.1.0">
+    <ns2:Filter>
+        <ns2:PropertyIsLike wildCard="*" singleChar="#" escapeChar="!">
+            <ns2:PropertyName>$propertyName$</ns2:PropertyName>
+            <ns2:Literal>$literal$</ns2:Literal>
+        </ns2:PropertyIsLike>
+
+    </ns2:Filter>
+</ns10:Constraint>
+</ns10:Query>
+        </csw:GetRecords>

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/csw-rim-node.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/csw-rim-node.xml
@@ -19,14 +19,17 @@
      objects id should be a uuid that is globally unique-->
 <!-- top level registry object id is turned into the regsitry-id internally. metacard content type will be set using the lid.-->
 <!-- home attribute should be set by the framework to the base url of the originating instance -->
-<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+<rim:RegistryPackage id="$id$" home="https://somehost:someport"
+                     objectType="urn:registry:federation:node"
                      xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
                      xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
                      xmlns:gml="http://www.opengis.net/gml">
 
     <!-- external identifiers are set by the framework to track the local metacard id and the origin-id. origin-id is the metacard id of the registry entry on the originating instance-->
-    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
-    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="$id$"
+                            identificationScheme="MetacardId" value="$someUUID$"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="$id$"
+                            identificationScheme="MetacardId" value="$someUUID$"/>
 
     <!-- RegistryObjectList holds all the actual registry content-->
     <rim:RegistryObjectList>
@@ -53,7 +56,7 @@
             <!-- Date this entries data was last updated/created by its originator -->
             <rim:Slot name="lastUpdated" slotType="xs:dateTime">
                 <rim:ValueList>
-                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                    <rim:Value>$lastUpdated$</rim:Value>
                 </rim:ValueList>
             </rim:Slot>
             <!--Optional: Any links that might be associated with this instance like wiki pages -->
@@ -73,7 +76,8 @@
                 </wrs:ValueList>
             </rim:Slot>
             <!--Optional: Region of this instance described by a UNSD region. The location should be within this region -->
-            <rim:Slot name="region" slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+            <rim:Slot name="region"
+                      slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
                 <rim:ValueList>
                     <rim:Value>USA</rim:Value>
                 </rim:ValueList>
@@ -102,16 +106,18 @@
 
             <!-- Name used primarily for display in UI interfaces to uniquely identify this node -->
             <rim:Name>
-                <rim:LocalizedString value="Node Name"/>
+                <rim:LocalizedString value="$nodeName$"/>
             </rim:Name>
             <rim:Description>
-                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+                <rim:LocalizedString
+                        value="A little something describing this node in less than 1024 characters"/>
             </rim:Description>
             <rim:VersionInfo versionName="2.9.x"/>
         </rim:ExtrinsicObject>
 
         <!-- all extrinsic objects with lid=urn:registry:content:collection will be used to create content collections -->
-        <rim:ExtrinsicObject id="urn:content:collection:id0" objectType="urn:registry:content:collection">
+        <rim:ExtrinsicObject id="urn:content:collection:id0"
+                             objectType="urn:registry:content:collection">
 
             <rim:Slot name="types" slotType="xs:string">
                 <rim:ValueList>
@@ -146,7 +152,7 @@
             </rim:Slot>
             <rim:Slot name="lastUpdated" slotType="xs:dateTime">
                 <rim:ValueList>
-                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                    <rim:Value>$lastUpdated$</rim:Value>
                 </rim:ValueList>
             </rim:Slot>
             <!--Optional: A gml feature describing the geographic bounds of the data contained in this collection-->
@@ -171,11 +177,13 @@
                 <rim:LocalizedString value="Collection Name"/>
             </rim:Name>
             <rim:Description>
-                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+                <rim:LocalizedString
+                        value="A little something describing this collection in less than 1024 characters"/>
             </rim:Description>
         </rim:ExtrinsicObject>
 
-        <rim:ExtrinsicObject id="urn:content:collection:id1" objectType="urn:registry:content:collection">
+        <rim:ExtrinsicObject id="urn:content:collection:id1"
+                             objectType="urn:registry:content:collection">
             <rim:Slot name="types" slotType="xs:string">
                 <rim:ValueList>
                     <rim:Value>video</rim:Value>
@@ -207,14 +215,15 @@
             </rim:Slot>
             <rim:Slot name="lastUpdated" slotType="xs:dateTime">
                 <rim:ValueList>
-                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                    <rim:Value>$lastUpdated$</rim:Value>
                 </rim:ValueList>
             </rim:Slot>
             <rim:Name>
                 <rim:LocalizedString value="Collection Name2"/>
             </rim:Name>
             <rim:Description>
-                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+                <rim:LocalizedString
+                        value="A little something describing this collection in less than 1024 characters"/>
             </rim:Description>
         </rim:ExtrinsicObject>
 
@@ -272,7 +281,9 @@
                 <rim:VersionInfo versionName="2.0.2"/>
 
                 <!-- SpecificationLinks are also RegistryObjects so if needed slots can be added directly to them. If possible use an ExtrinsicObject instead.-->
-                <rim:SpecificationLink id="urn:request:parameters" serviceBinding="urn:registry:federation:method:csw" specificationObject="urn:service:params:id0"/>
+                <rim:SpecificationLink id="urn:request:parameters"
+                                       serviceBinding="urn:registry:federation:method:csw"
+                                       specificationObject="urn:service:params:id0"/>
             </rim:ServiceBinding>
             <rim:ServiceBinding id="urn:registry:federation:method:soap13"
                                 service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
@@ -320,7 +331,7 @@
         </rim:Service>
 
         <rim:Organization id="urn:organization:id0"
-                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276">
+                          parent="$id$">
             <rim:Name>
                 <rim:LocalizedString value="Codice"/>
             </rim:Name>
@@ -331,7 +342,7 @@
         </rim:Organization>
 
         <rim:Organization id="urn:organization:id1"
-                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276">
+                          parent="$id$">
             <rim:Name>
                 <rim:LocalizedString value="MyOrg"/>
             </rim:Name>
@@ -341,7 +352,7 @@
             <rim:EmailAddress address="emailaddress@something.com"/>
         </rim:Organization>
 
-        <rim:Person id="urn:contact:id0" >
+        <rim:Person id="urn:contact:id0">
             <rim:PersonName firstName="john" lastName="doe"/>
             <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234"/>
             <rim:EmailAddress address="emailaddress@something.com"/>
@@ -361,12 +372,21 @@
 
         <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
         with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
-        <rim:Association id="urn:assoication:1" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
-        <rim:Association id="urn:assoication:2" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:organization:id0"/>
-        <rim:Association id="urn:assoication:3" associationType="RelatedTo" sourceObject="urn:contact:person1" targetObject="urn:content:collection:id0"/>
-        <rim:Association id="urn:assoication:4" associationType="RelatedTo" sourceObject="urn:contact:person2" targetObject="urn:content:collection:id1"/>
-        <rim:Association id="urn:assoication:5" associationType="RelatedTo" sourceObject="urn:organization:id1" targetObject="urn:service:id0"/>
-        <rim:Association id="urn:assoication:6" associationType="RelatedTo" sourceObject="urn:organization:id0" targetObject="urn:content:collection:id0"/>
+        <rim:Association id="urn:assoication:1" associationType="RelatedTo"
+                         sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
+        <rim:Association id="urn:assoication:2" associationType="RelatedTo"
+                         sourceObject="urn:registry:node" targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:assoication:3" associationType="RelatedTo"
+                         sourceObject="urn:contact:person1"
+                         targetObject="urn:content:collection:id0"/>
+        <rim:Association id="urn:assoication:4" associationType="RelatedTo"
+                         sourceObject="urn:contact:person2"
+                         targetObject="urn:content:collection:id1"/>
+        <rim:Association id="urn:assoication:5" associationType="RelatedTo"
+                         sourceObject="urn:organization:id1" targetObject="urn:service:id0"/>
+        <rim:Association id="urn:assoication:6" associationType="RelatedTo"
+                         sourceObject="urn:organization:id0"
+                         targetObject="urn:content:collection:id0"/>
 
     </rim:RegistryObjectList>
 </rim:RegistryPackage>


### PR DESCRIPTION
#### What does this PR do?
Updated the registry itests to test the functionality of the `RegistryStore`(update, create, and delete) tested by calling upon methods within the `FederationAdminServiceImpl`. Also tests the functionality of the REST endpoint. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard 
@gordocanchola 
@vinamartin 
@brianfelix 
@mcalcote 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison 

#### How should this be tested?
Build and run itests
#### Any background context you want to provide?

- `FederationAdminService` is not declared globally because within the itest it loads at a different time causing a `ClassNotFoundException`
- The reasoning behind using `FederationAdminServiceImpl` within the itest is to test the functionality of the `RegistryStore`. Currently, there is not a REST endpoint that provides CUD operations with a destination which is required to test the `RegistryStore`, making the `RegistryStore` only reachable through `FederationAdminServiceImpl`
- The `try and catch` in the create, update, and deleteRegistryStore is set due to the lambda expression `org.codice.ddf.security.common.Security.runAsAdmin()`. 
 
#### What are the relevant tickets?
DDF-2146
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
