### PR TITLE
DDF-2250 Make SaxEventToXmlConverter handle edge cases

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
@@ -141,7 +141,6 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
                  */
                 if ((tmpAttr = metacard.getAttribute(attribute.getName())) != null) {
                     List<Serializable> tmpAttrValues = tmpAttr.getValues();
-
                     tmpAttrValues.addAll(attribute.getValues());
                     tmpAttr = new AttributeImpl(attribute.getName(), tmpAttrValues);
                     metacard.setAttribute(tmpAttr);
@@ -231,6 +230,13 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
     public void startPrefixMapping(String prefix, String uri) throws SAXException {
         for (SaxEventHandler transformer : eventHandlers) {
             transformer.startPrefixMapping(prefix, uri);
+        }
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        for (SaxEventHandler transformer : eventHandlers) {
+            transformer.endPrefixMapping(prefix);
         }
     }
 

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
@@ -117,8 +117,7 @@ public class TestGenericXmlLib {
     }
 
     @Test
-    public void testNoConfigTransform()
-            throws IOException, CatalogTransformerException {
+    public void testNoConfigTransform() throws IOException, CatalogTransformerException {
         SaxEventHandlerFactory saxEventHandlerFactory = mock(SaxEventHandlerFactory.class);
         when(saxEventHandlerFactory.getId()).thenReturn("test");
         SaxEventHandler handler = getNewHandler();
@@ -227,6 +226,58 @@ public class TestGenericXmlLib {
                 is("<foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">&amp;lt;chara&amp;gt;cte</foo:test><foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">characte</foo:test>"));
         saxEventToXmlElementConverter.reset();
         assertThat(saxEventToXmlElementConverter.toString(), is(""));
+    }
+
+    @Test
+    public void testSaxEventToXmlElementConverterEdgeCase()
+            throws UnsupportedEncodingException, XMLStreamException {
+        // set up mock Attribute object
+        Attributes attrs = mock(Attributes.class);
+        when(attrs.getLength()).thenReturn(2);
+        when(attrs.getLocalName(0)).thenReturn("foo");
+        when(attrs.getLocalName(1)).thenReturn("bar");
+        when(attrs.getURI(0)).thenReturn("ns1uri");
+        when(attrs.getURI(1)).thenReturn("");
+        when(attrs.getValue(anyInt())).thenReturn("test");
+        // inner attrs
+        Attributes attrs2 = mock(Attributes.class);
+        when(attrs2.getLength()).thenReturn(2);
+        when(attrs2.getLocalName(0)).thenReturn("foo");
+        when(attrs2.getLocalName(1)).thenReturn("bar");
+        when(attrs2.getURI(0)).thenReturn("ns1uri.v2");
+        when(attrs2.getURI(1)).thenReturn("");
+        when(attrs2.getValue(anyInt())).thenReturn("test");
+
+        SaxEventToXmlElementConverter converter = new SaxEventToXmlElementConverter();
+
+        // Simulate begin reading
+        converter.addNamespace("ns1", "ns1uri");
+        converter.addNamespace("ns2", "ns2uri");
+
+        // Write parent element and characters
+        converter.toElement("ns1uri", "element1", attrs);
+        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
+
+        // Declare new namespace, using same prefix as previous
+        converter.addNamespace("ns1", "ns1uri.v2");
+        converter.toElement("ns1uri.v2", "nestedElement", attrs2);
+        converter.toElement("ns1uri.v2", "nestedElement");
+
+        // Pop prefix
+        converter.removeNamespace("ns1");
+
+        converter.toElement("ns1uri", "element1", attrs);
+        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
+        converter.toElement("ns1uri", "element1");
+
+        // Finish writing parent
+        converter.toElement("ns1uri", "element1");
+
+        converter.toElement("ns1uri", "element1", attrs);
+        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
+        converter.toElement("ns1uri", "element1");
+        assertThat(converter.toString(),
+                is("<ns1:element1 xmlns:ns1=\"ns1uri\" ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF<ns1:nestedElement xmlns:ns1=\"ns1uri.v2\" ns1:foo=\"test\" bar=\"test\"></ns1:nestedElement><ns1:element1 ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF</ns1:element1></ns1:element1><ns1:element1 xmlns:ns1=\"ns1uri\" ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF</ns1:element1>"));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
SaxEventToXmlConverter can handle nested prefix redeclarations
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@AzGoalie @brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris
#### How should this be tested?
The unit tests should be sufficient
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2250
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

specifically nested redeclaration of a namespace prefix