### PR TITLE
DDF-2188 Adds new service definition for extracting metadata from text content files.

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/ContentMetadataExtractor.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/ContentMetadataExtractor.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.content.operation;
+
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+
+/**
+ * Parses content, extracting metadata and adding it to the provided card.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface ContentMetadataExtractor {
+    /**
+     * Parses the input string, extracting metadata from it to add to the metacard.
+     *
+     * @param input    the content to process
+     * @param metacard the incoming metacard
+     */
+    void process(String input, Metacard metacard);
+
+    /**
+     * Returns the valid set of Metacard attributes that are populated by this extractor.
+     *
+     * @return set of attributes populated by this extractor
+     */
+    Set<AttributeDescriptor> getMetacardAttributes();
+}

--- a/catalog/security/catalog-security-metacardattributeplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/security/catalog-security-metacardattributeplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,13 +18,15 @@
          name="Metacard Attribute Security Policy Plugin"
          id="org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin">
 
-        <AD name="Metacard Attributes:" id="metacardAttributes" description="Attributes within the metacard that will be collected for security information."
+        <AD name="Metacard Attributes:" id="metacardAttributes"
+            description="Metacard attributes that will be collected and mapped to security information. Example: security.classification=classification"
             required="true" type="String" cardinality="1000"
             default=""/>
 
     </OCD>
 
-    <Designate pid="org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin">
+    <Designate
+            pid="org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin">
         <Object ocdref="org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin"/>
     </Designate>
 

--- a/catalog/security/catalog-security-metacardattributeplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/MetacardAttributeSecurityPolicyPluginTest.java
+++ b/catalog/security/catalog-security-metacardattributeplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/MetacardAttributeSecurityPolicyPluginTest.java
@@ -55,11 +55,13 @@ public class MetacardAttributeSecurityPolicyPluginTest {
         metacard1.setAttribute(new AttributeImpl("parsed.countries", Arrays.asList("GBR", "CAN")));
         metacard1.setAttribute(new AttributeImpl("parsed.other", Arrays.asList("E", "F")));
         plugin = new MetacardAttributeSecurityPolicyPlugin();
-        plugin.setMetacardAttributes(Arrays.asList("parsed.security", "parsed.countries"));
+        plugin.setMetacardAttributes(Arrays.asList("parsed.security=mapped.security",
+                "parsed.countries=mapped.countries"));
     }
 
     @Test
-    public void testProcessPreCreate() throws StopProcessingException {
+    public void testBadAttributeDef() throws StopProcessingException {
+        plugin.setMetacardAttributes(Arrays.asList("parsed.security", "parsed.countries"));
         PolicyResponse policyResponse = plugin.processPreCreate(metacard, new HashMap<>());
         assertThat(policyResponse.itemPolicy()
                 .size(), is(2));
@@ -82,6 +84,39 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .contains("CAN"));
 
         assertNull(policyResponse.itemPolicy()
+                .get("mapped.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("mapped.countries"));
+    }
+
+    @Test
+    public void testProcessPreCreate() throws StopProcessingException {
+        PolicyResponse policyResponse = plugin.processPreCreate(metacard, new HashMap<>());
+        assertThat(policyResponse.itemPolicy()
+                .size(), is(2));
+
+        assertTrue(policyResponse.itemPolicy()
+                .get("mapped.security")
+                .contains("A"));
+        assertTrue(policyResponse.itemPolicy()
+                .get("mapped.security")
+                .contains("B"));
+        assertTrue(policyResponse.itemPolicy()
+                .get("mapped.security")
+                .contains("C"));
+
+        assertTrue(policyResponse.itemPolicy()
+                .get("mapped.countries")
+                .contains("USA"));
+        assertTrue(policyResponse.itemPolicy()
+                .get("mapped.countries")
+                .contains("CAN"));
+
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
+        assertNull(policyResponse.itemPolicy()
                 .get("parsed.other"));
     }
 
@@ -92,22 +127,26 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .size(), is(2));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("A"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("B"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("C"));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("USA"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("CAN"));
 
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
         assertNull(policyResponse.itemPolicy()
                 .get("parsed.other"));
     }
@@ -120,33 +159,38 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .size(), is(2));
 
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("A"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("B"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("C"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("X"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("Y"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("Z"));
 
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("USA"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("CAN"));
         assertTrue(policyResponse.operationPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("GBR"));
+
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
     }
 
     @Test
@@ -156,22 +200,26 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .size(), is(2));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("A"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("B"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("C"));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("USA"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("CAN"));
 
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
         assertNull(policyResponse.itemPolicy()
                 .get("parsed.other"));
     }
@@ -185,22 +233,26 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .size(), is(2));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("A"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("B"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("C"));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("USA"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("CAN"));
 
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
         assertNull(policyResponse.itemPolicy()
                 .get("parsed.other"));
     }
@@ -213,22 +265,26 @@ public class MetacardAttributeSecurityPolicyPluginTest {
                 .size(), is(2));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("A"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("B"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.security")
+                .get("mapped.security")
                 .contains("C"));
 
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("USA"));
         assertTrue(policyResponse.itemPolicy()
-                .get("parsed.countries")
+                .get("mapped.countries")
                 .contains("CAN"));
 
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.security"));
+        assertNull(policyResponse.itemPolicy()
+                .get("parsed.countries"));
         assertNull(policyResponse.itemPolicy()
                 .get("parsed.other"));
     }
@@ -236,9 +292,11 @@ public class MetacardAttributeSecurityPolicyPluginTest {
     @Test
     public void testUnusedMethods() throws StopProcessingException {
         PolicyResponse policyResponse = plugin.processPreQuery(mock(Query.class), new HashMap<>());
-        assertThat(policyResponse.itemPolicy().size(), is(0));
+        assertThat(policyResponse.itemPolicy()
+                .size(), is(0));
 
         policyResponse = plugin.processPreResource(mock(ResourceRequest.class));
-        assertThat(policyResponse.itemPolicy().size(), is(0));
+        assertThat(policyResponse.itemPolicy()
+                .size(), is(0));
     }
 }

--- a/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
+++ b/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
@@ -14,6 +14,7 @@
 package ddf.catalog.transformer.common.tika;
 
 import java.util.Date;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.metadata.Metadata;
@@ -21,10 +22,15 @@ import org.apache.tika.metadata.TikaCoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Sets;
+
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 
 /**
  * Creates {@link Metacard}s from Tika {@link Metadata} objects.
@@ -46,7 +52,33 @@ public class MetacardCreator {
      */
     public static Metacard createBasicMetacard(final Metadata metadata, final String id,
             final String metadataXml) {
-        final Metacard metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+        return createMetacard(metadata, id, metadataXml, BasicTypes.BASIC_METACARD);
+    }
+
+    /**
+     * @param metadata           the {@code Metadata} object containing the metadata relevant to the
+     *                           metacard, must not be null
+     * @param id                 the value for the {@link Metacard#ID} attribute that should be set in the
+     *                           generated {@code Metacard}, may be null
+     * @param metadataXml        the XML for the {@link Metacard#METADATA} attribute that should be set in
+     *                           the generated {@code Metacard}, may be null
+     * @param typeName           the name to give to the dynamically created {@link MetacardType}
+     * @param extendedAttributes the extra attributes (on top of those already present in
+     *                           {@link BasicTypes#BASIC_METACARD}) that will be available in the metacard
+     * @return a new {@code Metacard}
+     */
+    public static Metacard createEnhancedMetacard(final Metadata metadata, final String id,
+            final String metadataXml, final String typeName,
+            final Set<AttributeDescriptor> extendedAttributes) {
+        MetacardTypeImpl metacardType = new MetacardTypeImpl(typeName,
+                Sets.union(BasicTypes.BASIC_METACARD.getAttributeDescriptors(),
+                        extendedAttributes));
+        return createMetacard(metadata, id, metadataXml, metacardType);
+    }
+
+    private static Metacard createMetacard(final Metadata metadata, final String id,
+            final String metadataXml, MetacardType metacardType) {
+        final Metacard metacard = new MetacardImpl(metacardType);
 
         final String contentType = metadata.get(Metadata.CONTENT_TYPE);
         if (StringUtils.isNotBlank(contentType)) {

--- a/catalog/transformer/catalog-transformer-pdf/pom.xml
+++ b/catalog/transformer/catalog-transformer-pdf/pom.xml
@@ -40,6 +40,10 @@
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>catalog-transformer-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -88,6 +92,12 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!--groovy dependencies-->
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -129,7 +139,7 @@
                         <Embed-Dependency>
                             catalog-core-api-impl,
                             platform-util,
-
+                            catalog-transformer-common,
                             <!-- external -->
                             commons-lang3,
                             fontbox,
@@ -161,22 +171,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.42</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.93</minimum>
+                                            <minimum>0.94</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,4 +27,10 @@
         </service-properties>
     </service>
 
+    <reference-list id="contentExtractors" interface="ddf.catalog.content.operation.ContentMetadataExtractor"
+                    availability="optional">
+        <reference-listener bind-method="addContentMetadataExtractors" unbind-method="removeContentMetadataExtractor"
+                            ref="pdfTransformer"/>
+    </reference-list>
+
 </blueprint>

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.imgscalr</groupId>
             <artifactId>imgscalr-lib</artifactId>
             <version>4.2</version>
@@ -96,6 +100,8 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             catalog-transformer-common,
+                            catalog-core-api-impl,
+                            platform-util,
                             imgscalr-lib,
                             jai-imageio-core,
                             jai-imageio-jpeg2000,
@@ -130,22 +136,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.89</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,13 @@
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
         <!-- The tika input transformer programmatically registers itself as a service -->
-    <bean class="ddf.catalog.transformer.input.tika.TikaInputTransformer">
+    <bean id="tikaTransformer" class="ddf.catalog.transformer.input.tika.TikaInputTransformer">
 		    <argument ref="blueprintBundleContext"/>
 		</bean>
+
+    <reference-list id="contentExtractors" interface="ddf.catalog.content.operation.ContentMetadataExtractor"
+                    availability="optional">
+        <reference-listener bind-method="addContentMetadataExtractors" unbind-method="removeContentMetadataExtractor"
+                            ref="tikaTransformer"/>
+    </reference-list>
 </blueprint>

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/configuring-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/configuring-catalog-contents.adoc
@@ -264,12 +264,12 @@
 |Default Value
 |Required
 
-1|Metacard Attributes:
-2|metacardAttributes
-3|String
-4|Attributes within the metacard that will be collected for security information.
-5|
-6|No
+|Metacard Attributes:
+|metacardAttributes
+|String
+|Metacard attributes that will be collected and mapped to security information. Example: `security.classification=classification`.
+|
+|No
 
 |===
 

--- a/distribution/docs/src/main/resources/_contents/securing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/securing-contents.adoc
@@ -1603,6 +1603,7 @@ While the *Security Attributes (intersection)* field will computer the intersect
 
 The *Metacard Attribute Security Policy Plugin* will pull attributes directly off of a metacard and combine these attributes into a security field for the metacard.
 This plugin assumes that the pertinent information has already been parsed out of the metadata and placed directly on the metacard itself.
+The plugin supports mapping attributes from their names on the metacard to a different security policy name.
 
 To configure these policy plugins:
 . Open the ${admin-console} at \${secure_url}/admin


### PR DESCRIPTION
#### What does this PR do?
Cherry pick of PR #864 to 2.9.x

This PR adds a new service interface for reading the content of a text document and parsing out any specific metadata it may have to be added to its associated Metacards. The two text importers - 
Tika and PDF - have been updated to find the ContentMetadataExtractor implementors and process each of them in turn.

This change also updates the MetacardAttributeSecurityPolicyPlugin so that it takes key-value pairs of attribute names. The metacard is checked to see if it has attributes named by those keys and then creates security policy map entries keyed by the values.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests