### PR TITLE
DDF-2221 - make the FeatureType to be queried configurable for WFS so…

### DIFF
--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
@@ -218,6 +218,8 @@ public class WfsSource extends MaskableImpl
 
     protected String configurationPid;
 
+    private String forcedFeatureType;
+
     private FeatureCollectionMessageBodyReaderWfs10 featureCollectionReader;
 
     public WfsSource(FilterAdapter filterAdapter, BundleContext context, AvailabilityTask task,
@@ -492,6 +494,11 @@ public class WfsSource extends MaskableImpl
         for (FeatureTypeType featureTypeType : featureTypes) {
             String ftName = featureTypeType.getName()
                     .getLocalPart();
+
+            if (StringUtils.isNotBlank(forcedFeatureType) && !StringUtils.equals(forcedFeatureType,
+                    ftName)) {
+                continue;
+            }
 
             if (mcTypeRegs.containsKey(ftName)) {
                 LOGGER.debug(
@@ -1155,5 +1162,9 @@ public class WfsSource extends MaskableImpl
             }
             return newAvailability;
         }
+    }
+
+    public void setForcedFeatureType(String featureType) {
+        this.forcedFeatureType = featureType;
     }
 }

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,6 +42,7 @@
             <property name="username" value=""/>
             <property name="password" value=""/>
             <property name="disableCnCheck" value="false"/>
+            <property name="forcedFeatureType" value=""/>
             <property name="nonQueryableProperties">
                 <list/>
             </property>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -31,6 +31,8 @@
             required="false" type="String"/>
         <AD description="Password for WFS Service (optional)" name="Password" id="password"
             required="false" type="Password"/>
+        <AD description="Force only a specific FeatureType to be queried instead of all featureTypes"
+            name="Forced Feature Type" id="forcedFeatureType" type="String" required="false"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -242,6 +242,8 @@ public class WfsSource extends MaskableImpl
 
     private FeatureCollectionMessageBodyReaderWfs20 featureCollectionReader;
 
+    private String forcedFeatureType;
+
     public WfsSource(FilterAdapter filterAdapter, BundleContext context, AvailabilityTask task,
             SecureCxfClientFactory factory, EncryptionService encryptionService)
             throws SecurityServiceException {
@@ -496,6 +498,11 @@ public class WfsSource extends MaskableImpl
             String ftSimpleName = featureTypeType.getName()
                     .getLocalPart();
 
+            if (StringUtils.isNotBlank(forcedFeatureType) && !StringUtils.equals(forcedFeatureType,
+                    ftSimpleName)) {
+                continue;
+            }
+
             if (mcTypeRegs.containsKey(ftSimpleName)) {
                 LOGGER.debug(
                         "WfsSource {}: MetacardType {} is already registered - skipping to next metacard type",
@@ -538,6 +545,7 @@ public class WfsSource extends MaskableImpl
                 LOGGER.warn(WFS_ERROR_MESSAGE, ie);
             }
         }
+
 
         registerFeatureMetacardTypes(mcTypeRegs);
 
@@ -1395,5 +1403,9 @@ public class WfsSource extends MaskableImpl
     public void setFeatureCollectionReader(
             FeatureCollectionMessageBodyReaderWfs20 featureCollectionMessageBodyReaderWfs20) {
         this.featureCollectionReader = featureCollectionMessageBodyReaderWfs20;
+    }
+
+    public void setForcedFeatureType(String featureType) {
+        this.forcedFeatureType = featureType;
     }
 }

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,6 +48,7 @@
             <property name="username" value=""/>
             <property name="password" value=""/>
             <property name="disableCnCheck" value="false"/>
+            <property name="forcedFeatureType" value=""/>
             <property name="nonQueryableProperties">
                 <list></list>
             </property>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,6 +34,9 @@
             <Option label="Lon/Lat" value="LON_LAT"/>
         </AD>
 
+        <AD description="Force only a specific FeatureType to be queried instead of all featureTypes"
+            name="Forced Feature Type" id="forcedFeatureType" type="String" required="false"/>
+
         <AD description="When selected, the system will not specify sort criteria with the query.  This should only be used if the remote source is unable to handle sorting even when the capabilities states 'ImplementsSorting' is supported."
             name="Disable Sorting" id="disableSorting" required="true"
             type="Boolean" default="false"/>

--- a/distribution/docs/src/main/resources/_contents/_spatial-contents/integrating-spatial-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_spatial-contents/integrating-spatial-contents.adoc
@@ -3272,6 +3272,13 @@ The configurable properties for the WFS Source are accessed from the WFS Federat
 |
 |No
 
+|Forced Feature Type
+|`forcedFeatureType`
+|String
+|Force only a specific FeatureType to be queried instead of all featureTypes
+|
+|No
+
 |Non Queryable Properties
 |`nonQueryableProperties`
 |List of Strings
@@ -3409,6 +3416,13 @@ This should only be used if the remote source is unable to handle sorting even w
 |`password`
 |String
 |Password for the WFS service.
+|
+|No
+
+|Forced Feature Type
+|`forcedFeatureType`
+|String
+|Force only a specific FeatureType to be queried instead of all featureTypes
 |
 |No
 


### PR DESCRIPTION
#### What does this PR do?
Adds the FeatureType as a configurable property to the WFS sources config.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
#### How should this be tested?
configure a WFS source and set the forceFeatureType property. (A Geoserver with the default data set should be fine)
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2221
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…urces