### PR TITLE
DDF-2176 Break up FederationAdminServiceImpl to reduce the class' complexity and better adhere to the Single Responsibility Principle

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
@@ -12,8 +12,8 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.codice.ddf.registry</groupId>
@@ -125,17 +125,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.registry.federationadmin.service.impl;
+
+import static org.codice.ddf.registry.schemabindings.EbrimConstants.RIM_FACTORY;
+
+import java.io.IOException;
+import java.security.PrivilegedActionException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import javax.xml.datatype.DatatypeConstants;
+
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.configuration.SystemInfo;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.schemabindings.helper.InternationalStringTypeHelper;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
+import org.codice.ddf.security.common.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.VersionInfoType;
+
+/**
+ * Creates a registry identity node when DDF Registry is first instantiated.
+ * If a previous registry node is not already found, then a registry identity metacard and its
+ * attributes are created. FederationAdminService adds the newly created identity metacard as a registry entry.
+ */
+public class IdentityNodeInitialization {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityNodeInitialization.class);
+
+    private static final String UNKNOWN_SITE_NAME = "Unknown Site Name";
+
+    private FederationAdminService federationAdminService;
+
+    private InputTransformer registryTransformer;
+
+    private MetacardMarshaller metacardMarshaller;
+
+    private SlotTypeHelper slotTypeHelper = new SlotTypeHelper();
+
+    private InternationalStringTypeHelper internationalStringTypeHelper =
+            new InternationalStringTypeHelper();
+
+    public void init() throws PrivilegedActionException {
+        Security.runAsAdminWithException(() -> {
+            if (!federationAdminService.getLocalRegistryIdentityMetacard()
+                    .isPresent()) {
+                createIdentityNode();
+            }
+            return null;
+        });
+
+    }
+
+    private void createIdentityNode() throws FederationAdminException {
+
+        String registryPackageId = RegistryConstants.GUID_PREFIX + UUID.randomUUID()
+                .toString()
+                .replaceAll("-", "");
+        RegistryPackageType registryPackage = RIM_FACTORY.createRegistryPackageType();
+        registryPackage.setId(registryPackageId);
+        registryPackage.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+
+        ExtrinsicObjectType extrinsicObject = RIM_FACTORY.createExtrinsicObjectType();
+        extrinsicObject.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+
+        String extrinsicObjectId = RegistryConstants.GUID_PREFIX + UUID.randomUUID()
+                .toString()
+                .replaceAll("-", "");
+        extrinsicObject.setId(extrinsicObjectId);
+
+        String siteName = SystemInfo.getSiteName();
+        if (StringUtils.isNotBlank(siteName)) {
+            extrinsicObject.setName(internationalStringTypeHelper.create(siteName));
+        } else {
+            extrinsicObject.setName(internationalStringTypeHelper.create(UNKNOWN_SITE_NAME));
+        }
+
+        String home = SystemBaseUrl.getBaseUrl();
+        extrinsicObject.setHome(home);
+
+        String version = SystemInfo.getVersion();
+        if (StringUtils.isNotBlank(version)) {
+            VersionInfoType versionInfo = RIM_FACTORY.createVersionInfoType();
+            versionInfo.setVersionName(version);
+
+            extrinsicObject.setVersionInfo(versionInfo);
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneId.of(ZoneOffset.UTC.toString()));
+        String rightNow = now.toString();
+
+        SlotType1 lastUpdated = slotTypeHelper.create(RegistryConstants.XML_LAST_UPDATED_NAME,
+                rightNow,
+                DatatypeConstants.DATETIME.toString());
+        extrinsicObject.getSlot()
+                .add(lastUpdated);
+
+        SlotType1 liveDate = slotTypeHelper.create(RegistryConstants.XML_LIVE_DATE_NAME,
+                rightNow,
+                DatatypeConstants.DATETIME.toString());
+        extrinsicObject.getSlot()
+                .add(liveDate);
+
+        if (registryPackage.getRegistryObjectList() == null) {
+            registryPackage.setRegistryObjectList(RIM_FACTORY.createRegistryObjectListType());
+        }
+
+        registryPackage.getRegistryObjectList()
+                .getIdentifiable()
+                .add(RIM_FACTORY.createIdentifiable(extrinsicObject));
+
+        Metacard identityMetacard = getRegistryMetacardFromRegistryPackage(registryPackage);
+        if (identityMetacard != null) {
+            identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
+                    true));
+            identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                    true));
+
+            federationAdminService.addRegistryEntry(identityMetacard);
+        }
+    }
+
+    private Metacard getRegistryMetacardFromRegistryPackage(RegistryPackageType registryPackage)
+            throws FederationAdminException {
+        Metacard metacard;
+        try {
+            metacard =
+                    registryTransformer.transform(metacardMarshaller.getRegistryPackageAsInputStream(
+                            registryPackage));
+
+        } catch (IOException | CatalogTransformerException | ParserException e) {
+            String message = "Error creating metacard from registry package.";
+            LOGGER.error("{} Registry id: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message, e);
+        }
+
+        return metacard;
+    }
+
+    public void setMetacardMarshaller(MetacardMarshaller helper) {
+        this.metacardMarshaller = helper;
+    }
+
+    public void setRegistryTransformer(InputTransformer inputTransformer) {
+        this.registryTransformer = inputTransformer;
+    }
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+}

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,13 +12,12 @@
  **/
 -->
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <bean id="federationAdminService"
-          class="org.codice.ddf.registry.federationadmin.service.impl.FederationAdminServiceImpl"
-          init-method="init">
+          class="org.codice.ddf.registry.federationadmin.service.impl.FederationAdminServiceImpl">
         <property name="catalogFramework" ref="catalogFramework"/>
         <property name="filterBuilder" ref="filterBuilder"/>
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
@@ -30,7 +29,16 @@
         <property name="federationAdminService" ref="federationAdminService"/>
     </bean>
 
-    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+    <bean id="identityNodeInitialization"
+          class="org.codice.ddf.registry.federationadmin.service.impl.IdentityNodeInitialization"
+          init-method="init">
+        <property name="metacardMarshaller" ref="metacardMarshaller"/>
+        <property name="registryTransformer" ref="inputTransformer"/>
+        <property name="federationAdminService" ref="federationAdminService"/>
+    </bean>
+
+    <bean id="metacardMarshaller"
+          class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
         <argument ref="xmlParser"/>
     </bean>
 
@@ -55,7 +63,8 @@
         <property name="federationAdminService" ref="federationAdminService"/>
     </bean>
 
-    <reference-list id="registryPublicationServiceRegistryStore" interface="org.codice.ddf.registry.api.RegistryStore"
+    <reference-list id="registryPublicationServiceRegistryStore"
+                    interface="org.codice.ddf.registry.api.RegistryStore"
                     availability="optional">
         <reference-listener bind-method="bindRegistryStore" unbind-method="unbindRegistryStore"
                             ref="registryPublicationService"/>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -121,14 +120,14 @@ public class FederationAdminServiceImplTest {
 
     private static final String TEST_XML_STRING = "SomeValidStringVersionOfXml";
 
+    @Mock
+    RefreshRegistrySubscriptions refreshRegistrySubscriptions;
+
     private FederationAdminServiceImpl federationAdminServiceImpl;
 
     private Metacard testMetacard;
 
     private FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
-
-    @Mock
-    RefreshRegistrySubscriptions refreshRegistrySubscriptions;
 
     @Mock
     private ParserConfigurator configurator;
@@ -239,113 +238,6 @@ public class FederationAdminServiceImplTest {
         when(security.getSystemSubject()).thenReturn(subject);
         when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
         federationAdminServiceImpl.getRegistryObjectByRegistryId(TEST_METACARD_ID);
-    }
-
-    @Test
-    public void initWithNoPreviousEntry() throws Exception {
-        QueryRequest request = getTestQueryRequest();
-        QueryResponse response = getPopulatedTestQueryResponse(request);
-        Metacard metacard = getTestMetacard();
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithPreviousNonPrimaryEntry() throws Exception {
-        Metacard addThisMetacard = getTestMetacard();
-        QueryRequest request = getTestQueryRequest();
-        QueryResponse response = getPopulatedTestQueryResponse(request);
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(addThisMetacard);
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithPreviousWithEmptyMetacard() throws Exception {
-        Metacard addThisMetacard = getTestMetacard();
-        QueryRequest request = getTestQueryRequest();
-        Result result = new ResultImpl();
-        QueryResponse response = getTestQueryResponse(request, Collections.singletonList(result));
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(addThisMetacard);
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithPreviousPrimaryEntry() throws Exception {
-        Metacard firstMetacard = testMetacard;
-        firstMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
-                true));
-        QueryRequest request = getTestQueryRequest();
-        QueryResponse response = getPopulatedTestQueryResponse(request, firstMetacard);
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithDuplicatePreviousPrimaryEntry() throws Exception {
-        Metacard firstMetacard = testMetacard;
-        Metacard secondMetacard = testMetacard;
-        secondMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
-                true));
-        QueryRequest request = getTestQueryRequest();
-        QueryResponse response = getPopulatedTestQueryResponse(request,
-                secondMetacard,
-                secondMetacard);
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(firstMetacard);
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithQueryException() throws Exception {
-        when(security.getSystemSubject()).thenReturn(subject);
-        doThrow(SourceUnavailableException.class).when(catalogFramework)
-                .query(any(QueryRequest.class));
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
-    }
-
-    @Test
-    public void initWithIngestException() throws Exception {
-        QueryRequest request = getTestQueryRequest();
-        Metacard identityMetacard = getTestMetacard();
-        identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
-                "someRegistryId"));
-        identityMetacard.setAttribute(new AttributeImpl(Metacard.TAGS,
-                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
-        QueryResponse response = getPopulatedTestQueryResponse(request);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(registryTransformer.transform(any(InputStream.class))).thenReturn(identityMetacard);
-        doThrow(IngestException.class).when(catalogFramework)
-                .create(any(CreateRequest.class));
-        federationAdminServiceImpl.init();
-        verify(registryTransformer).transform(any(InputStream.class));
-        verify(catalogFramework).create(any(CreateRequest.class));
-    }
-
-    @Test
-    public void initWithMarshalException() throws Exception {
-        QueryRequest request = getTestQueryRequest();
-        QueryResponse response = getPopulatedTestQueryResponse(request);
-        when(security.getSystemSubject()).thenReturn(subject);
-        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
-        doThrow(ParserException.class).when(parser)
-                .marshal(any(ParserConfigurator.class), any(Object.class), any(OutputStream.class));
-        federationAdminServiceImpl.init();
-        verify(catalogFramework).query(any(QueryRequest.class));
     }
 
     @Test

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.registry.federationadmin.service.impl;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivilegedActionException;
+import java.util.Optional;
+
+import org.codice.ddf.configuration.SystemInfo;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
+import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.registry.transformer.RegistryTransformer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.security.Subject;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdentityNodeInitializationTest {
+
+    private static final String TEST_SITE_NAME = "Slate Rock and Gravel Company";
+
+    private static final String TEST_VERSION = "FF 2.0";
+
+    @Mock
+    private FederationAdminServiceImpl federationAdminService;
+
+    private IdentityNodeInitialization identityNodeInitialization;
+
+    private Metacard testMetacard;
+
+    private RegistryTransformer registryTransformer;
+
+    @Mock
+    private Subject subject;
+
+    private XmlParser parser;
+
+    private MetacardMarshaller metacardMarshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        parser = spy(new XmlParser());
+        identityNodeInitialization = spy(new IdentityNodeInitialization());
+        registryTransformer = spy(new RegistryTransformer());
+        metacardMarshaller = spy(new MetacardMarshaller(parser));
+        registryTransformer.setParser(parser);
+        identityNodeInitialization.setRegistryTransformer(registryTransformer);
+        identityNodeInitialization.setMetacardMarshaller(metacardMarshaller);
+        identityNodeInitialization.setFederationAdminService(federationAdminService);
+        System.setProperty(SystemInfo.SITE_NAME, TEST_SITE_NAME);
+        System.setProperty(SystemInfo.VERSION, TEST_VERSION);
+        testMetacard = getTestMetacard();
+    }
+
+    @Test
+    public void initWithNoPreviousEntry() throws Exception {
+        ArgumentCaptor<Metacard> captor = ArgumentCaptor.forClass(Metacard.class);
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        identityNodeInitialization.init();
+        verify(federationAdminService).addRegistryEntry(captor.capture());
+        Metacard metacard = captor.getValue();
+        assertThat(metacard.getAttribute(Metacard.MODIFIED), notNullValue());
+        assertThat(metacard.getAttribute(Metacard.CREATED), notNullValue());
+        assertThat(metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
+                .getValue(), equalTo(true));
+        assertThat(metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
+                .getValue(), equalTo(true));
+    }
+
+    @Test
+    public void initWithPreviousPrimaryEntry() throws Exception {
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.of(
+                testMetacard));
+        identityNodeInitialization.init();
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = PrivilegedActionException.class)
+    public void initWithGetLocalRegistryNodeException() throws Exception {
+        doThrow(FederationAdminException.class).when(federationAdminService)
+                .getLocalRegistryIdentityMetacard();
+        identityNodeInitialization.init();
+    }
+
+    @Test(expected = PrivilegedActionException.class)
+    public void initWithIngestException() throws Exception {
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenThrow(
+                FederationAdminException.class);
+        identityNodeInitialization.init();
+    }
+
+    @Test(expected = PrivilegedActionException.class)
+    public void initWithRegistryTransformerException() throws Exception {
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        doThrow(CatalogTransformerException.class).when(registryTransformer)
+                .transform(any(InputStream.class));
+        identityNodeInitialization.init();
+    }
+
+    @Test(expected = PrivilegedActionException.class)
+    public void initWithParserException() throws Exception {
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        doThrow(ParserException.class).when(metacardMarshaller)
+                .getRegistryPackageAsInputStream(any(RegistryPackageType.class));
+        identityNodeInitialization.init();
+    }
+
+    @Test(expected = PrivilegedActionException.class)
+    public void initWithIOException() throws Exception {
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        doThrow(IOException.class).when(registryTransformer)
+                .transform(any(InputStream.class));
+        identityNodeInitialization.init();
+    }
+
+    private Metacard getTestMetacard() {
+        return new MetacardImpl(new RegistryObjectMetacardType());
+    }
+
+}


### PR DESCRIPTION
#### What does this PR do?
Extracts the identity node intialization methods, `init(),  createIdentityNode(), getRegistryMetcardFromRegistryPackage()` from `FederationAdminServiceImpl` and places them within the new class `IdentityNodeInitialization` . A new test class was implemented due to this change: `IdentityNodeInitializationTest` and a bean was setup in the blueprint. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard 
@gordocanchola 
@brianfelix 
@vinamartin 
@mcalcote
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@shaundmorris 
#### How should this be tested?
- Build and run, make sure that the registry identity node is being created properly when the DDF Registry starts. 
- There is a known issue where modifiedTime and lastUpdated of the identity metacard attributes were slightly off. Double check to make sure these values are the same. 

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2176
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

