### PR TITLE
DDF-2204: Remove dependency between ReliableResourceDownloader and ResourceCache

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -461,22 +461,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.46</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.43</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadManagerState.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadManagerState.java
@@ -23,32 +23,12 @@ public class DownloadManagerState {
 
     private DownloadState state;
 
-    private boolean cacheEnabled;
-
-    private boolean continueCaching;
-
     public DownloadState getDownloadState() {
         return state;
     }
 
     public void setDownloadState(DownloadState state) {
         this.state = state;
-    }
-
-    public boolean isCacheEnabled() {
-        return cacheEnabled;
-    }
-
-    public void setCacheEnabled(boolean cacheEnabled) {
-        this.cacheEnabled = cacheEnabled;
-    }
-
-    public boolean isContinueCaching() {
-        return continueCaching;
-    }
-
-    public void setContinueCaching(boolean continueCaching) {
-        this.continueCaching = continueCaching;
     }
 
     public enum DownloadState {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -14,7 +14,6 @@
 package ddf.catalog.resource.download;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -25,11 +24,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import javax.activation.MimeType;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,10 +37,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.io.FileBackedOutputStream;
 
-import ddf.catalog.cache.impl.CacheKey;
-import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventPublisher;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventPublisher.ProductRetrievalStatus;
@@ -50,7 +46,6 @@ import ddf.catalog.operation.impl.ResourceResponseImpl;
 import ddf.catalog.resource.Resource;
 import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
-import ddf.catalog.resource.data.ReliableResource;
 import ddf.catalog.resource.download.DownloadManagerState.DownloadState;
 import ddf.catalog.resource.impl.ResourceImpl;
 import ddf.catalog.resourceretriever.ResourceRetriever;
@@ -70,6 +65,8 @@ public class ReliableResourceDownloader implements Runnable {
 
     private Future<ReliableResourceStatus> downloadFuture;
 
+    private ReliableResourceStatus reliableResourceStatus = null;
+
     private ExecutorService downloadExecutor = Executors.newSingleThreadExecutor();
 
     private AtomicBoolean downloadStarted;
@@ -78,13 +75,11 @@ public class ReliableResourceDownloader implements Runnable {
 
     private ReliableResourceInputStream streamReadByClient;
 
-    private FileOutputStream fos;
+    private File cacheFile;
 
     private FileBackedOutputStream fbos;
 
     private CountingOutputStream countingFbos;
-
-    private ReliableResource reliableResource;
 
     private DownloadManagerState downloadState;
 
@@ -98,19 +93,26 @@ public class ReliableResourceDownloader implements Runnable {
 
     private DownloadsStatusEventListener eventListener;
 
-    private ResourceCacheImpl resourceCache;
-
     private DownloadsStatusEventPublisher eventPublisher;
 
-    private String filePath;
+    private String filePath = "";
 
     private ResourceRetriever retriever;
+
+    private Resource resource;
+
+    private long reliableResourceByteSize = 0;
+
+    private boolean continueDownloadingWhenCancelled = false;
+
+    private Consumer<DownloadStatus> downloadStatusListener = downloadStatus -> {
+
+    };
 
     /**
      * Only set to true if cacheEnabled is true *AND* product being downloaded is not already
      * pending caching, e.g., another client has already started downloading and caching it.
      */
-    private boolean doCaching;
 
     public ReliableResourceDownloader(ReliableResourceDownloaderConfig downloaderConfig,
             AtomicBoolean downloadStarted, String downloadIdentifier,
@@ -124,19 +126,20 @@ public class ReliableResourceDownloader implements Runnable {
         this.downloadState = new DownloadManagerState();
         this.downloadState.setDownloadState(DownloadManagerState.DownloadState.NOT_STARTED);
 
-        // Do not enable caching yet - wait until determine if this product about to be downloaded
-        // is already pending caching by another download in progress
-        this.downloadState.setCacheEnabled(false);
-
         this.eventListener = downloaderConfig.getEventListener();
         this.eventPublisher = downloaderConfig.getEventPublisher();
-        this.resourceCache = downloaderConfig.getResourceCache();
-        this.downloadState.setContinueCaching(this.downloaderConfig.isCacheWhenCanceled());
     }
 
-    public ResourceResponse setupDownload(Metacard metacard,
-            DownloadStatusInfo downloadStatusInfo) {
-        Resource resource = resourceResponse.getResource();
+    /**
+     * Setup before the downloader is run.
+     *
+     * @param metacard  the metacard associated with the file to be downloaded.
+     * @param cacheFile A cache File that may arrive null.
+     * @return the resourceResponse at the end of the setup.
+     */
+    public ResourceResponse setupDownload(Metacard metacard, File cacheFile,
+            boolean continueDownloadingWhenCancelled) {
+        resource = resourceResponse.getResource();
         MimeType mimeType = resource.getMimeType();
         String resourceName = resource.getName();
 
@@ -149,6 +152,8 @@ public class ReliableResourceDownloader implements Runnable {
                 resourceResponse);
 
         this.metacard = metacard;
+        this.cacheFile = cacheFile;
+        this.continueDownloadingWhenCancelled = continueDownloadingWhenCancelled;
 
         // Create new ResourceResponse to return that will encapsulate the
         // ReliableResourceInputStream that will be read by the client simultaneously as the product
@@ -162,55 +167,12 @@ public class ReliableResourceDownloader implements Runnable {
         resourceInputStream = resource.getInputStream();
 
         eventListener.setDownloadMap(downloadIdentifier, resourceResponse);
-        downloadStatusInfo.addDownloadInfo(downloadIdentifier, this, resourceResponse);
-
-        if (downloaderConfig.isCacheEnabled()) {
-
-            CacheKey keyMaker = null;
-            String key = null;
-            try {
-                keyMaker = new CacheKey(metacard, resourceResponse.getRequest());
-                key = keyMaker.generateKey();
-            } catch (IllegalArgumentException e) {
-                LOGGER.info("Cannot create cache key for resource with metacard ID = {}",
-                        metacard.getId());
-                return resourceResponse;
-            }
-
-            if (!resourceCache.isPending(key)) {
-
-                // Fully qualified path to cache file that will be written to.
-                // Example:
-                // <INSTALL-DIR>/data/product-cache/<source-id>-<metacard-id>
-                // <INSTALL-DIR>/data/product-cache/ddf.distribution-abc123
-                filePath = FilenameUtils.concat(resourceCache.getProductCacheDirectory(), key);
-                reliableResource = new ReliableResource(key,
-                        filePath,
-                        mimeType,
-                        resourceName,
-                        metacard);
-                resourceCache.addPendingCacheEntry(reliableResource);
-
-                try {
-                    fos = FileUtils.openOutputStream(new File(filePath));
-                    doCaching = true;
-                    this.downloadState.setCacheEnabled(true);
-                } catch (IOException e) {
-                    LOGGER.info("Unable to open cache file {} - no caching will be done.",
-                            filePath);
-                }
-            } else {
-                LOGGER.debug("Cache key {} is already pending caching", key);
-            }
-        }
-
         return resourceResponse;
     }
 
     @Override
     public void run() {
         long bytesRead = 0;
-        ReliableResourceStatus reliableResourceStatus = null;
         int retryAttempts = 0;
 
         downloaderConfig.getEventPublisher().postRetrievalStatus(resourceResponse,
@@ -223,7 +185,7 @@ public class ReliableResourceDownloader implements Runnable {
         try {
             reliableResourceCallable = new ReliableResourceCallable(resourceInputStream,
                     countingFbos,
-                    fos,
+                    cacheFile,
                     downloaderConfig.getChunkSize(),
                     lock);
             downloadFuture = null;
@@ -248,7 +210,7 @@ public class ReliableResourceDownloader implements Runnable {
                             reliableResourceStatus.getBytesRead(),
                             downloadIdentifier);
                     delay();
-                    reliableResourceCallable = retrieveResource(bytesRead);
+                    reliableResourceCallable = retrieveResourceWithOffset(bytesRead);
                     continue;
                 }
                 retryAttempts++;
@@ -293,6 +255,7 @@ public class ReliableResourceDownloader implements Runnable {
                 }
 
                 LOGGER.debug("reliableResourceStatus = {}", reliableResourceStatus);
+                downloadStatusListener.accept(reliableResourceStatus.getDownloadStatus());
 
                 if (DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(reliableResourceStatus.getDownloadStatus())) {
                     LOGGER.debug("Cancelling resourceRetrievalMonitor");
@@ -317,20 +280,10 @@ public class ReliableResourceDownloader implements Runnable {
                                 false,
                                 true);
                     }
-                    if (doCaching) {
-                        LOGGER.debug("Setting reliableResource size");
-                        reliableResource.setSize(reliableResourceStatus.getBytesRead());
-                        LOGGER.debug("Adding caching key = {} to cache map",
-                                reliableResource.getKey());
-                        resourceCache.put(reliableResource);
-                    }
                     break;
                 } else {
                     bytesRead = reliableResourceStatus.getBytesRead();
                     LOGGER.debug("Download not complete, only read {} bytes", bytesRead);
-                    if (fos != null) {
-                        fos.flush();
-                    }
 
                     // Synchronized so that the Callable is not shutdown while in the middle of
                     // writing to the
@@ -363,38 +316,7 @@ public class ReliableResourceDownloader implements Runnable {
                         IOUtils.closeQuietly(resourceInputStream);
                         resourceInputStream = null;
                         delay();
-                        reliableResourceCallable = retrieveResource(bytesRead);
-                    } else if (DownloadStatus.CACHED_FILE_OUTPUT_STREAM_EXCEPTION.equals(
-                            reliableResourceStatus.getDownloadStatus())) {
-
-                        // Detected exception when writing the product data to the product cache
-                        // directory - assume this OutputStream cannot be fixed (e.g., disk full)
-                        // and just continue streaming product to the client, i.e., writing to the
-                        // FileBackedOutputStream
-                        LOGGER.info("Handling FileOutputStream exception");
-                        eventPublisher.postRetrievalStatus(resourceResponse,
-                                ProductRetrievalStatus.RETRYING,
-                                metacard,
-                                String.format("Attempt %d of %d.",
-                                        retryAttempts,
-                                        downloaderConfig.getMaxRetryAttempts()),
-                                reliableResourceStatus.getBytesRead(),
-                                downloadIdentifier);
-                        if (doCaching) {
-                            deleteCacheFile(fos);
-                            resourceCache.removePendingCacheEntry(reliableResource.getKey());
-                            // Disable caching since the cache file being written to had issues
-                            downloaderConfig.setCacheEnabled(false);
-                            doCaching = false;
-                            downloadState.setCacheEnabled(downloaderConfig.isCacheEnabled());
-                            downloadState.setContinueCaching(doCaching);
-                        }
-                        reliableResourceCallable = new ReliableResourceCallable(resourceInputStream,
-                                countingFbos,
-                                downloaderConfig.getChunkSize(),
-                                lock);
-                        reliableResourceCallable.setBytesRead(bytesRead);
-
+                        reliableResourceCallable = retrieveResourceWithOffset(bytesRead);
                     } else if (DownloadStatus.CLIENT_OUTPUT_STREAM_EXCEPTION.equals(
                             reliableResourceStatus.getDownloadStatus())) {
 
@@ -409,12 +331,11 @@ public class ReliableResourceDownloader implements Runnable {
                                 "",
                                 reliableResourceStatus.getBytesRead(),
                                 downloadIdentifier);
-                        IOUtils.closeQuietly(fbos);
-                        IOUtils.closeQuietly(countingFbos);
                         LOGGER.debug("Cancelling resourceRetrievalMonitor");
                         resourceRetrievalMonitor.cancel();
+                        closeAndNullUserOutputStreams();
                         reliableResourceCallable = new ReliableResourceCallable(resourceInputStream,
-                                fos,
+                                cacheFile,
                                 downloaderConfig.getChunkSize(),
                                 lock);
                         reliableResourceCallable.setBytesRead(bytesRead);
@@ -433,11 +354,12 @@ public class ReliableResourceDownloader implements Runnable {
                                 "",
                                 reliableResourceStatus.getBytesRead(),
                                 downloadIdentifier);
-                        if (doCaching && downloaderConfig.isCacheWhenCanceled()) {
+                        if (continueDownloadingWhenCancelled) {
                             LOGGER.debug("Continuing to cache product");
+                            closeAndNullUserOutputStreams();
                             reliableResourceCallable = new ReliableResourceCallable(
                                     resourceInputStream,
-                                    fos,
+                                    cacheFile,
                                     downloaderConfig.getChunkSize(),
                                     lock);
                             reliableResourceCallable.setBytesRead(bytesRead);
@@ -470,16 +392,14 @@ public class ReliableResourceDownloader implements Runnable {
                                 reliableResourceStatus.getBytesRead(),
                                 downloadIdentifier);
                         delay();
-                        reliableResourceCallable = retrieveResource(bytesRead);
+                        reliableResourceCallable = retrieveResourceWithOffset(bytesRead);
                     }
                 }
             }
 
             if (null != reliableResourceStatus && !DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(
                     reliableResourceStatus.getDownloadStatus())) {
-                if (doCaching) {
-                    deleteCacheFile(fos);
-                }
+
                 if (!DownloadStatus.RESOURCE_DOWNLOAD_CANCELED.equals(reliableResourceStatus.getDownloadStatus())) {
                     eventPublisher.postRetrievalStatus(resourceResponse,
                             ProductRetrievalStatus.FAILED,
@@ -487,24 +407,17 @@ public class ReliableResourceDownloader implements Runnable {
                             "Unable to retrieve product file.",
                             reliableResourceStatus.getBytesRead(),
                             downloadIdentifier);
+                    FileUtils.deleteQuietly(cacheFile);
                 }
             }
-        } catch (IOException e) {
-            LOGGER.error("Unable to store product file {}", filePath, e);
-            downloadState.setDownloadState(DownloadState.FAILED);
-            eventPublisher.postRetrievalStatus(resourceResponse,
-                    ProductRetrievalStatus.FAILED,
-                    metacard,
-                    "Unable to store product file.",
-                    reliableResourceStatus.getBytesRead(),
-                    downloadIdentifier);
         } finally {
+            reliableResourceByteSize = bytesRead;
             cleanupAfterDownload(reliableResourceStatus);
             downloadExecutor.shutdown();
         }
     }
 
-    private ReliableResourceCallable retrieveResource(long bytesRead) {
+    private ReliableResourceCallable retrieveResourceWithOffset(long bytesRead) {
 
         ReliableResourceCallable reliableResourceCallable = null;
 
@@ -551,7 +464,7 @@ public class ReliableResourceDownloader implements Runnable {
 
             reliableResourceCallable = new ReliableResourceCallable(resourceInputStream,
                     countingFbos,
-                    fos,
+                    cacheFile,
                     downloaderConfig.getChunkSize(),
                     lock);
 
@@ -564,27 +477,12 @@ public class ReliableResourceDownloader implements Runnable {
         return reliableResourceCallable;
     }
 
-    private void deleteCacheFile(FileOutputStream fos) {
-        LOGGER.debug("Deleting partially cached file {}", filePath);
-        IOUtils.closeQuietly(fos);
-
-        // Delete the cache file since it will no longer be written to and it currently has
-        // incomplete or corrupted data in it
-        boolean result = FileUtils.deleteQuietly(new File(filePath));
-        LOGGER.debug("result of deleting partial cache file = {}", result);
-    }
-
     private void cleanupAfterDownload(ReliableResourceStatus reliableResourceStatus) {
 
         if (reliableResourceStatus != null) {
-            // If caching was not successful, then remove this product from the pending cache list
-            // (Otherwise partially cached files will remain in pending list and returned to
-            // subsequent clients)
             if (reliableResourceStatus.getDownloadStatus()
                     != DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE) {
-                if (doCaching) {
-                    resourceCache.removePendingCacheEntry(reliableResource.getKey());
-                }
+
                 if (reliableResourceStatus.getDownloadStatus()
                         == DownloadStatus.RESOURCE_DOWNLOAD_CANCELED) {
                     this.downloadState.setDownloadState(DownloadManagerState.DownloadState.CANCELED);
@@ -600,10 +498,6 @@ public class ReliableResourceDownloader implements Runnable {
             }
         }
         IOUtils.closeQuietly(countingFbos);
-        if (doCaching) {
-            IOUtils.closeQuietly(fos);
-        }
-        LOGGER.debug("Closing source InputStream");
         IOUtils.closeQuietly(resourceInputStream);
         LOGGER.debug("Closed source InputStream");
     }
@@ -631,6 +525,19 @@ public class ReliableResourceDownloader implements Runnable {
         }
     }
 
+    private void closeAndNullUserOutputStreams() {
+        try {
+            fbos.reset();
+        } catch (IOException e) {
+            LOGGER.error("Error closing file-backed user output stream", e);
+        }
+        IOUtils.closeQuietly(fbos);
+        IOUtils.closeQuietly(countingFbos);
+
+        fbos = null;
+        countingFbos = null;
+    }
+
     public Long getReliableResourceInputStreamBytesCached() {
         return streamReadByClient.getBytesCached();
     }
@@ -649,9 +556,45 @@ public class ReliableResourceDownloader implements Runnable {
         return resourceResponse;
     }
 
+    /**
+     * Gets the download status from the reliable resource status.
+     *
+     * @return the DownloadStatus accessed through the ReliableResourceStatus object.
+     */
+    public DownloadStatus getDownloadStatus() {
+        return reliableResourceStatus.getDownloadStatus();
+    }
+
+    /**
+     * Gets the entire ReliableResourceStatus object.
+     *
+     * @return the ReliableResourceStatus object, reliableResourceStatus.
+     */
+    public ReliableResourceStatus getReliableResourceStatus() {
+        return reliableResourceStatus;
+    }
+
+    /**
+     * Get the bytes already downloaded of the reliable resource.
+     *
+     * @return The number of bytes already downloaded for the reliable resource.
+     */
+    public long getReliableResourceByteSize() {
+        return reliableResourceByteSize;
+    }
+
+    /**
+     * Gets the Resource object created during setup.
+     *
+     * @return the Resource object resource.
+     */
+    public Resource getResource() {
+        return resource;
+    }
+
     @VisibleForTesting
-    void setFileOutputStream(FileOutputStream fos) {
-        this.fos = fos;
+    void setFile(File cacheFile) {
+        this.cacheFile = cacheFile;
     }
 
     @VisibleForTesting

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadCallback.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadCallback.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.FutureCallback;
+
+import ddf.catalog.cache.ResourceCacheInterface;
+import ddf.catalog.resource.data.ReliableResource;
+
+public class ResourceDownloadCallback implements FutureCallback<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceDownloadCallback.class);
+
+    private ReliableResourceDownloader downloader;
+
+    private ResourceCacheInterface resourceCache;
+
+    private ReliableResource reliableResource;
+
+    private File cacheFile;
+
+    public ResourceDownloadCallback(ReliableResourceDownloader downloader, File cacheFile,
+            ReliableResource reliableResource, ResourceCacheInterface resourceCache) {
+
+        this.downloader = downloader;
+        this.reliableResource = reliableResource;
+        this.cacheFile = cacheFile;
+        this.resourceCache = resourceCache;
+    }
+
+    /**
+     * If the download is complete, put the reliable resource into the resource cache.
+     *
+     * @param b is void.
+     */
+    public void onSuccess(Void b) {
+        DownloadStatus downloadStatus = downloader.getDownloadStatus();
+
+        if (DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(downloadStatus)) {
+            LOGGER.debug("Setting reliableResource size");
+            reliableResource.setSize(downloader.getReliableResourceStatus()
+                    .getBytesRead());
+            LOGGER.debug("Adding caching key = {} to cache map", reliableResource.getKey());
+            resourceCache.put(reliableResource);
+
+        } else if (!DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(downloader.getReliableResourceStatus()
+                .getDownloadStatus())) {
+            FileUtils.deleteQuietly(cacheFile);
+        }
+
+        ReliableResourceStatus reliableResourceStatus = downloader.getReliableResourceStatus();
+        cleanupAfterDownload(reliableResourceStatus);
+
+    }
+
+    public void onFailure(Throwable thrown) {
+        ReliableResourceStatus reliableResourceStatus = downloader.getReliableResourceStatus();
+        cleanupAfterDownload(reliableResourceStatus);
+    }
+
+    /**
+     * Removes a pending cache entry from the reliable resource cache.
+     *
+     * @param reliableResourceStatus used to get the key of the item to remove from the pending
+     *                               cache.
+     */
+    private void cleanupAfterDownload(ReliableResourceStatus reliableResourceStatus) {
+        if (reliableResourceStatus != null) {
+            // If caching was not successful, then remove this product from the pending cache list
+            // (Otherwise partially cached files will remain in pending list and returned to
+            // subsequent clients)
+            resourceCache.removePendingCacheEntry(reliableResource.getKey());
+        }
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -223,6 +223,11 @@
         <argument value="$[org.codice.ddf.system.threadPoolSize]"/>
     </bean>
 
+    <bean id="downloadThreadPoolListener" class="com.google.common.util.concurrent.MoreExecutors"
+          factory-method="listeningDecorator">
+        <argument ref="downloadThreadPool"/>
+    </bean>
+
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
                filter="id=catalog.data.metacard.resource"
                availability="optional"/>
@@ -335,7 +340,7 @@
             </bean>
         </argument>
         <argument ref="downloadStatusInfo"/>
-        <argument ref="downloadThreadPool"/>
+        <argument ref="downloadThreadPoolListener"/>
     </bean>
 
     <bean id="historian" class="ddf.catalog.history.Historian">

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import ddf.catalog.cache.impl.ResourceCacheImpl;
@@ -79,7 +80,8 @@ public class DownloadsStatusEventListenerTest {
         downloaderConfig.setResourceCache(testResourceCache);
         downloaderConfig.setEventPublisher(testEventPublisher);
         downloaderConfig.setEventListener(testEventListener);
-        testDownloadManager = new ReliableResourceDownloadManager(downloaderConfig, testDownloadStatusInfo, Executors.newSingleThreadExecutor());
+        testDownloadManager = new ReliableResourceDownloadManager(downloaderConfig, testDownloadStatusInfo,
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor()));
         testDownloadManager.setMaxRetryAttempts(1);
         testDownloadManager.setDelayBetweenAttempts(0);
         testDownloadManager.setMonitorPeriod(5);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceCallableTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceCallableTest.java
@@ -1,0 +1,461 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.cxf.common.i18n.Exception;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.io.CountingOutputStream;
+
+public class ReliableResourceCallableTest {
+
+    private static final int END_OF_FILE = -1;
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    public File testFile;
+
+    private AtomicLong bytesRead;
+
+    private Object lock;
+
+    private InputStream input = null;
+
+    private ByteArrayOutputStream streamArray = new ByteArrayOutputStream();
+
+    private CountingOutputStream countingFbos = new CountingOutputStream(streamArray);
+
+    private FileInputStream cacheFis;
+
+    private int chunkSize;
+
+    private ReliableResourceStatus reliableResourceStatus;
+
+    @Before
+    public void setup() throws IOException {
+
+        bytesRead = new AtomicLong(0);
+        lock = mock(Object.class);
+        input = mock(InputStream.class);
+        testFile = testFolder.newFile("test.txt");
+        chunkSize = 0;
+        reliableResourceStatus = mock(ReliableResourceStatus.class);
+        cacheFis = new FileInputStream(testFile);
+
+    }
+
+    /**
+     * Checks that the value returned by getBytesRead changes to a new value after setBytesRead
+     * has been passed a new value.
+     */
+    @Test
+    public void setBytesReadChangesValue() throws Exception {
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                chunkSize,
+                lock);
+
+        testReliableResourceCallable.setBytesRead(0L);
+        assertThat(testReliableResourceCallable.getBytesRead(), is(0L));
+        testReliableResourceCallable.setBytesRead(15L);
+        assertThat(testReliableResourceCallable.getBytesRead(), is(15L));
+    }
+
+    /**
+     * Checks that when passed a true value, the set interrupt download recreates the reliable
+     * resource status with the new interrupted status and the number of bytes in bytesRead.
+     * Determines if the bytesRead are correct by comparing with what is returned by the
+     * reliable resource status's getBytesRead method.
+     */
+    @Test
+    public void setInterruptDownloadToTrue() throws Exception {
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                chunkSize,
+                lock);
+
+        testReliableResourceCallable.setInterruptDownload(true);
+
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getDownloadStatus(), is(DownloadStatus.RESOURCE_DOWNLOAD_INTERRUPTED));
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getBytesRead(), is(0L));
+    }
+
+    /**
+     * Checks that when passed a true value, the set cancel download recreates the reliable
+     * resource status with the new cancelled status and the number of bytes in bytesRead.
+     * Determines if the bytesRead are correct by comparing with what is returned by the
+     * reliable resource status's getBytesRead method.
+     */
+    @Test
+    public void setCancelDownloadToTrue() throws Exception {
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                chunkSize,
+                lock);
+
+        testReliableResourceCallable.setCancelDownload(true);
+
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getDownloadStatus(), is(DownloadStatus.RESOURCE_DOWNLOAD_CANCELED));
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getBytesRead(), is(0L));
+
+    }
+
+    /**
+     * Confirms that when the input is just an end of file, the download status and message
+     * are set to indicate the download is complete.
+     */
+    @Test
+    public void callDownloadSuccess() throws Exception, IOException {
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                testFile,
+                chunkSize,
+                lock);
+
+        when(input.read(any(byte[].class))).thenReturn(END_OF_FILE);
+        returnedStatus = testReliableResourceCallable.call();
+
+        assertThat(returnedStatus.getDownloadStatus(),
+                is(DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE));
+
+        assertThat(returnedStatus.toString(),
+                is("bytesRead = 0,  downloadStatus = RESOURCE_DOWNLOAD_COMPLETE,  message = Download completed successfully"));
+
+    }
+
+    /**
+     * Throw an IOException while reading the input and check that the download status
+     * is changed to indicate the product input stream exception by checking the
+     * downloadStatus's getDownloadStatus() and toString().
+     */
+    @Test
+    public void callDownloadIOException() throws Exception, IOException {
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                testFile,
+                chunkSize,
+                lock);
+
+        when(input.read(any(byte[].class))).thenThrow(new IOException());
+        returnedStatus = testReliableResourceCallable.call();
+
+        assertThat(returnedStatus.getDownloadStatus(),
+                is(DownloadStatus.PRODUCT_INPUT_STREAM_EXCEPTION));
+
+        assertThat(returnedStatus.toString(),
+                is("bytesRead = 0,  downloadStatus = PRODUCT_INPUT_STREAM_EXCEPTION,  message = IOException during read of product's InputStream"));
+
+    }
+
+    /**
+     * Confirms that, when the cache file passed to the constructor is null, the input is read
+     * the expected number of times, and the bytes streamed to the client
+     * match what is expected.
+     */
+    @Test
+    public void callDownloadWithBytesToReadWhenCacheFileDoesNotExist()
+            throws Exception, IOException {
+
+        chunkSize = 1;
+        int n = 1;
+
+        byte[] expectedTotalBuffer = new byte[2];
+        Arrays.fill(expectedTotalBuffer, (byte) 1);
+
+        byte[] expectedLoopByLoopBuffer = new byte[1];
+        Arrays.fill(expectedLoopByLoopBuffer, (byte) 1);
+
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                null,
+                chunkSize,
+                lock);
+
+        when(input.read(any(byte[].class))).thenAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] args = invocationOnMock.getArguments();
+                byte[] buffer = (byte[]) (args[0]);
+                Arrays.fill(buffer, (byte) 1);
+                return n;
+            }
+        })
+                .thenAnswer(new Answer() {
+
+                    @Override
+                    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        Object[] args = invocationOnMock.getArguments();
+                        byte[] buffer = (byte[]) (args[0]);
+                        Arrays.fill(buffer, (byte) 1);
+                        return n;
+                    }
+                })
+                .thenReturn(END_OF_FILE);
+
+        returnedStatus = testReliableResourceCallable.call();
+
+        verify(input, times(3)).read(expectedLoopByLoopBuffer);
+
+        assertThat(streamArray.toByteArray(), is(expectedTotalBuffer));
+    }
+
+    /**
+     * Confirms that, when the cache file passed to the constructor is null, the download status
+     * is set to complete when done, and the toString method reflects the number of bytes read.
+     */
+    @Test
+    public void callDownloadWithBytesToReadWhenCacheFileDoesNotExistMessage()
+            throws Exception, IOException {
+
+        chunkSize = 1;
+        int n = 1;
+
+        byte[] expectedTotalBuffer = new byte[2];
+        Arrays.fill(expectedTotalBuffer, (byte) 1);
+
+        byte[] expectedLoopByLoopBuffer = new byte[1];
+        Arrays.fill(expectedLoopByLoopBuffer, (byte) 1);
+
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                null,
+                chunkSize,
+                lock);
+
+        when(input.read(any(byte[].class))).thenAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] args = invocationOnMock.getArguments();
+                byte[] buffer = (byte[]) (args[0]);
+                Arrays.fill(buffer, (byte) 1);
+                return n;
+            }
+        })
+                .thenAnswer(new Answer() {
+
+                    @Override
+                    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        Object[] args = invocationOnMock.getArguments();
+                        byte[] buffer = (byte[]) (args[0]);
+                        Arrays.fill(buffer, (byte) 1);
+                        return n;
+                    }
+                })
+                .thenReturn(END_OF_FILE);
+
+        returnedStatus = testReliableResourceCallable.call();
+
+        assertThat(returnedStatus.getDownloadStatus(),
+                is(DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE));
+
+        assertThat(returnedStatus.toString(),
+                is("bytesRead = 2,  downloadStatus = RESOURCE_DOWNLOAD_COMPLETE,  message = Download completed successfully"));
+
+    }
+
+    /**
+     * Confirms that when the callable's call method is executed and the constructor is given
+     * a cache file, data that is read from the input is also added to the cache file. Also
+     * confirms that the input is read the expected number of times, and that the download status
+     * is set to complete when the download is over.
+     */
+    @Test
+    public void callDownloadWithBytesToReadWhenCacheFileExists() throws Exception, IOException {
+
+        chunkSize = 1;
+        int n = 1;
+
+        byte[] expectedTotalBuffer = new byte[2];
+        Arrays.fill(expectedTotalBuffer, (byte) 2);
+
+        byte[] expectedLoopByLoopBuffer = new byte[1];
+        Arrays.fill(expectedLoopByLoopBuffer, (byte) 2);
+
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                testFile,
+                chunkSize,
+                lock);
+
+        when(input.read(any(byte[].class))).thenAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] args = invocationOnMock.getArguments();
+                byte[] buffer = (byte[]) (args[0]);
+                Arrays.fill(buffer, (byte) 2);
+                return n;
+            }
+        })
+                .thenAnswer(new Answer() {
+
+                    @Override
+                    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        Object[] args = invocationOnMock.getArguments();
+                        byte[] buffer = (byte[]) (args[0]);
+                        Arrays.fill(buffer, (byte) 2);
+                        return n;
+                    }
+                })
+                .thenReturn(END_OF_FILE);
+
+        returnedStatus = testReliableResourceCallable.call();
+
+        verify(input, times(3)).read(expectedLoopByLoopBuffer);
+
+        assertThat(returnedStatus.getDownloadStatus(),
+                is(DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE));
+
+        assertThat(cacheFis.read(), is(2));
+        assertThat(cacheFis.read(), is(2));
+        assertThat(cacheFis.read(), is(END_OF_FILE));
+
+    }
+
+    /**
+     * When the cache file passed to the constructor is not null, tests the input is read
+     * the expected number of times and the bytes streamed to the client
+     * match what is expected.
+     */
+    @Test
+    public void callDownloadWritesToClientOutputStream() throws IOException {
+        int n = 5;
+        chunkSize = 5;
+        byte[] expectedBuffer = new byte[5];
+        Arrays.fill(expectedBuffer, (byte) 5);
+
+        when(input.read(any(byte[].class))).thenAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] args = invocationOnMock.getArguments();
+                byte[] buffer = (byte[]) (args[0]);
+                Arrays.fill(buffer, (byte) 5);
+                return n;
+            }
+        })
+                .thenReturn(END_OF_FILE);
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                testFile,
+                chunkSize,
+                lock);
+
+        testReliableResourceCallable.call();
+
+        assertThat(streamArray.toByteArray(), is(expectedBuffer));
+    }
+
+    /**
+     * Confirms that setting the interrupt download flag to true means that the input is never
+     * read, and the download status and message indicate interruption.
+     */
+    @Test
+    public void interruptStopsRead() throws IOException {
+        chunkSize = 1;
+        int n = 1;
+        byte[] expectedTotalBuffer = new byte[2];
+        Arrays.fill(expectedTotalBuffer, (byte) 2);
+
+        byte[] expectedLoopByLoopBuffer = new byte[1];
+        Arrays.fill(expectedLoopByLoopBuffer, (byte) 2);
+
+        ReliableResourceStatus returnedStatus = null;
+
+        ReliableResourceCallable testReliableResourceCallable = new ReliableResourceCallable(input,
+                countingFbos,
+                testFile,
+                chunkSize,
+                lock);
+
+        testReliableResourceCallable.setInterruptDownload(true);
+
+        when(input.read(any(byte[].class))).thenAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] args = invocationOnMock.getArguments();
+                byte[] buffer = (byte[]) (args[0]);
+                Arrays.fill(buffer, (byte) 2);
+                return n;
+            }
+        })
+                .thenAnswer(new Answer() {
+
+                    @Override
+                    public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        Object[] args = invocationOnMock.getArguments();
+                        byte[] buffer = (byte[]) (args[0]);
+                        Arrays.fill(buffer, (byte) 2);
+                        return n;
+                    }
+                })
+                .thenReturn(END_OF_FILE);
+
+        returnedStatus = testReliableResourceCallable.call();
+
+        verify(input, times(0)).read(expectedLoopByLoopBuffer);
+
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getDownloadStatus(), is(DownloadStatus.RESOURCE_DOWNLOAD_INTERRUPTED));
+        assertThat(testReliableResourceCallable.getReliableResourceStatus()
+                .getBytesRead(), is(0L));
+        assertThat(returnedStatus.toString(),
+                is("bytesRead = 0,  downloadStatus = RESOURCE_DOWNLOAD_INTERRUPTED,  message = Download interrupted - returning 0 bytes read"));
+
+    }
+
+}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -60,6 +60,8 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.MoreExecutors;
+
 import ddf.catalog.cache.MockInputStream;
 import ddf.catalog.cache.impl.CacheKey;
 import ddf.catalog.cache.impl.ResourceCacheImpl;
@@ -159,7 +161,7 @@ public class ReliableResourceDownloadManagerTest {
     }
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         resourceCache = mock(ResourceCacheImpl.class);
         when(resourceCache.getProductCacheDirectory()).thenReturn(productCacheDirectory);
         eventPublisher = mock(DownloadsStatusEventPublisher.class);
@@ -168,7 +170,9 @@ public class ReliableResourceDownloadManagerTest {
 
         downloadMgr = new ReliableResourceDownloadManager(getDownloaderConfig(),
                 downloadStatusInfo,
-                Executors.newSingleThreadExecutor());
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor()));
+
+        FileUtils.forceMkdir(new File(productCacheDirectory));
 
     }
 
@@ -631,7 +635,7 @@ public class ReliableResourceDownloadManagerTest {
 
         downloadMgr = new ReliableResourceDownloadManager(getDownloaderConfig(),
                 downloadStatusInfo,
-                Executors.newSingleThreadExecutor());
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor()));
 
         // Use small chunk size so download takes long enough for client
         // to have time to simulate FileBackedOutputStream exception

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceInputStreamTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceInputStreamTest.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
@@ -40,6 +39,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.io.CountingOutputStream;
 import com.google.common.io.FileBackedOutputStream;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import ddf.catalog.operation.ResourceResponse;
 
@@ -190,8 +192,9 @@ public class ReliableResourceInputStreamTest {
             }
         };
 
-        ExecutorService executor = Executors.newCachedThreadPool();
-        Future<Integer> future = executor.submit(callable);
+        ListeningExecutorService executor =
+                MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+        ListenableFuture<Integer> future = executor.submit(callable);
 
         // Write second string to FileBackedOutputStream - ReliableResourceInputStream's running
         // read(byte[], off, len) method is in loop waiting for new bytes to be written and should

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadCallbackTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadCallbackTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.resource.download;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.apache.cxf.common.i18n.Exception;
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.cache.ResourceCacheInterface;
+import ddf.catalog.resource.data.ReliableResource;
+
+public class ResourceDownloadCallbackTest {
+    private ReliableResourceDownloader downloader;
+
+    private File cacheFile;
+
+    private ReliableResource reliableResource;
+
+    private ResourceCacheInterface resourceCache;
+
+    private ReliableResourceStatus reliableResourceStatus;
+
+    @Before
+    public void setup() {
+        downloader = mock(ReliableResourceDownloader.class);
+        cacheFile = mock(File.class);
+        reliableResource = mock(ReliableResource.class);
+        resourceCache = mock(ResourceCacheInterface.class);
+        reliableResourceStatus = mock(ReliableResourceStatus.class);
+    }
+
+    /**
+     * Checks that if the downloader indicates a success and the download was completed,
+     * the size of the reliable resource is set and then the reliable resource is given
+     * to the resource cache. Finally, the pending cache entry is removed from the resource cache.
+     */
+    @Test
+    public void onSuccessDownloadComplete() throws Exception {
+        when(downloader.getDownloadStatus()).thenReturn(DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE);
+        when(downloader.getReliableResourceByteSize()).thenReturn(100L);
+        when(downloader.getReliableResourceStatus()).thenReturn(reliableResourceStatus);
+
+        when(reliableResource.getKey()).thenReturn("something");
+
+        ResourceDownloadCallback resourceDownloadCallback = new ResourceDownloadCallback(downloader,
+                cacheFile,
+                reliableResource,
+                resourceCache);
+
+        resourceDownloadCallback.onSuccess(null);
+
+        verify(reliableResource, times(1)).setSize(reliableResourceStatus.getBytesRead());
+        verify(resourceCache, times(1)).put(reliableResource);
+        verify(resourceCache, times(1)).removePendingCacheEntry(reliableResource.getKey());
+
+    }
+
+    /**
+     * Checks that if the downloader indicates a success but the download was not completed
+     * it does not add the reliable resource to the resource cache and it
+     * enters the if statement that deletes the cache file and then removes the pending cache
+     * entry from the resource cache.
+     */
+    @Test
+    public void onSuccessDownloadNotComplete() throws Exception {
+        when(downloader.getDownloadStatus()).thenReturn(DownloadStatus.RESOURCE_DOWNLOAD_INTERRUPTED);
+        when(downloader.getReliableResourceStatus()).thenReturn(reliableResourceStatus);
+        when(reliableResourceStatus.getDownloadStatus()).thenReturn(DownloadStatus.RESOURCE_DOWNLOAD_INTERRUPTED);
+
+        when(reliableResource.getKey()).thenReturn("something");
+
+        ResourceDownloadCallback resourceDownloadCallback = new ResourceDownloadCallback(downloader,
+                cacheFile,
+                reliableResource,
+                resourceCache);
+
+        resourceDownloadCallback.onSuccess(null);
+
+        verify(resourceCache, times(0)).put(reliableResource);
+
+        assertThat(!DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(downloader.getReliableResourceStatus()
+                .getDownloadStatus()), is(true));
+
+        verify(resourceCache, times(1)).removePendingCacheEntry(reliableResource.getKey());
+    }
+
+    /**
+     * Checks that the pending cache entry is removed, even if the downloader indicates a failure.
+     */
+    @Test
+    public void onFailure() throws Exception {
+        when(downloader.getReliableResourceStatus()).thenReturn(reliableResourceStatus);
+
+        when(reliableResource.getKey()).thenReturn("something");
+
+        ResourceDownloadCallback resourceDownloadCallback = new ResourceDownloadCallback(downloader,
+                cacheFile,
+                reliableResource,
+                resourceCache);
+
+        resourceDownloadCallback.onFailure(null);
+
+        verify(downloader, times(1)).getReliableResourceStatus();
+        verify(resourceCache, times(1)).removePendingCacheEntry(reliableResource.getKey());
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadEndpointTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ResourceDownloadEndpointTest.java
@@ -51,6 +51,9 @@ public class ResourceDownloadEndpointTest {
 
     private static final String SOURCE_ID = "ddf.distribution";
 
+    private static final String SUCCESSFUL_DOWNLOAD_TO_CACHE_MSG_TEMPLATE =
+            "The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.";
+
     private static final String DOWNLOAD_ID = "download ID";
 
     private static final String DOWNLOAD_ID_KEY = "downloadId";


### PR DESCRIPTION
#### What does this PR do?
- Remove dependency between ReliableResourceDownloader and ResourceCache
-Added ResourceDownloadCallback.
- Cleaned up code in the ReliableResourceDownloader, ReliableResourceDownloadManager, and ReliableResourceCallable.
 - Now the callable will handle removal of a half-written cache object
 in the case of the storage running out of space or for any other mid-write
 cancellation situation.
 - Updated existing unit tests and added some for the new classes.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@figliold
@lessarderic
@Lambeaux 
@bantillo 
@oconnormi 
@garrettfreibott 
@pklinef 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

#### How should this be tested?

-Integration tests & unit tests
-manual testing of downloads

 - Cleaned up code in the ReliableResourceDownloader, ReliableResourceDownloadManager,
 ResourceDownloadCallback, and ReliableResourceCallable.
 - Now the callable will handle removal of a half-written cache object
 in the case of the storage running out of space or for any other mid-write
 cancellation situation.
 - Updated existing unit tests and added some for the new classes.