### PR TITLE
DDF-2232: updated pom-fix to run correctly on maven build in windows,…

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -487,5 +487,10 @@
             <artifactId>catalog-core-ftp</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-resourcestatusplugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/libs/libs-pomfix-run/package.json
+++ b/libs/libs-pomfix-run/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "pom-fix"
+    "test": "pom-fix -d ../../"
   },
   "author": "Codice",
   "license": "LGPL-3.0",

--- a/libs/libs-pomfix-run/pom.xml
+++ b/libs/libs-pomfix-run/pom.xml
@@ -71,7 +71,7 @@
                         </goals>
                         <phase>install</phase>
                         <configuration>
-                            <arguments>test -- "-d" "${project.parent.parent.basedir}"</arguments>
+                            <arguments>test</arguments>
                         </configuration>
                     </execution>
                     <execution>

--- a/libs/libs-pomfix/bin/pom-fix
+++ b/libs/libs-pomfix/bin/pom-fix
@@ -15,6 +15,7 @@
 var chalk = require('chalk')
 var es = require('event-stream')
 var program = require('commander')
+var path = require('path')
 
 var pkg = require('../package.json')
 var util = require('../lib/util')
@@ -66,7 +67,12 @@ var options = {
   }
 }
 
-util.find(program.dir, [ '!libs-pomfix' ])
+var rootDir = path.resolve(program.dir || '')
+var bin = path.basename(process.argv[1])
+
+console.log('Running ' +  chalk.blue(bin) + ' from ' + chalk.green(rootDir))
+
+util.find(rootDir, [ '!libs-pomfix' ])
   .pipe(util.read())
   .pipe(fix(util.load, options))
   .pipe(apply())

--- a/libs/libs-pomfix/lib/util.js
+++ b/libs/libs-pomfix/lib/util.js
@@ -26,7 +26,7 @@ exports.load = function (key) {
 // find all the feature/pom xml files
 exports.find = function (dir, filter) {
   return readdirp({
-    root: dir || process.cwd(),
+    root: dir,
     fileFilter: ['pom.xml', 'features.xml'],
     directoryFilter: ['!target', '!node_modules']
       .concat(filter || [])


### PR DESCRIPTION
#### What does this PR do?

Fixes how pom-fix handles paths.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@Lambeaux 
@rzwiefel 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@stustison 

#### How should this be tested?

A quick build on both windows and osx and check the directory pom-fix is running from.

#### Any background context you want to provide?

The module lib-pomfix-run, was recently updated to work on windows by quoting the parameters that maven passes to pom-fix. Although this seemed to fix the issue on windows, it actually was passing the incorrect parameters to pom-fix.

`-d` became `"-d"` and `/path/to/ddf` became `"/path/to/ddf"`

Since pom-fix didn't have a `"-d"` parameter, the parameter was ignored and it just used the current directory of execution which was `libs/libs-pomfix-run`.

#### What are the relevant tickets?

[DDF-2232](https://codice.atlassian.net/browse/DDF-2232)