### PR TITLE
DDF-2168: Add integration tests for resource download & caching

### DIFF
--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -103,6 +103,17 @@
             <artifactId>platform-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.xebialabs.restito</groupId>
+            <artifactId>restito</artifactId>
+            <version>0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-http-server</artifactId>
+            <version>2.3.17</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.common.test.mock.csw;
+
+import static org.junit.Assert.fail;
+import static com.xebialabs.restito.semantics.Action.bytesContent;
+import static com.xebialabs.restito.semantics.Action.contentType;
+import static com.xebialabs.restito.semantics.Action.ok;
+import static com.xebialabs.restito.semantics.Condition.get;
+import static com.xebialabs.restito.semantics.Condition.post;
+import static com.xebialabs.restito.semantics.Condition.withPostBodyContaining;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.LoggerFactory;
+import org.slf4j.ext.XLogger;
+
+import com.xebialabs.restito.builder.stub.StubHttp;
+import com.xebialabs.restito.builder.verify.VerifyHttp;
+import com.xebialabs.restito.server.StubServer;
+
+/**
+ * Encompasses a Restito CSW Stub Server for use in integration testing. Handles handshake responses
+ * and federated query responses for a csw endpoint.
+ */
+public class FederatedCswMockServer {
+    private static final XLogger LOGGER =
+            new XLogger(LoggerFactory.getLogger(FederatedCswMockServer.class));
+
+    private final String sourceId;
+
+    private final String httpRoot;
+
+    private final int port;
+
+    private StubServer cswStubServer;
+
+    /**
+     * Constructor for the federated CSW Restito stub server.
+     *
+     * @param sourceId DDF sourceId to give to the stub server.
+     * @param httpRoot httpRoot address. Typically the non-secure root "http://localhost:".
+     * @param port     Port number on which to respond.
+     */
+    public FederatedCswMockServer(String sourceId, String httpRoot, int port) {
+        if (httpRoot.endsWith(":")) {
+            this.httpRoot = httpRoot.substring(0, httpRoot.length() - 1);
+        } else {
+            this.httpRoot = httpRoot;
+        }
+
+        this.sourceId = sourceId;
+        this.port = port;
+    }
+
+    /**
+     * Starts the Restito stub server.
+     */
+    public void start() {
+        try {
+            cswStubServer = new StubServer(port).run();
+
+            setDefaultCapabilityResponse();
+            setDefaultQueryResponse();
+        } catch (IOException | RuntimeException e) {
+            fail(String.format("Failed to setup %s: %s", getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    /**
+     * Stops the Restito stub server.
+     */
+    public void stop() {
+        cswStubServer.stop();
+    }
+
+    /**
+     * Resets the Restito server by stopping and starting it.
+     */
+    public void reset() {
+        // There is no way in version 0.7 of Restito to clear the calls and reset the
+        // StubServer so we need to stop the current one and create a new instance.
+        // TODO - Replace this code when the new version of Restito is used.
+        stop();
+        start();
+    }
+
+    /**
+     * Returns StubHttp's whenHttp method with the stub server as the parameter. Use is the same.
+     * Sets up an Action when a specific Http call is made.
+     *
+     * @return StubHttp using whenHttp method with the stub server as the parameter.
+     */
+    public StubHttp whenHttp() {
+        return StubHttp.whenHttp(cswStubServer);
+    }
+
+    /**
+     * Returns VerifyHttp's verifyHttp method with the stub server as the parameter. Use is the same.
+     * Provides itest verification when a specific Http call is made.
+     *
+     * @return VerifyHttp using verifyHttp method with the stub server as the parameter.
+     */
+    public VerifyHttp verifyHttp() {
+        return VerifyHttp.verifyHttp(cswStubServer);
+    }
+
+    /**
+     * Get the port being used by the stub server.
+     *
+     * @return the port being used by the stub server.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Get the root url being used by the stub server.
+     *
+     * @return the root url being used by the stub server.
+     */
+    public String getRoot() {
+        return httpRoot;
+    }
+
+    /**
+     * Returns the restito stub server to allow for any unsupported actions
+     *
+     * @return the stub server managed by this class
+     */
+    public StubServer getServer() {
+        return cswStubServer;
+    }
+
+    /**
+     * Set a specific capability Response. Overwrites default/previous response condition.
+     *
+     * @param resourceName name of capability file
+     * @throws IOException
+     */
+    public void setCapabilityResponse(String resourceName) throws IOException {
+        try (InputStream inputStream = getClass().getResourceAsStream("/" + resourceName)) {
+            String document = substituteTags(IOUtils.toString(inputStream));
+
+            LOGGER.debug("Capability response: \n{}", document);
+
+            whenHttp().match(get("/services/csw"))
+                    .then(ok(), contentType("text/xml"), bytesContent(document.getBytes()));
+        }
+    }
+
+    /**
+     * Set a specific query Response. Overwrites default/previous response condition.
+     *
+     * @param resourceName name of resource file
+     * @throws IOException
+     */
+    public void setQueryResponse(String resourceName) throws IOException {
+        try (InputStream inputStream = getClass().getResourceAsStream("/" + resourceName)) {
+            String document = substituteTags(IOUtils.toString(inputStream));
+
+            LOGGER.debug("Query response: \n{}", document);
+
+            whenHttp().match(post("/services/csw"), withPostBodyContaining("GetRecords"))
+                    .then(ok(), contentType("text/xml"), bytesContent(document.getBytes()));
+        }
+    }
+
+    private void setDefaultCapabilityResponse() throws IOException {
+        setCapabilityResponse("csw-get-capabilities-response.xml");
+    }
+
+    private void setDefaultQueryResponse() throws IOException {
+        setQueryResponse("csw-query-response.xml");
+    }
+
+    private String substituteTags(String document) {
+        String resultDocument = substituteSourceId(document);
+        resultDocument = substitutePortNumber(resultDocument);
+        return substituteHttpRoot(resultDocument);
+    }
+
+    private String substitutePortNumber(String document) {
+        return document.replaceAll("\\$port\\$", Integer.toString(port));
+    }
+
+    private String substituteSourceId(String document) {
+        return document.replaceAll("\\$sourceId\\$", sourceId);
+    }
+
+    private String substituteHttpRoot(String document) {
+        return document.replaceAll("\\$httpRoot\\$", httpRoot);
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/restito/ChunkedContent.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/restito/ChunkedContent.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.common.test.restito;
+
+import static java.lang.Thread.sleep;
+import static com.xebialabs.restito.semantics.Action.composite;
+import static com.xebialabs.restito.semantics.Action.contentType;
+import static com.xebialabs.restito.semantics.Action.custom;
+import static com.xebialabs.restito.semantics.Action.header;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.glassfish.grizzly.http.server.Response;
+import org.slf4j.LoggerFactory;
+import org.slf4j.ext.XLogger;
+
+import com.xebialabs.restito.semantics.Action;
+import com.xebialabs.restito.semantics.Function;
+
+/**
+ * Encompasses the response for a product retrieval for a Restito stub server.
+ * Allows for the simple setup of specific responses, slow sending, and simulated
+ * network failure retry testing.
+ */
+public class ChunkedContent {
+    private static final XLogger LOGGER =
+            new XLogger(LoggerFactory.getLogger(ChunkedContent.class));
+
+    /**
+     * Returns the minimum headers required for sending a chunked data response, but does not
+     * include the response function itself.
+     *
+     * @return the minimum headers required for sending a chunked data response
+     */
+    private static Action getHeaders() {
+        return composite(contentType("text/plain"),
+                header("Transfer-Encoding", "chunked"),
+                header("content-type", "text/plain"));
+    }
+
+    /**
+     * Constructor for a response that has a delay and a number of planned failures.
+     *
+     * @param responseMessage  Message to be sent in response.
+     * @param messageDelay     Time to wait between sending each character of the message.
+     * @param numberOfFailures Number of times to fail (simulate network disconnect) after sending
+     *                         the first character. Once this number is reached, the message will
+     *                         send successfully.
+     */
+    public static Action chunkedContent(String responseMessage, Duration messageDelay,
+            int numberOfFailures) {
+        return custom(new ChunkedContentFunction(responseMessage, messageDelay, numberOfFailures));
+
+    }
+
+    /**
+     * Returns a composite action that holds the headers required for a plain text response as well
+     * as the response function itself. Unless the headers included are not wanted, this is the
+     * preferred way to set the Restito response actions.
+     * <p>
+     * Note that additional headers may also be needed for specific endpoint functionality. This
+     * method returns a composite action so that additional headers can be set alongside this action.
+     *
+     * @param responseMessage  Message to be sent in response.
+     * @param messageDelay     Time to wait between sending each character of the message.
+     * @param numberOfFailures Number of times to fail (simulate network disconnect) after sending
+     *                         the first character. Once this number is reached, the message will
+     *                         send successfully.
+     * @return composite action that holds the headers required for a plain text response as well
+     * as the response function itself.
+     */
+    public static Action chunkedContentWithHeaders(String responseMessage, Duration messageDelay,
+            int numberOfFailures) {
+        return composite(getHeaders(),
+                chunkedContent(responseMessage, messageDelay, numberOfFailures));
+    }
+
+    /**
+     * Private inner class representing the response function
+     */
+    private static class ChunkedContentFunction implements Function<Response, Response> {
+        private String responseMessage;
+
+        private long messageDelayMs;
+
+        private int numberOfFailures;
+
+        private int numberOfRetries = 0;
+
+        /**
+         * Constructor for a response that has a delay and a number of planned failures.
+         *
+         * @param responseMessage  Message to be sent in response.
+         * @param messageDelay     Time to wait between sending each character of the message.
+         * @param numberOfFailures Number of times to fail (simulate network disconnect) after sending
+         *                         the first character. Once this number is reached, the message will
+         *                         send successfully.
+         */
+        private ChunkedContentFunction(String responseMessage, Duration messageDelay,
+                int numberOfFailures) {
+            this.responseMessage = responseMessage;
+            this.messageDelayMs = messageDelay.toMillis();
+            this.numberOfFailures = numberOfFailures;
+        }
+
+        /**
+         * Implementation of the Function interface's apply method. This class can also be used as a
+         * Function<Response, Response> directly in the Restito response if custom actions are needed.
+         *
+         * @param response
+         * @return
+         */
+        @Override
+        public Response apply(Response response) {
+            return respond(response);
+        }
+
+        private Response respond(Response response) {
+            for (char c : responseMessage.toCharArray()) {
+                try {
+                    response.getNIOWriter()
+                            .write(c);
+                    response.flush();
+                    sleep(messageDelayMs);
+
+                    // fail download by ungracefully closing the output buffer to simulate connection lost
+                    if (numberOfRetries < numberOfFailures) {
+                        response.getOutputBuffer()
+                                .recycle();
+                        numberOfRetries++;
+                        break;
+                    }
+                } catch (IOException | InterruptedException e) {
+                    LOGGER.error("Error", e);
+                    break;
+                }
+            }
+            response.finish();
+
+            return response;
+        }
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/test/resources/csw-get-capabilities-response.xml
+++ b/distribution/test/itests/test-itests-common/src/test/resources/csw-get-capabilities-response.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:Capabilities ns10:schemaLocation="" version="2.0.2"
+                  xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                  xmlns:gml="http://www.opengis.net/gml"
+                  xmlns:ns10="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:ns2="http://www.w3.org/1999/xlink"
+                  xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows">
+    <ows:ServiceIdentification>
+        <ows:Title>Catalog Service for the Web</ows:Title>
+        <ows:Abstract>DDF CSW Endpoint</ows:Abstract>
+        <ows:ServiceType>CSW</ows:ServiceType>
+        <ows:ServiceTypeVersion>2.0.2</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>DDF</ows:ProviderName>
+        <ows:ProviderSite/>
+        <ows:ServiceContact/>
+    </ows:ServiceProvider>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get ns2:href="$httpRoot$:$port$/services/csw"/>
+                    <ows:Post ns2:href="$httpRoot$:$port$/services/csw">
+                        <ows:Constraint name="PostEncoding">
+                            <ows:Value>XML</ows:Value>
+                        </ows:Constraint>
+                    </ows:Post>
+                </ows:HTTP>
+            </ows:DCP>
+            <ows:Parameter name="sections">
+                <ows:Value>ServiceIdentification</ows:Value>
+                <ows:Value>ServiceProvider</ows:Value>
+                <ows:Value>OperationsMetadata</ows:Value>
+                <ows:Value>Filter_Capabilities</ows:Value>
+            </ows:Parameter>
+        </ows:Operation>
+        <ows:Operation name="DescribeRecord">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get ns2:href="$httpRoot$:$port$/services/csw"/>
+                    <ows:Post ns2:href="$httpRoot$:$port$/services/csw">
+                        <ows:Constraint name="PostEncoding">
+                            <ows:Value>XML</ows:Value>
+                        </ows:Constraint>
+                    </ows:Post>
+                </ows:HTTP>
+            </ows:DCP>
+            <ows:Parameter name="typeName">
+                <ows:Value>csw:Record</ows:Value>
+                <ows:Value>gmd.MD_Metadata</ows:Value>
+                <ows:Value>rim:RegistryPackage</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="OutputFormat">
+                <ows:Value>application/xml</ows:Value>
+                <ows:Value>application/json</ows:Value>
+                <ows:Value>application/atom+xml</ows:Value>
+                <ows:Value>text/xml</ows:Value>
+                <ows:Value>application/zip</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="schemaLanguage">
+                <ows:Value>http://www.w3.org/XMLSchema</ows:Value>
+                <ows:Value>http://www.w3.org/XML/Schema</ows:Value>
+                <ows:Value>http://www.w3.org/2001/XMLSchema</ows:Value>
+                <ows:Value>http://www.w3.org/TR/xmlschema-1/</ows:Value>
+            </ows:Parameter>
+        </ows:Operation>
+        <ows:Operation name="GetRecords">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get ns2:href="$httpRoot$:$port$/services/csw"/>
+                    <ows:Post ns2:href="$httpRoot$:$port$/services/csw">
+                        <ows:Constraint name="PostEncoding">
+                            <ows:Value>XML</ows:Value>
+                        </ows:Constraint>
+                    </ows:Post>
+                </ows:HTTP>
+            </ows:DCP>
+            <ows:Parameter name="ResultType">
+                <ows:Value>hits</ows:Value>
+                <ows:Value>results</ows:Value>
+                <ows:Value>validate</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="OutputFormat">
+                <ows:Value>application/xml</ows:Value>
+                <ows:Value>application/json</ows:Value>
+                <ows:Value>application/atom+xml</ows:Value>
+                <ows:Value>text/xml</ows:Value>
+                <ows:Value>application/zip</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="OutputSchema">
+                <ows:Value>urn:catalog:metacard</ows:Value>
+                <ows:Value>http://www.isotc211.org/2005/gmd</ows:Value>
+                <ows:Value>http://www.opengis.net/cat/csw/2.0.2</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="typeNames">
+                <ows:Value>csw:Record</ows:Value>
+                <ows:Value>gmd.MD_Metadata</ows:Value>
+                <ows:Value>rim:RegistryPackage</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="ConstraintLanguage">
+                <ows:Value>Filter</ows:Value>
+                <ows:Value>CQL_Text</ows:Value>
+            </ows:Parameter>
+            <ows:Constraint name="FederatedCatalogs"/>
+        </ows:Operation>
+        <ows:Operation name="GetRecordById">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get ns2:href="$httpRoot$:$port$/services/csw"/>
+                    <ows:Post ns2:href="$httpRoot$:$port$/services/csw">
+                        <ows:Constraint name="PostEncoding">
+                            <ows:Value>XML</ows:Value>
+                        </ows:Constraint>
+                    </ows:Post>
+                </ows:HTTP>
+            </ows:DCP>
+            <ows:Parameter name="OutputSchema">
+                <ows:Value>urn:catalog:metacard</ows:Value>
+                <ows:Value>http://www.isotc211.org/2005/gmd</ows:Value>
+                <ows:Value>http://www.opengis.net/cat/csw/2.0.2</ows:Value>
+                <ows:Value>http://www.iana.org/assignments/media-types/application/octet-stream</ows:Value>
+            </ows:Parameter>`
+            <ows:Parameter name="OutputFormat">
+                <ows:Value>application/xml</ows:Value>
+                <ows:Value>application/json</ows:Value>
+                <ows:Value>application/atom+xml</ows:Value>
+                <ows:Value>text/xml</ows:Value>
+                <ows:Value>application/zip</ows:Value>
+                <ows:Value>application/octet-stream</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="ResultType">
+                <ows:Value>hits</ows:Value>
+                <ows:Value>results</ows:Value>
+                <ows:Value>validate</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="ElementSetName">
+                <ows:Value>brief</ows:Value>
+                <ows:Value>summary</ows:Value>
+                <ows:Value>full</ows:Value>
+            </ows:Parameter>
+        </ows:Operation>
+        <ows:Operation name="Transaction">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Post ns2:href="$httpRoot$:$port$/services/csw">
+                        <ows:Constraint name="PostEncoding">
+                            <ows:Value>XML</ows:Value>
+                        </ows:Constraint>
+                    </ows:Post>
+                </ows:HTTP>
+            </ows:DCP>
+            <ows:Parameter name="typeNames">
+                <ows:Value>xml</ows:Value>
+                <ows:Value>appxml</ows:Value>
+                <ows:Value>gmd:MD_Metadata</ows:Value>
+                <ows:Value>csw:Record</ows:Value>
+                <ows:Value>tika</ows:Value>
+            </ows:Parameter>
+            <ows:Parameter name="ConstraintLanguage">
+                <ows:Value>Filter</ows:Value>
+                <ows:Value>CQL_Text</ows:Value>
+            </ows:Parameter>
+        </ows:Operation>
+        <ows:Parameter name="service">
+            <ows:Value>CSW</ows:Value>
+        </ows:Parameter>
+        <ows:Parameter name="version">
+            <ows:Value>2.0.2</ows:Value>
+        </ows:Parameter>
+    </ows:OperationsMetadata>
+    <ogc:Filter_Capabilities>
+        <ogc:Spatial_Capabilities>
+            <ogc:GeometryOperands>
+                <ogc:GeometryOperand>gml:Point</ogc:GeometryOperand>
+                <ogc:GeometryOperand>gml:LineString</ogc:GeometryOperand>
+                <ogc:GeometryOperand>gml:Polygon</ogc:GeometryOperand>
+            </ogc:GeometryOperands>
+            <ogc:SpatialOperators>
+                <ogc:SpatialOperator name="BBOX"/>
+                <ogc:SpatialOperator name="Beyond"/>
+                <ogc:SpatialOperator name="Contains"/>
+                <ogc:SpatialOperator name="Crosses"/>
+                <ogc:SpatialOperator name="Disjoint"/>
+                <ogc:SpatialOperator name="DWithin"/>
+                <ogc:SpatialOperator name="Intersects"/>
+                <ogc:SpatialOperator name="Overlaps"/>
+                <ogc:SpatialOperator name="Touches"/>
+                <ogc:SpatialOperator name="Within"/>
+            </ogc:SpatialOperators>
+        </ogc:Spatial_Capabilities>
+        <ogc:Scalar_Capabilities>
+            <ogc:LogicalOperators/>
+            <ogc:ComparisonOperators>
+                <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>NullCheck</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>Like</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>GreaterThan</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>GreaterThanEqualTo</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>LessThan</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>LessThanEqualTo</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+                <ogc:ComparisonOperator>NotEqualTo</ogc:ComparisonOperator>
+            </ogc:ComparisonOperators>
+        </ogc:Scalar_Capabilities>
+        <ogc:Id_Capabilities>
+            <ogc:EID/>
+        </ogc:Id_Capabilities>
+    </ogc:Filter_Capabilities>
+</csw:Capabilities>

--- a/distribution/test/itests/test-itests-common/src/test/resources/csw-query-response-modified.xml
+++ b/distribution/test/itests/test-itests-common/src/test/resources/csw-query-response-modified.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:GetRecordsResponse version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <csw:SearchStatus timestamp="2016-06-07T10:08:46.223-07:00"/>
+    <csw:SearchResults elementSet="full" nextRecord="0" numberOfRecordsMatched="1" numberOfRecordsReturned="1" recordSchema="http://www.opengis.net/cat/csw/2.0.2">
+        <csw:Record>
+            <dc:identifier>4cdb5d6bc8c1428f874f28a944d18b84</dc:identifier>
+            <dct:bibliographicCitation>4cdb5d6bc8c1428f874f28a944d18b84</dct:bibliographicCitation>
+            <dc:title>Michael.txt</dc:title>
+            <dct:alternative>Michael.txt</dct:alternative>
+            <dc:type>text/plain; charset=ISO-8859-1</dc:type>
+            <dc:relation>$httpRoot$:$port$/services/catalog/sources/$sourceId$/4cdb5d6bc8c1428f874f28a944d18b84?transform=resource</dc:relation>
+            <dc:date>2016-06-07T09:49:06.005-07:00</dc:date>
+            <dct:modified>2016-06-08T09:49:06.005-07:00</dct:modified>
+            <dct:created>2016-06-07T09:49:06.005-07:00</dct:created>
+            <dct:dateAccepted>2016-06-07T09:49:06.005-07:00</dct:dateAccepted>
+            <dct:dateCopyrighted>2016-06-07T09:49:06.005-07:00</dct:dateCopyrighted>
+            <dct:dateSubmitted>2016-06-07T09:49:06.005-07:00</dct:dateSubmitted>
+            <dct:issued>2016-06-07T09:49:06.005-07:00</dct:issued>
+            <dc:creator/>
+            <dc:publisher/>
+            <dc:contributor/>
+            <dc:source>content:4cdb5d6bc8c1428f874f28a944d18b84</dc:source>
+            <dc:publisher>$sourceId$</dc:publisher>
+        </csw:Record>
+    </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/distribution/test/itests/test-itests-common/src/test/resources/csw-query-response.xml
+++ b/distribution/test/itests/test-itests-common/src/test/resources/csw-query-response.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:GetRecordsResponse version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <csw:SearchStatus timestamp="2016-06-07T10:08:46.223-07:00"/>
+    <csw:SearchResults elementSet="full" nextRecord="0" numberOfRecordsMatched="1" numberOfRecordsReturned="1" recordSchema="http://www.opengis.net/cat/csw/2.0.2">
+        <csw:Record>
+            <dc:identifier>4cdb5d6bc8c1428f874f28a944d18b84</dc:identifier>
+            <dct:bibliographicCitation>4cdb5d6bc8c1428f874f28a944d18b84</dct:bibliographicCitation>
+            <dc:title>Michael.txt</dc:title>
+            <dct:alternative>Michael.txt</dct:alternative>
+            <dc:type>text/plain; charset=ISO-8859-1</dc:type>
+            <dc:relation>$httpRoot$:$port$/services/catalog/sources/$sourceId$/4cdb5d6bc8c1428f874f28a944d18b84?transform=resource</dc:relation>
+            <dc:date>2016-06-07T09:49:06.005-07:00</dc:date>
+            <dct:modified>2016-06-07T09:49:06.005-07:00</dct:modified>
+            <dct:created>2016-06-07T09:49:06.005-07:00</dct:created>
+            <dct:dateAccepted>2016-06-07T09:49:06.005-07:00</dct:dateAccepted>
+            <dct:dateCopyrighted>2016-06-07T09:49:06.005-07:00</dct:dateCopyrighted>
+            <dct:dateSubmitted>2016-06-07T09:49:06.005-07:00</dct:dateSubmitted>
+            <dct:issued>2016-06-07T09:49:06.005-07:00</dct:issued>
+            <dc:creator/>
+            <dc:publisher/>
+            <dc:contributor/>
+            <dc:source>content:4cdb5d6bc8c1428f874f28a944d18b84</dc:source>
+            <dc:publisher>$sourceId$</dc:publisher>
+        </csw:Record>
+    </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -13,6 +13,7 @@
  */
 package ddf.test.itests.catalog;
 
+import static java.lang.Thread.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,13 +30,18 @@ import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 import static com.jayway.restassured.path.json.JsonPath.with;
 import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
+import static com.xebialabs.restito.semantics.Action.composite;
+import static com.xebialabs.restito.semantics.Action.header;
 import static com.xebialabs.restito.semantics.Action.success;
+import static ddf.common.test.restito.ChunkedContent.chunkedContentWithHeaders;
+import static ddf.test.itests.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -69,6 +75,7 @@ import org.slf4j.ext.XLogger;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.internal.http.Method;
 import com.jayway.restassured.path.xml.XmlPath;
+import com.xebialabs.restito.semantics.Action;
 import com.xebialabs.restito.semantics.Call;
 import com.xebialabs.restito.semantics.Condition;
 import com.xebialabs.restito.server.StubServer;
@@ -78,6 +85,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.endpoint.CatalogEndpoint;
 import ddf.catalog.endpoint.impl.CatalogEndpointImpl;
 import ddf.common.test.BeforeExam;
+import ddf.common.test.mock.csw.FederatedCswMockServer;
 import ddf.test.itests.AbstractIntegrationTest;
 import ddf.test.itests.common.CswQueryBuilder;
 import ddf.test.itests.common.Library;
@@ -113,6 +121,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
     private static final String CONNECTED_SOURCE_ID = "cswConnectedSource";
 
+    private static final String CSW_STUB_SOURCE_ID = "cswStubServer";
+
     private static final String CSW_SOURCE_WITH_METACARD_XML_ID = "cswSource2";
 
     private static final String GMD_SOURCE_ID = "gmdSource";
@@ -121,9 +131,19 @@ public class TestFederation extends AbstractIntegrationTest {
 
     private static final String DEFAULT_SAMPLE_PRODUCT_FILE_NAME = "sample.txt";
 
+    private static final String CSW_STUB_RESOURCE_ID = "4cdb5d6bc8c1428f874f28a944d18b84";
+
+    private static final String STUB_SERVER_TEST_STRING = "testData";
+
     private static final DynamicPort RESTITO_STUB_SERVER_PORT = new DynamicPort(6);
 
     private static final Path PRODUCT_CACHE = Paths.get("data", "Product_Cache");
+
+    private static final DynamicPort CSW_STUB_SERVER_PORT = new DynamicPort(7);
+
+    public static final DynamicUrl CSW_STUB_SERVER_PATH = new DynamicUrl(INSECURE_ROOT,
+            CSW_STUB_SERVER_PORT,
+            "/services/csw");
 
     private static String[] metacardIds = new String[2];
 
@@ -137,6 +157,8 @@ public class TestFederation extends AbstractIntegrationTest {
             RESTITO_STUB_SERVER_PORT, SUBSCRIBER);
 
     private static StubServer server;
+
+    private static FederatedCswMockServer cswServer;
 
     @Rule
     public TestName testName = new TestName();
@@ -156,9 +178,21 @@ public class TestFederation extends AbstractIntegrationTest {
             getServiceManager().createManagedService(OpenSearchSourceProperties.FACTORY_PID,
                     openSearchProperties);
 
+            cswServer = new FederatedCswMockServer(CSW_STUB_SOURCE_ID,
+                    INSECURE_ROOT,
+                    Integer.parseInt(CSW_STUB_SERVER_PORT.getPort()));
+            cswServer.start();
+
+            CswSourceProperties cswStubServerProperties =
+                    new CswSourceProperties(CSW_STUB_SOURCE_ID);
+            cswStubServerProperties.put("cswUrl", CSW_STUB_SERVER_PATH.getUrl());
+            getServiceManager().createManagedService(CswSourceProperties.FACTORY_PID,
+                    cswStubServerProperties);
+
             getServiceManager().waitForHttpEndpoint(CSW_PATH + "?_wadl");
             get(CSW_PATH + "?_wadl").prettyPrint();
             CswSourceProperties cswProperties = new CswSourceProperties(CSW_SOURCE_ID);
+
             getServiceManager().createManagedService(CswSourceProperties.FACTORY_PID,
                     cswProperties);
 
@@ -174,12 +208,14 @@ public class TestFederation extends AbstractIntegrationTest {
                     gmdProperties);
 
             getCatalogBundle().waitForFederatedSource(OPENSEARCH_SOURCE_ID);
+            getCatalogBundle().waitForFederatedSource(CSW_STUB_SOURCE_ID);
             getCatalogBundle().waitForFederatedSource(CSW_SOURCE_ID);
             getCatalogBundle().waitForFederatedSource(CSW_SOURCE_WITH_METACARD_XML_ID);
             getCatalogBundle().waitForFederatedSource(GMD_SOURCE_ID);
 
             getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(),
                     OPENSEARCH_SOURCE_ID,
+                    CSW_STUB_SOURCE_ID,
                     CSW_SOURCE_ID,
                     CSW_SOURCE_WITH_METACARD_XML_ID,
                     GMD_SOURCE_ID);
@@ -198,7 +234,7 @@ public class TestFederation extends AbstractIntegrationTest {
     }
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         cleanProductCache();
         getCatalogBundle().setupCaching(true);
         urlResourceReaderConfigurator = getUrlResourceReaderConfigurator();
@@ -211,6 +247,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
         server = new SecureStubServer(Integer.parseInt(RESTITO_STUB_SERVER_PORT.getPort())).run();
         server.start();
+
+        cswServer.reset();
     }
 
     @After
@@ -231,6 +269,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
             resourcesToDelete.clear();
         }
+
+        cswServer.stop();
 
         if (server != null) {
             server.stop();
@@ -859,11 +899,11 @@ public class TestFederation extends AbstractIntegrationTest {
         Bundle bundle = bundleService.getBundle("spatial-csw-endpoint");
         bundle.stop();
         while (bundle.getState() != Bundle.RESOLVED) {
-            Thread.sleep(1000);
+            sleep(1000);
         }
         bundle.start();
         while (bundle.getState() != Bundle.ACTIVE) {
-            Thread.sleep(1000);
+            sleep(1000);
         }
         getServiceManager().waitForHttpEndpoint(CSW_SUBSCRIPTION_PATH + "?_wadl");
         //get subscription
@@ -958,6 +998,153 @@ public class TestFederation extends AbstractIntegrationTest {
 
     }
 
+    /**
+     * Tests basic download from the live federated csw source
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDownloadFromFederatedCswSource() throws Exception {
+        cswServer.whenHttp()
+                .match(Condition.get("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"))
+                .then(getCswRetrievalHeaders(),
+                        chunkedContentWithHeaders(STUB_SERVER_TEST_STRING,
+                                Duration.ofMillis(0),
+                                0));
+
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + CSW_STUB_SOURCE_ID + "/" + CSW_STUB_RESOURCE_ID
+                        + "?transform=resource";
+
+        // Verify that the testData from the csw stub server is returned.
+        // @formatter:off
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        // @formatter:on
+    }
+
+    /**
+     * Tests that if the endpoint disconnects twice, the retrieval retries both times
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRetrievalReliablility() throws Exception {
+        cswServer.whenHttp()
+                .match(Condition.get("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"))
+                .then(getCswRetrievalHeaders(),
+                        chunkedContentWithHeaders(STUB_SERVER_TEST_STRING,
+                                Duration.ofMillis(200),
+                                2));
+
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + CSW_STUB_SOURCE_ID + "/" + CSW_STUB_RESOURCE_ID
+                        + "?transform=resource";
+
+        // Verify that the testData from the csw stub server is returned.
+        // @formatter:off
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        // @formatter:on
+        cswServer.verifyHttp()
+                .times(3,
+                        Condition.uri("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"));
+    }
+
+    /**
+     * Tests that if the endpoint disconnects 3 times, the retrieval fails after 3 attempts
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRetrievalReliabilityFails() throws Exception {
+        cswServer.whenHttp()
+                .match(Condition.get("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"))
+                .then(getCswRetrievalHeaders(),
+                        chunkedContentWithHeaders(STUB_SERVER_TEST_STRING,
+                                Duration.ofMillis(200),
+                                3));
+
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + CSW_STUB_SOURCE_ID + "/" + CSW_STUB_RESOURCE_ID
+                        + "?transform=resource";
+
+        // Verify that product retrieval fails from the csw stub server.
+        // @formatter:off
+        when().get(restUrl).then().log().all().assertThat().statusCode(500).contentType("text/plain")
+                .body(containsString("cannot retrieve product"));
+        // @formatter:on
+    }
+
+    /**
+     * Tests that ddf will return the cached copy if there are no changes to the remote metacard
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDownloadFromCacheIfAvailable() throws Exception {
+        cswServer.whenHttp()
+                .match(Condition.get("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"))
+                .then(getCswRetrievalHeaders(),
+                        chunkedContentWithHeaders(STUB_SERVER_TEST_STRING,
+                                Duration.ofMillis(0),
+                                0));
+
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + CSW_STUB_SOURCE_ID + "/" + CSW_STUB_RESOURCE_ID
+                        + "?transform=resource";
+
+        // Download product twice, should only call the stub server to download once
+        // @formatter:off
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        // @formatter:on
+        cswServer.verifyHttp()
+                .times(1,
+                        Condition.uri("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"));
+    }
+
+    /**
+     * Tests that ddf will redownload a product if the remote metacard has changed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCacheIsUpdatedIfRemoteProductChanges() throws Exception {
+        cswServer.whenHttp()
+                .match(Condition.get("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"))
+                .then(getCswRetrievalHeaders(),
+                        chunkedContentWithHeaders(STUB_SERVER_TEST_STRING,
+                                Duration.ofMillis(0),
+                                0));
+
+        String restUrl =
+                REST_PATH.getUrl() + "sources/" + CSW_STUB_SOURCE_ID + "/" + CSW_STUB_RESOURCE_ID
+                        + "?transform=resource";
+
+        // Download product twice, and change metacard on stub server between calls.
+        // @formatter:off
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        cswServer.setQueryResponse("csw-query-response-modified.xml");
+        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
+                .body(is(STUB_SERVER_TEST_STRING));
+        // @formatter:on
+        cswServer.verifyHttp()
+                .times(2,
+                        Condition.uri("/services/csw"),
+                        Condition.parameter("request", "GetRecordById"));
+    }
+
     @Test
     public void testFederatedDownloadProductToCacheOnlyCacheEnabled() throws Exception {
         /**
@@ -967,14 +1154,16 @@ public class TestFederation extends AbstractIntegrationTest {
         String fileName = testName.getMethodName() + ".txt";
         String metacardId = ingestXmlWithProduct(fileName);
         metacardsToDelete.add(metacardId);
-        String productDirectory = new File(fileName).getAbsoluteFile().getParent();
+        String productDirectory = new File(fileName).getAbsoluteFile()
+                .getParent();
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
-                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory);
+                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS,
+                productDirectory);
 
         getCatalogBundle().setupCaching(true);
 
-        String resourceDownloadEndpoint = RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID
-                + "/" + metacardId;
+        String resourceDownloadEndpoint =
+                RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID + "/" + metacardId;
 
         // Perform Test and Verify
         // @formatter:off
@@ -982,9 +1171,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 .body(is(String.format("The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.", metacardId, CSW_SOURCE_ID)));
         // @formatter:on
 
-        assertThat(Files.exists(Paths.get(ddfHome).resolve(PRODUCT_CACHE)
+        assertThat(Files.exists(Paths.get(ddfHome)
+                .resolve(PRODUCT_CACHE)
                 .resolve(CSW_SOURCE_ID + "-" + metacardId)), is(true));
-        assertThat(Files.exists(Paths.get(ddfHome).resolve(PRODUCT_CACHE)
+        assertThat(Files.exists(Paths.get(ddfHome)
+                .resolve(PRODUCT_CACHE)
                 .resolve(CSW_SOURCE_ID + "-" + metacardId + ".ser")), is(true));
     }
 
@@ -997,14 +1188,16 @@ public class TestFederation extends AbstractIntegrationTest {
         String fileName = testName.getMethodName() + ".txt";
         String metacardId = ingestXmlWithProduct(fileName);
         metacardsToDelete.add(metacardId);
-        String productDirectory = new File(fileName).getAbsoluteFile().getParent();
+        String productDirectory = new File(fileName).getAbsoluteFile()
+                .getParent();
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
-                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory);
+                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS,
+                productDirectory);
 
         getCatalogBundle().setupCaching(false);
 
-        String resourceDownloadEndpoint = RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID
-                + "/" + metacardId;
+        String resourceDownloadEndpoint =
+                RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID + "/" + metacardId;
 
         // Perform Test and Verify
         // @formatter:off
@@ -1012,9 +1205,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 .body(is("Caching of products is not enabled."));
         // @formatter:on
 
-        assertThat(Files.exists(Paths.get(ddfHome).resolve(PRODUCT_CACHE)
+        assertThat(Files.exists(Paths.get(ddfHome)
+                .resolve(PRODUCT_CACHE)
                 .resolve(CSW_SOURCE_ID + "-" + metacardId)), is(false));
-        assertThat(Files.exists(Paths.get(ddfHome).resolve(PRODUCT_CACHE)
+        assertThat(Files.exists(Paths.get(ddfHome)
+                .resolve(PRODUCT_CACHE)
                 .resolve(CSW_SOURCE_ID + "-" + metacardId + ".ser")), is(false));
     }
 
@@ -1031,7 +1226,7 @@ public class TestFederation extends AbstractIntegrationTest {
             Set<String> foundIds = null;
 
             try {
-                Thread.sleep(EVENT_UPDATE_WAIT_INTERVAL);
+                sleep(EVENT_UPDATE_WAIT_INTERVAL);
                 millis += EVENT_UPDATE_WAIT_INTERVAL;
             } catch (InterruptedException e) {
                 LOGGER.info("Interrupted exception while trying to sleep for events", e);
@@ -1119,10 +1314,12 @@ public class TestFederation extends AbstractIntegrationTest {
         FileUtils.cleanDirectory(Paths.get(ddfHome).resolve(PRODUCT_CACHE).toFile());
     }
 
-    @Override
-    protected Option[] configureCustom() {
-
-        return options(mavenBundle("ddf.test.thirdparty", "restito").versionAsInProject());
+    private Action getCswRetrievalHeaders() {
+        return composite(header("X-Csw-Product", "true"));
     }
 
+    @Override
+    protected Option[] configureCustom() {
+        return options(mavenBundle("ddf.test.thirdparty", "restito").versionAsInProject());
+    }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/open-search-stub-query-response.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/open-search-stub-query-response.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacards xmlns="urn:catalog:metacard" xmlns:gml="http://www.opengis.net/gml">
+    <metacard xmlns="urn:catalog:metacard" xmlns:gml="http://www.opengis.net/gml"
+              gml:id="metacardId">
+        <type>ddf.metacard</type>
+        <source>openSearchStubSource</source>
+        <dateTime name="created">
+            <value>2013-04-18T17:50:27.371+00:00</value>
+        </dateTime>
+        <string name="resource-download-url">
+            <value>
+                https://localhost:{{port}}/services/catalog/sources/openSearchStubSource/metacardId?transform=resource
+            </value>
+        </string>
+        <geometry xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+                  name="location">
+            <value>
+                <ns2:Point>
+                    <ns2:pos>30.0 10.0</ns2:pos>
+                </ns2:Point>
+            </value>
+        </geometry>
+        <dateTime name="modified">
+            <value>2013-04-18T17:50:27.371+00:00</value>
+        </dateTime>
+        <string name="metadata-content-type-version">
+            <value>myVersion</value>
+        </string>
+        <string name="metadata-content-type">
+            <value>myType</value>
+        </string>
+        <stringxml name="metadata">
+            <value>
+                <xml xmlns="urn:catalog:metacard">text</xml>
+            </value>
+        </stringxml>
+        <string name="metacard-tags">
+            <value>resource</value>
+        </string>
+        <dateTime name="effective">
+            <value>2016-06-06T22:23:54.930+00:00</value>
+        </dateTime>
+        <base64Binary name="thumbnail">
+            <value>
+                /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=
+            </value>
+        </base64Binary>
+        <string name="title">
+            <value>myXmlTitle</value>
+        </string>
+    </metacard>
+</metacards>


### PR DESCRIPTION
#### What does this PR do?
Adds integration tests for federated resource downloading and caching. Also adds a reusable restito stub server class and a retrieval action class for live csw itest federation.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie 
@oconnormi 
@bantillo 
@Lambeaux 
@cmthom10 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic

  - Added integration tests to test current resource downloading functionality.
  - Added reusable classes for setting up a federated CSW stub server for
  integration tests