### PR TITLE
DDF-2165 Create registry action provider for publishing/unpublishing

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -29,6 +29,7 @@
         <abdera.version>1.1.3</abdera.version>
         <commons-beanutils.version>1.9.2</commons-beanutils.version>
         <commons-weaver-privilizer-api.version>1.1</commons-weaver-privilizer-api.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <cglib.version>3.2.0</cglib.version>
         <logkit.version>1.0.1</logkit.version>
@@ -420,6 +421,11 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>ddf.platform.solr</groupId>

--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -108,6 +108,11 @@
             </dependency>
             <dependency>
                 <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-publication-action-provider</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
                 <artifactId>registry-report-viewer</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -179,6 +184,7 @@
         <module>registry-admin-modules</module>
         <module>registry-publication-update-handler</module>
         <module>registry-report-action-provider</module>
+        <module>registry-publication-action-provider</module>
         <module>registry-report-viewer</module>
         <module>registry-source-configuration-handler</module>
     </modules>

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -85,6 +85,10 @@
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-publication-action-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-report-viewer</artifactId>
         </dependency>
         <dependency>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -46,6 +46,7 @@
     <bundle>mvn:org.codice.ddf.registry/registry-source-configuration-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-publication-update-handler/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-action-provider/${project.version}</bundle>
+    <bundle>mvn:org.codice.ddf.registry/registry-publication-action-provider/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-report-viewer/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-admin-local-ui/${project.version}</bundle>
     <bundle>mvn:org.codice.ddf.registry/registry-admin-remote-ui/${project.version}</bundle>

--- a/catalog/spatial/registry/registry-publication-action-provider/pom.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>registry</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>registry-publication-action-provider</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Registry :: Publication :: Action Provider</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                        <Embed-Dependency>common-system,commons-lang3</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.94</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.94</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-publication-action-provider/pom.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>ddf.lib</groupId>

--- a/catalog/spatial/registry/registry-publication-action-provider/pom.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>common-system</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,7 +85,16 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package/>
-                        <Embed-Dependency>common-system,commons-lang3</Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util.http,
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                        <Embed-Dependency>
+                            common-system,
+                            commons-lang3,
+                            ddf-security-common
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
@@ -111,13 +111,10 @@ public class RegistryPublicationActionProvider implements ActionProvider, EventH
                 continue;
             }
 
-            if (currentPublications.contains(registry.getId())) {
-                CollectionUtils.addIgnoreNull(actions,
-                        getAction(registryId, registry.getId(), false));
-            } else {
-                CollectionUtils.addIgnoreNull(actions,
-                        getAction(registryId, registry.getId(), true));
-            }
+            CollectionUtils.addIgnoreNull(actions,
+                    getAction(registryId,
+                            registry.getId(),
+                            !currentPublications.contains(registry.getId())));
         }
 
         return actions;

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication.action.provider;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.action.Action;
+import ddf.action.ActionProvider;
+import ddf.action.impl.ActionImpl;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.source.Source;
+
+public class RegistryPublicationActionProvider implements ActionProvider, EventHandler {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RegistryPublicationActionProvider.class);
+
+    private static final String REGISTRY_PATH = "/registries";
+
+    private static final String PUBLICATION_PATH = "publication";
+
+    private static final String PUBLISH_DESCRIPTION = "Publishes this nodes information to ";
+
+    private static final String PUBLISH_OPERATION = "publish";
+
+    private static final String PUBLISH_TITLE = "Publish to ";
+
+    private static final String UNPUBLISH_DESCRIPTION = "Unpublishes this nodes information from ";
+
+    private static final String UNPUBLISH_OPERATION = "unpublish";
+
+    private static final String UNPUBLISH_TITLE = "Unpublish from ";
+
+    private static final String HTTP_POST = "HTTP_POST";
+
+    private static final String HTTP_DELETE = "HTTP_DELETE";
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String CREATED_TOPIC = "ddf/catalog/event/CREATED";
+
+    private static final String UPDATED_TOPIC = "ddf/catalog/event/UPDATED";
+
+    private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
+
+    private String providerId;
+
+    private ConfigurationAdmin configAdmin;
+
+    private FederationAdminService federationAdminService;
+
+    private List<RegistryStore> registryStores;
+
+    private Map<String, List<String>> publications = new HashMap<>();
+
+    @Override
+    public <T> List<Action> getActions(T subject) {
+        String registryId = getRegistryId(subject);
+        if (registryId == null) {
+            return Collections.emptyList();
+        }
+        List<Action> actions = new ArrayList<>();
+        List<String> currentPublications = publications.get(registryId);
+
+        for (RegistryStore registry : registryStores) {
+            //can't publish to yourself
+            if (!registry.isPushAllowed() || StringUtils.isBlank(registry.getRegistryId()) || registryId.equals(registry.getRegistryId())) {
+                continue;
+            }
+
+            if (currentPublications.contains(registry.getId())) {
+                actions.add(getAction(registryId, registry.getId(), false));
+            } else {
+                actions.add(getAction(registryId, registry.getId(), true));
+            }
+        }
+
+        return actions;
+    }
+
+    @Override
+    public String getId() {
+        return providerId;
+    }
+
+    @Override
+    public <T> boolean canHandle(T subject) {
+        return getRegistryId(subject) != null;
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        if (mcard == null || !mcard.getTags()
+                .contains(RegistryConstants.REGISTRY_TAG)) {
+            return;
+        }
+
+        String registryId = mcard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                .getValue()
+                .toString();
+        Attribute locationAttribute =
+                mcard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        List<String> locations = new ArrayList<>();
+        if (locationAttribute != null) {
+            locations = locationAttribute.getValues()
+                    .stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+        if (event.getTopic()
+                .equals(CREATED_TOPIC) || event.getTopic()
+                .equals(UPDATED_TOPIC)) {
+            publications.put(registryId, locations);
+        } else if (event.getTopic()
+                .equals(DELETED_TOPIC)) {
+            publications.remove(registryId);
+        }
+    }
+
+    public void init() throws FederationAdminException {
+        List<Metacard> metacards = federationAdminService.getRegistryMetacards();
+        for (Metacard mcard : metacards) {
+            Attribute locations =
+                    mcard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+            if (locations != null) {
+                publications.put(mcard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                                .getValue()
+                                .toString(),
+                        locations.getValues()
+                                .stream()
+                                .map(Object::toString)
+                                .collect(Collectors.toList()));
+            } else {
+                publications.put(mcard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                        .getValue()
+                        .toString(), new ArrayList<>());
+            }
+        }
+    }
+
+    private Action getAction(String regId, String destinationId, boolean publish) {
+
+        URL url;
+        String title = publish ? PUBLISH_TITLE + destinationId : UNPUBLISH_TITLE + destinationId;
+        String description = publish ?
+                PUBLISH_DESCRIPTION + destinationId :
+                UNPUBLISH_DESCRIPTION + destinationId;
+        String operation = publish ? PUBLISH_OPERATION : UNPUBLISH_OPERATION;
+        String httpOp = publish ? HTTP_POST : HTTP_DELETE;
+        try {
+
+            String path = String.format("%s/%s/%s/%s",
+                    REGISTRY_PATH,
+                    regId,
+                    PUBLICATION_PATH,
+                    URLEncoder.encode(destinationId, "UTF-8"));
+            URI uri = new URI(SystemBaseUrl.constructUrl(path, true));
+            url = uri.toURL();
+
+        } catch (MalformedURLException | URISyntaxException | UnsupportedEncodingException e) {
+            LOGGER.error("Malformed URL exception", e);
+            return null;
+        }
+        String id = String.format("%s.%s.%s", getId(), operation, httpOp);
+        return new ActionImpl(id, title, description, url);
+    }
+
+    private <T> String getRegistryId(T subject) {
+        if (subject instanceof Metacard) {
+            Metacard mcard = (Metacard) subject;
+            if (!mcard.getTags()
+                    .contains(RegistryConstants.REGISTRY_TAG)) {
+                return null;
+            }
+            return ((Metacard) subject).getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                    .getValue()
+                    .toString();
+        } else if (subject instanceof Source) {
+            try {
+                Configuration[] configurations = configAdmin.listConfigurations(String.format(
+                        "(id=%s)",
+                        ((Source) subject).getId()));
+                return (String) Arrays.stream(configurations)
+                        .map(Configuration::getProperties)
+                        .map(p -> p.get(RegistryObjectMetacardType.REGISTRY_ID))
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
+
+            } catch (IOException | InvalidSyntaxException e) {
+                LOGGER.warn("Couldn't get configuration for {}", ((Source) subject).getId(), e);
+            }
+        } else if (subject instanceof Configuration) {
+            return (String) ((Configuration) subject).getProperties()
+                    .get(RegistryObjectMetacardType.REGISTRY_ID);
+        }
+        return null;
+    }
+
+    public void setProviderId(String id) {
+        this.providerId = id;
+    }
+
+    public void setConfigAdmin(ConfigurationAdmin admin) {
+        this.configAdmin = admin;
+    }
+
+    public void setRegistryStores(List<RegistryStore> registryStores) {
+        this.registryStores = registryStores;
+    }
+
+    public void setFederationAdminService(FederationAdminService adminService) {
+        this.federationAdminService = adminService;
+    }
+
+    public Map<String, List<String>> getPublications() {
+        return publications;
+    }
+}

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication.manager;
+
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.security.auth.Subject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.karaf.jaas.boot.principal.RolePrincipal;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+
+public class RegistryPublicationManager implements EventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryPublicationManager.class);
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String CREATED_TOPIC = "ddf/catalog/event/CREATED";
+
+    private static final String UPDATED_TOPIC = "ddf/catalog/event/UPDATED";
+
+    private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
+
+    private static final java.lang.String KARAF_LOCAL_ROLES = "karaf.local.roles";
+
+    private Map<String, List<String>> publications = new ConcurrentHashMap<>();
+
+    private FederationAdminService federationAdminService;
+
+    @Override
+    public void handleEvent(Event event) {
+        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        if (mcard == null || !mcard.getTags()
+                .contains(RegistryConstants.REGISTRY_TAG)) {
+            return;
+        }
+
+        Attribute registryIdAttribute = mcard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID);
+        if (registryIdAttribute == null || StringUtils.isBlank(registryIdAttribute.getValue()
+                .toString())) {
+            return;
+        }
+        String registryId = registryIdAttribute.getValue()
+                .toString();
+
+        Attribute locationAttribute =
+                mcard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        List<String> locations = new ArrayList<>();
+        if (locationAttribute != null) {
+            locations = locationAttribute.getValues()
+                    .stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+        if (event.getTopic()
+                .equals(CREATED_TOPIC) || event.getTopic()
+                .equals(UPDATED_TOPIC)) {
+            publications.put(registryId, locations);
+        } else if (event.getTopic()
+                .equals(DELETED_TOPIC)) {
+            publications.remove(registryId);
+        }
+    }
+
+    public void init() throws FederationAdminException, PrivilegedActionException {
+
+        // Change from here
+        // Remove this subject stuff and change to use Security.runAsAdmin() once the PrivilegedException option has been implemented
+        Set<Principal> principals = new HashSet<>();
+        String localRoles = System.getProperty(KARAF_LOCAL_ROLES, "");
+        for (String role : localRoles.split(",")) {
+            principals.add(new RolePrincipal(role));
+        }
+        Subject subject = new Subject(true, principals, new HashSet(), new HashSet());
+
+        PrivilegedExceptionAction<List<Metacard>> federationAdminServiceAction =
+                () -> federationAdminService.getRegistryMetacards();
+        List<Metacard> metacards = subject.doAs(subject, federationAdminServiceAction);
+        // To here
+
+        for (Metacard metacard : metacards) {
+            Attribute registryIdAttribute =
+                    metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID);
+            if (registryIdAttribute == null || StringUtils.isBlank(registryIdAttribute.getValue()
+                    .toString())) {
+                LOGGER.warn("Warning metacard (id: {}} did not contain a registry id.",
+                        metacard.getId());
+                continue;
+            }
+            Attribute locations =
+                    metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+
+            String registryId = registryIdAttribute.getValue()
+                    .toString();
+            if (locations != null) {
+                publications.put(registryId,
+                        locations.getValues()
+                                .stream()
+                                .map(Object::toString)
+                                .collect(Collectors.toList()));
+            } else {
+                publications.put(registryId, Collections.emptyList());
+            }
+        }
+    }
+
+    public Map<String, List<String>> getPublications() {
+        return Collections.unmodifiableMap(publications);
+    }
+
+    public void setFederationAdminService(FederationAdminService adminService) {
+        this.federationAdminService = adminService;
+    }
+}

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
@@ -87,7 +87,7 @@ public class RegistryPublicationManager implements EventHandler {
         if (event.getTopic()
                 .equals(CREATED_TOPIC) || event.getTopic()
                 .equals(UPDATED_TOPIC)) {
-            publications.put(registryId, locations);
+            publications.put(registryId, Collections.unmodifiableList(locations));
         } else if (event.getTopic()
                 .equals(DELETED_TOPIC)) {
             publications.remove(registryId);
@@ -126,10 +126,10 @@ public class RegistryPublicationManager implements EventHandler {
                     .toString();
             if (locations != null) {
                 publications.put(registryId,
-                        locations.getValues()
+                        Collections.unmodifiableList(locations.getValues()
                                 .stream()
                                 .map(Object::toString)
-                                .collect(Collectors.toList()));
+                                .collect(Collectors.toList())));
             } else {
                 publications.put(registryId, Collections.emptyList());
             }

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <reference id="federationAdminService"
+               interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+
+    <reference-list id="registryStores" interface="org.codice.ddf.registry.api.RegistryStore" availability="optional"/>
+
+    <bean id="registryActionProvider"
+          class="org.codice.ddf.registry.publication.action.provider.RegistryPublicationActionProvider" init-method="init">
+        <property name="providerId" value="catalog.source.operation.publication.registry"/>
+        <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="configAdmin" ref="configurationAdmin"/>
+        <property name="registryStores" ref="registryStores"/>
+    </bean>
+
+    <service ref="registryActionProvider" interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.source.operation.publication.registry"/>
+        </service-properties>
+    </service>
+
+    <service ref="registryActionProvider" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>ddf/catalog/event/CREATED</value>
+                    <value>ddf/catalog/event/UPDATED</value>
+                    <value>ddf/catalog/event/DELETED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,11 +22,15 @@
     <reference-list id="registryStores" interface="org.codice.ddf.registry.api.RegistryStore" availability="optional"/>
 
     <bean id="registryActionProvider"
-          class="org.codice.ddf.registry.publication.action.provider.RegistryPublicationActionProvider" init-method="init">
+          class="org.codice.ddf.registry.publication.action.provider.RegistryPublicationActionProvider">
+        <property name="registryPublicationManager" ref="registryPublicationManager"/>
         <property name="providerId" value="catalog.source.operation.publication.registry"/>
-        <property name="federationAdminService" ref="federationAdminService"/>
         <property name="configAdmin" ref="configurationAdmin"/>
         <property name="registryStores" ref="registryStores"/>
+    </bean>
+
+    <bean id="registryPublicationManager" class="org.codice.ddf.registry.publication.manager.RegistryPublicationManager" init-method="init">
+        <property name="federationAdminService" ref="federationAdminService"/>
     </bean>
 
     <service ref="registryActionProvider" interface="ddf.action.ActionProvider">
@@ -35,7 +39,7 @@
         </service-properties>
     </service>
 
-    <service ref="registryActionProvider" interface="org.osgi.service.event.EventHandler">
+    <service ref="registryPublicationManager" interface="org.osgi.service.event.EventHandler">
         <service-properties>
             <entry key="event.topics">
                 <array value-type="java.lang.String">

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication.action.provider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.Event;
+
+import ddf.action.Action;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.source.Source;
+
+public class RegistryPublicationActionProviderTest {
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String CREATED_TOPIC = "ddf/catalog/event/CREATED";
+
+    private static final String UPDATED_TOPIC = "ddf/catalog/event/UPDATED";
+
+    private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
+
+    private ConfigurationAdmin configAdmin;
+
+    private Configuration configuration;
+
+    private Source source;
+
+    private FederationAdminService federationAdmin;
+
+    private RegistryStore store;
+
+    private RegistryPublicationActionProvider publicationActionProvider;
+
+    @Before
+    public void setup() throws Exception {
+        configAdmin = mock(ConfigurationAdmin.class);
+        federationAdmin = mock(FederationAdminService.class);
+        configuration = mock(Configuration.class);
+        source = mock(Source.class);
+        store = mock(RegistryStore.class);
+
+        publicationActionProvider = new RegistryPublicationActionProvider();
+        publicationActionProvider.setConfigAdmin(configAdmin);
+        publicationActionProvider.setFederationAdminService(federationAdmin);
+        publicationActionProvider.setProviderId("catalog.source.operation.registry");
+        publicationActionProvider.setRegistryStores(Collections.singletonList(store));
+
+        when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {
+                configuration});
+
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        Metacard mcard1 = getRegistryMetacard("regId1");
+        Metacard mcard2 = getRegistryMetacard("regId2");
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        mcard1.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                locations));
+        List<Metacard> metacardList = new ArrayList<>();
+        metacardList.add(mcard1);
+        metacardList.add(mcard2);
+        when(federationAdmin.getRegistryMetacards()).thenReturn(metacardList);
+
+        publicationActionProvider.init();
+
+        Map<String, List<String>> publications = publicationActionProvider.getPublications();
+        assertThat(publications.size(), is(2));
+        assertThat(publications.get("regId1"), equalTo(locations));
+        assertThat(publications.get("regId2")
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventNonRegistryMcard() throws Exception {
+        Metacard mcard = new MetacardImpl();
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventNoMcard() throws Exception {
+
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventCreate() throws Exception {
+        Event event = getRegistryEvent(CREATED_TOPIC);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventCreateExistingPublications() throws Exception {
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        Event event = getRegistryEvent(CREATED_TOPIC, locations);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(1));
+        assertThat(publicationActionProvider.getPublications()
+                .get("regId1")
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventUpdate() throws Exception {
+        Event event = getRegistryEvent(UPDATED_TOPIC);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventDelete() throws Exception {
+        publicationActionProvider.handleEvent(getRegistryEvent(CREATED_TOPIC));
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(1));
+        Event event = getRegistryEvent(DELETED_TOPIC);
+        publicationActionProvider.handleEvent(event);
+        assertThat(publicationActionProvider.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testCanHandleNull() throws Exception {
+        assertThat(publicationActionProvider.canHandle(null), is(false));
+    }
+
+    @Test
+    public void testCanHandleNonRegistryMetacard() throws Exception {
+        assertThat(publicationActionProvider.canHandle(new MetacardImpl()), is(false));
+    }
+
+    @Test
+    public void testCanHandleRegistryMetacard() throws Exception {
+        assertThat(publicationActionProvider.canHandle(getRegistryMetacard("regId1")), is(true));
+    }
+
+    @Test
+    public void testCanHandleNonRegistrySource() throws Exception {
+        when(source.getId()).thenReturn("someId");
+        Dictionary<String, Object> properties = new Hashtable<>();
+        when(configuration.getProperties()).thenReturn(properties);
+        assertThat(publicationActionProvider.canHandle(source), is(false));
+    }
+
+    @Test
+    public void testCanHandleRegistrySource() throws Exception {
+        when(source.getId()).thenReturn("regId1");
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(RegistryObjectMetacardType.REGISTRY_ID, "regId1");
+        when(configuration.getProperties()).thenReturn(properties);
+        assertThat(publicationActionProvider.canHandle(source), is(true));
+    }
+
+    @Test
+    public void testCanHandleNonRegistryConfig() throws Exception {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        when(configuration.getProperties()).thenReturn(properties);
+        assertThat(publicationActionProvider.canHandle(configuration), is(false));
+    }
+
+    @Test
+    public void testCanHandleRegistryConfig() throws Exception {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(RegistryObjectMetacardType.REGISTRY_ID, "regId1");
+        when(configuration.getProperties()).thenReturn(properties);
+        assertThat(publicationActionProvider.canHandle(configuration), is(true));
+    }
+
+    @Test
+    public void testGetActionMcardBadSubject() throws Exception {
+        List<Action> actions = publicationActionProvider.getActions(new MetacardImpl());
+        assertThat(actions.size(), is(0));
+    }
+
+    @Test
+    public void testGetActionMcardForSameRegistry() throws Exception {
+        when(store.isPushAllowed()).thenReturn(true);
+        when(store.getId()).thenReturn("store1");
+        when(store.getRegistryId()).thenReturn("regId1");
+        List<Action> actions = publicationActionProvider.getActions(getRegistryMetacard("regId1"));
+        assertThat(actions.size(), is(0));
+    }
+
+    @Test
+    public void testGetActionMcardForNoPushRegistry() throws Exception {
+        when(store.isPushAllowed()).thenReturn(false);
+        when(store.getId()).thenReturn("store1");
+        when(store.getRegistryId()).thenReturn("regId2");
+        List<Action> actions = publicationActionProvider.getActions(getRegistryMetacard("regId1"));
+        assertThat(actions.size(), is(0));
+    }
+
+    @Test
+    public void testGetActionMcardPublish() throws Exception {
+        when(store.isPushAllowed()).thenReturn(true);
+        when(store.getId()).thenReturn("store1");
+        when(store.getRegistryId()).thenReturn("regId2");
+        publicationActionProvider.getPublications()
+                .put("regId1", new ArrayList<>());
+        List<Action> actions = publicationActionProvider.getActions(getRegistryMetacard("regId1"));
+        assertThat(actions.size(), is(1));
+        assertThat(actions.get(0)
+                .getId(), equalTo("catalog.source.operation.registry.publish.HTTP_POST"));
+        assertThat(actions.get(0)
+                        .getUrl()
+                        .toString(),
+                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/store1", true)));
+    }
+
+    @Test
+    public void testGetActionMcardUnpublish() throws Exception {
+        when(store.isPushAllowed()).thenReturn(true);
+        when(store.getId()).thenReturn("store1");
+        when(store.getRegistryId()).thenReturn("regId2");
+        publicationActionProvider.getPublications()
+                .put("regId1", Collections.singletonList("store1"));
+        List<Action> actions = publicationActionProvider.getActions(getRegistryMetacard("regId1"));
+        assertThat(actions.size(), is(1));
+        assertThat(actions.get(0)
+                .getId(), equalTo("catalog.source.operation.registry.unpublish.HTTP_DELETE"));
+        assertThat(actions.get(0)
+                        .getUrl()
+                        .toString(),
+                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/store1", true)));
+    }
+
+    private Metacard getRegistryMetacard(String regId) {
+        MetacardImpl mcard = new MetacardImpl(new RegistryObjectMetacardType());
+        mcard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG));
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, regId);
+        return mcard;
+    }
+
+    private Event getRegistryEvent(String topic) {
+        return getRegistryEvent(topic, null);
+    }
+
+    private Event getRegistryEvent(String topic, ArrayList<String> locations) {
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Metacard mcard = getRegistryMetacard("regId1");
+        if (locations != null) {
+            mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                    locations));
+        }
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        return new Event(topic, eventProperties);
+    }
+
+}

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -35,6 +34,9 @@ import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.event.Event;
@@ -45,6 +47,7 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.source.Source;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RegistryPublicationActionProviderTest {
 
     private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
@@ -55,26 +58,25 @@ public class RegistryPublicationActionProviderTest {
 
     private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
 
+    @Mock
     private ConfigurationAdmin configAdmin;
 
+    @Mock
     private Configuration configuration;
 
+    @Mock
     private Source source;
 
+    @Mock
     private FederationAdminService federationAdmin;
 
+    @Mock
     private RegistryStore store;
 
     private RegistryPublicationActionProvider publicationActionProvider;
 
     @Before
     public void setup() throws Exception {
-        configAdmin = mock(ConfigurationAdmin.class);
-        federationAdmin = mock(FederationAdminService.class);
-        configuration = mock(Configuration.class);
-        source = mock(Source.class);
-        store = mock(RegistryStore.class);
-
         publicationActionProvider = new RegistryPublicationActionProvider();
         publicationActionProvider.setConfigAdmin(configAdmin);
         publicationActionProvider.setFederationAdminService(federationAdmin);

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManagerTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManagerTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.publication.manager;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.service.event.Event;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegistryPublicationManagerTest {
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String CREATED_TOPIC = "ddf/catalog/event/CREATED";
+
+    private static final String UPDATED_TOPIC = "ddf/catalog/event/UPDATED";
+
+    private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
+
+    @Mock
+    private FederationAdminService federationAdmin;
+
+    private RegistryPublicationManager publicationManager;
+
+    @Before
+    public void setup() throws Exception {
+        publicationManager = new RegistryPublicationManager();
+        publicationManager.setFederationAdminService(federationAdmin);
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        Metacard mcard1 = getRegistryMetacard("regId1");
+        Metacard mcard2 = getRegistryMetacard("regId2");
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        mcard1.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                locations));
+        List<Metacard> metacardList = new ArrayList<>();
+        metacardList.add(mcard1);
+        metacardList.add(mcard2);
+        when(federationAdmin.getRegistryMetacards()).thenReturn(metacardList);
+
+        publicationManager.init();
+
+        Map<String, List<String>> publications = publicationManager.getPublications();
+        assertThat(publications.size(), is(2));
+        assertThat(publications.get("regId1"), equalTo(locations));
+        assertThat(publications.get("regId2")
+                .size(), is(0));
+    }
+
+    @Test
+    public void testInitWithNullMetacard() throws Exception {
+        Metacard mcard1 = getRegistryMetacard("regId1");
+        Metacard mcard2 = getRegistryMetacard(null);
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        mcard1.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                locations));
+        List<Metacard> metacardList = new ArrayList<>();
+        metacardList.add(mcard1);
+        metacardList.add(mcard2);
+        when(federationAdmin.getRegistryMetacards()).thenReturn(metacardList);
+
+        publicationManager.init();
+
+        Map<String, List<String>> publications = publicationManager.getPublications();
+        assertThat(publications.size(), is(1));
+        assertThat(publications.get("regId1"), equalTo(locations));
+    }
+
+    @Test
+    public void testInitWithBlankMetacard() throws Exception {
+        Metacard mcard1 = getRegistryMetacard("regId1");
+        Metacard mcard2 = getRegistryMetacard(" ");
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        mcard1.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                locations));
+        List<Metacard> metacardList = new ArrayList<>();
+        metacardList.add(mcard1);
+        metacardList.add(mcard2);
+        when(federationAdmin.getRegistryMetacards()).thenReturn(metacardList);
+
+        publicationManager.init();
+
+        Map<String, List<String>> publications = publicationManager.getPublications();
+        assertThat(publications.size(), is(1));
+        assertThat(publications.get("regId1"), equalTo(locations));
+    }
+
+    @Test
+    public void testHandleEventNonRegistryMcard() throws Exception {
+        Metacard mcard = new MetacardImpl();
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventNoMcard() throws Exception {
+
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventNoRegistryId() throws Exception {
+        Metacard mcard = getRegistryMetacard(null);
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventBlankRegistryId() throws Exception {
+        Metacard mcard = getRegistryMetacard(" ");
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        Event event = new Event(CREATED_TOPIC, eventProperties);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(0));
+    }
+
+    @Test
+    public void testHandleEventCreate() throws Exception {
+        Event event = getRegistryEvent(CREATED_TOPIC);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventCreateExistingPublications() throws Exception {
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        Event event = getRegistryEvent(CREATED_TOPIC, locations);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(1));
+        assertThat(publicationManager.getPublications()
+                .get("regId1")
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventUpdate() throws Exception {
+        Event event = getRegistryEvent(UPDATED_TOPIC);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(1));
+    }
+
+    @Test
+    public void testHandleEventDelete() throws Exception {
+        publicationManager.handleEvent(getRegistryEvent(CREATED_TOPIC));
+        assertThat(publicationManager.getPublications()
+                .size(), is(1));
+        Event event = getRegistryEvent(DELETED_TOPIC);
+        publicationManager.handleEvent(event);
+        assertThat(publicationManager.getPublications()
+                .size(), is(0));
+    }
+
+    private Metacard getRegistryMetacard(String regId) {
+        MetacardImpl mcard = new MetacardImpl(new RegistryObjectMetacardType());
+        mcard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG));
+        if (StringUtils.isNotEmpty(regId)) {
+            mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, regId);
+        }
+        return mcard;
+    }
+
+    private Event getRegistryEvent(String topic) {
+        return getRegistryEvent(topic, null);
+    }
+
+    private Event getRegistryEvent(String topic, ArrayList<String> locations) {
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        Metacard mcard = getRegistryMetacard("regId1");
+        if (locations != null) {
+            mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                    locations));
+        }
+        eventProperties.put(METACARD_PROPERTY, mcard);
+        return new Event(topic, eventProperties);
+    }
+}

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManagerTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManagerTest.java
@@ -51,6 +51,8 @@ public class RegistryPublicationManagerTest {
 
     private static final String DELETED_TOPIC = "ddf/catalog/event/DELETED";
 
+    private static final String DEFAULT_REGISTRY_ID = "defaultRegistryId";
+
     @Mock
     private FederationAdminService federationAdmin;
 
@@ -184,8 +186,29 @@ public class RegistryPublicationManagerTest {
         assertThat(publicationManager.getPublications()
                 .size(), is(1));
         assertThat(publicationManager.getPublications()
-                .get("regId1")
+                .get(DEFAULT_REGISTRY_ID)
                 .size(), is(1));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetPublicationsMapNotModifiable() throws Exception {
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        Event event = getRegistryEvent(CREATED_TOPIC, locations);
+        publicationManager.handleEvent(event);
+        Map<String, List<String>> map = publicationManager.getPublications();
+        map.put("SomeKey", Collections.singletonList("ShouldNotWork"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetPublicationsMapValueListNotModifiable() throws Exception {
+        ArrayList<String> locations = new ArrayList<>();
+        locations.add("location1");
+        Event event = getRegistryEvent(CREATED_TOPIC, locations);
+        publicationManager.handleEvent(event);
+        Map<String, List<String>> map = publicationManager.getPublications();
+        List<String> unmodifiable = map.get(DEFAULT_REGISTRY_ID);
+        unmodifiable.add("ShouldNotWork");
     }
 
     @Test
@@ -222,7 +245,7 @@ public class RegistryPublicationManagerTest {
 
     private Event getRegistryEvent(String topic, ArrayList<String> locations) {
         Dictionary<String, Object> eventProperties = new Hashtable<>();
-        Metacard mcard = getRegistryMetacard("regId1");
+        Metacard mcard = getRegistryMetacard(DEFAULT_REGISTRY_ID);
         if (locations != null) {
             mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
                     locations));


### PR DESCRIPTION
#### What does this PR do?
  A new action provider is being added that returns a RESTful endpoint used for publishing/unpublishing a registry node.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @lessarderic 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@shaundmorris 
#### How should this be tested?
Verify the build
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2165
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Adding RegistryPublicationActionProvider
  Provides the action(RESTful endpoint) to publish/unpublish a registry entry to an external source