### PR TITLE
DDF-2025 Restore backwards compatibility for ActionProvider

### DIFF
--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.catalog.service.ConfiguredService;
 import ddf.catalog.source.ConnectedSource;
 import ddf.catalog.source.FederatedSource;
@@ -94,9 +94,9 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
 
     private final AdminSourceHelper helper;
 
-    private List<ActionProvider> reportActionProviders;
+    private List<MultiActionProvider> reportActionProviders;
 
-    private List<ActionProvider> operationActionProviders;
+    private List<MultiActionProvider> operationActionProviders;
 
     public AdminPollerServiceBean(ConfigurationAdmin configurationAdmin) {
         helper = getHelper();
@@ -236,9 +236,9 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
     }
 
     private List<Map<String, String>> getActions(Configuration config,
-            List<ActionProvider> providers) {
+            List<MultiActionProvider> providers) {
         List<Map<String, String>> actions = new ArrayList<>();
-        for (ActionProvider provider : providers) {
+        for (MultiActionProvider provider : providers) {
             if (!provider.canHandle(config)) {
                 continue;
             }
@@ -324,11 +324,11 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
         }
     }
 
-    public void setReportActionProviders(List<ActionProvider> reportActionProviders) {
+    public void setReportActionProviders(List<MultiActionProvider> reportActionProviders) {
         this.reportActionProviders = reportActionProviders;
     }
 
-    public void setOperationActionProviders(List<ActionProvider> operationActionProviders) {
+    public void setOperationActionProviders(List<MultiActionProvider> operationActionProviders) {
         this.operationActionProviders = operationActionProviders;
     }
 }

--- a/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,10 +18,10 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <reference-list id="reportActionProviders" interface="ddf.action.ActionProvider"
+    <reference-list id="reportActionProviders" interface="ddf.action.MultiActionProvider"
                     filter="(id=catalog.source.report.*)" availability="optional"/>
 
-    <reference-list id="operationActionProviders" interface="ddf.action.ActionProvider"
+    <reference-list id="operationActionProviders" interface="ddf.action.MultiActionProvider"
                     filter="(id=catalog.source.operation.*)" availability="optional"/>
 
     <bean id="adminPoller"

--- a/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
+++ b/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
@@ -44,7 +44,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import com.google.common.collect.ImmutableList;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
@@ -98,7 +98,7 @@ public class AdminPollerTest {
                 "operationTitleTwo",
                 "operationDescriptionTwo",
                 "https://localhost:8993/provider/someAction");
-        ImmutableList<ActionProvider> operationActions = ImmutableList.of(
+        ImmutableList<MultiActionProvider> operationActions = ImmutableList.of(
                 getHandleableTestActionProvider(operatorActionOne),
                 getNotHandleableTestActionProvider(),
                 getHandleableTestActionProvider(operatorActionTwo));
@@ -108,7 +108,7 @@ public class AdminPollerTest {
                 "reportTitle",
                 "reportDescription",
                 "https://localhost:8993/provider/someAction");
-        ImmutableList<ActionProvider> reportActions = ImmutableList.of(
+        ImmutableList<MultiActionProvider> reportActions = ImmutableList.of(
                 getHandleableTestActionProvider(reportActionOne),
                 getNotHandleableTestActionProvider(),
                 getNotHandleableTestActionProvider());
@@ -199,8 +199,8 @@ public class AdminPollerTest {
         }
     }
 
-    private ActionProvider getHandleableTestActionProvider(Action action) {
-        ActionProvider actionProvider = mock(ActionProvider.class);
+    private MultiActionProvider getHandleableTestActionProvider(Action action) {
+        MultiActionProvider actionProvider = mock(MultiActionProvider.class);
         when(actionProvider.canHandle(any(Configuration.class))).thenReturn(true);
         when(actionProvider.getActions(any(Class.class))).thenReturn(CollectionUtils.asList(action));
 
@@ -222,8 +222,8 @@ public class AdminPollerTest {
         return action;
     }
 
-    private ActionProvider getNotHandleableTestActionProvider() {
-        ActionProvider actionProvider = mock(ActionProvider.class);
+    private MultiActionProvider getNotHandleableTestActionProvider() {
+        MultiActionProvider actionProvider = mock(MultiActionProvider.class);
 
         when(actionProvider.canHandle(any(Configuration.class))).thenReturn(false);
 

--- a/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
+++ b/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
@@ -14,8 +14,6 @@
 package org.codice.ddf.catalog.actions;
 
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -74,30 +72,30 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
      * {@inheritDoc}
      */
     @Override
-    public <T> List<Action> getActions(T subject) {
+    public <T> Action getAction(T subject) {
 
         if (!canHandle(subject)) {
-            return Collections.emptyList();
+            return null;
         }
 
         Metacard metacard = (Metacard) subject;
 
         if (StringUtils.isBlank(metacard.getId())) {
             LOGGER.warn("Cannot create Action: No metacard ID.");
-            return Collections.emptyList();
+            return null;
         }
 
         if (isHostUnset(SystemBaseUrl.getHost())) {
             LOGGER.warn("Cannot create Action URL for metacard {}: Host name/IP not set.",
                     metacard.getId());
-            return Collections.emptyList();
+            return null;
         }
 
         try {
-            return Collections.singletonList(getMetacardAction(getSource(metacard), metacard));
+            return getMetacardAction(getSource(metacard), metacard);
         } catch (Exception e) {
             LOGGER.warn("Cannot create Action URL for metacard {}.", metacard.getId(), e);
-            return Collections.emptyList();
+            return null;
         }
     }
 
@@ -112,7 +110,6 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
      * <p>
      * {@inheritDoc}
      */
-    @Override
     public <T> boolean canHandle(T subject) {
         return (subject instanceof Metacard) && (canHandleMetacard((Metacard) subject));
     }

--- a/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
+++ b/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
@@ -13,9 +13,8 @@
  */
 package org.codice.ddf.catalog.actions;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -27,7 +26,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
@@ -144,9 +142,9 @@ public class AbstractMetacardActionProviderTest {
     public void getActionsWithNull() throws Exception {
         MetacardActionProvider actionProvider = createMetacardActionProvider();
 
-        List<Action> actions = actionProvider.getActions(null);
+        Action action = actionProvider.getAction(null);
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -154,9 +152,9 @@ public class AbstractMetacardActionProviderTest {
     public void getActionsWithNonMetacard() throws Exception {
         MetacardActionProvider actionProvider = createMetacardActionProvider();
 
-        List<Action> actions = actionProvider.getActions("blah");
+        Action action = actionProvider.getAction("blah");
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -165,9 +163,9 @@ public class AbstractMetacardActionProviderTest {
         MetacardActionProvider actionProvider = createMetacardActionProvider();
         when(metacard.getId()).thenReturn(null);
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -176,9 +174,9 @@ public class AbstractMetacardActionProviderTest {
         MetacardActionProvider actionProvider = createMetacardActionProvider();
         when(metacard.getId()).thenReturn(" ");
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -193,9 +191,9 @@ public class AbstractMetacardActionProviderTest {
         when(actionProvider.getMetacardActionUrl(SOURCE_ID, metacard)).thenReturn(url);
         System.clearProperty(SystemBaseUrl.HOST);
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, hasItem(action));
+        assertThat(action, is(this.action));
         verify(actionProvider).createMetacardAction(ACTION_ID, TITLE, DESCRIPTION, url);
     }
 
@@ -210,9 +208,9 @@ public class AbstractMetacardActionProviderTest {
         when(actionProvider.getMetacardActionUrl(SOURCE_ID, metacard)).thenReturn(url);
         System.setProperty(SystemBaseUrl.HOST, "0.0.0.0");
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -221,9 +219,9 @@ public class AbstractMetacardActionProviderTest {
         MetacardActionProvider actionProvider = createMetacardActionProvider();
         when(actionProvider.canHandleMetacard(metacard)).thenReturn(false);
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, is(empty()));
+        assertThat(action, is(nullValue()));
         verify(actionProvider, never()).getMetacardAction(any(), any());
     }
 
@@ -236,9 +234,9 @@ public class AbstractMetacardActionProviderTest {
                 any())).thenReturn(action);
         System.setProperty(SystemBaseUrl.HOST, "codice.org");
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, hasItem(action));
+        assertThat(action, is(this.action));
     }
 
     @Test
@@ -255,8 +253,8 @@ public class AbstractMetacardActionProviderTest {
         };
 
         System.setProperty(SystemBaseUrl.HOST, "codice.org");
-        List<Action> actions = actionProvider.getActions(metacard);
-        assertThat(actions, is(empty()));
+        Action action = actionProvider.getAction(metacard);
+        assertThat(action, is(nullValue()));
     }
 
     @Test
@@ -270,9 +268,9 @@ public class AbstractMetacardActionProviderTest {
                 eq(DESCRIPTION),
                 any())).thenReturn(action);
 
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, hasItem(action));
+        assertThat(action, is(this.action));
         verify(actionProvider).getMetacardAction("ddf", metacard);
     }
 

--- a/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
@@ -29,11 +29,12 @@ import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
 import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.action.impl.ActionImpl;
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.data.Metacard;
 
-public class DerivedContentActionProvider implements ActionProvider {
+public class DerivedContentActionProvider implements MultiActionProvider {
 
     private static final String ID = "catalog.data.metacard.derived-content";
 
@@ -53,9 +54,8 @@ public class DerivedContentActionProvider implements ActionProvider {
         if (!canHandle(input)) {
             return Collections.emptyList();
         }
-        // Expect only 1
-        List<Action> resourceActions = resourceActionProvider.getActions(input);
-        if (resourceActions.isEmpty()) {
+        Action resourceAction = resourceActionProvider.getAction(input);
+        if (resourceAction == null) {
             return Collections.emptyList();
         }
 
@@ -65,7 +65,7 @@ public class DerivedContentActionProvider implements ActionProvider {
                 .map(value -> {
                     try {
                         URI uri = new URI(value.toString());
-                        URIBuilder builder = new URIBuilder(resourceActions.get(0)
+                        URIBuilder builder = new URIBuilder(resourceAction
                                 .getUrl()
                                 .toURI());
                         if (StringUtils.equals(uri.getScheme(), ContentItem.CONTENT_SCHEME)) {

--- a/catalog/core/catalog-core-contentresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-contentresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,7 +43,7 @@
 
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider" filter="(id=catalog.data.metacard.resource)"/>
 
-    <service interface="ddf.action.ActionProvider" >
+    <service interface="ddf.action.MultiActionProvider" >
         <service-properties>
             <entry key="id" value="catalog.data.metacard.derived-content"/>
         </service-properties>

--- a/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
@@ -84,8 +84,7 @@ public class DerivedContentActionProviderTest {
                 "expected",
                 "expected",
                 actionUri.toURL());
-        when(mockResourceActionProvider.getActions(any(Metacard.class))).thenReturn(Arrays.asList(
-                expectedAction));
+        when(mockResourceActionProvider.getAction(any(Metacard.class))).thenReturn(expectedAction);
         List<Action> actions = actionProvider.getActions(metacard);
         assertThat(actions, hasSize(1));
         assertThat(actions.get(0), notNullValue());
@@ -103,8 +102,7 @@ public class DerivedContentActionProviderTest {
                 "expected",
                 "expected",
                 actionUri.toURL());
-        when(mockResourceActionProvider.getActions(any(Metacard.class))).thenReturn(Arrays.asList(
-                expectedAction));
+        when(mockResourceActionProvider.getAction(any(Metacard.class))).thenReturn(expectedAction);
         when(attribute.getValues()).thenReturn(Arrays.asList(EXAMPLE_URL));
         List<Action> actions = actionProvider.getActions(metacard);
         assertThat(actions, hasSize(1));

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventPublisher.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventPublisher.java
@@ -174,11 +174,8 @@ public class DownloadsStatusEventPublisher {
             Action downloadAction = null;
             if (null != actionProviders && !actionProviders.isEmpty()) {
                 // take the first one
-                List<Action> downloadActions = actionProviders.get(0)
-                        .getActions(metacard);
-                if (!downloadActions.isEmpty()){
-                    downloadAction = downloadActions.get(0);
-                }
+                downloadAction = actionProviders.get(0)
+                        .getAction(metacard);
             }
 
             // send activity event

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/QueryResponsePostProcessor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/QueryResponsePostProcessor.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
 import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -38,14 +39,14 @@ import ddf.catalog.operation.QueryResponse;
 public class QueryResponsePostProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryResponsePostProcessor.class);
 
-    private ActionProvider derivedActionProvider;
+    private MultiActionProvider derivedMultiActionProvider;
 
     private ActionProvider resourceActionProvider;
 
     public QueryResponsePostProcessor(ActionProvider resourceActionProvider,
-            ActionProvider derivedActionProvider) {
+            MultiActionProvider derivedActionProvider) {
         this.resourceActionProvider = resourceActionProvider;
-        this.derivedActionProvider = derivedActionProvider;
+        this.derivedMultiActionProvider = derivedActionProvider;
     }
 
     /**
@@ -58,7 +59,7 @@ public class QueryResponsePostProcessor {
      */
     public void processResponse(QueryResponse queryResponse) {
 
-        if (resourceActionProvider == null && derivedActionProvider == null) {
+        if (resourceActionProvider == null && derivedMultiActionProvider == null) {
             LOGGER.debug("No ActionProvider, skipping addition of {} attribute in Metacards",
                     Metacard.RESOURCE_DOWNLOAD_URL);
             return;
@@ -68,11 +69,10 @@ public class QueryResponsePostProcessor {
             final Metacard metacard = result.getMetacard();
 
             if (metacard.getResourceURI() != null && resourceActionProvider != null) {
-                List<Action> actions = resourceActionProvider.getActions(metacard);
+                Action action = resourceActionProvider.getAction(metacard);
 
-                if (!CollectionUtils.isEmpty(actions)) {
-                    final URL resourceUrl = actions.get(0)
-                            .getUrl();
+                if (action != null) {
+                    final URL resourceUrl = action.getUrl();
 
                     if (resourceUrl != null) {
                         metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_DOWNLOAD_URL,
@@ -84,8 +84,8 @@ public class QueryResponsePostProcessor {
                     && !metacard.getAttribute(Metacard.DERIVED_RESOURCE_URI)
                     .getValues()
                     .isEmpty() &&
-                    derivedActionProvider != null) {
-                List<Action> actions = derivedActionProvider.getActions(metacard);
+                    derivedMultiActionProvider != null) {
+                List<Action> actions = derivedMultiActionProvider.getActions(metacard);
 
                 if (!CollectionUtils.isEmpty(actions)) {
                     metacard.setAttribute(new AttributeImpl(Metacard.DERIVED_RESOURCE_DOWNLOAD_URL,

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -226,13 +226,13 @@
     <reference id="resourceActionProvider" interface="ddf.action.ActionProvider"
                filter="id=catalog.data.metacard.resource"
                availability="optional"/>
-    <reference id="derivedActionProvider" interface="ddf.action.ActionProvider"
+    <reference id="derivedActionsProvider" interface="ddf.action.MultiActionProvider"
                filter="id=catalog.data.metacard.derived-content"
                availability="optional"/>
 
     <bean id="queryResponsePostProcessor" class="ddf.catalog.impl.QueryResponsePostProcessor">
         <argument ref="resourceActionProvider"/>
-        <argument ref="derivedActionProvider"/>
+        <argument ref="derivedActionsProvider"/>
     </bean>
 
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/ActivityEventPublisherTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/ActivityEventPublisherTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;
-import java.util.Arrays;
 
 import com.google.common.collect.ImmutableList;
 
@@ -37,7 +36,7 @@ public class ActivityEventPublisherTest extends AbstractDownloadsStatusEventPubl
         actionProvider = mock(ActionProvider.class);
         Action downloadAction = mock(Action.class);
         try {
-            when(actionProvider.getActions(metacard)).thenReturn(Arrays.asList(downloadAction));
+            when(actionProvider.getAction(metacard)).thenReturn(downloadAction);
             when(downloadAction.getUrl()).thenReturn(new URL("http://example.com/download"));
         } catch (Exception e) {
             LOGGER.warn("Could not set download action URL", e);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/NotificationEventPublisherTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/NotificationEventPublisherTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;
-import java.util.Arrays;
 
 import com.google.common.collect.ImmutableList;
 
@@ -37,7 +36,7 @@ public class NotificationEventPublisherTest extends AbstractDownloadsStatusEvent
         actionProvider = mock(ActionProvider.class);
         Action downloadAction = mock(Action.class);
         try {
-            when(actionProvider.getActions(metacard)).thenReturn(Arrays.asList(downloadAction));
+            when(actionProvider.getAction(metacard)).thenReturn(downloadAction);
             when(downloadAction.getUrl()).thenReturn(new URL("http://example.com/download"));
         } catch (Exception e) {
             LOGGER.warn("Could not set download action URL", e);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/QueryResponsePostProcessorImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/QueryResponsePostProcessorImplTest.java
@@ -41,6 +41,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import ddf.action.Action;
 import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -62,7 +63,7 @@ public class QueryResponsePostProcessorImplTest {
     private ActionProvider resourceActionProvider;
 
     @Mock
-    private ActionProvider derivedActionProvider;
+    private MultiActionProvider derivedActionProvider;
 
     @Mock
     private QueryResponse queryResponse;
@@ -169,7 +170,7 @@ public class QueryResponsePostProcessorImplTest {
         when(results.get(0)
                 .getMetacard()).thenReturn(metacards[0]);
         when(metacards[0].getResourceURI()).thenReturn(uris[0]);
-        when(resourceActionProvider.getActions(metacards[0])).thenReturn(null);
+        when(resourceActionProvider.getAction(metacards[0])).thenReturn(null);
 
         setUpExpectationsForResult(1);
 
@@ -186,8 +187,8 @@ public class QueryResponsePostProcessorImplTest {
         when(results.get(0)
                 .getMetacard()).thenReturn(metacards[0]);
         when(metacards[0].getResourceURI()).thenReturn(uris[0]);
-        when(resourceActionProvider.getActions(metacards[0])).thenReturn(Arrays.asList(
-                resourceActions));
+        when(resourceActionProvider.getAction(metacards[0])).thenReturn(
+                resourceActions[0]);
         when(resourceActions[0].getUrl()).thenReturn(null);
 
         setUpExpectationsForResult(1);
@@ -202,8 +203,8 @@ public class QueryResponsePostProcessorImplTest {
         when(results.get(resultNumber)
                 .getMetacard()).thenReturn(metacards[resultNumber]);
         when(metacards[resultNumber].getResourceURI()).thenReturn(uris[resultNumber]);
-        when(resourceActionProvider.getActions(metacards[resultNumber])).thenReturn(Arrays.asList(
-                resourceActions[resultNumber]));
+        when(resourceActionProvider.getAction(metacards[resultNumber])).thenReturn(
+                resourceActions[resultNumber]);
         when(resourceActions[resultNumber].getUrl()).thenReturn(urls[resultNumber]);
 
         when(metacards[resultNumber].getAttribute(Metacard.DERIVED_RESOURCE_URI)).thenReturn(attrs[resultNumber]);

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/action/AbstractMetacardActionProvider.java
@@ -15,9 +15,6 @@ package org.codice.ddf.endpoints.rest.action;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.lang.CharEncoding;
 import org.apache.commons.lang.StringUtils;
@@ -53,40 +50,35 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
     protected abstract Action getAction(String metacardId, String metacardSource);
 
     @Override
-    public <T> List<Action> getActions(T input) {
-
-        if (input instanceof Metacard) {
-
-            Metacard metacard = (Metacard) input;
-
-            if (StringUtils.isBlank(metacard.getId())) {
-                LOGGER.info("No id given. No action to provide.");
-                return Collections.emptyList();
-            }
-
-            if (isHostUnset(SystemBaseUrl.getHost())) {
-                LOGGER.info("Host name/ip not set. Cannot create link for metacard.");
-                return Collections.emptyList();
-            }
-
-            String metacardId = null;
-            String metacardSource = null;
-
-            try {
-                metacardId = URLEncoder.encode(metacard.getId(), CharEncoding.UTF_8);
-                metacardSource = URLEncoder.encode(getSource(metacard), CharEncoding.UTF_8);
-            } catch (UnsupportedEncodingException e) {
-                LOGGER.info("Unsupported Encoding exception", e);
-                return Collections.emptyList();
-            }
-
-            Action action = getAction(metacardId, metacardSource);
-            if (action == null) {
-                return Collections.emptyList();
-            }
-            return Arrays.asList(action);
+    public <T> Action getAction(T input) {
+        if (!canHandle(input)) {
+            return null;
         }
-        return Collections.emptyList();
+
+        Metacard metacard = (Metacard) input;
+
+        if (StringUtils.isBlank(metacard.getId())) {
+            LOGGER.info("No id given. No action to provide.");
+            return null;
+        }
+
+        if (isHostUnset(SystemBaseUrl.getHost())) {
+            LOGGER.info("Host name/ip not set. Cannot create link for metacard.");
+            return null;
+        }
+
+        String metacardId = null;
+        String metacardSource = null;
+
+        try {
+            metacardId = URLEncoder.encode(metacard.getId(), CharEncoding.UTF_8);
+            metacardSource = URLEncoder.encode(getSource(metacard), CharEncoding.UTF_8);
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.info("Unsupported Encoding exception", e);
+            return null;
+        }
+
+        return getAction(metacardId, metacardSource);
     }
 
     protected boolean isHostUnset(String host) {
@@ -109,8 +101,7 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
         return this.actionProviderId;
     }
 
-    @Override
-    public <T> boolean canHandle(T subject) {
+    private <T> boolean canHandle(T subject) {
         return subject instanceof Metacard;
     }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestActionProviderRegistryProxy.java
@@ -41,8 +41,6 @@ import org.osgi.framework.ServiceRegistration;
 
 import ddf.action.ActionProvider;
 import ddf.catalog.Constants;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transformer.attribute.AttributeMetacardTransformer;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -159,9 +157,6 @@ public class TestActionProviderRegistryProxy {
         Object value = captor.getValue();
         assertThat(value, notNullValue());
         assertThat(value instanceof ActionProvider, is(true));
-        ActionProvider provider = (ActionProvider) value;
-        Metacard metacard = new MetacardImpl();
-        assertThat(provider.canHandle(metacard), is(false));
     }
 
     @Test

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -15,7 +15,6 @@ package org.codice.ddf.endpoints.rest.action;
 
 import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
 import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -25,7 +24,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.List;
 
 import org.apache.commons.lang.CharEncoding;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -76,10 +74,8 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
 
     @Test
     public void createMetacardAction() throws MalformedURLException {
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, hasSize(1));
-        Action action = actions.get(0);
         assertThat(action.getId(), is(ACTION_PROVIDER_ID));
         assertThat(action.getTitle(), is("Export as " + SAMPLE_TRANSFORMER_ID));
         assertThat(action.getDescription(),

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
@@ -15,7 +15,6 @@ package org.codice.ddf.endpoints.rest.action;
 
 import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
 import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -25,7 +24,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.List;
 
 import org.apache.commons.lang.CharEncoding;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -73,10 +71,8 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
     @Test
     public void createMetacardAction() throws MalformedURLException {
-        List<Action> actions = actionProvider.getActions(metacard);
+        Action action = actionProvider.getAction(metacard);
 
-        assertThat(actions, hasSize(1));
-        Action action = actions.get(0);
         assertThat(action.getId(), is(ACTION_PROVIDER_ID));
         assertThat(action.getTitle(), is("Export Metacard XML"));
         assertThat(action.getDescription(), is("Provides a URL to the metacard"));

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/DescriptionTemplateHelper.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/DescriptionTemplateHelper.java
@@ -136,8 +136,7 @@ public class DescriptionTemplateHelper {
 
     public String resourceUrl(Metacard context) {
         if (resourceActionProvider != null) {
-            List<Action> actions = resourceActionProvider.getActions(context);
-            Action action = (actions.isEmpty()) ? null : actions.get(0);
+            Action action = resourceActionProvider.getAction(context);
             if (action != null) {
                 return action.getUrl()
                         .toString();

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestDescriptionTemplateHelper.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestDescriptionTemplateHelper.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -70,7 +69,7 @@ public class TestDescriptionTemplateHelper {
     public static void setUp() throws MalformedURLException {
         mockActionProvider = mock(ActionProvider.class);
         mockAction = mock(Action.class);
-        when(mockActionProvider.getActions(any(Metacard.class))).thenReturn(Arrays.asList(mockAction));
+        when(mockActionProvider.getAction(any(Metacard.class))).thenReturn(mockAction);
         when(mockAction.getUrl()).thenReturn(new URL(ACTION_URL));
         helper = new DescriptionTemplateHelper(mockActionProvider);
     }

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestKMLTransformerImpl.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestKMLTransformerImpl.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -90,7 +89,7 @@ public class TestKMLTransformerImpl {
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         ActionProvider mockActionProvider = mock(ActionProvider.class);
         Action mockAction = mock(Action.class);
-        when(mockActionProvider.getActions(any(Metacard.class))).thenReturn(Arrays.asList(mockAction));
+        when(mockActionProvider.getAction(any(Metacard.class))).thenReturn(mockAction);
         when(mockAction.getUrl()).thenReturn(new URL(ACTION_URL));
         kmlTransformer = new KMLTransformerImpl(mockContext,
                 DEFAULT_STYLE_LOCATION,

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
@@ -39,13 +39,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.action.impl.ActionImpl;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.source.Source;
 
-public class RegistryPublicationActionProvider implements ActionProvider {
+public class RegistryPublicationActionProvider implements MultiActionProvider {
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(RegistryPublicationActionProvider.class);

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,7 @@
         <property name="federationAdminService" ref="federationAdminService"/>
     </bean>
 
-    <service ref="registryActionProvider" interface="ddf.action.ActionProvider">
+    <service ref="registryActionProvider" interface="ddf.action.MultiActionProvider">
         <service-properties>
             <entry key="id" value="catalog.source.operation.publication.registry"/>
         </service-properties>

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryReportActionProvider.java
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryReportActionProvider.java
@@ -35,12 +35,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.action.impl.ActionImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.source.Source;
 
-public class RegistryReportActionProvider implements ActionProvider {
+public class RegistryReportActionProvider implements MultiActionProvider {
 
     private static final String REGISTRY_PATH = "/registries";
 

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
         <property name="description" value="Provides a URL to the metacard report"/>
     </bean>
 
-    <service ref="registryMetacardActionProvider" interface="ddf.action.ActionProvider">
+    <service ref="registryMetacardActionProvider" interface="ddf.action.MultiActionProvider">
         <service-properties>
             <entry key="id" value="catalog.data.metacard.registry"/>
         </service-properties>
@@ -37,7 +37,7 @@
         <property name="description" value="Provides a URL to the source report"/>
     </bean>
 
-    <service ref="registrySourceActionProvider" interface="ddf.action.ActionProvider">
+    <service ref="registrySourceActionProvider" interface="ddf.action.MultiActionProvider">
         <service-properties>
             <entry key="id" value="catalog.source.report.registry"/>
         </service-properties>

--- a/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
@@ -38,7 +38,6 @@ import org.apache.abdera.model.Element;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Feed;
 import org.apache.abdera.model.Link;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemInfo;
@@ -427,13 +426,13 @@ public class AtomTransformer implements QueryResponseTransformer {
         if (actionProvider != null) {
             try {
 
-                List<Action> actions = actionProvider.getActions(metacard);
+                Action action = actionProvider.getAction(metacard);
 
-                if (!CollectionUtils.isEmpty(actions)) {
+                if (action != null) {
                     if (actionProvider.equals(resourceActionProvider)
                             && metacard.getResourceURI() != null) {
 
-                        Link viewLink = addLinkHelper(actions.get(0),
+                        Link viewLink = addLinkHelper(action,
                                 entry,
                                 linkType,
                                 MIME_TYPE_OCTET_STREAM);
@@ -448,11 +447,11 @@ public class AtomTransformer implements QueryResponseTransformer {
                     } else if (actionProvider.equals(thumbnailActionProvider)
                             && metacard.getThumbnail() != null) {
 
-                        addLinkHelper(actions.get(0), entry, linkType, MIME_TYPE_JPEG);
+                        addLinkHelper(action, entry, linkType, MIME_TYPE_JPEG);
                     } else if (!actionProvider.equals(resourceActionProvider)
                             && !actionProvider.equals(thumbnailActionProvider)) {
 
-                        addLinkHelper(actions.get(0), entry, linkType, MIME_TYPE_OCTET_STREAM);
+                        addLinkHelper(action, entry, linkType, MIME_TYPE_OCTET_STREAM);
                     }
 
                 }

--- a/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/test/java/ddf/catalog/transformer/response/query/atom/TestAtomTransformer.java
@@ -959,7 +959,7 @@ public class TestAtomTransformer {
         when(viewAction.getUrl()).thenReturn(new URL("http://host:80/" + SAMPLE_ID));
 
         ActionProvider viewActionProvider = mock(ActionProvider.class);
-        when(viewActionProvider.getActions(isA(Metacard.class))).thenReturn(Arrays.asList(viewAction));
+        when(viewActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
         AtomTransformer transformer = new AtomTransformer();
 
@@ -1061,15 +1061,13 @@ public class TestAtomTransformer {
         when(viewAction.getUrl()).thenReturn(new URL("http://host:80/" + SAMPLE_ID));
 
         ActionProvider viewActionProvider = mock(ActionProvider.class);
-        when(viewActionProvider.getActions(isA(Metacard.class))).thenReturn(Arrays.asList(viewAction));
+        when(viewActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
         ActionProvider resourceActionProvider = mock(ActionProvider.class);
-        when(resourceActionProvider.getActions(isA(Metacard.class))).thenReturn(Arrays.asList(
-                viewAction));
+        when(resourceActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
         ActionProvider thumbnailActionProvider = mock(ActionProvider.class);
-        when(thumbnailActionProvider.getActions(isA(Metacard.class))).thenReturn(Arrays.asList(
-                viewAction));
+        when(thumbnailActionProvider.getAction(isA(Metacard.class))).thenReturn(viewAction);
 
         AtomTransformer transformer = new AtomTransformer();
 

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/actions/ActionRegistryImpl.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/actions/ActionRegistryImpl.java
@@ -21,22 +21,34 @@ import org.apache.commons.collections.CollectionUtils;
 import ddf.action.Action;
 import ddf.action.ActionProvider;
 import ddf.action.ActionRegistry;
+import ddf.action.MultiActionProvider;
 
 /**
  * The {@code ActionRegistryImpl} provides an ActionRegistry for {@code Metacard}s.
  */
 public class ActionRegistryImpl implements ActionRegistry {
 
-    public List<ActionProvider> providers;
+    public List<ActionProvider> actionProviders;
 
-    public ActionRegistryImpl(List<ActionProvider> actionProviders) {
-        this.providers = actionProviders;
+    public List<MultiActionProvider> multiActionProviders;
+
+    public ActionRegistryImpl(List<ActionProvider> actionProviders,
+            List<MultiActionProvider> multiActionProviders) {
+        this.actionProviders = actionProviders;
+        this.multiActionProviders = multiActionProviders;
     }
 
     public <Metacard> List<Action> list(Metacard metacard) {
         List<Action> availableActions = new ArrayList<>();
 
-        for (ActionProvider provider : providers) {
+        for (ActionProvider provider : actionProviders) {
+            Action action = provider.getAction(metacard);
+            if (action != null) {
+                availableActions.add(action);
+            }
+        }
+
+        for (MultiActionProvider provider : multiActionProviders) {
             if (provider.canHandle(metacard)) {
                 List<Action> actions = provider.getActions(metacard);
                 if (!CollectionUtils.isEmpty(actions)) {
@@ -44,6 +56,7 @@ public class ActionRegistryImpl implements ActionRegistry {
                 }
             }
         }
+
         return availableActions;
     }
 }

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -39,8 +39,11 @@
 
     <reference-list id="actionProviders" interface="ddf.action.ActionProvider" filter="(id=catalog.data.metacard.*)"/>
 
+    <reference-list id="actionsProviders" interface="ddf.action.MultiActionProvider" filter="(id=catalog.data.metacard.*)"/>
+
     <bean id="actionRegistry" class="org.codice.ddf.ui.searchui.query.actions.ActionRegistryImpl">
         <argument ref="actionProviders"/>
+        <argument ref="actionsProviders"/>
     </bean>
 
     <bean class="org.codice.ddf.ui.searchui.query.endpoint.CometdEndpoint" init-method="init"

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
@@ -72,7 +72,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.Futures;
 
-import ddf.action.ActionProvider;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BasicTypes;
@@ -144,7 +143,7 @@ public class SearchControllerTest {
         framework = createFramework();
 
         searchController = new SearchController(framework,
-                new ActionRegistryImpl(Collections.<ActionProvider>emptyList()),
+                new ActionRegistryImpl(Collections.emptyList(), Collections.emptyList()),
                 new GeotoolsFilterAdapterImpl(),
                 new SequentialExecutorService());
 
@@ -297,7 +296,7 @@ public class SearchControllerTest {
         when(framework.query(any(QueryRequest.class))).thenReturn(response);
 
         searchController = new SearchController(framework,
-                new ActionRegistryImpl(Collections.<ActionProvider>emptyList()),
+                new ActionRegistryImpl(Collections.emptyList(), Collections.emptyList()),
                 new GeotoolsFilterAdapterImpl(),
                 new SequentialExecutorService());
 
@@ -523,7 +522,7 @@ public class SearchControllerTest {
     private void runTestForReasonMessages(Exception exception, String expectedReasonMessage)
             throws Exception {
         searchController = new SearchController(framework,
-                new ActionRegistryImpl(Collections.<ActionProvider>emptyList()),
+                new ActionRegistryImpl(Collections.emptyList(), Collections.emptyList()),
                 new GeotoolsFilterAdapterImpl(),
                 mockExecutor);
         searchController.setBayeuxServer(mockBayeuxServer);

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
@@ -138,7 +138,7 @@ public class CometdEndpointTest {
                 mock(PersistentStore.class),
                 mock(BundleContext.class),
                 mock(EventAdmin.class),
-                new ActionRegistryImpl(Collections.EMPTY_LIST),
+                new ActionRegistryImpl(Collections.EMPTY_LIST, Collections.EMPTY_LIST),
                 Executors.newSingleThreadExecutor());
     }
 

--- a/distribution/docs/src/main/resources/_contents/_platform-contents/extending-platform-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_platform-contents/extending-platform-contents.adoc
@@ -5,6 +5,7 @@ This section supports developers creating extensions of the existing framework.
 
 The following packages have been exported by the ${ddf-platform} application and are approved for use by third parties:
 
+* `${ddf-branding-lowercase}.action`
 * `${ddf-branding-lowercase}.security`
 * `${ddf-branding-lowercase}.security.assertion`
 * `${ddf-branding-lowercase}.security.common.audit`

--- a/platform/action/core/platform-action-core-api/pom.xml
+++ b/platform/action/core/platform-action-core-api/pom.xml
@@ -35,6 +35,48 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Generate Javadocs for this project -->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/platform/action/core/platform-action-core-api/src/main/java/ddf/action/Action.java
+++ b/platform/action/core/platform-action-core-api/src/main/java/ddf/action/Action.java
@@ -19,10 +19,6 @@ import java.net.URL;
  * An {@link Action} has a {@link URL} meant to be used in a browser or be able to be invoked to
  * provide some resource or business logic. An example would be providing a link to a product or a
  * link to calculate information about a specific resource.
- *
- * <b> This code is experimental. While this interface is functional and tested, it may change or be
- * removed in a future version of the library. </b>
- *
  */
 public interface Action {
 

--- a/platform/action/core/platform-action-core-api/src/main/java/ddf/action/ActionRegistry.java
+++ b/platform/action/core/platform-action-core-api/src/main/java/ddf/action/ActionRegistry.java
@@ -17,9 +17,6 @@ import java.util.List;
 
 /**
  * This class is used to find all {@link Action} objects that correspond to a certain input object.
- *
- * <b> This code is experimental. While this interface is functional and tested, it may change or be
- * removed in a future version of the library. </b>
  */
 public interface ActionRegistry {
 

--- a/platform/action/core/platform-action-core-api/src/main/java/ddf/action/MultiActionProvider.java
+++ b/platform/action/core/platform-action-core-api/src/main/java/ddf/action/MultiActionProvider.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,6 +13,8 @@
  */
 package ddf.action;
 
+import java.util.List;
+
 /**
  * This class provides an {@link Action} for a given subject. Objects that the
  * {@link ActionProvider} can handle are not restricted to a particular class and can be whatever
@@ -20,24 +22,31 @@ package ddf.action;
  *
  * @see Action
  * @see ActionRegistry
+ *
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
  */
-public interface ActionProvider {
+public interface MultiActionProvider {
 
     /**
-     *
-     * @param subject
-     *            object for which the {@link ActionProvider} is requested to provide an
-     *            {@link Action}
+     * @param subject object for which the {@link ActionProvider} is requested to provide an
+     *                {@link Action}
      * @return an {@link Action} object. If no action can be taken on the input, then
-     *         <code>null</code> shall be returned
+     * <code>Collections.emptyList()</code> shall be returned
      */
-    public <T> Action getAction(T subject);
+    <T> List<Action> getActions(T subject);
 
     /**
-     *
      * @return a unique identifier to distinguish the type of service this {@link ActionProvider}
-     *         provides
+     * provides
      */
-    public String getId();
+    String getId();
+
+    /**
+     * Checks if an {@link ActionProvider} supports a given subject.
+     * @param subject the input to check
+     * @return true if is supported, false otherwise.
+     */
+    <T> boolean canHandle(T subject);
 
 }

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
@@ -15,8 +15,6 @@ package org.codice.ddf.security.idp.client;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.shiro.subject.Subject;
@@ -48,8 +46,10 @@ public class IdpLogoutActionProvider implements ActionProvider {
      * @param realmSubjectMap containing a realm of "idp" with the corresponding subject
      * @return IdpLogoutActionProvider containing the logout url
      */
-    @Override
-    public <T> List<Action> getActions(T realmSubjectMap) {
+    public <T> Action getAction(T realmSubjectMap) {
+        if (!canHandle(realmSubjectMap)) {
+            return null;
+        }
 
         URL logoutUrl = null;
         if (realmSubjectMap instanceof Map) {
@@ -73,7 +73,7 @@ public class IdpLogoutActionProvider implements ActionProvider {
                         e);
             }
         }
-        return Arrays.asList(new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl));
+        return new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl);
     }
 
     @Override
@@ -85,8 +85,7 @@ public class IdpLogoutActionProvider implements ActionProvider {
         this.encryptionService = encryptionService;
     }
 
-    @Override
-    public <T> boolean canHandle(T subject) {
+    private <T> boolean canHandle(T subject) {
         return subject instanceof Map;
     }
 

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/IdpLogoutActionProviderTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/IdpLogoutActionProviderTest.java
@@ -51,8 +51,7 @@ public class IdpLogoutActionProviderTest {
         Subject subject = mock(Subject.class);
         HashMap map = new HashMap();
         map.put("idp", subject);
-        Action action = idpLogoutActionProvider.getActions(map)
-                .get(0);
+        Action action = idpLogoutActionProvider.getAction(map);
         Assert.assertTrue("Expected the encrypted nameId and time",
                 action.getUrl()
                         .getQuery()
@@ -65,8 +64,7 @@ public class IdpLogoutActionProviderTest {
         HashMap map = new HashMap();
         map.put("idp", notsubject);
         when(encryptionService.encrypt(any(String.class))).thenReturn(nameIdTime);
-        Action action = idpLogoutActionProvider.getActions(map)
-                .get(0);
+        Action action = idpLogoutActionProvider.getAction(map);
         Assert.assertNull("Expected the url to be null", action.getUrl());
     }
 

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/KarafLogoutAction.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/KarafLogoutAction.java
@@ -15,8 +15,6 @@ package org.codice.ddf.security.servlet.logout;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.slf4j.Logger;
@@ -48,18 +46,13 @@ public class KarafLogoutAction implements ActionProvider {
     }
 
     @Override
-    public <T> List<Action> getActions(T subject) {
-        return Arrays.asList(new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl));
+    public <T> Action getAction(T subject) {
+        return new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl);
     }
 
     @Override
     public String getId() {
         return ID;
-    }
-
-    @Override
-    public <T> boolean canHandle(T subject) {
-        return true;
     }
 
 }

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LdapLogoutAction.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LdapLogoutAction.java
@@ -15,8 +15,6 @@ package org.codice.ddf.security.servlet.logout;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.slf4j.Logger;
@@ -48,8 +46,8 @@ public class LdapLogoutAction implements ActionProvider {
     }
 
     @Override
-    public <T> List<Action> getActions(T subject) {
-        return Arrays.asList(new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl));
+    public <T> Action getAction(T subject) {
+        return new ActionImpl(ID, TITLE, DESCRIPTION, logoutUrl);
     }
 
     @Override
@@ -57,8 +55,4 @@ public class LdapLogoutAction implements ActionProvider {
         return ID;
     }
 
-    @Override
-    public <T> boolean canHandle(T subject) {
-        return true;
-    }
 }

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.cxf.common.util.CollectionUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.shiro.subject.Subject;
 
@@ -70,29 +69,27 @@ public class LogoutService {
         List<Map<String, String>> realmToPropMaps = new ArrayList<>();
 
         for (ActionProvider actionProvider : logoutActionProviders) {
-            List<Action> actions = actionProvider.getActions(realmSubjectMap);
-            if (!CollectionUtils.isEmpty(actions)) {
-                for (Action action : actions) {
-                    String realm = StringUtils.substringAfterLast(action.getId(), ".");
+            Action action = actionProvider.getAction(realmSubjectMap);
+            if (action != null) {
+                String realm = StringUtils.substringAfterLast(action.getId(), ".");
 
-                    //if the user is logged in and isn't a guest, add them
-                    if (realmTokenMap.get(realm) != null) {
-                        Map<String, String> actionProperties = new HashMap<>();
-                        String displayName = SubjectUtils.getName(realmSubjectMap.get(realm),
-                                "",
-                                true);
+                //if the user is logged in and isn't a guest, add them
+                if (realmTokenMap.get(realm) != null) {
+                    Map<String, String> actionProperties = new HashMap<>();
+                    String displayName = SubjectUtils.getName(realmSubjectMap.get(realm),
+                            "",
+                            true);
 
-                        if (displayName != null
-                                && !displayName.equals(SubjectUtils.GUEST_DISPLAY_NAME)) {
-                            actionProperties.put("title", action.getTitle());
-                            actionProperties.put("realm", realm);
-                            actionProperties.put("auth", displayName);
-                            actionProperties.put("description", action.getDescription());
-                            actionProperties.put("url",
-                                    action.getUrl()
-                                            .toString());
-                            realmToPropMaps.add(actionProperties);
-                        }
+                    if (displayName != null
+                            && !displayName.equals(SubjectUtils.GUEST_DISPLAY_NAME)) {
+                        actionProperties.put("title", action.getTitle());
+                        actionProperties.put("realm", realm);
+                        actionProperties.put("auth", displayName);
+                        actionProperties.put("description", action.getDescription());
+                        actionProperties.put("url",
+                                action.getUrl()
+                                        .toString());
+                        realmToPropMaps.add(actionProperties);
                     }
                 }
             }

--- a/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutService.java
+++ b/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/TestLogoutService.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
@@ -70,8 +69,8 @@ public class TestLogoutService {
     public void testLogout() throws IOException, ParseException, SecurityServiceException {
         KarafLogoutAction karafLogoutActionProvider = new KarafLogoutAction();
         LdapLogoutAction ldapLogoutActionProvider = new LdapLogoutAction();
-        List<Action> karafLogoutActions = karafLogoutActionProvider.getActions(null);
-        List<Action> ldapLogoutActions = ldapLogoutActionProvider.getActions(null);
+        Action karafLogoutAction = karafLogoutActionProvider.getAction(null);
+        Action ldapLogoutAction = ldapLogoutActionProvider.getAction(null);
 
         LogoutService logoutService = new LogoutService();
         logoutService.setHttpSessionFactory(sessionFactory);
@@ -88,38 +87,38 @@ public class TestLogoutService {
         JSONObject karafActionProperty = ((JSONObject) actionProperties.get(0));
 
         assertEquals(karafActionProperty.get("description"),
-                karafLogoutActions.get(0)
+                karafLogoutAction
                         .getDescription());
         assertEquals(karafActionProperty.get("realm"),
-                karafLogoutActions.get(0)
+                karafLogoutAction
                         .getId()
-                        .substring(karafLogoutActions.get(0)
+                        .substring(karafLogoutAction
                                 .getId()
                                 .lastIndexOf(".") + 1));
         assertEquals(karafActionProperty.get("title"),
-                karafLogoutActions.get(0)
+                karafLogoutAction
                         .getTitle());
         assertEquals(karafActionProperty.get("url"),
-                karafLogoutActions.get(0)
+                karafLogoutAction
                         .getUrl()
                         .toString());
 
         JSONObject ldapActionProperty = ((JSONObject) actionProperties.get(1));
 
         assertEquals(ldapActionProperty.get("description"),
-                ldapLogoutActions.get(0)
+                ldapLogoutAction
                         .getDescription());
         assertEquals(ldapActionProperty.get("realm"),
-                ldapLogoutActions.get(0)
+                ldapLogoutAction
                         .getId()
-                        .substring(ldapLogoutActions.get(0)
+                        .substring(ldapLogoutAction
                                 .getId()
                                 .lastIndexOf(".") + 1));
         assertEquals(ldapActionProperty.get("title"),
-                ldapLogoutActions.get(0)
+                ldapLogoutAction
                         .getTitle());
         assertEquals(ldapActionProperty.get("url"),
-                ldapLogoutActions.get(0)
+                ldapLogoutAction
                         .getUrl()
                         .toString());
     }


### PR DESCRIPTION
#### What does this PR do?
Restores backwards compatibility for the ActionProvider interface.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ricklarsen 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison

#### How should this be tested?

#### Any background context you want to provide?
This interface was modified between 2.8.x and 2.9.x in a backwards incompatible way.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2025

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [ n/a ] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests
