### PR TITLE
DDF-2244 Add batching to the validation command and allow it to handle catalog queries

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
@@ -13,32 +13,42 @@
  */
 package org.codice.ddf.commands.catalog;
 
-import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_CYAN;
-import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_DEFAULT;
-import static org.apache.karaf.shell.support.ansi.SimpleAnsi.COLOR_RED;
-
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.karaf.shell.api.action.Action;
-import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.support.completers.FileCompleter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.shiro.util.ThreadContext;
+import org.codice.ddf.commands.catalog.validation.ValidateExecutor;
+import org.codice.ddf.commands.catalog.validation.ValidatePrinter;
+import org.codice.ddf.commands.catalog.validation.ValidateReport;
+import org.codice.ddf.security.common.Security;
+import org.geotools.filter.text.cql2.CQL;
+import org.opengis.filter.Filter;
 
+import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.util.Describable;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.validation.MetacardValidator;
-import ddf.catalog.validation.ValidationException;
 
 /**
  * Custom Karaf command to validate XML files against services that implement MetacardValidator
@@ -47,178 +57,117 @@ import ddf.catalog.validation.ValidationException;
 @Service
 public class ValidateCommand implements Action {
 
-    @Argument(index = 0, name = "fileName", description = "The path to the file that you want to validate", required = true, multiValued = false)
+    @Option(name = "--path", aliases = "-p", description = "The path to the file to be validated")
     @Completion(FileCompleter.class)
-    String filename;
+    String path;
+
+    @Option(name = "--cqlQuery", aliases = "-q", description =
+            "Search using CQL Filter expressions.\n" + "CQL Examples:\n"
+                    + "\tTextual:   search --cql \"title like 'some text'\"\n"
+                    + "\tTemporal:  search --cql \"modified before 2012-09-01T12:30:00Z\"\n"
+                    + "\tSpatial:   search --cql \"DWITHIN(location, POINT (1 2) , 10, kilometers)\"\n"
+                    + "\tComplex:   search --cql \"title like 'some text' AND modified before 2012-09-01T12:30:00Z\"")
+    String cqlQuery;
+
+    @Option(name = "--recurse", aliases = "-r", description = "Allows for searching subdirectories "
+            + "of the specified directory to be searched for metacards.")
+    boolean recurse = false;
+
+    @Option(name = "--include-extensions", multiValued = true,
+            description = "List of file extensions to use in the path search. Leave blank for all "
+                    + "file extensions to be included.")
+    List<String> filteredExtensions;
 
     @Reference
     List<MetacardValidator> validators;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ValidateCommand.class);
-
-    // Using system out for println is caught by our githooks to prevent bad practice.
-    // We actually need to use it here.
-    protected PrintStream console = System.out;
-
-    // These constants are to help in trying to make the output
-    // both uniform and readable.
-    private static final String INDENT = "|   ";
-
-    private static final String LAST_INDENT = "    ";
-
-    private static final String ELEMENT = "+-- ";
-
-    private static final String LAST_ELEMENT = "`-- ";
-
-    private static final String WARNING_TITLE = "Warnings";
-
-    private static final String ERROR_TITLE = "Errors";
-
-    private static final String WARNING_COLOR = COLOR_CYAN;
-
-    private static final String ERROR_COLOR = COLOR_RED;
+    @Reference
+    CatalogFramework catalog;
 
     @Override
     public Object execute() throws Exception {
-
-        if (fileExists() && hasValidators()) {
-            Metacard metacard = createMetacard();
-            if (metacard != null) {
-                runValidators(metacard);
-            }
-        }
-
-        // We must return an object per the Action contract which
-        // this class implements. It is sufficient to return null.
-        return null;
-    }
-
-    private boolean fileExists() {
-        File fileToValidate = new File(filename);
-        if (!fileToValidate.exists()) {
-            console.printf(ERROR_COLOR +
-                    "Unable to locate file '%s'. Double check the path is correct and the file exists.%n"
-                    + COLOR_DEFAULT, filename);
-            return false;
-        }
-
-        if (!fileToValidate.isFile()) {
-            console.printf(ERROR_COLOR + "'%s' is not a file.%n" + COLOR_DEFAULT, filename);
-            return false;
-        }
-        return true;
-    }
-
-    private boolean hasValidators() {
-        if (validators == null || validators.size() < 1) {
-            console.println(ERROR_COLOR + "No validators have been configured" + COLOR_DEFAULT);
-            return false;
-        }
-        return true;
-    }
-
-    private Metacard createMetacard() {
-
-        // Although we are given XML, we need to put it in a metacard to work with the validators.
-        MetacardImpl metacard = null;
-        try {
-            String metadata = IOUtils.toString(new File(filename).toURI());
-            metacard = new MetacardImpl();
-            metacard.setMetadata(metadata);
-        } catch (IOException e) {
-            console.println(ERROR_COLOR + "Error reading file. Check the log for the stacktrace"
-                    + COLOR_DEFAULT);
-            LOGGER.error("Error trying to read file {}", filename, e);
-        }
-        return metacard;
-    }
-
-    private void runValidators(Metacard metacard) {
-
-        // In an effort to make the output of this command more readable on the console,
-        // we model it after the 'tree' command in Linux. We are printing a hierarchy of lists,
-        // so we want to make the last element of the list pronounced so that we can more
-        // easily see the groupings of the hierarchy. This is why we use an iterator
-        // and if-else rather than a more simple for-loop.
-        Iterator<MetacardValidator> iterator = validators.iterator();
-        while (iterator.hasNext()) {
-            MetacardValidator validator = iterator.next();
-            if (iterator.hasNext()) {
-                printValidator(validator, ELEMENT);
-                printErrorsAndWarnings(validator, metacard, INDENT);
+        int numMetacardsWithErrorsOrWarnings = 0;
+        if (validators == null || validators.size() == 0) {
+            ValidatePrinter.printError("No validators have been configured");
+        } else {
+            List<Metacard> metacards;
+            if (path != null) {
+                metacards = createMetacards();
+            } else if (cqlQuery != null) {
+                metacards = getMetacardsFromCatalog();
             } else {
-                printValidator(validator, LAST_ELEMENT);
-                printErrorsAndWarnings(validator, metacard, LAST_INDENT);
-            }
-        }
-    }
-
-    private void printValidator(MetacardValidator validator, String prefix) {
-        String name = validator.getClass()
-                .getName();
-        if (validator instanceof Describable && ((Describable) validator).getId() != null) {
-            name = ((Describable) validator).getId();
-        }
-        prettyPrint(prefix, name);
-    }
-
-    private void printErrorsAndWarnings(MetacardValidator validator, Metacard metacard,
-            String prefix) {
-        try {
-            validator.validate(metacard);
-            prettyPrint(prefix + LAST_ELEMENT, "No errors or warnings");
-        } catch (ValidationException e) {
-
-            // The seemingly unnecessary complexity here is because we want the end result
-            // on the console to look good. We know that errors will come before warnings,
-            // so the whole error block uses the "indent" prefix. Further, we print
-            // errors and warnings with different
-            prettyPrint(prefix + ELEMENT, ERROR_TITLE);
-            if (e.getErrors() == null) {
-                prettyPrint(prefix + INDENT + LAST_ELEMENT, "None");
-            } else {
-                printList(prefix + INDENT, e.getErrors(), ERROR_COLOR);
+                ValidatePrinter.printError(
+                        "Usage: catalog:validate < --path filePath > < --cqlQuery cqlQuery >");
+                return null;
             }
 
-            // We know that warnings come last, so we format each line knowing that it's the last
-            // in its hierarchy.
-            prettyPrint(prefix + LAST_ELEMENT, WARNING_TITLE);
-            if (e.getWarnings() == null) {
-                prettyPrint(prefix + LAST_INDENT + LAST_ELEMENT, "None");
-            } else {
-                printList(prefix + LAST_INDENT, e.getWarnings(), WARNING_COLOR);
+            List<ValidateReport> reports = ValidateExecutor.execute(metacards, validators);
+            for (ValidateReport report : reports) {
+                if (report.getEntries()
+                        .size() > 0) {
+                    numMetacardsWithErrorsOrWarnings++;
+                    ValidatePrinter.print(report);
+                }
             }
-
-        } catch (RuntimeException e) {
-            prettyPrint(prefix + LAST_ELEMENT,
-                    "Unhandled exception while running validator. Check the log for the stack trace and fix the validator.",
-                    ERROR_COLOR);
-            LOGGER.error("Unhandled exception while trying to validate.", e);
+            ValidatePrinter.printSummary(numMetacardsWithErrorsOrWarnings, reports.size());
         }
+
+        return numMetacardsWithErrorsOrWarnings;
     }
 
-    private void prettyPrint(String prefix, String message) {
-        prettyPrint(prefix, message, COLOR_DEFAULT);
-    }
-
-    private void prettyPrint(String prefix, String message, String color) {
-
-        // We want to get rid of all whitespace and newlines to make everything look uniform.
-        console.println(prefix + color + message.replaceAll("[\r\n\t ]+", " ") + COLOR_DEFAULT);
-    }
-
-    private void printList(String prefix, List<String> messages, String color) {
-
-        // Using an iterator instead of a for loop to make sure the last element
-        // in the list is printed differently for console readability.
-        Iterator<String> iterator = messages.iterator();
-        while (iterator.hasNext()) {
-            String message = iterator.next();
-            if (iterator.hasNext()) {
-                prettyPrint(prefix + ELEMENT, message, color);
-            } else {
-                prettyPrint(prefix + LAST_ELEMENT, message, color);
-            }
+    private List<Metacard> createMetacards() throws IOException {
+        Collection<File> files = getFiles();
+        List<Metacard> metacards = new ArrayList<>();
+        for (File file : files) {
+            Metacard metacard = new MetacardImpl();
+            String metadata = IOUtils.toString(file.toURI());
+            metacard.setAttribute(new AttributeImpl(Metacard.METADATA, metadata));
+            metacard.setAttribute(new AttributeImpl(Metacard.TITLE, file.getName()));
+            metacards.add(metacard);
         }
+        return metacards;
+    }
+
+    private List<Metacard> getMetacardsFromCatalog() throws Exception {
+        List<Metacard> results = new ArrayList<>();
+
+        Filter cqlFilter = CQL.toFilter(cqlQuery);
+
+        QueryImpl query = new QueryImpl(cqlFilter);
+        ThreadContext.bind(Security.getInstance()
+                .getSystemSubject());
+
+        SourceResponse response = catalog.query(new QueryRequestImpl(query));
+        List<Result> resultList = response.getResults();
+        if (resultList != null) {
+            results.addAll(resultList.stream()
+                    .map(Result::getMetacard)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
+        }
+
+        return results;
+    }
+
+    private Collection<File> getFiles() throws FileNotFoundException {
+        File file = new File(path);
+
+        if (!file.exists()) {
+            throw new FileNotFoundException(String.format("File or directory %s does not exist",
+                    path));
+        }
+
+        Collection<File> files;
+        if (file.isFile()) {
+            files = Collections.singletonList(file);
+        } else if (filteredExtensions == null) { //directory with any extensions
+            files = FileUtils.listFiles(file, null, recurse);
+        } else { //directory with restricted extensions
+            files = FileUtils.listFiles(file,
+                    filteredExtensions.toArray(new String[filteredExtensions.size()]),
+                    recurse);
+        }
+
+        return files;
     }
 }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateExecutor.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateExecutor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog.validation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.util.Describable;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ValidationException;
+
+public class ValidateExecutor {
+
+    public static List<ValidateReport> execute(List<Metacard> metacards,
+            List<MetacardValidator> validators) throws ExecutionException, InterruptedException {
+
+        ForkJoinPool forkJoinPool = new ForkJoinPool();
+        List<ValidateReport> results;
+        results = forkJoinPool.submit(() -> metacards.stream()
+                .parallel()
+                .map(metacard -> generateReport(metacard, validators))
+                .collect(Collectors.toList()))
+                .get();
+        return results;
+    }
+
+    private static ValidateReport generateReport(Metacard metacard,
+            List<MetacardValidator> validators) {
+
+        ValidateReport report = new ValidateReport(metacard.getTitle());
+
+        for (MetacardValidator validator : validators) {
+            try {
+                validator.validate(metacard);
+            } catch (ValidationException e) {
+                String name = validator.getClass()
+                        .getName();
+                if (validator instanceof Describable && ((Describable) validator).getId() != null) {
+                    name = ((Describable) validator).getId();
+                }
+                List<String> warnings =
+                        e.getWarnings() == null ? Collections.emptyList() : e.getWarnings();
+                List<String> errors =
+                        e.getErrors() == null ? Collections.emptyList() : e.getErrors();
+                report.addEntry(new ValidateReportEntry(name, errors, warnings));
+            }
+        }
+
+        return report;
+    }
+}
+
+

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidatePrinter.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidatePrinter.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog.validation;
+
+import java.io.PrintStream;
+
+import org.fusesource.jansi.Ansi;
+
+public class ValidatePrinter {
+
+    private static final String ERROR_COLOR = Ansi.ansi()
+            .fg(Ansi.Color.RED)
+            .toString();
+
+    private static final String WARNING_COLOR = Ansi.ansi()
+            .fg(Ansi.Color.MAGENTA)
+            .toString();
+
+    private static final String DEFAULT_COLOR = Ansi.ansi()
+            .fg(Ansi.Color.DEFAULT)
+            .toString();
+
+    protected static final PrintStream CONSOLE = System.out;
+
+    public static void print(ValidateReport report) {
+        CONSOLE.println(report.getId());
+        report.getEntries()
+                .forEach(ValidatePrinter::printEntry);
+    }
+
+    private static void printEntry(ValidateReportEntry entry) {
+        if (entry.getWarnings()
+                .isEmpty() || entry.getErrors()
+                .isEmpty()) {
+            CONSOLE.println("  " + entry.getValidatorName());
+            entry.getErrors()
+                    .forEach(e -> printError("\t" + e));
+            entry.getWarnings()
+                    .forEach(e -> printWarning("\t" + e));
+        }
+    }
+
+    public static void printError(String error) {
+        CONSOLE.printf("%s%s%s%n", ERROR_COLOR, error, DEFAULT_COLOR);
+    }
+
+    public static void printWarning(String warning) {
+        CONSOLE.printf("%s%s%s%n", WARNING_COLOR, warning, DEFAULT_COLOR);
+    }
+
+    public static void printSummary(int bad, int total) {
+        CONSOLE.printf("%nSUMMARY:%n  %d/%d metacards contain errors or warnings%n", bad, total);
+    }
+}

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateReport.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateReport.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValidateReport {
+    private String id;
+    private List<ValidateReportEntry> entries = new ArrayList<>();
+
+    public ValidateReport(String id) {
+        this.id = id;
+    }
+
+    public void addEntry(ValidateReportEntry entry) {
+        entries.add(entry);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<ValidateReportEntry> getEntries() {
+        return entries;
+    }
+}

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateReportEntry.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/validation/ValidateReportEntry.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog.validation;
+
+import java.util.List;
+
+
+public class ValidateReportEntry {
+
+    private String validatorName;
+    private List<String> errors;
+    private List<String> warnings;
+
+    public ValidateReportEntry(String validatorName, List<String> errors, List<String> warnings) {
+        this.validatorName = validatorName;
+        this.errors = errors;
+        this.warnings = warnings;
+    }
+
+    public String getValidatorName() {
+        return validatorName;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
This PR enables the Validate Command to accept paths pointing to directories as arguments and supports validating all the files in the specified directory and its subdirectories. The user can now also query the catalog in order to find metacards to validate.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ahoffer 
@harrison-tarr 
@spearskw 
@brendan-hofmann 
@AzGoalie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@shaundmorris

#### How should this be tested?
Attempt the following commands:

- `catalog:validate --path <pathToDirectory>`
- `catalog:validate --path <pathToFile>`
- `catalog:validate --query <metacardQuery>` (make sure to use a query that'll actually return results)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
