### PR TITLE
DDF-2219 Fixed Registry handlers to use the admin subject when executing system call

### DIFF
--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
@@ -28,6 +28,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -74,7 +76,11 @@ public class Security {
 
     private static final RolePrincipal ADMIN_ROLE = new RolePrincipal("admin");
 
+    private static final String KARAF_LOCAL_ROLE = "karaf.local.roles";
+
     private Subject cachedSystemSubject;
+
+    private static final javax.security.auth.Subject JAVA_ADMIN_SUBJECT = getAdminJavaSubject();
 
     private Security() {
         // Singleton
@@ -291,14 +297,21 @@ public class Security {
     }
 
     public static <T> T runAsAdmin(PrivilegedAction<T> action) {
-        Set<Principal> principals = new HashSet<>();
-        principals.add(new RolePrincipal("admin"));
-        javax.security.auth.Subject subject = new javax.security.auth.Subject(true,
-                principals,
-                new HashSet(),
-                new HashSet());
+        return javax.security.auth.Subject.doAs(JAVA_ADMIN_SUBJECT, action);
+    }
 
-        return javax.security.auth.Subject.doAs(subject, action);
+    public static <T> T runAsAdminWithException(PrivilegedExceptionAction<T> action)
+            throws PrivilegedActionException {
+        return javax.security.auth.Subject.doAs(JAVA_ADMIN_SUBJECT, action);
+    }
+
+    private static javax.security.auth.Subject getAdminJavaSubject() {
+        Set<Principal> principals = new HashSet<>();
+        String localRoles = System.getProperty(KARAF_LOCAL_ROLE, "");
+        for (String role : localRoles.split(",")) {
+            principals.add(new RolePrincipal(role));
+        }
+        return new javax.security.auth.Subject(true, principals, new HashSet(), new HashSet());
     }
 
     private BundleContext getBundleContext() {

--- a/platform/security/common/src/test/java/org/codice/ddf/security/SecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/SecurityTest.java
@@ -79,6 +79,8 @@ public class SecurityTest {
 
     @Before
     public void setup() throws URISyntaxException {
+        System.setProperty("karaf.local.roles", "admin,local");
+
         initMocks(this);
         mockStatic(SecurityUtils.class);
         mockStatic(FrameworkUtil.class);
@@ -197,16 +199,9 @@ public class SecurityTest {
         when(systemSubject.execute(callable)).thenReturn("Success!");
         configureMocksForBundleContext("server");
 
-        String result = Security.runAsAdmin(() -> {
-
-            try {
-                return security.runWithSubjectOrElevate(callable);
-            } catch (Exception e) {
-                fail("Unexpected exception thrown: " + e.getMessage());
-            }
-
-            return null;
-        });
+        String result =
+                Security.runAsAdminWithException(() -> security.runWithSubjectOrElevate(
+                        callable));
 
         assertThat(result, is("Success!"));
         verifyStatic();


### PR DESCRIPTION
#### What does this PR do?
Runs some 'system' commands in the registry handlers as admin so the commands don't get blocked by security.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @ryeats 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison 

#### How should this be tested?
Startup DDF and install the DDF-Registry app. Add a new additional node in the DDF-Registry->Local Node Information with at least one service binding. Verify that the node shows up in the sources tab as disabled. Configure the DDF-Registry to auto start configurations by going to DDF-Registry->Configuration-> Registry Source Configuration Handler and checking Activate Configurations and unchecking Preserve Active Configuration. Save the configuration and go back to the sources tab and verify that the node is no longer disabled. 
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2219
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

