### PR TITLE
DDF-2125 Require sample metacard validator to be installed manually

### DIFF
--- a/distribution/sdk/sdk-app/src/main/resources/features.xml
+++ b/distribution/sdk/sdk-app/src/main/resources/features.xml
@@ -38,7 +38,7 @@
         <bundle>mvn:ddf.distribution/sample-rest-endpoint/${project.version}</bundle>
     </feature>
 
-    <feature name="sample-validator" version="${project.version}" install="auto"
+    <feature name="sample-validator" version="${project.version}" install="manual"
              description="SDK sample metacard validator">
         <feature prerequisite="true">sdk-app</feature>
         <bundle>


### PR DESCRIPTION
#### What does this PR do?
Changes the sample metacard validator to `install="manual"`, so integration tests that want to use it have to manually start and stop the feature.

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison

#### How should this be tested?
Run itests

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

