### PR TITLE
DDF-2220: Additional query parameters are not preserved after a search is performed

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Filter.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Filter.js
@@ -123,66 +123,17 @@ define([
         },
 
         addValueToGroupFilter: function(fieldName, value){
-            var existingFilters = this.where({fieldName: fieldName});
-            var groupedFilterValues = [];
-            _.each(existingFilters, function(existingFilter){
-                var existingFilterString = existingFilter.get('stringValue1');  // we assume string group filters.
-                if(existingFilterString && existingFilterString !== ''){
-                    var parsedIds = existingFilterString.split(',');
-                    _.each(parsedIds, function(parsedId){
-                        if(parsedId !== value){
-                            groupedFilterValues.push(parsedId);
-                        }
-                    });
-                }
-            });
-            groupedFilterValues.push(value);
-            this.remove(existingFilters);
-            this.add(new Filter.Model({
-                fieldName: fieldName,
-                fieldType: 'string',
-                fieldOperator: 'contains',
-                stringValue1: groupedFilterValues.join(',')
-            }));
-        },
-
-        removeAllFromGroupFilter: function(fieldName){
-            var existingFilters = this.where({fieldName: fieldName});
-            this.remove(existingFilters);
-        },
-
-        removeValueFromGroupFilter: function(fieldName, value){
-            var existingFilters = this.where({fieldName: fieldName});
-            var groupedFilterValues = [];
-            _.each(existingFilters, function(existingFilter){
-                var existingFilterString = existingFilter.get('stringValue1'); // we assume string group filters.
-                if(existingFilterString && existingFilterString !== ''){
-                    var parsedIds = existingFilterString.split(',');
-                    _.each(parsedIds, function(parsedId){
-                        if(parsedId !== value){
-                            groupedFilterValues.push(parsedId);
-                        }
-                    });
-                }
-            });
-            this.remove(existingFilters);
-            this.add(new Filter.Model({
-                fieldName: fieldName,
-                fieldType: 'string',
-                fieldOperator: 'contains',
-                stringValue1: groupedFilterValues.join(',')
-            }));
-        },
-
-        replaceGroupFilter: function(fieldName, value){
-            var existingFilters = this.where({fieldName: fieldName});
-            this.remove(existingFilters);
             this.add(new Filter.Model({
                 fieldName: fieldName,
                 fieldType: 'string',
                 fieldOperator: 'contains',
                 stringValue1: value
             }));
+        },
+
+        removeValueFromGroupFilter: function(fieldName, value){
+            var existingFilters = this.where({fieldName: fieldName, stringValue1: value});
+            this.remove(existingFilters);
         }
     });
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -389,7 +389,7 @@ define([
             },
 
             buildSearchData: function(){
-                var data = _.clone(this.attributes);
+                var data = this.toJSON();
                 if(this.filters.length === 0){
                     this.clearFilters(); // init filters from search parameters.
                 }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -325,99 +325,6 @@ define([
                 return filters;
             },
 
-            getCql: function () {
-                var filters = [];
-
-                // contextual
-                var q = this.get('q');
-                if (q) {
-                    var likeOp = this.get('matchcase') ? ' LIKE ' : ' ILIKE ';
-                    filters.push('anyText' + likeOp + this.getValue(q));
-                }
-
-                // temporal
-                var start = this.get('dtstart'),
-                    end = this.get('dtend'),
-                    offset = this.get('dtoffset'),
-                    timeType = this.get('timeType');
-                if (start && end) {
-                    filters.push(timeType + ' DURING ' + this.getValue(new Date(start)) + '/' +
-                        this.getValue(new Date(end)));
-                } else if (start) {
-                    filters.push(timeType + ' AFTER ' + this.getValue(new Date(start)));
-                } else if (end) {
-                    filters.push(timeType + ' BEFORE ' + this.getValue(new Date(end)));
-                } else if (offset) {
-                    filters.push(timeType + ' AFTER ' +
-                        moment.utc().subtract(offset, 'milliseconds').format(properties.CQL_DATE_FORMAT));
-                }
-
-                // spatial
-                var north = this.get('north'),
-                    south = this.get('south'),
-                    west = this.get('west'),
-                    east = this.get('east'),
-                    lat = this.get('lat'),
-                    lon = this.get('lon'),
-                    radius = this.get('radius'),
-                    polygon = this.get('polygon');
-                if (north && south && east && west) {
-                    var bbox = 'POLYGON ((' +
-                        west + ' ' + south +
-                        ', ' + west + ' ' + north +
-                        ', ' + east + ' ' + north +
-                        ', ' + east + ' ' + south +
-                        ', ' + west + ' ' + south +
-                        '))';
-                    filters.push('INTERSECTS(anyGeo, ' + bbox + ')');
-                } else if (polygon) {
-                    var poly = 'POLYGON ((';
-                    var polyPoint;
-                    for (var i = 0;i<polygon.length;i++) {
-                        polyPoint = polygon[i];
-                        poly += polyPoint[0] + ' ' + polyPoint[1];
-                        if (i < polygon.length - 1) {
-                            poly += ', ';
-                        }
-                    }
-                    poly += '))';
-                    filters.push('INTERSECTS(anyGeo, ' + poly + ')');
-                } else if (lat && lon && radius) {
-                    var point = 'POINT(' + lon + ' ' + lat + ')';
-                    filters.push('DWITHIN(anyGeo, ' + point + ', ' + radius + ', meters)');
-                }
-
-                // type
-                var types = this.get('type');
-                if (types) {
-                    var typeFilters = [];
-                    _.each(types.split(','), function (type) {
-                        typeFilters.push('"' + properties.filters.METADATA_CONTENT_TYPE + '" = ' + this.getValue(type));
-                    }, this);
-
-                    filters.push(this.logicalCql(typeFilters, 'OR'));
-                }
-
-                var cql = this.logicalCql(filters, 'AND');
-                if (!cql) {
-                    cql = "anyText LIKE '%'";
-                }
-
-                return cql;
-            },
-
-            logicalCql: function (filters, operator) {
-                var cql = '';
-                if (filters.length === 1) {
-                    cql = filters[0];
-                } else if (filters.length > 1) {
-                    cql = _.map(filters, function (filter) {
-                        return '(' + filter + ')';
-                    }).join(' ' + operator + ' ');
-                }
-                return cql;
-            },
-
             getValue: function(value) {
                 switch (typeof value) {
                     case 'string':
@@ -434,14 +341,6 @@ define([
                     default:
                         throw new Error("Can't write value to CQL: " + value);
                 }
-            },
-
-            toJSON: function() {
-                var json = _.clone(this.attributes);
-
-                json.cql = this.getCql();
-
-                return json;
             },
 
             startScheduledSearch: function() {
@@ -490,12 +389,24 @@ define([
             },
 
             buildSearchData: function(){
-                var data = this.toJSON();
+                var data = _.clone(this.attributes);
                 if(this.filters.length === 0){
                     this.clearFilters(); // init filters from search parameters.
                 }
                 // this overrides the cql generation with the filters cql.
-                data.cql = this.filters.toCQL();
+                // The toCQL method requires the metadata-content-type to be in a comma seperated array
+                var types = this.filters.where({fieldName: 'metadata-content-type'}).map(function(e){return e.get('stringValue1');}).join(',');
+                var tempFilters = this.filters.filter(function(filter) {return filter.get('fieldName') !== 'metadata-content-type';});
+                if (types) {
+                    tempFilters.push(new Filter.Model({
+                        fieldName: 'metadata-content-type',
+                        fieldType: 'string',
+                        fieldOperator: 'contains',
+                        stringValue1: types
+                    }));
+                }
+                tempFilters = new Filter.Collection(tempFilters);
+                data.cql = tempFilters.toCQL();
 
                 // lets handle the source-id filters since they are not included in the cql.
                 var sourceFilters = this.filters.where({fieldName: properties.filters.SOURCE_ID});

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
@@ -29,27 +29,11 @@ define([
             events: {
                 'click .toggle-facet': 'toggleFacet',
                 'click .any-button':'anyButtonClicked',
-                'click .toggle-button':'toggleState'
             },
             initialize: function(){
-                this.stateModel = new Backbone.Model({
-                    state: this.options.isAny ? 'any' : 'specific'
-                });
-                this.listenTo(this.stateModel, 'change', this.render);
-            },
-            templateHelpers: function(){
-                return {
-                    isAny: this.options.isAny,
-                    state: this.stateModel.get('state')
-                };
             },
             anyButtonClicked: function(){
                 wreqr.vent.trigger('anyFacetClicked', this.model.get('fieldName'));
-            },
-            toggleState: function(){
-                this.stateModel.set({
-                    state: this.stateModel.get('state') === 'any' ? 'specific' : 'any'
-                });
             },
             toggleFacet: function(evt){
                 if (evt.target.checked) {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
@@ -29,8 +29,6 @@ define([
             events: {
                 'click .toggle-facet': 'toggleFacet'
             },
-            initialize: function(){
-            },
             toggleFacet: function(evt){
                 if (evt.target.checked) {
                     this.addFacet(evt);

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FacetItem.view.js
@@ -27,13 +27,9 @@ define([
             template: 'facetItemTemplate',
             tagName: 'div',
             events: {
-                'click .toggle-facet': 'toggleFacet',
-                'click .any-button':'anyButtonClicked',
+                'click .toggle-facet': 'toggleFacet'
             },
             initialize: function(){
-            },
-            anyButtonClicked: function(){
-                wreqr.vent.trigger('anyFacetClicked', this.model.get('fieldName'));
             },
             toggleFacet: function(evt){
                 if (evt.target.checked) {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterCollection.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterCollection.view.js
@@ -57,7 +57,7 @@ define([
             },
             addChild: function(item){
                 var fieldName = item.get('fieldName');
-                if (fieldName !== Properties.filters.SOURCE_ID && fieldName) {
+                if (fieldName !== Properties.filters.SOURCE_ID) {
                     Backbone.Marionette.CollectionView.prototype.addChild.apply(this, arguments);
                 }
             }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterCollection.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterCollection.view.js
@@ -57,7 +57,7 @@ define([
             },
             addChild: function(item){
                 var fieldName = item.get('fieldName');
-                if (fieldName !== Properties.filters.SOURCE_ID && fieldName !== Properties.filters.METADATA_CONTENT_TYPE) {
+                if (fieldName !== Properties.filters.SOURCE_ID && fieldName) {
                     Backbone.Marionette.CollectionView.prototype.addChild.apply(this, arguments);
                 }
             }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterItem.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/filter/FilterItem.view.js
@@ -41,10 +41,6 @@ define([
                 'change:geoType' : 'render',
                 'EndExtent': 'drawingStopped'
             },
-            collectionEvents: {
-                'remove': 'render',
-                'add': 'render'
-            },
             initialize: function(){
                 this.modelbinder = new Backbone.ModelBinder();
             },
@@ -129,9 +125,6 @@ define([
                     hasValue = true;
                 }
                 elem.parent().toggleClass('has-value', hasValue);
-            },
-            toggleRemoveButton: function(removeButtonFlag){
-                this.$('.btn.remove').toggle(removeButtonFlag);
             },
             drawClicked: function(){
                 this.$('.draw').attr('disabled', 'disabled');

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/filter/facet.item.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/filter/facet.item.handlebars
@@ -22,7 +22,7 @@
             <td>
                 <div class="pull-left margin-right-6">
                     <input class="toggle-facet" type="checkbox" {{#is isInFilter true}}
-                        checked="checked" {{/is}} {{#is ../state "any"}} checked="checked" {{/is}} data-field-value="{{value}}" data-value-count="{{count}}" data-field-name="{{../fieldName}}"/>
+                        checked="checked" {{/is}} data-field-value="{{value}}" data-value-count="{{count}}" data-field-name="{{../fieldName}}"/>
                 </div>
 
                 <div class="pull-left" title="{{value}}">


### PR DESCRIPTION
#### What does this PR do?
Fixed the metadata-content-type filter query parameter.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ahoffer @brendan-hofmann @andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison 
@pklinef
#### How should this be tested?
Ingest two different types of files (png/pdf) and do an initial search.
Verify that all the checkboxes under Metacard-Content-Type are unchecked.
Verify that adding and removing checkmarks changes the query with the proper content type.
Verify that searching with new metacard-content-type queries return the results of their respective types.
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
