### PR TITLE
DDF-2177 Add Auto Push configuration property to the registry store

### DIFF
--- a/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
+++ b/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemInfo;
 
 import com.codahale.metrics.Histogram;
@@ -248,8 +249,9 @@ public final class CatalogMetrics
         } else if (sourceIds == null) {
             return false;
         } else {
-            return (sourceIds.size() > 1) || (sourceIds.size() == 1 && !sourceIds.contains("")
-                    && !sourceIds.contains(null) && !sourceIds.contains(SystemInfo.getSiteName()));
+            return (sourceIds.size() > 1) || (sourceIds.size() == 1 && sourceIds.stream()
+                    .noneMatch(StringUtils::isEmpty)
+                    && !sourceIds.contains(SystemInfo.getSiteName()));
         }
     }
 }

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
@@ -37,6 +37,7 @@ function (Q, Service, Backbone, _) {
         remoteId: 'remoteName',
         pullAttribute: 'pullAllowed',
         pushAttribute: 'pushAllowed',
+        autoPushAttribute: 'autoPush',
         pidAttribute: 'pid',
         initialize: function() {
             this.set('registryConfiguration', new Registry.ConfigurationList());
@@ -65,11 +66,12 @@ function (Q, Service, Backbone, _) {
             var remoteIdName = configuration.get("properties").get('remoteName');
             var allowPull = configuration.get("properties").get('pullAllowed');
             var allowPush = configuration.get("properties").get('pushAllowed');
+            var pushAuto = configuration.get("properties").get('autoPush');
             var id = configuration.get('id');
             if(this.get(registryId)) {
                 registry = this.get(registryId);
             } else {
-                registry = new Registry.Model({name: registryId, remoteName: remoteIdName, pullAllowed: allowPull, pushAllowed: allowPush, pid: id});
+                registry = new Registry.Model({name: registryId, remoteName: remoteIdName, pullAllowed: allowPull, pushAllowed: allowPush, autoPush: pushAuto, pid: id});
                 this.add(registry);
             }
 

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/ModalRegistry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/ModalRegistry.view.js
@@ -91,6 +91,7 @@ function (ich,Marionette,Backbone,ConfigurationEdit,wreqr,_,$,Utils,Service,moda
             wreqr.vent.trigger('beforesave');
             var view = this;
             var service = view.model.get('registryConfiguration').at(0);
+            service.get('properties').set('remoteName', view.model.get('remoteName'));
             if (service) {
                 if (_.isUndefined(service.get('properties').id)) {
                     var name = this.$(".registryName").find('input').val().trim();

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryList.handlebars
@@ -14,7 +14,7 @@
 <table class='table table-striped align-middle'>
     <thead>
         <th class="name">Local Name</th>
-        <th class="remote">Remote Name</th>
+        <th class="remoteName">Remote Name</th>
         <th class="status">Status</th>
         <th class="push">Allow Push</th>
         <th class="pull">Allow Pull</th>

--- a/catalog/spatial/registry/registry-api-impl/pom.xml
+++ b/catalog/spatial/registry/registry-api-impl/pom.xml
@@ -175,6 +175,11 @@
             <artifactId>spatial-csw-endpoint</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -241,22 +246,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.79</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStorePublisher.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStorePublisher.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.api.impl;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.federationadmin.service.RegistryPublicationService;
+import org.codice.ddf.security.common.Security;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.source.SourceMonitor;
+
+/**
+ * The RegistryStorePublisher controls the auto publication of RegistryStores. Upon creation,
+ * the reference listener will call the bindRegistryStore method and publish if isAutoPush is
+ * true. After editing the RegistryStore handleEvent will evaluate if the publish or unpublish
+ * should occur.
+ */
+public class RegistryStorePublisher implements EventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryStorePublisher.class);
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private static final String PUBLISH = "publish";
+
+    private static final String UNPUBLISH = "unpublish";
+
+    private ConcurrentHashMap<String, Boolean> registryStoreMap = new ConcurrentHashMap<>();
+
+    private RegistryPublicationService registryPublicationService;
+
+    private FederationAdminService federationAdminService;
+
+    private ScheduledExecutorService executor;
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+
+    public void setRegistryPublicationService(
+            RegistryPublicationService registryPublicationService) {
+        this.registryPublicationService = registryPublicationService;
+    }
+
+    public void setExecutor(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.error("Thread pool failed to terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+    }
+
+    public void bindRegistryStore(ServiceReference<RegistryStore> reference) {
+        BundleContext bundleContext = getBundleContext();
+
+        if (reference == null || bundleContext == null
+                || bundleContext.getService(reference) == null) {
+            LOGGER.warn("Reference or BundleContext was null/unset.");
+            return;
+        }
+
+        RegistryStore registryStore = bundleContext.getService(reference);
+
+        Boolean previousState = registryStoreMap.put(registryStore.getConfigurationPid(),
+                registryStore.isAutoPush());
+
+        SourceMonitor storeRegisteredSourceMonitor = new SourceMonitor() {
+            @Override
+            public void setAvailable() {
+                if (registryStore.isAutoPush()) {
+                    registryPublish(registryStore, PUBLISH);
+                }
+            }
+
+            @Override
+            public void setUnavailable() {
+            }
+        };
+
+        if (registryStore.isAvailable(storeRegisteredSourceMonitor) && registryStore.isAutoPush()) {
+            if (previousState == null || !previousState) {
+                registryPublish(registryStore, PUBLISH);
+            }
+        }
+    }
+
+    public void unbindRegistryStore(ServiceReference<RegistryStore> reference) {
+
+        BundleContext bundleContext = getBundleContext();
+
+        if (reference != null && bundleContext != null) {
+            RegistryStore registryStore = bundleContext.getService(reference);
+
+            registryStoreMap.remove(registryStore.getConfigurationPid());
+        }
+    }
+
+    void registryPublish(RegistryStore registryStore, String publish) {
+
+        if (registryStore.getRegistryId()
+                .isEmpty()) {
+            LOGGER.warn(String.format("RegistryStore missing id. Unable to complete %s request.",
+                    publish));
+            return;
+        }
+
+        executor.schedule(() -> {
+            try {
+                Optional<Metacard> registryIdentityMetacardOpt =
+                        Security.runAsAdminWithException(() -> federationAdminService.getLocalRegistryIdentityMetacard());
+
+                if (registryIdentityMetacardOpt.isPresent()) {
+                    Metacard registryIdentityMetacard = registryIdentityMetacardOpt.get();
+                    String localRegistryId = registryIdentityMetacard.getAttribute(
+                            RegistryObjectMetacardType.REGISTRY_ID)
+                            .getValue()
+                            .toString();
+                    Security.runAsAdminWithException(() -> {
+                        if (publish.equals(PUBLISH)) {
+                            registryPublicationService.publish(localRegistryId,
+                                    registryStore.getRegistryId());
+                        } else {
+                            registryPublicationService.unpublish(localRegistryId,
+                                    registryStore.getRegistryId());
+                        }
+                        return null;
+                    });
+                }
+
+            } catch (Exception e) {
+                LOGGER.error("Failed to {} registry configuration to {}",
+                        publish,
+                        ((RegistryStoreImpl) registryStore).getRemoteName());
+            }
+        }, 3, TimeUnit.SECONDS);
+    }
+
+    BundleContext getBundleContext() {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle != null) {
+            return bundle.getBundleContext();
+        }
+        return null;
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        if (((ServiceEvent) event.getProperty(EventConstants.EVENT)).getType()
+                != ServiceEvent.MODIFIED) {
+            return;
+        }
+        String pid = event.getProperty(Constants.SERVICE_PID)
+                .toString();
+
+        BundleContext bundleContext = getBundleContext();
+
+        RegistryStore registryStore =
+                (RegistryStore) bundleContext.getService(((ServiceEvent) event.getProperty(
+                        EventConstants.EVENT)).getServiceReference());
+
+        Boolean previousAutoPush = registryStoreMap.get(pid);
+
+        if (previousAutoPush == null) {
+            return;
+        }
+
+        if (!previousAutoPush && registryStore.isAutoPush()) {
+            registryPublish(registryStore, PUBLISH);
+            registryStoreMap.put(pid, true);
+        } else if (previousAutoPush && !registryStore.isAutoPush()) {
+            registryPublish(registryStore, UNPUBLISH);
+            registryStoreMap.put(pid, false);
+        }
+    }
+}

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,7 +34,38 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+    <reference id="federationAdminService"
+               interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
+    <reference id="registryPublicationService"
+               interface="org.codice.ddf.registry.federationadmin.service.RegistryPublicationService"/>
+
+    <bean id="executor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
+
+    <bean id="registryPublisher"
+          class="org.codice.ddf.registry.api.impl.RegistryStorePublisher">
+        <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="registryPublicationService" ref="registryPublicationService"/>
+        <property name="executor" ref="executor"/>
+    </bean>
+
+    <reference-list id="registryPubList" interface="org.codice.ddf.registry.api.RegistryStore"
+                    availability="optional">
+        <reference-listener ref="registryPublisher" bind-method="bindRegistryStore"
+                            unbind-method="unbindRegistryStore"/>
+    </reference-list>
+
+    <service ref="registryPublisher" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>org/osgi/framework/ServiceEvent/MODIFIED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+
+    <bean id="metacardMarshaller"
+          class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
         <argument ref="xmlParser"/>
     </bean>
 
@@ -59,11 +90,13 @@
                             ref="metacardTransformers"/>
     </reference-list>
 
-    <bean id="cswTransactionWriter" class="org.codice.ddf.spatial.ogc.csw.catalog.common.source.writer.CswTransactionRequestWriter">
+    <bean id="cswTransactionWriter"
+          class="org.codice.ddf.spatial.ogc.csw.catalog.common.source.writer.CswTransactionRequestWriter">
         <argument ref="cswTransformProvider"/>
     </bean>
 
     <cm:managed-service-factory
+
             id="ddf.catalog.registry.api.impl.RegistryStoreImpl.id"
             factory-pid="Csw_Registry_Store">
         <interfaces>

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,7 +19,7 @@
         <AD description="The unique name of the store" name="Registry ID" id="id" required="true"
             type="String"/>
 
-        <AD description="URL to the endpoint implementing CSW spec capable of returning ebrim formatted records, e.g. https://hostname.here:port#/services/csw"
+        <AD description="URL to the endpoint implementing CSW spec capable of returning ebrim formatted records"
             name="Registry Service URL" id="cswUrl" required="true" type="String"/>
 
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
@@ -27,12 +27,16 @@
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
             required="false" type="Password"/>
 
-        <AD description="Enable push (write) to this registry store"
+        <AD description="Enable push (write) to this registry"
             name="Allow Push" id="pushAllowed" required="true"
             type="Boolean" default="true"/>
 
-        <AD description="Enable pull (read) from this registry store"
+        <AD description="Enable pull (read) from this registry"
             name="Allow Pull" id="pullAllowed" required="true"
+            type="Boolean" default="true"/>
+
+        <AD description="Enable an automatic publish from the local identity node to this registry. Setting this to Off will have the effect of unpublishing the identity from this registry."
+            name="Push Identity Node" id="autoPush" required="true"
             type="Boolean" default="true"/>
 
     </OCD>

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
@@ -17,6 +17,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
@@ -25,9 +28,13 @@ import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
 
 import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.codice.ddf.parser.Parser;
@@ -36,10 +43,13 @@ import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.Csw;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.CswAxisOrder;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.source.CswFilterFactory;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.opengis.filter.Filter;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
@@ -48,29 +58,42 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import com.thoughtworks.xstream.converters.Converter;
 
 import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.FilterDelegate;
+import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.encryption.EncryptionService;
+import net.opengis.cat.csw.v_2_0_2.BriefRecordType;
+import net.opengis.cat.csw.v_2_0_2.CapabilitiesType;
+import net.opengis.cat.csw.v_2_0_2.ElementSetType;
+import net.opengis.cat.csw.v_2_0_2.InsertResultType;
 import net.opengis.cat.csw.v_2_0_2.TransactionResponseType;
 import net.opengis.cat.csw.v_2_0_2.TransactionSummaryType;
+import net.opengis.cat.csw.v_2_0_2.dc.elements.SimpleLiteral;
+import net.opengis.filter.v_1_1_0.FilterType;
 
 public class TestRegistryStore {
 
     private RegistryStoreImpl registryStore;
-
-    private RegistryStoreImplTest registryStoreImplTest;
 
     private Parser parser;
 
@@ -84,18 +107,20 @@ public class TestRegistryStore {
 
     private TransformerManager transformer;
 
-    private EncryptionService encryptionService;
-
     private ConfigurationAdmin configAdmin;
 
-    private FilterAdapter filterAdapter;
+    private FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
+
+    private FilterBuilder filterBuilder = spy(new GeotoolsFilterBuilder());
 
     private Configuration config;
 
-    private Filter filter;
+    private EncryptionService encryptionService;
+
+    private List<Result> queryResults;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         parser = new XmlParser();
         context = mock(BundleContext.class);
         provider = mock(Converter.class);
@@ -103,44 +128,86 @@ public class TestRegistryStore {
         factory = mock(SecureCxfClientFactory.class);
         transformer = mock(TransformerManager.class);
         encryptionService = mock(EncryptionService.class);
-        registryStore = new RegistryStoreImpl(context,
-                configuration,
-                provider,
-                factory,
-                encryptionService);
-        registryStore.setMetacardMarshaller(new MetacardMarshaller(parser));
-        registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
-        registryStore.setSchemaTransformerManager(transformer);
         configAdmin = mock(ConfigurationAdmin.class);
-        filterAdapter = mock(FilterAdapter.class);
         config = mock(Configuration.class);
-        filter = mock(Filter.class);
-    }
-
-    @Test
-    public void testUpdate() throws Exception {
-        registryStore = new RegistryStoreImpl(context,
+        queryResults = new ArrayList<>();
+        registryStore = spy(new RegistryStoreImpl(context,
                 configuration,
                 provider,
                 factory,
                 encryptionService) {
             @Override
-            public SourceResponse query(QueryRequest queryRequest)
-                    throws UnsupportedQueryException {
-                List<Result> results = new ArrayList<>();
-                results.add(new ResultImpl(getDefaultMetacard()));
-                return new SourceResponseImpl(queryRequest, results);
+            protected void validateOperation() {
             }
 
             @Override
-            protected void validateOperation() {
-
+            protected SourceResponse query(QueryRequest queryRequest, ElementSetType elementSetName,
+                    List<QName> elementNames, Csw csw) throws UnsupportedQueryException {
+                if(queryResults == null){
+                    throw new UnsupportedQueryException("Test - Bad Query");
+                }
+                return new SourceResponseImpl(queryRequest, queryResults);
             }
-        };
-        registryStore.setMetacardMarshaller(new MetacardMarshaller(parser));
-        registryStore.setFilterBuilder(new GeotoolsFilterBuilder());
-        registryStore.setSchemaTransformerManager(transformer);
 
+            @Override
+            protected CapabilitiesType getCapabilities() {
+                return mock(CapabilitiesType.class);
+            }
+        });
+
+        registryStore.setFilterBuilder(filterBuilder);
+        registryStore.setFilterAdapter(filterAdapter);
+        registryStore.setConfigAdmin(configAdmin);
+        registryStore.setMetacardMarshaller(new MetacardMarshaller(parser));
+        registryStore.setSchemaTransformerManager(transformer);
+        registryStore.setAutoPush(true);
+
+        when(configAdmin.getConfiguration(any())).thenReturn(config);
+        when(config.getProperties()).thenReturn(new Hashtable<>());
+    }
+
+    @Test(expected = IngestException.class)
+    public void testCreateNonRegistryMetacard() throws Exception {
+        MetacardImpl mcard = getDefaultMetacard();
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, null);
+        CreateRequest request = new CreateRequestImpl(mcard);
+        registryStore.create(request);
+    }
+
+    @Test
+    public void testCreateWithExistingMetacard() throws Exception {
+        Metacard mcard = getDefaultMetacard();
+        queryResults.add(new ResultImpl(mcard));
+        CreateRequest request = new CreateRequestImpl(mcard);
+        CreateResponse response = registryStore.create(request);
+        assertThat(response.getCreatedMetacards().get(0), is(mcard));
+    }
+
+    @Test
+    public void testCreateNoExistingMetacard() throws Exception {
+        Metacard mcard = getDefaultMetacard();
+        Csw csw = mock(Csw.class);
+        TransactionResponseType responseType = mock(TransactionResponseType.class);
+        InsertResultType insertResultType = mock(InsertResultType.class);
+        BriefRecordType briefRecord = mock(BriefRecordType.class);
+        JAXBElement identifier = mock(JAXBElement.class);
+        SimpleLiteral literal = mock(SimpleLiteral.class);
+        when(literal.getContent()).thenReturn(Collections.singletonList(mcard.getId()));
+        when(identifier.getValue()).thenReturn(literal);
+        when(briefRecord.getIdentifier()).thenReturn(Collections.singletonList(identifier));
+        when(insertResultType.getBriefRecord()).thenReturn(Collections.singletonList(briefRecord));
+        when(responseType.getInsertResult()).thenReturn(Collections.singletonList(insertResultType));
+        when(factory.getClientForSubject(any())).thenReturn(csw);
+        when(csw.transaction(any())).thenReturn(responseType);
+        when(transformer.getTransformerIdForSchema(any())).thenReturn("myInsertType");
+        queryResults.add(new ResultImpl(mcard));
+        CreateRequest request = new CreateRequestImpl(mcard);
+        CreateResponse response = registryStore.create(request);
+        assertThat(response.getCreatedMetacards().get(0), is(mcard));
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
         Csw csw = mock(Csw.class);
         TransactionResponseType responseType = mock(TransactionResponseType.class);
         TransactionSummaryType tst = new TransactionSummaryType();
@@ -157,12 +224,146 @@ public class TestRegistryStore {
                         Collections.singletonList(updatedMcard));
         request.getProperties()
                 .put(Constants.OPERATION_TRANSACTION_KEY, opTrans);
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
         registryStore.update(request);
         assertThat(request.getUpdates()
                 .get(0)
                 .getValue()
                 .getMetadata()
                 .contains("value=\"newTestId\""), is(true));
+    }
+
+    @Test(expected = IngestException.class)
+    public void testUpdateNonRegistryMetacard() throws Exception {
+        MetacardImpl updatedMcard = getDefaultMetacard();
+        updatedMcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, null);
+        UpdateRequestImpl request = new UpdateRequestImpl("testId", updatedMcard);
+        registryStore.update(request);
+    }
+
+    @Test
+    public void registryInfoQuery() throws Exception {
+        assertThat(registryStore.getRegistryId(), is(""));
+        assertThat(registryStore.getRemoteName(), is(""));
+
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        registryStore.registryInfoQuery();
+
+        assertThat(registryStore.getRegistryId(), is("registryId"));
+        assertThat(registryStore.getRemoteName(), is("testRegistryMetacard"));
+    }
+
+    @Test
+    public void registryInfoQueryNoIdentityMetacard() throws Exception {
+        assertThat(registryStore.getRegistryId(), is(""));
+        assertThat(registryStore.getRemoteName(), is(""));
+
+        registryStore.registryInfoQuery();
+
+        assertThat(registryStore.getRegistryId(), is(""));
+        assertThat(registryStore.getRemoteName(), is(""));
+    }
+
+    @Test
+    public void testNonRegistryQuery() throws Exception {
+        Filter filter = filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_ID)
+                .is()
+                .like()
+                .text("registryId");
+        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        SourceResponse answer = registryStore.query(testRequest);
+        List<Result> testResults = answer.getResults();
+
+        assertThat(testResults.size(), is(0));
+    }
+
+    @Test
+    public void testRegistryQuery() throws Exception {
+        Filter filter = filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .like()
+                .text(RegistryConstants.REGISTRY_TAG);
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
+        SourceResponse answer = registryStore.query(testRequest);
+        List<Result> testResults = answer.getResults();
+
+        assertThat(testResults.size(), is(1));
+    }
+
+    @Test
+    public void testRegistryQueryUpdateRemoteName() throws Exception {
+
+        assertThat(registryStore.getRemoteName(), is(""));
+
+        Filter filter = filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .like()
+                .text(RegistryConstants.REGISTRY_TAG);
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
+        registryStore.setRegistryId("registryId");
+        registryStore.query(testRequest);
+
+        assertThat(registryStore.getRemoteName(), is("testRegistryMetacard"));
+        verify(registryStore, times(1)).getConfigurationPid();
+    }
+
+    @Test
+    public void testRegistryQueryUpdateRemoteNameIsTheSame() throws Exception {
+
+        Filter filter = filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .like()
+                .text(RegistryConstants.REGISTRY_TAG);
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
+        registryStore.setRegistryId("registryId");
+        registryStore.setRemoteName("testRegistryMetacard");
+        registryStore.query(testRequest);
+
+        verify(registryStore, times(0)).getConfigurationPid();
+
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Csw csw = mock(Csw.class);
+        when(factory.getClientForSubject(any())).thenReturn(csw);
+        when(transformer.getTransformerIdForSchema(any())).thenReturn(null);
+        FilterAdapter mockAdaptor = mock(FilterAdapter.class);
+        CswFilterFactory filterFactory = new CswFilterFactory(CswAxisOrder.LAT_LON, false);
+        FilterType filterType = filterFactory.buildPropertyIsLikeFilter(Metacard.ID,
+                "testId",
+                false);
+        when(mockAdaptor.adapt(any(Filter.class),
+                any(FilterDelegate.class))).thenReturn(filterType);
+        registryStore.setFilterAdapter(mockAdaptor);
+        DeleteRequestImpl request = new DeleteRequestImpl(Collections.singletonList(
+                RegistryObjectMetacardType.REGISTRY_ID), "registryId", new HashMap<>());
+
+        OperationTransactionImpl opTrans =
+                new OperationTransactionImpl(OperationTransaction.OperationType.DELETE,
+                        Collections.singletonList(getDefaultMetacard()));
+        request.getProperties()
+                .put(Constants.OPERATION_TRANSACTION_KEY, opTrans);
+        registryStore.delete(request);
+
+        verify(filterBuilder).attribute(captor.capture());
+        assertThat(captor.getValue(), is("id"));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        Csw csw = mock(Csw.class);
+        when(factory.getClientForSubject(any())).thenReturn(csw);
+        when(configuration.getCswUrl()).thenReturn("https://localhost");
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        registryStore.init();
+        assertThat(registryStore.getRegistryId(), is("registryId"));
+        assertThat(registryStore.getRemoteName(), is("testRegistryMetacard"));
     }
 
     private MetacardImpl getDefaultMetacard() {
@@ -178,56 +379,5 @@ public class TestRegistryStore {
         mcard.setMetadata(xml);
         mcard.setTitle("testRegistryMetacard");
         return mcard;
-    }
-
-    @Test
-    public void testSetAvailable() throws Exception {
-        setupRegistryStoreImplTest();
-
-        registryStoreImplTest.registryInfoQuery();
-
-        assertThat(registryStoreImplTest.getRegistryId(), is("registryId"));
-        assertThat(registryStoreImplTest.getRemoteName(), is("testRegistryMetacard"));
-    }
-
-    @Test
-    public void testQuery() throws Exception {
-        setupRegistryStoreImplTest();
-
-        QueryRequest testRequest = new QueryRequestImpl(new QueryImpl(filter));
-        SourceResponse answer = registryStoreImplTest.query(testRequest);
-        List<Result> testResults = answer.getResults();
-
-        assertThat(testResults.size(), is(1));
-        assertThat(testResults.get(0)
-                .getMetacard()
-                .getTitle(), is("testRegistryMetacard"));
-    }
-
-    private void setupRegistryStoreImplTest() throws Exception{
-        registryStoreImplTest = new RegistryStoreImplTest();
-
-        registryStoreImplTest.setFilterBuilder(new GeotoolsFilterBuilder());
-        registryStoreImplTest.setFilterAdapter(filterAdapter);
-        registryStoreImplTest.setConfigAdmin(configAdmin);
-        registryStoreImplTest.setRegistryId("registryId");
-
-        when(filterAdapter.adapt(any(), any())).thenReturn(true);
-        when(configAdmin.getConfiguration(any())).thenReturn(config);
-        when(config.getProperties()).thenReturn(new Hashtable<>());
-    }
-
-    private class RegistryStoreImplTest extends RegistryStoreImpl {
-
-        RegistryStoreImplTest() {
-            super(encryptionService);
-        }
-
-        @Override
-        public SourceResponse queryResponse(QueryRequest request) {
-            List<Result> results = new ArrayList<>();
-            results.add(new ResultImpl(getDefaultMetacard()));
-            return new SourceResponseImpl(request, results);
-        }
     }
 }

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStorePublisher.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStorePublisher.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.api.impl;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.registry.api.RegistryStore;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
+import org.codice.ddf.registry.federationadmin.service.RegistryPublicationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class TestRegistryStorePublisher extends RegistryStorePublisher {
+
+    private static final String PUBLISH = "publish";
+
+    private static final String UNPUBLISH = "unpublish";
+
+    private RegistryStorePublisher registryStorePublisher;
+
+    private RegistryPublicationService mockRegPubService;
+
+    private FederationAdminService mockFedAdminService;
+
+    private ScheduledExecutorService executorService;
+
+    private ServiceReference serviceReference;
+
+    private RegistryStore mockRegistryStore;
+
+    private Optional<Metacard> optMetacard;
+
+    private ServiceEvent mockServiceEvent;
+
+    private BundleContext bundleContext;
+
+    private Metacard mockIdentity;
+
+    private Attribute registryId;
+
+    private Event event;
+
+    @Before
+    public void setup() {
+        registryId = new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID, "registryId");
+
+        mockRegPubService = mock(RegistryPublicationService.class);
+        mockFedAdminService = mock(FederationAdminService.class);
+        executorService = mock(ScheduledExecutorService.class);
+        serviceReference = mock(ServiceReference.class);
+        mockRegistryStore = mock(RegistryStore.class);
+        mockServiceEvent = mock(ServiceEvent.class);
+        bundleContext = mock(BundleContext.class);
+        mockIdentity = mock(Metacard.class);
+
+        optMetacard = Optional.of(mockIdentity);
+
+        registryStorePublisher = spy(new RegistryStorePublisher() {
+            @Override
+            BundleContext getBundleContext() {
+                return bundleContext;
+            }
+        });
+
+        registryStorePublisher.setExecutor(executorService);
+        registryStorePublisher.setFederationAdminService(mockFedAdminService);
+        registryStorePublisher.setRegistryPublicationService(mockRegPubService);
+
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put(EventConstants.EVENT, mockServiceEvent);
+        eventProperties.put(Constants.SERVICE_PID, "servicePid");
+        event = new Event("org/osgi/framework/ServiceEvent/MODIFIED", eventProperties);
+    }
+
+    @Test
+    public void testBindRegistryStoreNoContext() {
+        registryStorePublisher = spy(new RegistryStorePublisher());
+        registryStorePublisher.bindRegistryStore(serviceReference);
+
+        verify(registryStorePublisher, Mockito.times(0)).registryPublish(any(), anyString());
+    }
+
+    @Test
+    public void testBindThenUnbindRegistryStoreAutoPush() {
+        when(bundleContext.getService(any())).thenReturn(mockRegistryStore);
+        when(mockRegistryStore.getConfigurationPid()).thenReturn("configPid");
+        when(mockRegistryStore.isAvailable(any())).thenReturn(true);
+        when(mockRegistryStore.isAutoPush()).thenReturn(true);
+        when(mockRegistryStore.getRegistryId()).thenReturn("registryId");
+
+        registryStorePublisher.bindRegistryStore(serviceReference);
+
+        registryStorePublisher.unbindRegistryStore(serviceReference);
+
+        verify(registryStorePublisher, Mockito.times(1)).registryPublish(any(), eq(PUBLISH));
+    }
+
+    @Test
+    public void testUnbindRegistryStoreNoContext() {
+        registryStorePublisher = spy(new RegistryStorePublisher());
+        registryStorePublisher.unbindRegistryStore(serviceReference);
+
+        verify(registryStorePublisher, Mockito.times(0)).registryPublish(any(), eq(UNPUBLISH));
+    }
+
+    @Test
+    public void testRegistryPublishFailed() throws Exception {
+        RegistryStoreImpl mockRegistryStoreImpl = mock(RegistryStoreImpl.class);
+        when(mockRegistryStoreImpl.getRegistryId()).thenReturn("registryId");
+        when(mockRegistryStoreImpl.getRemoteName()).thenReturn("remoteName");
+        when(mockFedAdminService.getLocalRegistryIdentityMetacard()).thenReturn(optMetacard);
+
+        registryStorePublisher.registryPublish(mockRegistryStoreImpl, PUBLISH);
+
+        verify(mockRegPubService, Mockito.times(0)).publish(any(), any());
+    }
+
+    @Test
+    public void testRegistryPublish() throws Exception {
+        when(mockRegistryStore.getRegistryId()).thenReturn("registryId");
+        when(mockFedAdminService.getLocalRegistryIdentityMetacard()).thenReturn(optMetacard);
+        when(mockIdentity.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)).thenReturn(
+                registryId);
+
+        setupSerialExecutor();
+
+        registryStorePublisher.registryPublish(mockRegistryStore, PUBLISH);
+
+        verify(mockRegPubService, Mockito.times(1)).publish(any(), any());
+    }
+
+    @Test
+    public void testRegistryUnpublishFailed() throws Exception {
+        RegistryStoreImpl mockRegistryStoreImpl = mock(RegistryStoreImpl.class);
+        when(mockRegistryStoreImpl.getRegistryId()).thenReturn("registryId");
+        when(mockRegistryStoreImpl.getRemoteName()).thenReturn("remoteName");
+        when(mockFedAdminService.getLocalRegistryIdentityMetacard()).thenReturn(optMetacard);
+
+        registryStorePublisher.registryPublish(mockRegistryStoreImpl, UNPUBLISH);
+
+        verify(mockRegPubService, Mockito.times(0)).unpublish(any(), any());
+    }
+
+    @Test
+    public void testRegistryUnpublish() throws Exception {
+        when(mockRegistryStore.getRegistryId()).thenReturn("registryId");
+        when(mockFedAdminService.getLocalRegistryIdentityMetacard()).thenReturn(optMetacard);
+        when(mockIdentity.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)).thenReturn(
+                registryId);
+
+        setupSerialExecutor();
+
+        registryStorePublisher.registryPublish(mockRegistryStore, UNPUBLISH);
+
+        verify(mockRegPubService, Mockito.times(1)).unpublish(any(), any());
+    }
+
+    @Test
+    public void testRegistryUnpublishNoId() throws Exception {
+        when(mockRegistryStore.getRegistryId()).thenReturn("");
+
+        registryStorePublisher.registryPublish(mockRegistryStore, UNPUBLISH);
+
+        verify(mockRegPubService, Mockito.times(0)).unpublish(any(), any());
+    }
+
+    @Test
+    public void testHandleFalseEvent() throws Exception {
+        when(mockServiceEvent.getType()).thenReturn(ServiceEvent.UNREGISTERING);
+
+        registryStorePublisher.handleEvent(event);
+
+        verify(mockRegPubService, Mockito.times(0)).publish(any(), any());
+    }
+
+    @Test
+    public void testHandleEventNoAction() throws Exception {
+        when(mockServiceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
+        registryStorePublisher.handleEvent(event);
+
+        verify(mockRegPubService, Mockito.times(0)).publish(any(), any());
+        verify(mockRegPubService, Mockito.times(0)).unpublish(any(), any());
+    }
+
+    @Test
+    public void testHandleEventPublish() throws Exception {
+        when(mockServiceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
+        when(bundleContext.getService(any())).thenReturn(mockRegistryStore);
+        when(mockRegistryStore.getConfigurationPid()).thenReturn("servicePid");
+        when(mockRegistryStore.isAvailable(any())).thenReturn(true);
+        when(mockRegistryStore.isAutoPush()).thenReturn(false);
+        when(mockRegistryStore.getRegistryId()).thenReturn("registryId");
+
+        registryStorePublisher.bindRegistryStore(serviceReference);
+
+        when(mockRegistryStore.isAutoPush()).thenReturn(true);
+
+        registryStorePublisher.handleEvent(event);
+
+        verify(registryStorePublisher, Mockito.times(1)).registryPublish(any(), eq(PUBLISH));
+    }
+
+    @Test
+    public void testHandleEventUnpublish() throws Exception {
+        when(mockServiceEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
+        when(bundleContext.getService(any())).thenReturn(mockRegistryStore);
+        when(mockRegistryStore.getConfigurationPid()).thenReturn("servicePid");
+        when(mockRegistryStore.isAvailable(any())).thenReturn(true);
+        when(mockRegistryStore.isAutoPush()).thenReturn(true);
+        when(mockRegistryStore.getRegistryId()).thenReturn("registryId");
+
+        registryStorePublisher.bindRegistryStore(serviceReference);
+
+        when(mockRegistryStore.isAutoPush()).thenReturn(false);
+
+        registryStorePublisher.handleEvent(event);
+
+        verify(registryStorePublisher, Mockito.times(1)).registryPublish(any(), eq(PUBLISH));
+        verify(registryStorePublisher, Mockito.times(1)).registryPublish(any(), eq(UNPUBLISH));
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        registryStorePublisher.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyTerminateTasks() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        registryStorePublisher.destroy();
+        verify(executorService, times(2)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterupt() throws Exception {
+        when(executorService.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException("interrupt"));
+        registryStorePublisher.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    private void setupSerialExecutor() {
+        doAnswer((args) -> {
+            ((Runnable) args.getArguments()[0]).run();
+            return null;
+        }).when(executorService)
+                .schedule(isA(Runnable.class), anyLong(), any());
+    }
+}

--- a/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
+++ b/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
@@ -38,4 +38,10 @@ public interface RegistryStore extends CatalogStore, ConfiguredService {
      * @return registry id in a string
      */
     String getRegistryId();
+
+    /**
+     * Indicates if the identity node should be automatically pushed to another registry store
+     * @return true if enabled otherwise false
+     */
+    boolean isAutoPush();
 }

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/pom.xml
@@ -125,17 +125,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistrySubscriptions.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistrySubscriptions.java
@@ -13,28 +13,21 @@
  **/
 package org.codice.ddf.registry.federationadmin.service.impl;
 
-import java.security.Principal;
 import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.codice.ddf.registry.api.RegistryStore;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
+import org.codice.ddf.security.common.Security;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,30 +39,18 @@ import ddf.catalog.data.Metacard;
  * class with external connections. This class is only meant to be accessed through a camel
  * route and should avoid elevating privileges for any other service or being exposed to any
  * other endpoint.
- *
  */
 @SuppressWarnings("PackageAccessibility")
 public class RefreshRegistrySubscriptions {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(RefreshRegistrySubscriptions.class);
 
-    private javax.security.auth.Subject subject;
-
-    private final Set<String> pollableSourceIds = ConcurrentHashMap.newKeySet();
+    private List<RegistryStore> registryStores;
 
     private FederationAdminService federationAdminService;
 
-    public void setFederationAdminService(FederationAdminService federationAdminService) {
-        this.federationAdminService = federationAdminService;
-    }
-
     public RefreshRegistrySubscriptions() {
-        Set<Principal> principals = new HashSet<>();
-        String localRoles = System.getProperty("karaf.local.roles", "");
-        for (String role : localRoles.split(",")) {
-            principals.add(new RolePrincipal(role));
-        }
-        subject = new javax.security.auth.Subject(true, principals, new HashSet(), new HashSet());
+
     }
 
     /**
@@ -80,23 +61,11 @@ public class RefreshRegistrySubscriptions {
      * @throws FederationAdminException
      */
     public void refreshRegistrySubscriptions() throws FederationAdminException {
-        if (CollectionUtils.isEmpty(pollableSourceIds)) {
-            return;
-        }
-        addOrUpdateMetacardsForRemoteRegistries();
-    }
-
-    private void addOrUpdateMetacardsForRemoteRegistries() throws FederationAdminException {
-        addOrUpdateMetacardsForRemoteRegistries(pollableSourceIds);
-    }
-
-    private void addOrUpdateMetacardsForRemoteRegistries(Set<String> sourceIds)
-            throws FederationAdminException {
-        if (CollectionUtils.isEmpty(sourceIds)) {
+        if (CollectionUtils.isEmpty(registryStores)) {
             return;
         }
 
-        Map<String, Metacard> remoteRegistryMetacardsMap = getRemoteRegistryMetacardsMap(sourceIds);
+        Map<String, Metacard> remoteRegistryMetacardsMap = getRemoteRegistryMetacardsMap();
         Map<String, Metacard> registryMetacardsMap = getRegistryMetacardsMap();
 
         List<Metacard> remoteMetacardsToUpdate = new ArrayList<>();
@@ -126,32 +95,36 @@ public class RefreshRegistrySubscriptions {
     }
 
     private Map<String, Metacard> getRegistryMetacardsMap() throws FederationAdminException {
-
-        Map<String, Metacard> registryMetacardsMap = new HashMap<>();
         try {
-            List<Metacard> registryMetacards = javax.security.auth.Subject.doAs(subject,
-                    (PrivilegedExceptionAction<List<Metacard>>) () -> federationAdminService.getRegistryMetacards());
+            List<Metacard> registryMetacards =
+                    Security.runAsAdminWithException(() -> federationAdminService.getRegistryMetacards());
 
-            for (Metacard metacard : registryMetacards) {
-                String registryId = metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
-                        .getValue()
-                        .toString();
-                registryMetacardsMap.put(registryId, metacard);
-            }
+            return registryMetacards.stream()
+                    .collect(Collectors.toMap(e -> e.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
+                            .getValue()
+                            .toString(), Function.identity()));
         } catch (Exception e) {
             throw new FederationAdminException("Error querying for metacards ", e);
         }
-
-        return registryMetacardsMap;
     }
 
-    private Map<String, Metacard> getRemoteRegistryMetacardsMap(Set<String> sourceIds)
-            throws FederationAdminException {
+    private Map<String, Metacard> getRemoteRegistryMetacardsMap() throws FederationAdminException {
         Map<String, Metacard> remoteRegistryMetacards = new HashMap<>();
+        Set<String> sourceIds = registryStores.stream()
+                .filter(RegistryStore::isAvailable)
+                .filter(RegistryStore::isPullAllowed)
+                .map(RegistryStore::getId)
+                .collect(Collectors.toSet());
+
+        if (CollectionUtils.isEmpty(sourceIds)) {
+            return remoteRegistryMetacards;
+        }
+
         try {
 
-            List<Metacard> fullList = javax.security.auth.Subject.doAs(subject,
-                    (PrivilegedExceptionAction<List<Metacard>>) () -> federationAdminService.getRegistryMetacards());
+            List<Metacard> fullList =
+                    Security.runAsAdminWithException(() -> federationAdminService.getRegistryMetacards(
+                            sourceIds));
             for (Metacard metacard : fullList) {
                 String registryId = metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID)
                         .getValue()
@@ -179,7 +152,7 @@ public class RefreshRegistrySubscriptions {
     private void writeRemoteUpdates(List<Metacard> remoteMetacardsToUpdate)
             throws FederationAdminException {
         try {
-            javax.security.auth.Subject.doAs(subject, (PrivilegedExceptionAction<Void>) () -> {
+            Security.runAsAdminWithException(() -> {
                 for (Metacard m : remoteMetacardsToUpdate) {
                     federationAdminService.updateRegistryEntry(m);
                 }
@@ -195,52 +168,19 @@ public class RefreshRegistrySubscriptions {
     private void createRemoteEntries(List<Metacard> remoteMetacardsToCreate)
             throws FederationAdminException {
         try {
-            javax.security.auth.Subject.doAs(subject,
-                    (PrivilegedExceptionAction<List<String>>) () -> federationAdminService.addRegistryEntries(
-                            remoteMetacardsToCreate,
-                            null));
+            Security.runAsAdminWithException(() -> federationAdminService.addRegistryEntries(
+                    remoteMetacardsToCreate,
+                    null));
         } catch (PrivilegedActionException e) {
             throw new FederationAdminException(e.getMessage());
         }
     }
 
-    public void bindRegistryStore(ServiceReference serviceReference) {
-        BundleContext bundleContext = getBundleContext();
-
-        if (serviceReference != null && bundleContext != null) {
-            RegistryStore registryStore =
-                    (RegistryStore) bundleContext.getService(serviceReference);
-
-            if (registryStore.isPullAllowed()) {
-                pollableSourceIds.add(registryStore.getId());
-                try {
-                    addOrUpdateMetacardsForRemoteRegistries(Collections.singleton(registryStore.getId()));
-                } catch (FederationAdminException e) {
-                    LOGGER.warn(
-                            "Trying to access the registry store before it has finished initializing. Couldn't update registry for new registry store (ID: {}). No actions required.",
-                            registryStore.getId());
-                }
-            }
-        }
+    public void setRegistryStores(List<RegistryStore> registryStores) {
+        this.registryStores = registryStores;
     }
 
-    public void unbindRegistryStore(ServiceReference serviceReference) {
-        BundleContext bundleContext = getBundleContext();
-
-        if (serviceReference != null && bundleContext != null) {
-            RegistryStore registryStore =
-                    (RegistryStore) bundleContext.getService(serviceReference);
-
-            pollableSourceIds.remove(registryStore.getId());
-        }
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
     }
-
-    BundleContext getBundleContext() {
-        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
-        if (bundle != null) {
-            return bundle.getBundleContext();
-        }
-        return null;
-    }
-
 }

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImpl.java
@@ -41,6 +41,8 @@ import ddf.catalog.data.impl.AttributeImpl;
 
 public class RegistryPublicationServiceImpl implements RegistryPublicationService {
 
+    private static final String NO_PUBLICATIONS = "No_Publications";
+
     private FederationAdminService federationAdminService;
 
     private List<RegistryStore> registryStores = new ArrayList<>();
@@ -78,6 +80,8 @@ public class RegistryPublicationServiceImpl implements RegistryPublicationServic
         } else {
             locAttr = new AttributeImpl(RegistryObjectMetacardType.PUBLISHED_LOCATIONS, locations);
         }
+
+        locAttr.getValues().remove(NO_PUBLICATIONS);
         metacard.setAttribute(locAttr);
         metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
                 Date.from(ZonedDateTime.now()
@@ -98,19 +102,24 @@ public class RegistryPublicationServiceImpl implements RegistryPublicationServic
             return;
         }
 
-        String sourceId = getSourceIdFromRegistryId(destinationRegistryId);
-
-        federationAdminService.deleteRegistryEntriesByRegistryIds(Collections.singletonList(
-                registryId), Collections.singleton(sourceId));
-
         locAttr.getValues()
                 .remove(destinationRegistryId);
+        if (CollectionUtils.isEmpty(locAttr.getValues())) {
+            locAttr.getValues()
+                    .add(NO_PUBLICATIONS);
+        }
         metacard.setAttribute(locAttr);
         metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED,
                 Date.from(ZonedDateTime.now()
                         .toInstant())));
 
         federationAdminService.updateRegistryEntry(metacard);
+
+        String sourceId = getSourceIdFromRegistryId(destinationRegistryId);
+
+        federationAdminService.deleteRegistryEntriesByRegistryIds(Collections.singletonList(
+                registryId), Collections.singleton(sourceId));
+
     }
 
     @Override

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,6 +27,7 @@
     <bean id="refreshRegistrySubscriptions"
           class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistrySubscriptions">
         <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="registryStores" ref="registryStore"/>
     </bean>
 
     <bean id="identityNodeInitialization"
@@ -51,11 +52,8 @@
     </cm:property-placeholder>
 
 
-    <reference-list id="fasRegistryStore" interface="org.codice.ddf.registry.api.RegistryStore"
-                    availability="optional">
-        <reference-listener bind-method="bindRegistryStore" unbind-method="unbindRegistryStore"
-                            ref="refreshRegistrySubscriptions"/>
-    </reference-list>
+    <reference-list id="registryStore" interface="org.codice.ddf.registry.api.RegistryStore"
+                    availability="optional"/>
 
 
     <bean id="registryPublicationService"

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -746,6 +746,24 @@ public class FederationAdminServiceImplTest {
         assertThat(metacards, hasSize(2));
     }
 
+    @Test
+    public void testGetRegistryMetacardsWithDestinations() throws Exception {
+        String destination = TEST_DESTINATION;
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+        Metacard findThisMetacard = testMetacard;
+        findThisMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
+                true));
+        QueryRequest request = getTestQueryRequest();
+        QueryResponse response = getPopulatedTestQueryResponse(request,
+                findThisMetacard,
+                getTestMetacard());
+        when(security.getSystemSubject()).thenReturn(subject);
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+        List<Metacard> metacards = federationAdminServiceImpl.getRegistryMetacards(destinations);
+        assertThat(metacards, hasSize(2));
+    }
+
     @Test(expected = FederationAdminException.class)
     public void testGetRegistryMetacardsWithUnsupportedQueryException() throws Exception {
         when(security.getSystemSubject()).thenReturn(subject);

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -218,7 +217,7 @@ public class RegistryPublicationServiceImplTest {
 
         Attribute publicationsAfter =
                 metacard.getAttribute(RegistryObjectMetacardType.PUBLISHED_LOCATIONS);
-        assertThat(publicationsAfter, nullValue());
+        assertThat(publicationsAfter.getValue(), is("No_Publications"));
     }
 
     @Test
@@ -284,7 +283,8 @@ public class RegistryPublicationServiceImplTest {
 
     @Test(expected = FederationAdminException.class)
     public void testNoRegistryStores() throws Exception {
-        doReturn(Collections.singletonList(metacard)).when(federationAdminService).getRegistryMetacardsByRegistryIds(any(List.class));
+        doReturn(Collections.singletonList(metacard)).when(federationAdminService)
+                .getRegistryMetacardsByRegistryIds(any(List.class));
         registryPublicationService.unbindRegistryStore(serviceReference);
         String publishThisRegistryId = "publishThisRegistryId";
         Date now = new Date();
@@ -296,7 +296,6 @@ public class RegistryPublicationServiceImplTest {
                         Collections.singletonList(REGISTRY_STORE_REGISTRY_ID));
         metacard.setAttribute(publishedLocationsAttribute);
         metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.LAST_PUBLISHED, before));
-
 
         registryPublicationService.publish(publishThisRegistryId, REGISTRY_STORE_REGISTRY_ID);
         verify(federationAdminService, never()).updateRegistryEntry(metacard);

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/FederationAdminService.java
@@ -180,6 +180,15 @@ public interface FederationAdminService {
     List<Metacard> getRegistryMetacards() throws FederationAdminException;
 
     /**
+     * Get a list of registry metacards
+     *
+     * @param destinations Set of destinations to query from
+     * @return List<Metacard>
+     * @throws FederationAdminException If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getRegistryMetacards(Set<String> destinations) throws FederationAdminException;
+
+    /**
      * Get a list of local registry metacards
      *
      * @return List<Metacard>
@@ -244,7 +253,7 @@ public interface FederationAdminService {
      * @return List<RegistryPackageType>
      * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
      */
-    RegistryPackageType getRegistryObjectByRegistryId(String registryId, List<String> sourceIds)
+    RegistryPackageType getRegistryObjectByRegistryId(String registryId, Set<String> sourceIds)
             throws FederationAdminException;
 
     /**

--- a/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
@@ -287,7 +287,7 @@ public class IdentificationPluginTest {
 
         Map<String, Serializable> properties = new HashMap<>();
         properties.put(Constants.OPERATION_TRANSACTION_KEY, operationTransaction);
-        properties.put(RegistryConstants.TRANSIENT_ATTRIBUTE_UPDATE, true);
+
         List<Map.Entry<Serializable, Metacard>> updatedEntries = new ArrayList<>();
 
         MetacardImpl updateMetacard = new MetacardImpl();

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
@@ -92,8 +92,8 @@ public class RegistryPublicationActionProvider implements ActionProvider {
                 .filter((registryStore) -> shouldRegistryPublishToStore(registryIdToPublish,
                         registryStore))
                 .map(registryStore -> getAction(registryIdToPublish,
-                        registryStore.getId(),
-                        !currentPublications.contains(registryStore.getId())))
+                        registryStore.getRegistryId(), registryStore.getId(),
+                        !currentPublications.contains(registryStore.getRegistryId())))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
@@ -109,13 +109,13 @@ public class RegistryPublicationActionProvider implements ActionProvider {
         return StringUtils.isNotBlank(getRegistryId(subject));
     }
 
-    private Action getAction(String regId, String destinationId, boolean publish) {
+    private Action getAction(String regId, String destinationId, String destinationName, boolean publish) {
 
         URL url;
-        String title = publish ? PUBLISH_TITLE + destinationId : UNPUBLISH_TITLE + destinationId;
+        String title = publish ? PUBLISH_TITLE + destinationName : UNPUBLISH_TITLE + destinationName;
         String description = publish ?
-                PUBLISH_DESCRIPTION + destinationId :
-                UNPUBLISH_DESCRIPTION + destinationId;
+                PUBLISH_DESCRIPTION + destinationName :
+                UNPUBLISH_DESCRIPTION + destinationName;
         String operation = publish ? PUBLISH_OPERATION : UNPUBLISH_OPERATION;
         String httpOp = publish ? HTTP_POST : HTTP_DELETE;
         try {

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
@@ -179,7 +179,7 @@ public class RegistryPublicationActionProviderTest {
         assertThat(actions.get(0)
                         .getUrl()
                         .toString(),
-                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/store1", true)));
+                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/regId2", true)));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class RegistryPublicationActionProviderTest {
         when(store.getRegistryId()).thenReturn("regId2");
 
         Map<String, List<String>> publications = new HashMap<>();
-        publications.put("regId1", Collections.singletonList("store1"));
+        publications.put("regId1", Collections.singletonList("regId2"));
         doReturn(publications).when(publicationManager)
                 .getPublications();
         List<Action> actions = publicationActionProvider.getActions(getRegistryMetacard("regId1"));
@@ -199,7 +199,7 @@ public class RegistryPublicationActionProviderTest {
         assertThat(actions.get(0)
                         .getUrl()
                         .toString(),
-                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/store1", true)));
+                equalTo(SystemBaseUrl.constructUrl("registries/regId1/publication/regId2", true)));
     }
 
     private Metacard getRegistryMetacard(String regId) {

--- a/catalog/spatial/registry/registry-rest-endpoint/src/main/java/org/codice/ddf/registry/rest/endpoint/RegistryRestEndpoint.java
+++ b/catalog/spatial/registry/registry-rest-endpoint/src/main/java/org/codice/ddf/registry/rest/endpoint/RegistryRestEndpoint.java
@@ -15,8 +15,10 @@
 package org.codice.ddf.registry.rest.endpoint;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -28,6 +30,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.FederationAdminService;
@@ -119,8 +122,12 @@ public class RegistryRestEndpoint {
 
         RegistryPackageType registryPackage;
         try {
+            Set<String> sourceIdsSet = new HashSet<>();
+            if (CollectionUtils.isNotEmpty(sourceIds)) {
+                sourceIdsSet.addAll(sourceIds);
+            }
             registryPackage = federationAdminService.getRegistryObjectByRegistryId(registryId,
-                    sourceIds);
+                    sourceIdsSet);
         } catch (FederationAdminException e) {
             String message = "Error getting registry package.";
             LOGGER.error("{} For registry id: '{}', optional sources: {}",

--- a/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/RegistryRestEndpointTest.java
+++ b/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/RegistryRestEndpointTest.java
@@ -16,7 +16,7 @@ package org.codice.ddf.registry.rest.endpoint;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -75,8 +75,8 @@ public class RegistryRestEndpointTest {
 
     @Test
     public void testReportWithFederationAdminException() throws FederationAdminException {
-        when(federationAdminService.getRegistryObjectByRegistryId(anyString(),
-                anyList())).thenThrow(new FederationAdminException());
+        when(federationAdminService.getRegistryObjectByRegistryId(anyString(), anySet())).thenThrow(
+                new FederationAdminException());
         Response response = restEndpoint.viewRegInfoHtml("metacardId", Arrays.asList("sourceIds"));
         assertThat(response.getStatusInfo()
                 .getStatusCode(), is(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
@@ -85,7 +85,7 @@ public class RegistryRestEndpointTest {
     @Test
     public void testReportRegistryPackageNotFound() throws FederationAdminException {
         when(federationAdminService.getRegistryObjectByRegistryId(anyString(),
-                anyList())).thenReturn(null);
+                anySet())).thenReturn(null);
         Response response = restEndpoint.viewRegInfoHtml("metacardId", Arrays.asList("sourceIds"));
         assertThat(response.getStatusInfo()
                 .getStatusCode(), is(Response.Status.NOT_FOUND.getStatusCode()));
@@ -94,7 +94,7 @@ public class RegistryRestEndpointTest {
     @Test
     public void testReportWithRegistryPackage() throws ParserException, FederationAdminException {
         when(federationAdminService.getRegistryObjectByRegistryId(anyString(),
-                anyList())).thenReturn(registryPackage);
+                anySet())).thenReturn(registryPackage);
 
         Response response = restEndpoint.viewRegInfoHtml("metacardId", Arrays.asList("sourceIds"));
         assertThat(response.getStatusInfo()


### PR DESCRIPTION
#### What does this PR do?
Add an Auto-Publish(Auto Push) Configuration property to the RegistryStore. This configuration is accessible in the add/edit modal on the remote registries tab in the registry app ui.

There are also fixes to subscription and publish services within the registry that manifested when this functionality was added.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@gordocanchola @vinamartin @ani6gup @clockard 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl @figliold 

#### How should this be tested?
Install registry app (with security) and connect to a second registry by adding it in the remote registries tab of the registry app with Auto-Push on. Observe presence of registry identity metacard when querying metacards in the second DDF's solr once the remote becomes 'available' on the first registry. 

#### Any background context you want to provide?
Minor UI updates are in this PR fixing the remote name as well as adding the autoPush to the registry model/modal. 

#### What are the relevant tickets?
DDF-2177 Add a configuration property to the registry store, 'Auto push identity node', which is disabled by default	

If the auto publish is enabled and push is enabled then the registry store will publish the local identity node to the remote registry when the it becomes available.

#### Screenshots (if appropriate)
![screen shot 2016-06-23 at 3 29 34 pm](https://cloud.githubusercontent.com/assets/11355332/16322345/5730eb1e-3957-11e6-9869-a96af2201aba.png)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

