### PR TITLE
DDF-2233 Add CQL filter expression support for the catalog-export scripts to dump filtered metacards

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/resources/bin/catalog-export
+++ b/catalog/core/catalog-core-commands/src/main/resources/bin/catalog-export
@@ -8,11 +8,36 @@
 # See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
 # <http://www.gnu.org/licenses/lgpl.html>.
 
-usage() { echo "Usage: $0 <-d directory> <-z zipname> <-k keystore location> [-a alias]" 1>&2; exit 1; }
+usage() {
+	echo "SYNTAX ";
+	echo "\t$0 <-d directory> <-z zipname> <-k keystore> [-a alias] [-c cql-expr]" 1>&2;
+	echo "";
+	echo "ARGUMENTS";
+	echo "\t-d directory : The absolute path of the directory to export the metacard";
+	echo "\t               archive. Directory path must exist.";
+	echo "";
+	echo "\t-z zipname   : The name of the archive file to be generated. The command";
+	echo "\t               will fail if this name is not unique in the directory.";
+	echo "";
+	echo "\t-k keystore  : The path to the keystore file.";
+	echo "";
+	echo "OPTIONS";
+	echo "\t-a alias     : Name of alias of the private key entry in the keystore.";
+	echo "\t               Typically matches the Common Name (CN) for the host in";
+	echo "\t               the keystore.";
+	echo "";
+	echo "\t-c cql-expr  : Search using CQL filter expressions.";
+	echo "\t               Example CQL Expressions:";
+	echo "\t                {Textual} \"title like 'some text'\"";
+	echo "\t               {Temporal} \"modified before 2012-09-01T12:30:00Z\"";
+	echo "\t                {Spatial} \"DWITHIN(location, POINT (1 2) , 10, kilometers)\"";
+	echo "";
+	exit 1;
+}
 
 JARSIGNER='jarsigner'
 
-while getopts ":d:z:k:a:" o; do
+while getopts "d:z:k:a:c:" o; do
     case "${o}" in
         d)
             d=${OPTARG}
@@ -25,6 +50,9 @@ while getopts ":d:z:k:a:" o; do
             ;;
         a)
             a=${OPTARG}
+            ;;
+        c)
+            c=${OPTARG}
             ;;
         *)
             usage
@@ -42,10 +70,18 @@ if [ -z "${d}" ] || [ -z "${z}" ] || [ -z "${k}" ]; then
 fi
 
 echo "Connecting to running DDF and exporting catalog to ${z}..."
-./client "catalog:dump --include-content=${z} ${d}"
+
+if [ -z "${c}" ]; then
+    echo Executing command: ./client catalog:dump --include-content ${z} ${d}
+    ./client "catalog:dump --include-content ${z} ${d}"
+else
+    echo Executing command: ./client -v "catalog:dump --include-content ${z} --cql \"${c}\" ${d}"
+    ./client "catalog:dump --include-content ${z} --cql \"${c}\" ${d}"
+fi
+
 if which ${JARSIGNER} >/dev/null; then
-        echo "Running  ${JARSIGNER} on ${z}, which will prompt you to enter the keystore password to sign the zip file..."
-         ${JARSIGNER} -keystore ${k} ${d}/${z} ${a}
+    echo "Running  ${JARSIGNER} on ${z}, which will prompt you to enter the keystore password to sign the zip file..."
+    ${JARSIGNER} -keystore ${k} ${d}/${z} ${a}
 else
     echo "Unable to find ${JARSIGNER}, ensure that $JAVA_HOME and $JAVA_HOME/bin are set on the path."
     exit 1

--- a/catalog/core/catalog-core-commands/src/main/resources/bin/catalog-export.bat
+++ b/catalog/core/catalog-core-commands/src/main/resources/bin/catalog-export.bat
@@ -19,24 +19,28 @@ set HOST=127.0.0.1
 
 :GETOPTS
 if %1 == -d (
-	setlocal
-	set DIR=%~2& shift
+    setlocal
+    set DIR=%~2& shift
 )
 if %1 == -z (
-	setlocal
-	set FILENAME=%~2& shift
+    setlocal
+    set FILENAME=%~2& shift
 )
 if %1 == -k (
-	setlocal
-	set KEYSTORE=%~2& shift
+    setlocal
+    set KEYSTORE=%~2& shift
 )
 if %1 == -a (
-	setlocal
-	set ALIAS=%~2& shift
+    setlocal
+    set ALIAS=%~2& shift
 )
 if %1 == -h (
-	setlocal
-	set HOST=%~2& shift
+    setlocal
+    set HOST=%~2& shift
+)
+if %1 == -c (
+    setlocal
+    set CQL=%~2& shift
 )
 shift
 if not (%1)==() goto GETOPTS
@@ -45,17 +49,42 @@ if "%FILENAME%"=="" goto USAGE
 if "%KEYSTORE%"=="" goto USAGE
 
 echo Connecting to running DDF and exporting catalog to %FILENAME%...
-call client.bat -h %HOST% "catalog:dump --include-content=%FILENAME% %DIR% "
+
+if "%CQL%"=="" (
+    echo Calling client with command:  catalog:dump --include-content %FILENAME% %DIR%
+    call client.bat -h %HOST% "catalog:dump --include-content %FILENAME% %DIR% "
+) else (
+    echo Calling client with command:  catalog:dump --include-content %FILENAME% --cql ^"%CQL%^" %DIR%
+    call client.bat -h %HOST% "catalog:dump --include-content %FILENAME% --cql ""%CQL%"" %DIR% "
+)
 
 where %JARSIGNER% >nul 2>nul
 if %ERRORLEVEL% NEQ 0 (
-	echo Unable to find %JARSIGNER%, ensure that $JAVA_HOME and $JAVA_HOME/bin are set on the path.
-	exit /b 1
+    echo Unable to find %JARSIGNER%, ensure that $JAVA_HOME and $JAVA_HOME/bin are set on the path.
+    exit /b 1
 ) else (
-	echo Running %JARSIGNER% on %FILENAME%, which will prompt you to enter the keystore password to sign the zip file...
-	call %JARSIGNER% -keystore %KEYSTORE% %DIR%/%FILENAME% %ALIAS% -signedJar %DIR%signed%FILENAME%
+    echo Running %JARSIGNER% on %FILENAME%, which will prompt you to enter the keystore password to sign the zip file...
+    call %JARSIGNER% -keystore %KEYSTORE% %DIR%/%FILENAME% %ALIAS% -signedJar %DIR%signed%FILENAME%
 )
 goto :eof
 
 :USAGE
-echo Usage: ^<-d directory^> ^<-z zipname^> ^<-k keystore location^> [-a alias] [-h hostname]
+echo SYNTAX
+echo    ^<-d directory^> ^<-z zipname^> ^<-k keystore location^> [-a alias] [-h hostname] [-c cql-expr]
+
+echo ARGUMENTS
+echo    -d directory : The absolute path of the directory to export the metacard
+echo                   archive. Directory path must exist.
+echo    -z zipname   : The name of the archive file to be generated. The command
+echo                   will fail if this name is not unique in the directory.
+echo    -k keystore  : The absolute path to the keystore directory.
+
+echo OPTIONS
+echo    -a alias     : Name of alias of the private key entry in the keystore.
+echo                   Typically matches the Common Name (CN) for the host in
+echo                   the keystore.
+echo    -c cql-expr  : Search using CQL Filter expressions.
+echo                   CQL Examples:
+echo                   {Textual}  -c "title like 'some text'"
+echo                   {Temporal} -c "modified before 2012-09-01T12:30:00Z"
+echo                   {Spatial}  -c "DWITHIN(location, POINT (1 2) , 10, kilometers)"


### PR DESCRIPTION
#### What does this PR do?
- Provides a CQL filter when dumping the catalog contents to file (used to import/export the entire catalog) using the existing catalog-export scripts in $DDF_HOME/bin. 
- Enhanced usage statements for the scripts.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @jrnorth @glenhein 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith @kcwire

#### How should this be tested?
**OSX**
1. Build and run DDF.
2. Ingest at least two items into catalog.
3. Navigate to $DDF_HOME/bin 
4. chmod +x catalog-export  (see bug https://codice.atlassian.net/browse/DDF-2240) 
5. Run catalog-export from the command line:
-   Regression test the original capability: 
`catalog-export -d DIRECTORY -z ZIPFILE -k KEYSTORE`
e.g. `catalog-export -d /Users/leahreese/Downloads -z test.zip -k ../etc/keystores/serverKeystore.jks`
Provide passphrase for keystore. Verify this generated a zipfile containing ALL ingested items at the location DIRECTORY/ZIPFILE.
- Test the CQL filter capability:
`catalog-export -d DIRECTORY -z ZIPFILE -k KEYSTORE -c CQLEXPRESSION`
e.g. `catalog-export -d /Users/leahreese/Downloads -z test.zip -k ../etc/keystores/serverKeystore.jks -c "title like '*firstmetacard'"`
Provide passphrase for keystore. Verify this generated a zipfile containing ONLY the ingested items matching the CQL filter at the location DIRECTORY/ZIPFILE.

**Windows**
1. Copy the DDF distribution from the above steps to a Windows VM.
2. Extract and run DDF.
3. Ingest at least two items into catalog.
4. Navigate to $DDF_HOME\bin 
5. Run catalog-export.bat from the command line:

- Regression test the original capability: 
`catalog-export.bat -d DIRECTORY -z ZIPFILE -k KEYSTORE`
e.g. `catalog-export.bat -d C:\\Users\\IEUser\\Downloads -z test.zip -k ..\\etc\\keystores\\serverKeystore.jks`
Verify this generated a zipfile containing ALL ingested items at the location DIRECTORY\ZIPFILE.

- Test the CQL filter capability:
`catalog-export.bat -d DIRECTORY -z ZIPFILE -k KEYSTORE -c CQLEXPRESSION`
e.g. `catalog-export.bat -d C:\\Users\\IEUser\\Downloads -z test.zip -k ..\\etc\\keystores\\serverKeystore.jks -c "title like '*firstmetacard'"`
Verify this generated a zipfile containing ONLY the ingested items matching the CQL filter at the location DIRECTORY\ZIPFILE.

#### Any background context you want to provide?


#### What are the relevant tickets?
Add CQL support to catalog-export scripts
https://codice.atlassian.net/browse/DDF-2233

#### Screenshots (if appropriate)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
