### PR TITLE
DDF-2250 Make SaxEventToXmlConverter handle edge cases

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
@@ -141,7 +141,6 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
                  */
                 if ((tmpAttr = metacard.getAttribute(attribute.getName())) != null) {
                     List<Serializable> tmpAttrValues = tmpAttr.getValues();
-
                     tmpAttrValues.addAll(attribute.getValues());
                     tmpAttr = new AttributeImpl(attribute.getName(), tmpAttrValues);
                     metacard.setAttribute(tmpAttr);
@@ -231,6 +230,13 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
     public void startPrefixMapping(String prefix, String uri) throws SAXException {
         for (SaxEventHandler transformer : eventHandlers) {
             transformer.startPrefixMapping(prefix, uri);
+        }
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        for (SaxEventHandler transformer : eventHandlers) {
+            transformer.endPrefixMapping(prefix);
         }
     }
 

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,18 +26,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.xml.stream.XMLStreamException;
-
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
 import org.junit.Test;
-import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
 import ddf.catalog.data.Attribute;
@@ -117,8 +112,7 @@ public class TestGenericXmlLib {
     }
 
     @Test
-    public void testNoConfigTransform()
-            throws IOException, CatalogTransformerException {
+    public void testNoConfigTransform() throws IOException, CatalogTransformerException {
         SaxEventHandlerFactory saxEventHandlerFactory = mock(SaxEventHandlerFactory.class);
         when(saxEventHandlerFactory.getId()).thenReturn("test");
         SaxEventHandler handler = getNewHandler();
@@ -201,32 +195,6 @@ public class TestGenericXmlLib {
         assertThat(inputTransformer.getOrganization(), is("foo"));
         assertThat(inputTransformer.getTitle(), is("foo"));
         assertThat(inputTransformer.getVersion(), is("foo"));
-    }
-
-    @Test
-    public void testSaxEventToXmlElementConverter()
-            throws UnsupportedEncodingException, XMLStreamException {
-        SaxEventToXmlElementConverter saxEventToXmlElementConverter =
-                new SaxEventToXmlElementConverter();
-        saxEventToXmlElementConverter.addNamespace("foo", "bar");
-        saxEventToXmlElementConverter.addNamespace("barfoo", "foobar");
-        Attributes attrs = mock(Attributes.class);
-        when(attrs.getLength()).thenReturn(2);
-        when(attrs.getLocalName(0)).thenReturn("foo");
-        when(attrs.getLocalName(1)).thenReturn("bar");
-        when(attrs.getURI(0)).thenReturn("foobar");
-        when(attrs.getURI(1)).thenReturn("");
-        when(attrs.getValue(anyInt())).thenReturn("test");
-        saxEventToXmlElementConverter.toElement("bar", "test", attrs);
-        saxEventToXmlElementConverter.toElement("&lt;chara&gt;cters".toCharArray(), 0, 16);
-        saxEventToXmlElementConverter.toElement("bar", "test");
-        saxEventToXmlElementConverter.toElement("bar", "test", attrs);
-        saxEventToXmlElementConverter.toElement("characters".toCharArray(), 0, 8);
-        saxEventToXmlElementConverter.toElement("bar", "test");
-        assertThat(saxEventToXmlElementConverter.toString(),
-                is("<foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">&amp;lt;chara&amp;gt;cte</foo:test><foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">characte</foo:test>"));
-        saxEventToXmlElementConverter.reset();
-        assertThat(saxEventToXmlElementConverter.toString(), is(""));
     }
 
     @Test

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxEventToXmlElementConverter.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxEventToXmlElementConverter.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+public class TestSaxEventToXmlElementConverter {
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredNamespaceUri()
+            throws XMLStreamException, IOException, SAXException {
+        String doubleDeclaredNamespaceUriSnippet =
+                "<x xmlns:n1=\"foobar\" \n" + "   xmlns=\"foobar\">\n"
+                        + "  <good a=\"1\"     b=\"2\" />\n" + "  <good a=\"1\"     n1:a=\"2\" />\n"
+                        + "</x>";
+
+        String reconstructedExpectation =
+                "<x xmlns=\"foobar\">\n  <good a=\"1\" b=\"2\"></good>\n  <good a=\"1\" xmlns:ns1=\"foobar\" ns1:a=\"2\"></good>\n</x>";
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(doubleDeclaredNamespaceUriSnippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    // This is broken
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredNamespaceUriVariation()
+            throws XMLStreamException, IOException, SAXException {
+        String doubleDeclaredNamespaceUriSnippet =
+                "<x:y xmlns=\"default\" xmlns:x=\"www.x.com\" x:one=\"2\" x:two=\"2\">\n"
+                        + "    <y:z xmlns:y=\"www.x.com\" x:one=\"1\" y:two=\"2\">\n"
+                        + "     <x:z>abcdefg</x:z>\n" + "    </y:z>\n" + "</x:y>";
+
+        String reconstructedExpectation = "<x:y xmlns:x=\"www.x.com\" x:one=\"2\" x:two=\"2\">\n"
+                + "    <y:z xmlns:y=\"www.x.com\" x:one=\"1\" y:two=\"2\">\n"
+                + "     <x:z>abcdefg</x:z>\n" + "    </y:z>\n" + "</x:y>";
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(doubleDeclaredNamespaceUriSnippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredNamespaceUriVariation2()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                + "<outer xmlns:aaa=\"whocares\" xmlns=\"http://www.w3.com\">\n"
+                + "    <aaa:foo name=\"outside\">\n" + "        <aaa:bar xmlns:bbb=\"inside1\">\n"
+                + "            <bbb:baz xmlns:aaa=\"inside2\">\n"
+                + "                <aaa:verybad name=\"scope matters\"/>\n"
+                + "            </bbb:baz>\n" + "        </aaa:bar>\n" + "    </aaa:foo>\n"
+                + "</outer>";
+
+        /*
+         * The reconstructed slightly different than the original snippet:
+         *   - it's missing the xml version declaration
+         *   - it has the aaa and bbb namespace declared later, however this is still perfectly valid
+         */
+        String reconstructedExpectation = "<outer xmlns=\"http://www.w3.com\">\n"
+                + "    <aaa:foo xmlns:aaa=\"whocares\" name=\"outside\">\n" + "        <aaa:bar>\n"
+                + "            <bbb:baz xmlns:bbb=\"inside1\">\n"
+                + "                <aaa:verybad xmlns:aaa=\"inside2\" name=\"scope matters\"></aaa:verybad>\n"
+                + "            </bbb:baz>\n" + "        </aaa:bar>\n" + "    </aaa:foo>\n"
+                + "</outer>";
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterNormal()
+            throws XMLStreamException, IOException, SAXException {
+        String normalSnippet = "<?xml version=\"1.0\"?>\n"
+                + "<!-- both namespace prefixes are available throughout -->\n"
+                + "<bk:book xmlns:bk='urn:loc.gov:books'\n"
+                + "         xmlns:isbn='urn:ISBN:0-395-36341-6'>\n"
+                + "    <bk:title>Cheaper by the Dozen</bk:title>\n"
+                + "    <isbn:number>1568491379</isbn:number>\n" + "</bk:book>";
+
+        /*
+         * The reconstructed slightly different than the original snippet:
+         *   - it's missing the xml version declaration
+         *   - it's missing the comment
+         *   - it has the isbn namespace declared later, however this is still perfectly valid
+         */
+        String reconstructedExpectation = "<bk:book xmlns:bk=\"urn:loc.gov:books\">\n"
+                + "    <bk:title>Cheaper by the Dozen</bk:title>\n"
+                + "    <isbn:number xmlns:isbn=\"urn:ISBN:0-395-36341-6\">1568491379</isbn:number>\n"
+                + "</bk:book>";
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(normalSnippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterScopedPrefixRedeclaration()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet = "<?xml version=\"1.0\"?>\n"
+                + "<!-- initially, the default namespace is \"books\" -->\n"
+                + "<book xmlns='urn:loc.gov:books'\n"
+                + "      xmlns:isbn='urn:ISBN:0-395-36341-6'>\n"
+                + "    <title>Cheaper by the Dozen</title>\n"
+                + "    <isbn:number>1568491379</isbn:number>\n" + "    <notes>\n"
+                + "      <!-- make HTML the default namespace for some commentary -->\n"
+                + "      <p xmlns='http://www.w3.org/1999/xhtml'>\n"
+                + "          This is a <i>funny</i> book!\n" + "      </p>\n" + "    </notes>\n"
+                + "</book>";
+
+        /*
+         * The reconstructed slightly different than the original snippet:
+         *   - it's missing the xml version declaration
+         *   - it's missing the comment
+         *   - it has the isbn namespace declared later, however this is still perfectly valid
+         */
+        String reconstructedExpectation =
+                "<book xmlns=\"urn:loc.gov:books\">\n" + "    <title>Cheaper by the Dozen</title>\n"
+                        + "    <isbn:number xmlns:isbn=\"urn:ISBN:0-395-36341-6\">1568491379</isbn:number>\n"
+                        + "    <notes>\n" + "      \n"
+                        + "      <p xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+                        + "          This is a <i>funny</i> book!\n" + "      </p>\n"
+                        + "    </notes>\n" + "</book>";
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterScopedPrefixRedeclaration2()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet = "<?xml version=\"1.0\"?>\n"
+                + "<!-- initially, the default namespace is \"books\" -->\n"
+                + "<book xmlns='urn:loc.gov:books'\n"
+                + "      xmlns:isbn='urn:ISBN:0-395-36341-6'>\n"
+                + "    <title>Cheaper by the Dozen</title>\n"
+                + "    <isbn:number>1568491379</isbn:number>\n" + "    <notes>\n"
+                + "      <!-- make HTML the default namespace for some commentary -->\n"
+                + "      <p xmlns='http://www.w3.org/1999/xhtml'>\n"
+                + "          This is a <i>funny</i> book!\n" + "      </p>\n" + "    </notes>\n"
+                + "    <title>Cheaper by the Baker's Dozen</title>\n" + "</book>";
+
+        /*
+         * The reconstructed slightly different than the original snippet:
+         *   - it's missing the xml version declaration
+         *   - it's missing the comment
+         *   - it has the isbn namespace declared later, however this is still perfectly valid
+         */
+        String reconstructedExpectation =
+                "<book xmlns=\"urn:loc.gov:books\">\n" + "    <title>Cheaper by the Dozen</title>\n"
+                        + "    <isbn:number xmlns:isbn=\"urn:ISBN:0-395-36341-6\">1568491379</isbn:number>\n"
+                        + "    <notes>\n" + "      \n"
+                        + "      <p xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+                        + "          This is a <i>funny</i> book!\n" + "      </p>\n"
+                        + "    </notes>\n" + "    <title>Cheaper by the Baker's Dozen</title>\n"
+                        + "</book>";
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+}

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxParser.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxParser.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DefaultHandler2;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+public class TestSaxParser extends DefaultHandler2 {
+
+    private XMLReader reader;
+
+    private SaxEventToXmlElementConverter converter;
+
+    @Override
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
+        try {
+            converter.addNamespace(prefix, uri);
+        } catch (XMLStreamException e) {
+            fail("Failed to add namespace");
+        }
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        converter.removeNamespace(prefix);
+
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts)
+            throws SAXException {
+        try {
+            converter.toElement(uri, localName, atts);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on startElement with pieces: %s %s %s %s", uri, localName, qName, atts));
+        }
+
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        try {
+            converter.toElement(uri, localName);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on endElement with pieces: %s %s %s", uri, localName, qName));
+        }
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        try {
+            converter.toElement(ch, start, length);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on endElement with pieces: %s", new String(ch, start, length)));
+        }
+    }
+
+    public String parseAndReconstruct(String xmlSnippet)
+            throws IOException, XMLStreamException, SAXException {
+        converter = new SaxEventToXmlElementConverter();
+        reader = XMLReaderFactory.createXMLReader();
+        reader.setContentHandler(this);
+        reader.setErrorHandler(this);
+//        reader.setDTDHandler(null);
+//        reader.setEntityResolver(null);
+        reader.parse(new InputSource(new ByteArrayInputStream(xmlSnippet.getBytes())));
+        return converter.toString();
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
SaxEventToXmlConverter can handle nested prefix redeclarations
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@AzGoalie @brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris
#### How should this be tested?
The unit tests should be sufficient
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2250
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

specifically nested redeclaration of a namespace prefix