### PR TITLE
DDF-2183 STS LDAP login bundle uses the configured username attribute

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_security-contents/integrating-security-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_security-contents/integrating-security-contents.adoc
@@ -1053,12 +1053,16 @@ Settings can be found in the ${admin-console} under *${ddf-security} -> Configur
 |Additional Information
 
 |LDAP URL
-`|ldap://localhost:1389`
+|`ldaps://${org.codice.ddf.system.hostname}:1636`
 |
+
+|StartTLS
+|`false`
+|Ignored if the URL uses ldaps.
  
 |LDAP Bind User DN
 |`cn=admin`
-|
+|This user should have the ability to verify passwords and read attributes for any user.
  
 |LDAP Bind User Password
 |`secret`
@@ -1146,12 +1150,16 @@ Configuration settings can be found in the ${admin-console} under *${ddf-securit
 |Additional Information
 
 |LDAP URL
-|`ldaps://localhost:1636`
+|`ldaps://${org.codice.ddf.system.hostname}:1636`
 |
+
+|StartTLS
+|`false`
+|Ignored if the URL uses ldaps.
  
 |LDAP Bind User DN
 |`cn=admin`
-|
+|This user should have the ability to verify passwords and read attributes for any user.
  
 |LDAP Bind User Password
 |`secret`
@@ -1168,10 +1176,6 @@ Configuration settings can be found in the ${admin-console} under *${ddf-securit
 |LDAP Base Group DN
 |`ou=groups,dc=example,dc=com`
 |
- 
-|SSL Keystore Alias
-|`localhost`
-|This alias is used when connecting to the LDAP using SSL/TLS (LDAPS) or startTLS.
 
 |===
 

--- a/platform/security/sts/security-sts-ldaplogin/pom.xml
+++ b/platform/security/sts/security-sts-ldaplogin/pom.xml
@@ -77,22 +77,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.28</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.08</minimum>
+                                            <minimum>0.05</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.25</minimum>
+                                            <minimum>0.38</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.30</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -13,6 +13,17 @@
  */
 package ddf.ldap.ldaplogin;
 
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.CONNECTION_PASSWORD;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.CONNECTION_URL;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.CONNECTION_USERNAME;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.ROLE_BASE_DN;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.ROLE_FILTER;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.ROLE_NAME_ATTRIBUTE;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.ROLE_SEARCH_SUBTREE;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.SSL_STARTTLS;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.USER_FILTER;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.USER_SEARCH_SUBTREE;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -41,6 +52,8 @@ public class LdapLoginConfig {
     public static final String START_TLS = "startTls";
 
     private static final String SUFFICIENT_FLAG = "sufficient";
+
+    private static final String USER_NAME_ATTRIBUTE = "userNameAttribute";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapLoginConfig.class);
 
@@ -79,21 +92,25 @@ public class LdapLoginConfig {
         ldapModule.setFlags(SUFFICIENT_FLAG);
         ldapModule.setName(id);
         Properties props = new Properties();
-        props.put("connection.username", properties.get(LDAP_BIND_USER_DN));
-        props.put("connection.password", properties.get(LDAP_BIND_USER_PASS));
-        props.put("connection.url",
+        props.put(CONNECTION_USERNAME, properties.get(LDAP_BIND_USER_DN));
+        props.put(CONNECTION_PASSWORD, properties.get(LDAP_BIND_USER_PASS));
+        props.put(CONNECTION_URL,
                 new PropertyResolver((String) properties.get(LDAP_URL)).toString());
-        props.put("user.base.dn", properties.get(USER_BASE_DN));
-        props.put("user.filter", "(uid=%u)");
-        props.put("user.search.subtree", "true");
-        props.put("role.base.dn", properties.get(GROUP_BASE_DN));
-        props.put("role.filter", "(member=uid=%u," + properties.get(USER_BASE_DN) + ")");
-        props.put("role.name.attribute", "cn");
-        props.put("role.search.subtree", "true");
+
+        final Object userBaseDn = properties.get(USER_BASE_DN);
+        props.put(SslLdapLoginModule.USER_BASE_DN, userBaseDn);
+
+        final Object userNameAttribute = properties.get(USER_NAME_ATTRIBUTE);
+        props.put(USER_FILTER, String.format("(%s=%%u)", userNameAttribute));
+        props.put(USER_SEARCH_SUBTREE, "true");
+        props.put(ROLE_BASE_DN, properties.get(GROUP_BASE_DN));
+        props.put(ROLE_FILTER, String.format("(member=%s=%%u,%s)", userNameAttribute, userBaseDn));
+        props.put(ROLE_NAME_ATTRIBUTE, "cn");
+        props.put(ROLE_SEARCH_SUBTREE, "true");
         props.put("authentication", "simple");
         props.put("ssl.protocol", "TLS");
         props.put("ssl.algorithm", "SunX509");
-        props.put("ssl.starttls", properties.get(START_TLS));
+        props.put(SSL_STARTTLS, properties.get(START_TLS));
         ldapModule.setOptions(props);
 
         return ldapModule;
@@ -136,6 +153,11 @@ public class LdapLoginConfig {
     public void setStartTls(String startTls) {
         LOGGER.trace("Setting startTls: {}", startTls);
         ldapProperties.put(START_TLS, startTls);
+    }
+
+    public void setUserNameAttribute(String userNameAttribute) {
+        LOGGER.trace("setUserNameAttribute called: {}", userNameAttribute);
+        ldapProperties.put(USER_NAME_ATTRIBUTE, userNameAttribute);
     }
 
     public void configure() {

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapService.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapService.java
@@ -16,7 +16,6 @@ package ddf.ldap.ldaplogin;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.karaf.jaas.config.JaasRealm;
 import org.apache.karaf.jaas.config.impl.Config;
@@ -54,10 +53,8 @@ public class LdapService {
      * @param newModule that will replace a module or be added to the list of modules.
      */
     public synchronized void update(Module newModule) {
-        modules = modules.stream()
-                .filter(m -> !m.getName()
-                        .equals(newModule.getName()))
-                .collect(Collectors.toList());
+        modules.removeIf(m -> m.getName()
+                .equals(newModule.getName()));
         modules.add(newModule);
         config.setModules(modules.toArray(new Module[modules.size()]));
     }
@@ -70,10 +67,8 @@ public class LdapService {
      */
     public synchronized boolean delete(String id) {
         int initSize = modules.size();
-        modules = modules.stream()
-                .filter(m -> !m.getName()
-                        .equals(id))
-                .collect(Collectors.toList());
+        modules.removeIf(m -> m.getName()
+                .equals(id));
         config.setModules(modules.toArray(new Module[modules.size()]));
         return initSize > modules.size();
     }

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -17,7 +17,7 @@
     <type-converters>
         <bean class="ddf.security.sts.PropertiesConverter"/>
     </type-converters>
-    
+
     <cm:managed-service-factory
             id="ddf.ldap.ldaplogin.LdapLoginConfig.id"
             factory-pid="Ldap_Login_Config"
@@ -32,6 +32,7 @@
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="startTls" value="false"/>
             <property name="ldapService" ref="ldapService"/>
+            <property name="userNameAttribute" value="uid"/>
             <cm:managed-properties persistent-id=""
                                    update-strategy="component-managed" update-method="update"/>
         </cm:managed-component>

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
@@ -23,11 +23,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.CONNECTION_USERNAME;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.ROLE_FILTER;
+import static ddf.ldap.ldaplogin.SslLdapLoginModule.USER_FILTER;
 
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.karaf.jaas.config.JaasRealm;
 import org.apache.karaf.jaas.config.impl.Module;
@@ -88,7 +92,7 @@ public class LdapLoginConfigTest {
         for (Module module : ldapModules) {
             String moduleName = module.getName();
             String username = module.getOptions()
-                    .getProperty("connection.username");
+                    .getProperty(CONNECTION_USERNAME);
             // Assert the ldap modules were updated.
             if (moduleName.equals(configIdOne)) {
                 assertThat(username, is(equalTo("cn=user1")));
@@ -122,6 +126,7 @@ public class LdapLoginConfigTest {
         ldapConfig.setUserBaseDn("ou=users,dc=example,dc=com");
         ldapConfig.setGroupBaseDn("ou=groups,dc=example,dc=com");
         ldapConfig.setStartTls(false);
+        ldapConfig.setUserNameAttribute("uid");
         return ldapConfig;
     }
 
@@ -134,6 +139,22 @@ public class LdapLoginConfigTest {
         ldapProps.put(LdapLoginConfig.GROUP_BASE_DN, "ou=groups,dc=example,dc=com");
         ldapProps.put(LdapLoginConfig.START_TLS, "false");
         return ldapProps;
+    }
+
+    @Test
+    public void testSetUserNameAttribute() {
+        LdapService ldapService = new LdapService(context);
+        LdapLoginConfig config = createLdapConfig(ldapService);
+        config.setUserNameAttribute("cn");
+
+        config.configure();
+
+        Properties properties = ldapService.getModules()
+                .get(0)
+                .getOptions();
+        assertThat(properties.getProperty(USER_FILTER), is("(cn=%u)"));
+        assertThat(properties.getProperty(ROLE_FILTER),
+                is("(member=cn=%u,ou=users,dc=example,dc=com)"));
     }
 }
 


### PR DESCRIPTION
#### What does this PR do?
- Updates the LDAP login bundle so it will actually use the configured username attribute
- Updates the LDAP Claims Handler and LDAP Login configuration documentation

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@codice/security 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@stustison

#### How should this be tested?
Set up the embedded LDAP server (or some other LDAP server) with a username attribute other than "uid". Start the LDAP login bundle and configure it to use that username attribute. Verify that you can log in via LDAP.

#### What are the relevant tickets?
[DDF-2183](https://codice.atlassian.net/browse/DDF-2183)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests