### PR TITLE
DDF-2194: Move the "Download Started" publish event to the ReliableResourceDownloader

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -213,6 +213,13 @@ public class ReliableResourceDownloader implements Runnable {
         ReliableResourceStatus reliableResourceStatus = null;
         int retryAttempts = 0;
 
+        downloaderConfig.getEventPublisher().postRetrievalStatus(resourceResponse,
+                ProductRetrievalStatus.STARTED,
+                metacard,
+                null,
+                0L,
+                downloadIdentifier);
+
         try {
             reliableResourceCallable = new ReliableResourceCallable(resourceInputStream,
                     countingFbos,


### PR DESCRIPTION
#### What does this PR do?
Consolidates all publish events to the `ReliableResourceDownloader` which is responsible for the full download lifecycle. Only the "Download Started" event was still in the manager and had to be moved. 

#### Who is reviewing it?
@cmthom10 
@garrettfreibott 
@figliold 
@emanns95

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested?
Validate the build. Using a CometD client of your choice, initiate downloads and ensure the JSON notification for **Download.STARTED** is received. See @oconnormi or @Lambeaux for more details. 

#### Any background context you want to provide?
This is part of the reliable resource refactor for a new download endpoint. See @lessarderic for more information if desired.

#### What are the relevant tickets?
**DDF-2194**, DDF-2210, and DDF-2215

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests