### PR TITLE
DDF-2175: Added field to indicate resource cache status

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -64,6 +64,7 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-localstorageprovider/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-standardframework/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-resourcestatusplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.security/catalog-security-logging/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-attribute/${project.version}</bundle>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -311,6 +311,12 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_CACHE_STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BOOLEAN_TYPE));
         return descriptors;
     }
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
@@ -237,6 +237,12 @@ public interface Metacard extends Serializable {
     String DERIVED_RESOURCE_DOWNLOAD_URL = "resource.derived-download-url";
 
     /**
+     * {@link Attribute} name for accessing the resources cache status for the products of this
+     * {@link Metacard}. <br/>
+     */
+    String RESOURCE_CACHE_STATUS = "resource.cached";
+
+    /**
      * Returns {@link Attribute} for given attribute name.
      *
      * @param name name of attribute

--- a/catalog/core/catalog-core-resourcestatusplugin/pom.xml
+++ b/catalog/core/catalog-core-resourcestatusplugin/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.catalog.core</groupId>
+        <artifactId>core</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>catalog-core-resourcestatusplugin</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Metacard Resource Status PostQuery Plugin</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-standardframework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>notifications</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>activities</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <!-- This should not be  embedding notifications: https://tools.codice.org/jira/browse/DDF-415-->
+                        <Embed-Dependency>
+                            notifications,
+                            activities,
+                            hazelcast;scope=runtime|compile,
+                            catalog-core-api-impl;scope=!test
+                        </Embed-Dependency>
+                        <Private-Package>
+                            ddf.catalog.cache.impl,
+                            ddf.catalog.core.resourcestatus.metacard,
+                            org.codice.ddf.platform.util
+                        </Private-Package>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.70</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-resourcestatusplugin/src/main/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatus.java
+++ b/catalog/core/catalog-core-resourcestatusplugin/src/main/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatus.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.resourcestatus.metacard;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.cache.ResourceCacheInterface;
+import ddf.catalog.cache.impl.CacheKey;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.impl.ResourceRequestById;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PostQueryPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.resource.data.ReliableResource;
+
+/**
+ * {@link PostQueryPlugin} that checks the {@link ddf.catalog.cache.impl.ResourceCache} for existence
+ * of each {@link Metacard}'s related {@link ddf.catalog.resource.Resource} and
+ * adds an {@link ddf.catalog.data.Attribute} to each {@link Metacard} in the {@link QueryResponse}.
+ */
+public class MetacardResourceStatus implements PostQueryPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetacardResourceStatus.class);
+
+    private ResourceCacheInterface cache;
+
+    public MetacardResourceStatus(ResourceCacheInterface cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public QueryResponse process(QueryResponse input)
+            throws PluginExecutionException, StopProcessingException {
+        List<Result> results = input.getResults();
+
+        results.stream()
+                .map(Result::getMetacard)
+                .filter(metacard -> metacard != null)
+                .forEach(this::addResourceCachedAttribute);
+
+        return input;
+    }
+
+    private void addResourceCachedAttribute(Metacard metacard) {
+        metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_CACHE_STATUS,
+                isResourceCached(metacard, new ResourceRequestById(metacard.getId()))));
+    }
+
+    private boolean isResourceCached(Metacard metacard, ResourceRequest resourceRequest) {
+        String key = getCacheKey(metacard, resourceRequest);
+
+        ReliableResource cachedResource = (ReliableResource) cache.getValid(key, metacard);
+        if (cachedResource != null) {
+            return true;
+        }
+        return false;
+    }
+
+    private String getCacheKey(Metacard metacard, ResourceRequest resourceRequest) {
+        CacheKey cacheKey = new CacheKey(metacard, resourceRequest);
+        return cacheKey.generateKey();
+    }
+}

--- a/catalog/core/catalog-core-resourcestatusplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-resourcestatusplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="metacardResourceStatus"
+          class="ddf.catalog.core.resourcestatus.metacard.MetacardResourceStatus">
+        <argument ref="resourceCache"/>
+    </bean>
+
+    <service ref="metacardResourceStatus" interface="ddf.catalog.plugin.PostQueryPlugin"/>
+    
+    <reference id="resourceCache" interface="ddf.catalog.cache.ResourceCacheInterface"/>
+
+</blueprint>

--- a/catalog/core/catalog-core-resourcestatusplugin/src/test/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatusTest.java
+++ b/catalog/core/catalog-core-resourcestatusplugin/src/test/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatusTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.resourcestatus.metacard;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import ddf.catalog.cache.ResourceCacheInterface;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.resource.data.ReliableResource;
+
+public class MetacardResourceStatusTest {
+
+    @Mock
+    private ResourceCacheInterface cache;
+    @Mock
+    private ReliableResource cachedResource;
+    @Mock
+    private QueryResponse queryResponse;
+    @Mock
+    private MetacardImpl basicMetacard;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testMetacardDisplaysCachedProduct() throws Exception {
+
+        setupCachedMock(getBasicMetacard());
+
+        MetacardResourceStatus plugin = new MetacardResourceStatus(cache);
+
+        Attribute resourceStatusAttribute = getReourceStatusAttribute(plugin.process(queryResponse));
+
+        assertThat(resourceStatusAttribute.getValue(), is(true));
+    }
+
+    @Test
+    public void testMetacardDisplaysNonCachedProduct() throws Exception {
+        setupNonCachedMock(getBasicMetacard());
+
+        MetacardResourceStatus plugin = new MetacardResourceStatus(cache);
+        QueryResponse queryResponse = plugin.process(this.queryResponse);
+
+        Attribute resourceStatusAttribute = getReourceStatusAttribute(plugin.process(queryResponse));
+
+        assertThat(resourceStatusAttribute.getValue(), is(false));
+    }
+
+    private MetacardImpl getBasicMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId("abc123");
+        metacard.setSourceId("ddf-1");
+        metacard.setResourceSize("N/A");
+
+        return metacard;
+    }
+
+    private void setupCachedMock(MetacardImpl metacard) {
+        when(cachedResource.getSize()).thenReturn(999L);
+        when(cachedResource.hasProduct()).thenReturn(true);
+        when(cache.getValid(anyString(), anyObject())).thenReturn(cachedResource);
+
+        setupSingleResultResponseMock(metacard);
+    }
+
+    private void setupNonCachedMock(MetacardImpl metacard) {
+
+        when(cachedResource.getSize()).thenReturn(0L);
+        when(cachedResource.hasProduct()).thenReturn(false);
+        when(cache.getValid(anyString(), anyObject())).thenReturn(null);
+
+        setupSingleResultResponseMock(metacard);
+    }
+
+    private void setupSingleResultResponseMock(MetacardImpl metacard) {
+        Result result = new ResultImpl(metacard);
+        List<Result> results = new ArrayList<>();
+        results.add(result);
+
+        when(queryResponse.getResults()).thenReturn(results);
+    }
+
+    private Attribute getReourceStatusAttribute(QueryResponse queryResponse) {
+        Metacard resultMetacard = queryResponse.getResults()
+                .get(0)
+                .getMetacard();
+        return resultMetacard.getAttribute(Metacard.RESOURCE_CACHE_STATUS);
+    }
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -116,6 +116,7 @@
         <module>catalog-core-validationparser</module>
         <module>catalog-core-attribute-registry</module>
         <module>catalog-core-defaultvalues</module>
+        <module>catalog-core-resourcestatusplugin</module>
         <module>catalog-core-ftp</module>
     </modules>
 </project>

--- a/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
@@ -831,6 +831,12 @@ The response is returned as a data map that contains an internal map with the fo
 |GeoJson-formatted value
 |This format is defined by the GeoJSON Metacard Transformer.
 
+|results/metacard/properties/resource.cached
+|A property indicating whether a metacard's associated resource is cached
+|Boolean
+|true, false
+|true, false
+
 |results/metacard/actions
 |An array of actions that applies to each metacard, injected into each metacard
 |Array of Maps
@@ -847,6 +853,7 @@ The response is returned as a data map that contains an internal map with the fo
 |Specifies the state of the query
 |String
 |SUCCEEDED, FAILED, ACTIVE
+|
 
 |status.elapsed
 |Time in milliseconds that it took for the source to complete the request

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -957,6 +957,50 @@ public class TestCatalog extends AbstractIntegrationTest {
         deleteMetacard(metacardId);
     }
 
+    @Test
+    public void testGetMetacardResourceStatusNotCached()
+            throws IOException, XPathExpressionException {
+        String fileName = testName.getMethodName() + ".txt";
+        String metacardId = ingestXmlWithProduct(fileName);
+
+        String productDirectory = new File(fileName).getAbsoluteFile()
+                .getParent();
+        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
+                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
+
+        String url = REST_PATH.getUrl() + "sources/ddf.distribution/" + metacardId;
+        String resourceCachedXpath = String.format("//*[@name='%s']/*/text()", Metacard.RESOURCE_CACHE_STATUS);
+
+        get(url).
+                then().
+                body(hasXPath(resourceCachedXpath, is("false")));
+
+        deleteMetacard(metacardId);
+    }
+
+    @Test
+    public void testGetMetacardResourceStatusCached()
+            throws IOException, XPathExpressionException {
+        String fileName = testName.getMethodName() + ".txt";
+        String metacardId = ingestXmlWithProduct(fileName);
+
+        String productDirectory = new File(fileName).getAbsoluteFile()
+                .getParent();
+        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
+                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
+
+        String url = REST_PATH.getUrl() + "sources/ddf.distribution/" + metacardId;
+        String resourceCachedXpath = String.format("//*[@name='%s']/*/text()", Metacard.RESOURCE_CACHE_STATUS);
+
+        get(url + "?transform=resource").then();
+
+        get(url).
+            then().
+                body(hasXPath(resourceCachedXpath, is("true")));
+
+        deleteMetacard(metacardId);
+    }
+
     private void verifyGetRecordByIdResponse(final ValidatableResponse response,
             final String... ids) {
         final String xPathGetRecordWithId = "//GetRecordByIdResponse/Record[identifier=\"%s\"]";


### PR DESCRIPTION
#### What does this PR do?

* Adds a field to each `Metacard` to allow for indicating the cache status of a related resource
* Adds a `PostQueryPlugin` to check the resource cache for resources related to each `Metacard`

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@lessarderic 
@garrettfreibott 
@Lambeaux 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@figliold 
@shaundmorris 

#### How should this be tested?

1. Upload a resource to the DDF
2. run `catalog:inspect <id>` and verify `resource.cache-status` is `false`
3. trigger retrieval of the resource
4. run `catalog:inspect <id>` and verify that `resource.cache-status` is now set to `true`

#### Any background context you want to provide?
#### What are the relevant tickets?

[DDF-2175](https://codice.atlassian.net/browse/DDF-2175)

#### Screenshots (if appropriate)
#### Checklist:
- [x] Changed from a feature to a bundle
- [ ] Simplified maven-bundle-plugin imports/embeds
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
