### PR TITLE
DDF-2185: Create new cache interface and deprecate ResourceCacheInterface

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -248,7 +248,9 @@
                             ddf.catalog.source.impl,
                             ddf.catalog.resource.download,
                             ddf.catalog.resource.impl,
-                            ddf.catalog.resourceretriever
+                            ddf.catalog.resourceretriever,
+                            org.codice.ddf.catalog.resource.cache,
+                            org.codice.ddf.catalog.resource.cache.impl
                         </Private-Package>
                         <Export-Package>
                             ddf.catalog.cache,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/ResourceCacheInterface.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/ResourceCacheInterface.java
@@ -20,8 +20,10 @@ import ddf.catalog.resource.data.ReliableResource;
 /**
  * Interface defining a cache of resources or references to resources.
  *
- * @author ddf.isgs@lmco.com
+ * @Deprecated As of version 2.10.0, this interface has been deprecated and will be removed in
+ * future versions of the product.
  */
+@Deprecated
 public interface ResourceCacheInterface {
 
     /**

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/ResourceCacheImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/ResourceCacheImpl.java
@@ -42,11 +42,11 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.resource.Resource;
 import ddf.catalog.resource.data.ReliableResource;
 
-public class ResourceCache implements ResourceCacheInterface {
+public class ResourceCacheImpl implements ResourceCacheInterface {
 
     private static final String KARAF_HOME = "karaf.home";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCache.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCacheImpl.class);
 
     private static final String PRODUCT_CACHE_NAME = "Product_Cache";
 
@@ -60,7 +60,7 @@ public class ResourceCache implements ResourceCacheInterface {
 
     private static final long DEFAULT_MAX_CACHE_DIR_SIZE_BYTES = 10737418240L;  //10 GB
 
-    private List<String> pendingCache = new ArrayList<String>();
+    private List<String> pendingCache = new ArrayList<>();
 
     /**
      * Directory for products cached to file system
@@ -71,8 +71,8 @@ public class ResourceCache implements ResourceCacheInterface {
 
     private IMap<Object, Object> cache;
 
-    private ProductCacheDirListener<Object, Object> cacheListener =
-            new ProductCacheDirListener<Object, Object>(DEFAULT_MAX_CACHE_DIR_SIZE_BYTES);
+    private ProductCacheDirListener<Object, Object> cacheListener = new ProductCacheDirListener<>(
+            DEFAULT_MAX_CACHE_DIR_SIZE_BYTES);
 
     private BundleContext context;
 
@@ -345,9 +345,7 @@ public class ResourceCache implements ResourceCacheInterface {
             return false;
         }
         ReliableResource cachedResource = (ReliableResource) cache.get(key);
-        return cachedResource != null ?
-                (validateCacheEntry(cachedResource, latestMetacard)) :
-                false;
+        return (cachedResource != null) && (validateCacheEntry(cachedResource, latestMetacard));
     }
 
     /**

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -74,7 +74,7 @@ import com.google.common.collect.Iterables;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.Constants;
 import ddf.catalog.cache.impl.CacheKey;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.content.StorageException;
 import ddf.catalog.content.StorageProvider;
 import ddf.catalog.content.data.ContentItem;
@@ -256,7 +256,7 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         this.fanoutEnabled = fanoutEnabled;
     }
 
-    void setProductCache(ResourceCache productCache) {
+    void setProductCache(ResourceCacheImpl productCache) {
         LOGGER.debug("Injecting productCache");
         frameworkProperties.setResourceCache(productCache);
     }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/FrameworkProperties.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/FrameworkProperties.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.osgi.framework.BundleContext;
 
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.cache.solr.impl.ValidationQueryFactory;
 import ddf.catalog.content.StorageProvider;
 import ddf.catalog.content.plugin.PostCreateStoragePlugin;
@@ -92,7 +92,7 @@ public class FrameworkProperties {
 
     private SourcePoller sourcePoller;
 
-    private ResourceCache resourceCache;
+    private ResourceCacheImpl resourceCache;
 
     private DownloadsStatusEventPublisher downloadsStatusEventPublisher;
 
@@ -255,11 +255,11 @@ public class FrameworkProperties {
         this.sourcePoller = sourcePoller;
     }
 
-    public ResourceCache getResourceCache() {
+    public ResourceCacheImpl getResourceCache() {
         return resourceCache;
     }
 
-    public void setResourceCache(ResourceCache resourceCache) {
+    public void setResourceCache(ResourceCacheImpl resourceCache) {
         this.resourceCache = resourceCache;
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/data/ReliableResource.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/data/ReliableResource.java
@@ -31,7 +31,7 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.resource.Resource;
 
 /**
- * The resource that will be stored in the @ResourceCache cache map.
+ * The resource that will be stored in the {@code ResourceCacheImpl} cache map.
  *
  */
 public class ReliableResource implements Resource, Serializable {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Stopwatch;
 
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
@@ -64,7 +64,7 @@ public class ReliableResourceDownloadManager {
 
     /**
      * @param resourceCache
-     *            reference to the @ResourceCache to cache the resource in
+     *            reference to the @ResourceCacheImpl to cache the resource in
      * @param eventPublisher
      *            reference to the publisher of status events as the download progresses
      * @param eventListener
@@ -72,7 +72,7 @@ public class ReliableResourceDownloadManager {
      * @param downloadStatusInfo
      *            reference to the {@link DownloadStatusInfo}
      */
-    public ReliableResourceDownloadManager(ResourceCache resourceCache,
+    public ReliableResourceDownloadManager(ResourceCacheImpl resourceCache,
             DownloadsStatusEventPublisher eventPublisher,
             DownloadsStatusEventListener eventListener, DownloadStatusInfo downloadStatusInfo,
             ExecutorService executor) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -39,7 +39,7 @@ import com.google.common.io.CountingOutputStream;
 import com.google.common.io.FileBackedOutputStream;
 
 import ddf.catalog.cache.impl.CacheKey;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
@@ -98,7 +98,7 @@ public class ReliableResourceDownloader implements Runnable {
 
     private DownloadsStatusEventListener eventListener;
 
-    private ResourceCache resourceCache;
+    private ResourceCacheImpl resourceCache;
 
     private DownloadsStatusEventPublisher eventPublisher;
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloaderConfig.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloaderConfig.java
@@ -13,7 +13,7 @@
  */
 package ddf.catalog.resource.download;
 
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventPublisher;
 
@@ -37,7 +37,7 @@ public class ReliableResourceDownloaderConfig {
 
     private boolean cacheWhenCanceled = false;
 
-    private ResourceCache resourceCache;
+    private ResourceCacheImpl resourceCache;
 
     private DownloadsStatusEventPublisher eventPublisher;
 
@@ -77,11 +77,11 @@ public class ReliableResourceDownloaderConfig {
         this.eventPublisher = eventPublisher;
     }
 
-    public ResourceCache getResourceCache() {
+    public ResourceCacheImpl getResourceCache() {
         return resourceCache;
     }
 
-    public void setResourceCache(ResourceCache resourceCache) {
+    public void setResourceCache(ResourceCacheImpl resourceCache) {
         this.resourceCache = resourceCache;
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/org/codice/ddf/catalog/resource/cache/ResourceCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/org/codice/ddf/catalog/resource/cache/ResourceCache.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.resource.cache;
+
+import java.util.Optional;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.resource.Resource;
+
+/**
+ * Interface that defines the operations related to the resource cache.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or
+ * be removed in the future.</b>
+ */
+public interface ResourceCache {
+
+    /**
+     * Gets the default resource associated with the {@link Metacard} provided.
+     *
+     * @param metacard metacard that corresponds to the resource that was requested
+     * @return resource associated with the {@link Metacard} provided, if any
+     */
+    Optional<Resource> get(Metacard metacard);
+
+    /**
+     * Gets a specific resource associated with the {@link Metacard} provided based on the
+     * attributes of the {@link ResourceRequest}.
+     *
+     * @param metacard        metacard that corresponds to the resource that was requested
+     * @param resourceRequest request object that was used to retrieve the resource. Will be used to
+     *                        determine the type of resource that will be returned.
+     * @return resource associated with the {@link Metacard} provided, if any
+     */
+    Optional<Resource> get(Metacard metacard, ResourceRequest resourceRequest);
+
+    /**
+     * Determines if the resource associated with the {@link Metacard} is present in the cache
+     *
+     * @param metacard metacard to use to find a matching resource
+     * @return {@code true} only if the default resource associated currently exists in the cache
+     */
+    boolean contains(Metacard metacard);
+
+    /**
+     * Determines if the resource associated with the {@link Metacard} is present in the cache
+     *
+     * @param metacard        metacard to use to find a matching resource
+     * @param resourceRequest request object that was used to retrieve the resource. Will be used to
+     *                        determine the type of resource to look up.
+     * @return {@code true} only if the resource of the given type associated currently exists in
+     * the cache
+     */
+    boolean contains(Metacard metacard, ResourceRequest resourceRequest);
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/org/codice/ddf/catalog/resource/cache/impl/ResourceCacheImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/org/codice/ddf/catalog/resource/cache/impl/ResourceCacheImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.resource.cache.impl;
+
+import java.util.Optional;
+
+import org.apache.commons.lang.Validate;
+import org.codice.ddf.catalog.resource.cache.ResourceCache;
+
+import ddf.catalog.cache.ResourceCacheInterface;
+import ddf.catalog.cache.impl.CacheKey;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.impl.ResourceRequestById;
+import ddf.catalog.resource.Resource;
+
+/**
+ * Metacard resource cache. Currently delegates to {@link ddf.catalog.cache.impl.ResourceCacheImpl}.
+ */
+public class ResourceCacheImpl implements ResourceCache {
+    private final ResourceCacheInterface delegate;
+
+    public ResourceCacheImpl(ResourceCacheInterface delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<Resource> get(Metacard metacard) {
+        Validate.notNull(metacard, "Metacard cannot be null");
+        return get(metacard, new ResourceRequestById(metacard.getId()));
+    }
+
+    @Override
+    public Optional<Resource> get(Metacard metacard, ResourceRequest resourceRequest) {
+        return Optional.ofNullable(delegate.getValid(new CacheKey(metacard,
+                resourceRequest).generateKey(), metacard));
+    }
+
+    @Override
+    public boolean contains(Metacard metacard) {
+        Validate.notNull(metacard, "Metacard cannot be null");
+        return contains(metacard, new ResourceRequestById(metacard.getId()));
+    }
+
+    @Override
+    public boolean contains(Metacard metacard, ResourceRequest resourceRequest) {
+        return delegate.containsValid(new CacheKey(metacard, resourceRequest).generateKey(),
+                metacard);
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -302,7 +302,8 @@
     <service ref="downloadStatusInfo"
              interface="ddf.catalog.event.retrievestatus.DownloadStatusInfo"/>
 
-    <bean id="productCache" class="ddf.catalog.cache.impl.ResourceCache" init-method="setupCache"
+    <bean id="deprecatedProductCache" class="ddf.catalog.cache.impl.ResourceCacheImpl"
+          init-method="setupCache"
           destroy-method="teardownCache">
         <property name="productCacheDirectory" value=""/>
         <property name="cacheDirMaxSizeMegabytes" value="10240"/>
@@ -311,12 +312,16 @@
         <property name="xmlConfigFilename" value="reliableResource-hazelcast.xml"/>
     </bean>
 
-    <service ref="productCache" interface="ddf.catalog.cache.ResourceCacheInterface"/>
+    <bean id="productCache" class="org.codice.ddf.catalog.resource.cache.impl.ResourceCacheImpl">
+        <argument ref="deprecatedProductCache"/>
+    </bean>
+
+    <service ref="deprecatedProductCache" interface="ddf.catalog.cache.ResourceCacheInterface"/>
 
     <bean id="reliableResourceDownloadManager"
           class="ddf.catalog.resource.download.ReliableResourceDownloadManager"
           init-method="init" destroy-method="cleanUp">
-        <argument ref="productCache"/>
+        <argument ref="deprecatedProductCache"/>
         <argument ref="retrieveStatusEventPublisher"/>
         <argument ref="retrieveStatusEventListener"/>
         <argument ref="downloadStatusInfo"/>
@@ -355,7 +360,7 @@
                 <property name="pool" ref="queryThreadPool"/>
                 <property name="queryResponsePostProcessor" ref="queryResponsePostProcessor"/>
                 <property name="sourcePoller" ref="sourcePoller"/>
-                <property name="resourceCache" ref="productCache"/>
+                <property name="resourceCache" ref="deprecatedProductCache"/>
                 <property name="downloadsStatusEventPublisher" ref="retrieveStatusEventPublisher"/>
                 <property name="reliableResourceDownloadManager"
                           ref="reliableResourceDownloadManager"/>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/ResourceCacheImplSizeLimitTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/ResourceCacheImplSizeLimitTest.java
@@ -40,16 +40,16 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import ddf.catalog.cache.impl.ProductCacheDirListener;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.resource.data.ReliableResource;
 
-public class ResourceCacheSizeLimitTest {
+public class ResourceCacheImplSizeLimitTest {
 
     private static final String PRODUCT_CACHE_NAME = "Product_Cache";
 
     private static final transient Logger LOGGER = LoggerFactory.getLogger(
-            ResourceCacheSizeLimitTest.class);
+            ResourceCacheImplSizeLimitTest.class);
 
     private static TestHazelcastInstanceFactory hcInstanceFactory;
 
@@ -62,7 +62,7 @@ public class ResourceCacheSizeLimitTest {
         String workingDir = System.getProperty("user.dir") + File.separator + "target";
         System.setProperty("karaf.home", workingDir);
         productCacheDir =
-                workingDir + File.separator + ResourceCache.DEFAULT_PRODUCT_CACHE_DIRECTORY;
+                workingDir + File.separator + ResourceCacheImpl.DEFAULT_PRODUCT_CACHE_DIRECTORY;
         hcInstanceFactory = new TestHazelcastInstanceFactory(10);
         listener = new ProductCacheDirListener<Object, Object>(15);
     }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.ResourceRequest;
@@ -66,10 +66,10 @@ public class DownloadsStatusEventListenerTest {
 
         testDownloadStatusInfo = new DownloadStatusInfoImpl();
         hcInstanceFactory = new TestHazelcastInstanceFactory(10);
-        ResourceCache testResourceCache = new ResourceCache();
+        ResourceCacheImpl testResourceCache = new ResourceCacheImpl();
         testResourceCache.setCache(hcInstanceFactory.newHazelcastInstance());
         productCacheDir = System.getProperty("user.dir") + "/target" + File.separator
-                + ResourceCache.DEFAULT_PRODUCT_CACHE_DIRECTORY;
+                + ResourceCacheImpl.DEFAULT_PRODUCT_CACHE_DIRECTORY;
         testResourceCache.setProductCacheDirectory(productCacheDir);
         DownloadsStatusEventPublisher testEventPublisher =
                 mock(DownloadsStatusEventPublisher.class);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -80,7 +80,7 @@ import com.google.common.io.ByteSource;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.Constants;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.cache.solr.impl.ValidationQueryFactory;
 import ddf.catalog.content.StorageProvider;
 import ddf.catalog.content.data.ContentItem;
@@ -869,7 +869,7 @@ public class CatalogFrameworkImplTest {
 
         String sourceId = "myId";
         resourceFramework.setId(sourceId);
-        ResourceCache resourceCache = mock(ResourceCache.class);
+        ResourceCacheImpl resourceCache = mock(ResourceCacheImpl.class);
         when(resourceCache.containsValid(isA(String.class), isA(Metacard.class))).thenReturn(false);
         //        ResourceResponse resourceResponseInCache = new ResourceResponseImpl(mockResource);
         //        when(resourceCache.put(isA(Metacard.class), isA(ResourceResponse.class),
@@ -2080,7 +2080,7 @@ public class CatalogFrameworkImplTest {
         List<ResourceReader> resourceReaders = new ArrayList<ResourceReader>();
         resourceReaders.add(resourceReader);
 
-        ResourceCache resourceCache = mock(ResourceCache.class);
+        ResourceCacheImpl resourceCache = mock(ResourceCacheImpl.class);
         Resource mockResource = mock(Resource.class);
         when(resourceCache.containsValid(isA(String.class), isA(Metacard.class))).thenReturn(true);
         when(resourceCache.getValid(isA(String.class),

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 
 import ddf.catalog.cache.MockInputStream;
 import ddf.catalog.cache.impl.CacheKey;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
@@ -109,7 +109,7 @@ public class ReliableResourceDownloadManagerTest {
         }
     };
 
-    private ResourceCache resourceCache;
+    private ResourceCacheImpl resourceCache;
 
     private DownloadsStatusEventPublisher eventPublisher;
 
@@ -145,7 +145,7 @@ public class ReliableResourceDownloadManagerTest {
 
     @Before
     public void setup() {
-        resourceCache = mock(ResourceCache.class);
+        resourceCache = mock(ResourceCacheImpl.class);
         when(resourceCache.getProductCacheDirectory()).thenReturn(productCacheDirectory);
         eventPublisher = mock(DownloadsStatusEventPublisher.class);
         eventListener = mock(DownloadsStatusEventListener.class);
@@ -269,7 +269,7 @@ public class ReliableResourceDownloadManagerTest {
 
         ByteArrayOutputStream clientBytesRead = clientRead(chunkSize, productInputStream);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         ArgumentCaptor<ReliableResource> argument = ArgumentCaptor.forClass(ReliableResource.class);
         verify(resourceCache).put(argument.capture());
 
@@ -308,7 +308,7 @@ public class ReliableResourceDownloadManagerTest {
         int clientChunkSize = 2;
         ByteArrayOutputStream clientBytesRead = clientRead(clientChunkSize, productInputStream);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         ArgumentCaptor<ReliableResource> argument = ArgumentCaptor.forClass(ReliableResource.class);
         verify(resourceCache).put(argument.capture());
 
@@ -369,7 +369,7 @@ public class ReliableResourceDownloadManagerTest {
 
         ByteArrayOutputStream clientBytesRead = clientRead(chunkSize, productInputStream);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         ArgumentCaptor<ReliableResource> argument = ArgumentCaptor.forClass(ReliableResource.class);
         verify(resourceCache).put(argument.capture());
 
@@ -403,7 +403,7 @@ public class ReliableResourceDownloadManagerTest {
 
         ByteArrayOutputStream clientBytesRead = clientRead(chunkSize, productInputStream);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         ArgumentCaptor<ReliableResource> argument = ArgumentCaptor.forClass(ReliableResource.class);
         verify(resourceCache).put(argument.capture());
 
@@ -439,7 +439,7 @@ public class ReliableResourceDownloadManagerTest {
         // of the product download
         clientRead(chunkSize, productInputStream, 2);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         ArgumentCaptor<ReliableResource> argument = ArgumentCaptor.forClass(ReliableResource.class);
         verify(resourceCache, timeout(3000)).put(argument.capture());
 
@@ -652,7 +652,7 @@ public class ReliableResourceDownloadManagerTest {
         // Verify client did not receive entire product download
         assertTrue(clientBytesRead.size() < expectedFileSize);
 
-        // Captures the ReliableResource object that should have been put in the ResourceCache's map
+        // Captures the ReliableResource object that should have been put in the ResourceCacheImpl's map
         verify(resourceCache, timeout(3000)).put(argument.capture());
 
         verifyCaching(argument.getValue(), EXPECTED_CACHE_KEY);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 import com.google.common.io.CountingOutputStream;
 
 import ddf.catalog.cache.MockInputStream;
-import ddf.catalog.cache.impl.ResourceCache;
+import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfoImpl;
@@ -130,7 +130,7 @@ public class ReliableResourceDownloaderTest {
 
         downloaderConfig.setCacheEnabled(true);
 
-        ResourceCache mockCache = mock(ResourceCache.class);
+        ResourceCacheImpl mockCache = mock(ResourceCacheImpl.class);
         when(mockCache.isPending(anyString())).thenReturn(false);
         when(mockCache.getProductCacheDirectory()).thenReturn(productCacheDirectory);
         downloaderConfig.setResourceCache(mockCache);
@@ -170,7 +170,7 @@ public class ReliableResourceDownloaderTest {
 
         downloaderConfig.setCacheEnabled(true);
 
-        ResourceCache mockCache = mock(ResourceCache.class);
+        ResourceCacheImpl mockCache = mock(ResourceCacheImpl.class);
         when(mockCache.isPending(anyString())).thenReturn(false);
         when(mockCache.getProductCacheDirectory()).thenReturn(productCacheDirectory);
         downloaderConfig.setResourceCache(mockCache);


### PR DESCRIPTION
#### What does this PR do?
Created new `org.codice.ddf.resource.cache.ResourceCache` interface, deprecated existing `ResourceCacheInterface`, added new interface to `ResourceCache` class with implementations that delegate to the existing code and wrote unit tests.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@figliold 
@Lambeaux 
@garrettfreibott 
@cmthom10 
@oconnormi 
@bantillo 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested?
Build and run integration tests

#### Any background context you want to provide?
See https://codice.atlassian.net/browse/DDF-2185

#### What are the relevant tickets?
See https://codice.atlassian.net/browse/DDF-2185

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests