### PR TITLE
DDF-2119: As an Integrator, I want to be able to trigger the caching …

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
@@ -44,6 +44,8 @@ public class CatalogBundle {
 
     public static final String RESOURCE_DOWNLOAD_MANAGER_PID = "ddf.catalog.resource.download.ReliableResourceDownloadManager";
 
+    private static final String CACHE_ENABLED_KEY = "cacheEnabled";
+
     private final ServiceManager serviceManager;
 
     private final AdminConfig adminConfig;
@@ -168,12 +170,53 @@ public class CatalogBundle {
         Hashtable<String, Object> updatedProperties = new Hashtable<>();
         updatedProperties.putAll(existingProperties);
         if (cachingEnabled) {
-            updatedProperties.put("cacheEnabled", "True");
+            updatedProperties.put(CACHE_ENABLED_KEY, Boolean.TRUE);
         } else {
-            updatedProperties.put("cacheEnabled", "False");
+            updatedProperties.put(CACHE_ENABLED_KEY, Boolean.FALSE);
         }
 
         Configuration configuration = adminConfig.getConfiguration(RESOURCE_DOWNLOAD_MANAGER_PID, null);
         configuration.update(updatedProperties);
+    }
+
+    public boolean isCacheEnabled() throws Exception {
+        Map<String, Object> existingProperties = adminConfig.getDdfConfigAdmin()
+                .getProperties(RESOURCE_DOWNLOAD_MANAGER_PID);
+
+        if (existingProperties != null) {
+            LOGGER.debug("Properties for PID [{}] are {}", RESOURCE_DOWNLOAD_MANAGER_PID,
+                    existingProperties);
+
+            if (!existingProperties.containsKey(CACHE_ENABLED_KEY)) {
+                String message = String.format("Properties for PID [%s] do not contain key [%s]",
+                        RESOURCE_DOWNLOAD_MANAGER_PID, CACHE_ENABLED_KEY);
+                LOGGER.error(message);
+                fail(message);
+            }
+
+            if (existingProperties.get(CACHE_ENABLED_KEY) == null) {
+                String message = String.format("Value of property [%s] for PID [%s] is null",
+                        CACHE_ENABLED_KEY, RESOURCE_DOWNLOAD_MANAGER_PID);
+                LOGGER.error(message);
+                fail(message);
+            }
+
+            if (existingProperties.get(CACHE_ENABLED_KEY) instanceof Boolean) {
+                return (Boolean) existingProperties.get(CACHE_ENABLED_KEY);
+            }
+
+            String message = String.format(
+                    "Unable to process [%s] property. [%s] type is: %s.  It must be of type %s",
+                    CACHE_ENABLED_KEY, CACHE_ENABLED_KEY,
+                    existingProperties.get(CACHE_ENABLED_KEY).getClass(), Boolean.class.getName());
+            LOGGER.error(message);
+            fail(message);
+        }
+
+        String message = String.format("Properties for PID [%s] are null.",
+                RESOURCE_DOWNLOAD_MANAGER_PID);
+        LOGGER.error(message);
+        fail(message);
+        return false;
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes itests (testFederatedDownloadProductToCacheOnlyCacheEnabled and testFederatedDownloadProductToCacheOnlyCacheDissabled) in TestFederation so they pass on Bamboo
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@Lambeaux 
@garrettfreibott 
@bantillo 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested?
 PRBS and verify Bamboo build passes
#### Any background context you want to provide?
testFederatedDownloadProductToCacheOnlyCacheEnabled and testFederatedDownloadProductToCacheOnlyCacheDissabled in TestFederation were failing on Bamboo but not failing for local builds.  This fixes the timing issues on Bamboo.
#### What are the relevant tickets?
 DDF-2119
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

…of selected products in order to allow users to download them from the cache at a later time

  - Fix itests (testFederatedDownloadProductToCacheOnlyCacheEnabled and testFederatedDownloadProductToCacheOnlyCacheDissabled) in TestFederation so they pass on Bamboo