### PR TITLE
DDF-2215: Remove pending state from ResourceCacheImpl.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/ResourceCacheImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/ResourceCacheImpl.java
@@ -20,6 +20,7 @@ import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -42,6 +43,10 @@ import ddf.catalog.resource.data.ReliableResource;
 import ddf.catalog.resource.download.ReliableResourceDownloadManager;
 
 public class ResourceCacheImpl implements ResourceCacheInterface {
+
+    private static final String DEPRECATE_MESSAGE =
+            "%s was part of the deprecated ResourceCacheInterface. Use instead the methods from"
+                    + "ReliableResourceDownloadManager";
 
     private static final String KARAF_HOME = "karaf.home";
 
@@ -74,12 +79,6 @@ public class ResourceCacheImpl implements ResourceCacheInterface {
     private BundleContext context;
 
     private String xmlConfigFilename;
-
-    private ReliableResourceDownloadManager manager;
-
-    public void setManager(ReliableResourceDownloadManager manager) {
-        this.manager = manager;
-    }
 
     /**
      * Called after all parameters are set
@@ -241,17 +240,10 @@ public class ResourceCacheImpl implements ResourceCacheInterface {
         this.xmlConfigFilename = xmlConfigFilename;
     }
 
-    /**
-     * Returns true if resource with specified cache key is already in the process of
-     * being cached. This check helps clients prevent attempting to cache the same resource
-     * multiple times.
-     *
-     * @param key
-     * @return
-     */
     @Override
     public boolean isPending(String key) {
-        return manager.isPending(key);
+        throw new NotImplementedException(String.format(DEPRECATE_MESSAGE,
+                "ResourceCacheImpl.isPending"));
     }
 
     /**
@@ -272,12 +264,14 @@ public class ResourceCacheImpl implements ResourceCacheInterface {
 
     @Override
     public void removePendingCacheEntry(String cacheKey) {
-        manager.removePendingCacheEntry(cacheKey);
+        throw new NotImplementedException(String.format(DEPRECATE_MESSAGE,
+                "ResourceCacheImpl.removePendingCacheEntry"));
     }
 
     @Override
     public void addPendingCacheEntry(ReliableResource reliableResource) {
-        manager.addPendingCacheEntry(reliableResource);
+        throw new NotImplementedException(String.format(DEPRECATE_MESSAGE,
+                "ResourceCacheImpl.addPendingCacheEntry"));
     }
 
     /**

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/actions/DownloadResourceActionProvider.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/actions/DownloadResourceActionProvider.java
@@ -77,7 +77,7 @@ public class DownloadResourceActionProvider extends AbstractMetacardActionProvid
 
     private boolean isCached(Metacard metacard) {
         String key = new CacheKey(metacard).generateKey();
-        return resourceCache.isPending(key) || resourceCache.containsValid(key, metacard);
+        return downloadManager.isPending(key) || resourceCache.containsValid(key, metacard);
     }
 
     private URL getActionUrl(String metacardSource, String metacardId) throws Exception {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -309,8 +309,6 @@
         <property name="productCacheDirectory" value=""/>
         <property name="context" ref="blueprintBundleContext"/>
         <property name="xmlConfigFilename" value="reliableResource-hazelcast.xml"/>
-        <!--            TODO: Temporary injection until removal            -->
-        <property name="manager" value="reliableResourceDownloadManager"/>
     </bean>
 
     <bean id="productCache" class="org.codice.ddf.catalog.resource.cache.impl.ResourceCacheImpl">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -309,6 +309,8 @@
         <property name="productCacheDirectory" value=""/>
         <property name="context" ref="blueprintBundleContext"/>
         <property name="xmlConfigFilename" value="reliableResource-hazelcast.xml"/>
+        <!--            TODO: Temporary injection until removal            -->
+        <property name="manager" value="reliableResourceDownloadManager"/>
     </bean>
 
     <bean id="productCache" class="org.codice.ddf.catalog.resource.cache.impl.ResourceCacheImpl">

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/ResourceCacheImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/ResourceCacheImplTest.java
@@ -49,6 +49,8 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.impl.ResourceRequestById;
 import ddf.catalog.resource.Resource;
 import ddf.catalog.resource.data.ReliableResource;
+import ddf.catalog.resource.download.ReliableResourceDownloadManager;
+import ddf.catalog.resource.download.ReliableResourceDownloaderConfig;
 
 public class ResourceCacheImplTest {
 
@@ -111,6 +113,12 @@ public class ResourceCacheImplTest {
 
         newResourceCache = new org.codice.ddf.catalog.resource.cache.impl.ResourceCacheImpl(
                 resourceCache);
+
+        ReliableResourceDownloaderConfig config = mock(ReliableResourceDownloaderConfig.class);
+        when(config.getResourceCache()).thenReturn(resourceCache);
+        resourceCache.setManager(new ReliableResourceDownloadManager(config,
+                null,
+                null));
     }
 
     @After

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/actions/DownloadResourceActionProviderTest.java
@@ -82,7 +82,7 @@ public class DownloadResourceActionProviderTest {
     public void canHandle() {
         assertThat(actionProvider.canHandleMetacard(metacard), is(true));
         verify(resourceCache).containsValid(anyString(), same(metacard));
-        verify(resourceCache).isPending(anyString());
+        verify(downloadManager).isPending(anyString());
         verify(downloadManager).isCacheEnabled();
     }
 
@@ -100,7 +100,7 @@ public class DownloadResourceActionProviderTest {
 
     @Test
     public void canHandleWhenResourceBeingDownloaded() {
-        when(resourceCache.isPending(anyString())).thenReturn(true);
+        when(downloadManager.isPending(anyString())).thenReturn(true);
         assertThat(actionProvider.canHandleMetacard(metacard), is(false));
     }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
@@ -82,6 +82,8 @@ public class ReliableResourceDownloaderTest {
 
     private Metacard mockMetacard;
 
+    private ReliableResourceDownloadManager manager;
+
     @BeforeClass
     public static void oneTimeSetup() throws IOException {
         String workingDir = System.getProperty("user.dir");
@@ -98,6 +100,8 @@ public class ReliableResourceDownloaderTest {
         // Don't wait between attempts
         downloaderConfig.setDelayBetweenAttemptsMS(0);
         mockMetacard = getMockMetacard(DOWNLOAD_ID, "sauce");
+
+        manager = mock(ReliableResourceDownloadManager.class);
     }
 
     @Test
@@ -113,7 +117,7 @@ public class ReliableResourceDownloaderTest {
                 DOWNLOAD_ID,
                 mockResponse,
                 getMockRetriever());
-        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl());
+        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl(), manager);
         downloader.run();
 
         verify(mockPublisher, times(retries)).postRetrievalStatus(any(ResourceResponse.class),
@@ -143,7 +147,7 @@ public class ReliableResourceDownloaderTest {
                 "123",
                 mockResponse,
                 getMockRetriever());
-        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl());
+        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl(), manager);
 
         FileOutputStream mockFos = mock(FileOutputStream.class);
         doThrow(new IOException()).when(mockFos)
@@ -158,7 +162,7 @@ public class ReliableResourceDownloaderTest {
                 anyString(),
                 anyLong(),
                 eq(DOWNLOAD_ID));
-        verify(mockCache, times(1)).removePendingCacheEntry(anyString());
+        verify(manager, times(1)).removePendingCacheEntry(anyString());
         assertThat(downloaderConfig.isCacheEnabled(), is(false));
 
     }
@@ -183,7 +187,7 @@ public class ReliableResourceDownloaderTest {
                 "123",
                 mockResponse,
                 getMockRetriever());
-        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl());
+        downloader.setupDownload(mockMetacard, new DownloadStatusInfoImpl(), manager);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         CountingOutputStream mockCountingFbos = new CountingOutputStream(baos);


### PR DESCRIPTION
#### What does this PR do?
The resource cache should not be storing the pending state of resources. It should only know about itself; **the cache** with **the products**. This PR removes the `List<String>` of keys for pending downloads from the `ResourceCacheImpl` and moves it to the `ReliableResourceDownloadManager`. It also updates the relevant tests accordingly. 

#### Who is reviewing it?
@cmthom10 
@garrettfreibott 
@figliold 
@emanns95

#### Choose 2 committers to review/merge the PR:
@lessarderic 
@shaundmorris

#### How should this be tested?
Verify the build. Make sure product downloads are still working. 

#### Any background context you want to provide?
This is part of the reliable resource refactor for a new download endpoint. See @lessarderic for more information if desired. 

#### What are the relevant tickets?
DDF-2194, DDF-2210, and **DDF-2215**