### PR TITLE
DDF-2242 Fixes a unit test's determination of a file path from a resource URL.

### DIFF
--- a/platform/security/expansion/security-expansion-impl/src/test/java/ddf/security/expansion/impl/AbstractExpansionTest.java
+++ b/platform/security/expansion/security-expansion-impl/src/test/java/ddf/security/expansion/impl/AbstractExpansionTest.java
@@ -16,6 +16,7 @@ package ddf.security.expansion.impl;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -225,13 +226,15 @@ public class AbstractExpansionTest {
     }
 
     @Test
-    public void testLoadConfiguration() {
-        Map<String, List<String[]>> map = new HashMap<String, List<String[]>>();
+    public void testLoadConfiguration() throws Exception {
+        Map<String, List<String[]>> map;
         StraightExpansionImpl exp = new StraightExpansionImpl();
 
         URL testConfigFile = ClassLoader.getSystemResource("testExpansionConfig.cfg");
         if (null != testConfigFile) {
-            String filename = testConfigFile.getFile();
+            String filename = Paths.get(testConfigFile.toURI())
+                    .toFile()
+                    .getAbsolutePath();
             exp.loadConfiguration(filename);
 
             map = exp.getExpansionMap();


### PR DESCRIPTION
#### What does this PR do?
Updates the way a filesystem path is extracted from a system resource in a unit test.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@Lambeaux @tbatie  

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested?
Unit test should pass

#### Any background context you want to provide?
Windows CI environment failed the test with a bad path.

#### What are the relevant tickets?
DDF-2242

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
