### PR TITLE
DDF-2181 Create registry publication service

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImpl.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.registry.federationadmin.service.impl;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.federationadmin.service.RegistryPublicationService;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class RegistryPublicationServiceImpl implements RegistryPublicationService {
+
+    private FederationAdminService federationAdminService;
+
+    private List<RegistryStore> registryStores = new ArrayList<>();
+
+    @Override
+    public void publish(String registryId, String destinationRegistryId)
+            throws FederationAdminException {
+        Metacard metacard = getMetacard(registryId);
+        String metacardId = metacard.getId();
+
+        List<Serializable> locations = new ArrayList<>();
+        Attribute locAttr = metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        if (locAttr != null) {
+            locations = new HashSet<>(locAttr.getValues()).stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        if (locations.contains(destinationRegistryId)) {
+            return;
+        }
+
+        String sourceId = getSourceIdFromRegistryId(destinationRegistryId);
+
+        federationAdminService.addRegistryEntry(metacard, Collections.singleton(sourceId));
+
+        //need to reset the id since the framework reset it in the groomer plugin
+        //and we don't want to update with the wrong id
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        locations.add(destinationRegistryId);
+        if (locAttr != null) {
+            locAttr.getValues()
+                    .add(destinationRegistryId);
+        } else {
+            locAttr = new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, locations);
+        }
+        metacard.setAttribute(locAttr);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
+                Date.from(ZonedDateTime.now()
+                        .toInstant())));
+
+        federationAdminService.updateRegistryEntry(metacard);
+
+    }
+
+    @Override
+    public void unpublish(String registryId, String destinationRegistryId)
+            throws FederationAdminException {
+        Metacard metacard = getMetacard(registryId);
+
+        Attribute locAttr = metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        if (locAttr == null || !locAttr.getValues()
+                .contains(destinationRegistryId)) {
+            return;
+        }
+
+        String sourceId = getSourceIdFromRegistryId(destinationRegistryId);
+
+        federationAdminService.deleteRegistryEntriesByRegistryIds(Collections.singletonList(
+                registryId), Collections.singleton(sourceId));
+
+        locAttr.getValues()
+                .remove(destinationRegistryId);
+        metacard.setAttribute(locAttr);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
+                Date.from(ZonedDateTime.now()
+                        .toInstant())));
+
+        federationAdminService.updateRegistryEntry(metacard);
+    }
+
+    @Override
+    public void update(Metacard metacard) throws FederationAdminException {
+        Attribute publishedLocations =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        if (publishedLocations == null) {
+            return;
+        }
+
+        Set<String> locations = publishedLocations.getValues()
+                .stream()
+                .map(Object::toString)
+                .collect(Collectors.toCollection(HashSet::new));
+
+        if (CollectionUtils.isNotEmpty(locations)) {
+            federationAdminService.updateRegistryEntry(metacard, locations);
+            metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
+                    Date.from(ZonedDateTime.now()
+                            .toInstant())));
+            federationAdminService.updateRegistryEntry(metacard);
+        }
+    }
+
+    public void bindRegistryStore(ServiceReference serviceReference) {
+        BundleContext bundleContext = getBundleContext();
+
+        if (serviceReference != null && bundleContext != null) {
+            RegistryStore registryStore =
+                    (RegistryStore) bundleContext.getService(serviceReference);
+
+            registryStores.add(registryStore);
+        }
+    }
+
+    public void unbindRegistryStore(ServiceReference serviceReference) {
+        BundleContext bundleContext = getBundleContext();
+
+        if (serviceReference != null && bundleContext != null) {
+            RegistryStore registryStore =
+                    (RegistryStore) bundleContext.getService(serviceReference);
+
+            registryStores.remove(registryStore);
+        }
+    }
+
+    BundleContext getBundleContext() {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle != null) {
+            return bundle.getBundleContext();
+        }
+        return null;
+    }
+
+    private Metacard getMetacard(String registryId) throws FederationAdminException {
+        List<Metacard> metacards = federationAdminService.getRegistryMetacardsByRegistryIds(
+                Collections.singletonList(registryId));
+
+        if (CollectionUtils.isEmpty(metacards)) {
+            throw new FederationAdminException(
+                    "Could not retrieve metacard with registry-id " + registryId);
+        }
+
+        return metacards.get(0);
+    }
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+
+    private String getSourceIdFromRegistryId(String registryId) throws FederationAdminException {
+
+        for (RegistryStore registryStore : registryStores) {
+            if (registryStore.getRegistryId()
+                    .equals(registryId)) {
+                if (StringUtils.isNotBlank(registryStore.getId())) {
+                    return registryStore.getId();
+                }
+            }
+        }
+
+        throw new FederationAdminException(
+                "Could not find a source id for registry-id " + registryId);
+    }
+
+}

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -46,8 +46,23 @@
     </reference-list>
 
 
+    <bean id="registryPublicationService"
+          class="org.codice.ddf.registry.federationadmin.service.impl.RegistryPublicationServiceImpl">
+        <property name="federationAdminService" ref="federationAdminService"/>
+    </bean>
+
+    <reference-list id="registryPublicationServiceRegistryStore" interface="org.codice.ddf.registry.api.RegistryStore"
+                    availability="optional">
+        <reference-listener bind-method="bindRegistryStore" unbind-method="unbindRegistryStore"
+                            ref="registryPublicationService"/>
+    </reference-list>
+
+
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
+
+    <service ref="registryPublicationService"
+             interface="org.codice.ddf.registry.federationadmin.service.RegistryPublicationService"/>
 
     <service ref="federationAdminService"
              interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -319,14 +319,20 @@ public class FederationAdminServiceImplTest {
     @Test
     public void initWithIngestException() throws Exception {
         QueryRequest request = getTestQueryRequest();
+        Metacard identityMetacard = getTestMetacard();
+        identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                "someRegistryId"));
+        identityMetacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
         QueryResponse response = getPopulatedTestQueryResponse(request);
         when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
         when(security.getSystemSubject()).thenReturn(subject);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(getTestMetacard());
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(identityMetacard);
         doThrow(IngestException.class).when(catalogFramework)
                 .create(any(CreateRequest.class));
         federationAdminServiceImpl.init();
         verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework).create(any(CreateRequest.class));
     }
 
     @Test

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.registry.federationadmin.service.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegistryPublicationServiceImplTest {
+
+    private FederationAdminService federationAdminService;
+
+    private RegistryPublicationServiceImpl registryPublicationService;
+
+    private MetacardImpl metacard;
+
+    @Mock
+    private BundleContext bundleContext;
+
+    @Mock
+    private ServiceReference serviceReference;
+
+    @Mock
+    private RegistryStore registryStore;
+
+    private static final String REGISTRY_STORE_REGISTRY_ID = "registryStoreRegistryId";
+
+    private static final String REGISTRY_STORE_ID = "registryStoreId";
+
+    @Before
+    public void setup() {
+        federationAdminService = mock(FederationAdminService.class);
+        registryPublicationService = spy(new RegistryPublicationServiceImpl());
+        registryPublicationService.setFederationAdminService(federationAdminService);
+
+        metacard = new MetacardImpl(new RegistryObjectMetacardType());
+        metacard.setId("mcardId");
+        metacard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG));
+
+        when(registryPublicationService.getBundleContext()).thenReturn(bundleContext);
+        when(bundleContext.getService(serviceReference)).thenReturn(registryStore);
+
+        doReturn(REGISTRY_STORE_REGISTRY_ID).when(registryStore)
+                .getRegistryId();
+        doReturn(REGISTRY_STORE_ID).when(registryStore)
+                .getId();
+        registryPublicationService.bindRegistryStore(serviceReference);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testPublishInvalidRegistryId() throws Exception {
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(any(List.class))).thenReturn(
+                Collections.emptyList());
+        registryPublicationService.publish(null, REGISTRY_STORE_REGISTRY_ID);
+    }
+
+    @Test
+    public void testPublishAlreadyPublished() throws Exception {
+        String publishThisRegistryId = "publishThisRegistryId";
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+
+        Attribute publishedLocationsAttribute =
+                new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                        Collections.singletonList(REGISTRY_STORE_REGISTRY_ID));
+        metacard.setAttribute(publishedLocationsAttribute);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(any(List.class))).thenReturn(
+                Collections.singletonList(metacard));
+
+        registryPublicationService.publish(publishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
+        verify(federationAdminService, never()).addRegistryEntry(metacard,
+                Collections.singleton(REGISTRY_STORE_REGISTRY_ID));
+        verify(federationAdminService, never()).updateRegistryEntry(metacard);
+
+        Attribute publicationsAfter =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        assertThat(publicationsAfter, is(equalTo(publishedLocationsAttribute)));
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate, is(equalTo(before)));
+    }
+
+    @Test
+    public void testPublishAddAnotherSource() throws Exception {
+        String someAlreadyPublishedRegistryId = "someAlreadyPublishedRegistryId";
+        String publishThisRegistryId = "publishThisRegistryId";
+
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+
+        Attribute publishedLocationsAttribute =
+                new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                        Collections.singletonList(someAlreadyPublishedRegistryId));
+        metacard.setAttribute(publishedLocationsAttribute);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(any(List.class))).thenReturn(
+                Collections.singletonList(metacard));
+
+        registryPublicationService.publish(publishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
+        verify(federationAdminService).addRegistryEntry(metacard,
+                Collections.singleton(REGISTRY_STORE_ID));
+        verify(federationAdminService).updateRegistryEntry(metacard);
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate.after(before), is(equalTo(true)));
+
+        Attribute publicationsAfter =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        List<Serializable> publications = publicationsAfter.getValues();
+        assertThat(publications, hasItem(REGISTRY_STORE_REGISTRY_ID));
+    }
+
+    @Test
+    public void testPublish() throws Exception {
+        doReturn(Collections.singletonList(metacard)).when(federationAdminService)
+                .getRegistryMetacardsByRegistryIds(any(List.class));
+        String publishThisRegistryId = "registryId";
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+
+        registryPublicationService.publish(publishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
+        verify(federationAdminService).addRegistryEntry(metacard,
+                Collections.singleton(REGISTRY_STORE_ID));
+        verify(federationAdminService).updateRegistryEntry(metacard);
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate.after(before), is(equalTo(true)));
+
+        Attribute publicationsAfter =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        List<Serializable> publications = publicationsAfter.getValues();
+        assertThat(publications, hasItem(REGISTRY_STORE_REGISTRY_ID));
+    }
+
+    @Test
+    public void testUnpublish() throws Exception {
+        String unPublishThisRegistryId = "unPublishThisRegistryId";
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                Collections.singletonList(REGISTRY_STORE_REGISTRY_ID)));
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(any(List.class))).thenReturn(
+                Collections.singletonList(metacard));
+        registryPublicationService.unpublish(unPublishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
+        verify(federationAdminService).deleteRegistryEntriesByRegistryIds(Collections.singletonList(
+                unPublishThisRegistryId), Collections.singleton(REGISTRY_STORE_ID));
+        verify(federationAdminService).updateRegistryEntry(metacard);
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate.after(before), is(equalTo(true)));
+
+        Attribute publicationsAfter =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        assertThat(publicationsAfter, nullValue());
+    }
+
+    @Test
+    public void testUnpublishNoCurrentlyPublished() throws Exception {
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                Collections.emptyList()));
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(any(List.class))).thenReturn(
+                Collections.singletonList(metacard));
+        registryPublicationService.unpublish("regId", "sourceId");
+        verify(federationAdminService,
+                never()).deleteRegistryEntriesByRegistryIds(Collections.singletonList("regId"),
+                Collections.singleton("sourceId"));
+        verify(federationAdminService, never()).updateRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testUpdateNoPublications() throws Exception {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, new ArrayList<>());
+        registryPublicationService.update(metacard);
+        verify(federationAdminService, never()).updateRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testUpdateEmptyPublications() throws Exception {
+        MetacardImpl metacard = new MetacardImpl();
+        registryPublicationService.update(metacard);
+        verify(federationAdminService, never()).updateRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        String publishedLocation = "myLocation";
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, publishedLocation);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+
+        registryPublicationService.update(metacard);
+        verify(federationAdminService, times(1)).updateRegistryEntry(metacard,
+                Collections.singleton(publishedLocation));
+        verify(federationAdminService, times(1)).updateRegistryEntry(metacard);
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate.after(before), is(equalTo(true)));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateException() throws Exception {
+        doThrow(new FederationAdminException("Test Error")).when(federationAdminService)
+                .updateRegistryEntry(any(Metacard.class), any(Set.class));
+        MetacardImpl mcard = new MetacardImpl();
+        mcard.setAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, "mylocation");
+
+        registryPublicationService.update(mcard);
+        verify(federationAdminService, never()).updateRegistryEntry(mcard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testNoRegistryStores() throws Exception {
+        doReturn(Collections.singletonList(metacard)).when(federationAdminService).getRegistryMetacardsByRegistryIds(any(List.class));
+        registryPublicationService.unbindRegistryStore(serviceReference);
+        String publishThisRegistryId = "publishThisRegistryId";
+        Date now = new Date();
+        Date before = new Date(now.getTime() - 100000);
+        MetacardImpl metacard = new MetacardImpl();
+
+        Attribute publishedLocationsAttribute =
+                new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
+                        Collections.singletonList(REGISTRY_STORE_REGISTRY_ID));
+        metacard.setAttribute(publishedLocationsAttribute);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
+
+
+        registryPublicationService.publish(publishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
+        verify(federationAdminService, never()).updateRegistryEntry(metacard);
+
+        Attribute publicationsAfter =
+                metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
+        assertThat(publicationsAfter, is(equalTo(publishedLocationsAttribute)));
+
+        Attribute lastPublished = metacard.getAttribute(RegistryObjectMetacardType.LAST_PUBLISHED);
+        assertThat(lastPublished, notNullValue());
+
+        Date lastPublishedDate = (Date) lastPublished.getValue();
+        assertThat(lastPublishedDate, is(equalTo(before)));
+
+    }
+
+    @Test
+    public void testBindRegistryStore() {
+        registryPublicationService.bindRegistryStore(serviceReference);
+    }
+
+    @Test
+    public void testBindRegistryStoreNullServiceReference() {
+        registryPublicationService.bindRegistryStore(null);
+    }
+
+    @Test
+    public void testUnBindRegistryStore() {
+        registryPublicationService.unbindRegistryStore(serviceReference);
+    }
+
+    @Test
+    public void testUnBindRegistryStoreNullServiceReference() {
+        registryPublicationService.unbindRegistryStore(null);
+    }
+}

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.registry.federationadmin.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import ddf.catalog.data.Metacard;
@@ -74,6 +75,7 @@ public interface FederationAdminService {
 
     /**
      * Add the given metacards to the registry catalog with the provided destinations
+     *
      * @param metacards    Metacards to be stored
      * @param destinations Set of destinations to add
      * @return List of Id's for the created metacards
@@ -244,5 +246,13 @@ public interface FederationAdminService {
      */
     RegistryPackageType getRegistryObjectByRegistryId(String registryId, List<String> sourceIds)
             throws FederationAdminException;
+
+    /**
+     * Returns the identity metacard for the local registry node.
+     *
+     * @return {@link java.util.Optional} containing the Identity {@link Metacard}
+     * @throws FederationAdminException if more than one metacard was found
+     */
+    Optional<Metacard> getLocalRegistryIdentityMetacard() throws FederationAdminException;
 
 }

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/RegistryPublicationService.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/RegistryPublicationService.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.registry.federationadmin.service;
+
+import ddf.catalog.data.Metacard;
+
+public interface RegistryPublicationService {
+
+    /**
+     * Publishes a local registry to a remote registry.
+     * <p>This will write the local metacard to the remote destination.
+     * <p>The remote destination will be added to the local metacard's list of published locations.
+     * The local metacard's last published time will also be updated. The updated metacard will be written to the local store.
+     *
+     * @param registryId the registry id of the registry to be published
+     * @param destinationRegistryId the registry of the remote registry to be published to
+     * @throws FederationAdminException if there were problems writing to the remote registry or updating the local metacard
+     */
+    void publish(String registryId, String destinationRegistryId) throws FederationAdminException;
+
+    /**
+     * Unpublishes a local registry from a remote registry.
+     * <p> The local registry metacard will be deleted from the remote registry.
+     * <p>The remote destination will be removed from the local metacard's list of published locations.
+     * The local metacard's last published time will also be updated. The updated metacard will be written to the local store.
+     * @param registryId the registry id of the registry to be unpublished
+     * @param destinationRegistryId the registry of the remote registry to be unpublished from
+     * @throws FederationAdminException if there were problems deleting from the remote registry or updating the local metacard
+     */
+    void unpublish(String registryId, String destinationRegistryId) throws FederationAdminException;
+
+    /**
+     * Writes the metacard to each of the remote registries in the metacard's list of published locations.
+     * <p>The metacard's last published time will be updated and the updated metacard will be written to the local store.
+     * @param metacard the metacard up write
+     * @throws FederationAdminException if there are any problems updating the local or remote registries.
+     */
+    void update(Metacard metacard) throws FederationAdminException;
+}

--- a/catalog/spatial/registry/registry-publication-update-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,15 +14,15 @@
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <reference id="federationAdminService"
-               interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+    <reference id="registryPublicationService"
+               interface="org.codice.ddf.registry.federationadmin.service.RegistryPublicationService"/>
 
     <bean id="executor" class="java.util.concurrent.Executors" factory-method="newFixedThreadPool">
         <argument value="1"/>
     </bean>
 
     <bean id="registryEventManager" class="org.codice.ddf.registry.publication.RegistryPublicationHandler" destroy-method="destroy">
-        <argument ref="federationAdminService"/>
+        <argument ref="registryPublicationService"/>
         <argument ref="executor"/>
     </bean>
 


### PR DESCRIPTION
#### What does this PR do?
  A new service is added to handle publishing, unpublishing, and updating published registries.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @ryeats
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@shaundmorris
#### How should this be tested?
Verify the build
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2181
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Creating RegistryPublicationService used for publishing, unpublishing, and pushing local metacard to the published locations
Adding getLocalRegistryIdentityMetacard to FederationAdminService
Changing RegistryPublicationHandler to using the RegsitryPublicationService for the update