### PR TITLE
DDF-2237 Upgraded Cesium to 1.17

### DIFF
--- a/catalog/ui/search-ui/standard/bower.json
+++ b/catalog/ui/search-ui/standard/bower.json
@@ -8,7 +8,7 @@
     "backbone.modelbinder": "1.1.0",
     "Backbone.Undo": "0.2.5",
     "bootswatch": "3.2.0",
-    "cesiumjs": "1.10.0",
+    "cesiumjs": "1.17.0",
     "backbone": "1.1.2",
     "bootstrap": "3.2.0",
     "font-awesome": "4.6.3",

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/cesium.metacard.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/cesium.metacard.js
@@ -377,7 +377,7 @@ define([
                         depthTest: {
                             enabled: true
                         },
-                        lineWidth: Math.min(2.0, this.geoController.scene.context.maximumAliasedLineWidth)
+                        lineWidth: Math.min(2.0, this.geoController.scene.maximumAliasedLineWidth)
                     }
                 });
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.bbox.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.bbox.js
@@ -231,7 +231,7 @@ define([
                             depthTest: {
                                 enabled: true
                             },
-                            lineWidth: Math.min(4.0, this.scene.context.maximumAliasedLineWidth)
+                            lineWidth: Math.min(4.0, this.scene.maximumAliasedLineWidth)
                         }
                     })
                 });

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.circle.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.circle.js
@@ -128,7 +128,7 @@ define([
                             depthTest: {
                                 enabled: true
                             },
-                            lineWidth: Math.min(4.0, this.scene.context.maximumAliasedLineWidth)
+                            lineWidth: Math.min(4.0, this.scene.maximumAliasedLineWidth)
                         }
                     })
                 });

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/cesium.polygon.js
@@ -68,7 +68,7 @@ define([
                             depthTest: {
                                 enabled: true
                             },
-                            lineWidth: Math.min(4.0, this.scene.context.maximumAliasedLineWidth)
+                            lineWidth: Math.min(4.0, this.scene.maximumAliasedLineWidth)
                         }
                     })
                 });

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/filter.cesium.geometry.group.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/widgets/filter.cesium.geometry.group.js
@@ -80,7 +80,7 @@ function (Marionette, Backbone, Cesium, _, wreqr) {
                         depthTest: {
                             enabled: true
                         },
-                        lineWidth: Math.min(4.0, this.options.geoController.scene.context.maximumAliasedLineWidth)
+                        lineWidth: Math.min(4.0, this.options.geoController.scene.maximumAliasedLineWidth)
                     }
                 })
             });
@@ -128,7 +128,7 @@ function (Marionette, Backbone, Cesium, _, wreqr) {
                         depthTest: {
                             enabled: true
                         },
-                        lineWidth: Math.min(4.0, this.options.geoController.scene.context.maximumAliasedLineWidth)
+                        lineWidth: Math.min(4.0, this.options.geoController.scene.maximumAliasedLineWidth)
                     }
                 })
             });
@@ -160,7 +160,7 @@ function (Marionette, Backbone, Cesium, _, wreqr) {
                         depthTest: {
                             enabled: true
                         },
-                        lineWidth: Math.min(4.0, this.options.geoController.scene.context.maximumAliasedLineWidth)
+                        lineWidth: Math.min(4.0, this.options.geoController.scene.maximumAliasedLineWidth)
                     }
                 })
             });


### PR DESCRIPTION
#### What does this PR do?
Moves Cesium up to 1.17.  This is the highest we can currently upgrade without breaking the Standard Search UI.  This PR was verified in Chrome, Firefox and Internet Explorer
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@codice/ui 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison
#### How should this be tested?
Build and test Standard Search UI in Chrome, Firefox, Internet Explorer
#### Any background context you want to provide?
When testing on Safari, it was noticed that DDF master would not render Cesium.  A ticket will be created for this issue.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2237
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

