### PR TITLE
DDF-2182: Fixed waitForReady script to wait for 3 bundle fragments.

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/shell.init.script
+++ b/distribution/ddf-common/src/main/resources/etc/shell.init.script
@@ -33,7 +33,8 @@ service:get = { $.context getService ($.context getServiceReference $args) };
 lna = { bundle:list -t 0 | grep -v Active };
 waitForReady = {
  while { (la | grep -i "active.*DDF\s::\sadmin\s::\sUI" | tac) isEmpty } { echo -n ". "; sleep 1000 }
- while {("4" equals ((la | grep -i -v "active" | grep -i "hosts:" | wc -l | tac) trim) | tac) equals "false"} { echo -n ". "; sleep 1000 }
+ while {("3" equals ((la | grep -i -v "active" | grep -i "hosts:" | wc -l | tac) trim) | tac) equals "false"} { echo -n ". "; sleep 1000 }
  echo ""
  echo "System Ready"
 };
+wfr = { waitForReady };


### PR DESCRIPTION
#### What does this PR do?
Fixes the temporary crutch that is waitForReady (and aliases it to `wfr`)
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@vinamartin 
@tbatie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison
@coyotesqrl  😄 
