### PR TITLE
DDF-2131: removed anytags query from catalogframework

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -2627,7 +2627,7 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                 if (value instanceof String) {
                     String metacardId = (String) value;
                     LOGGER.debug("metacardId = {},   site = {}", metacardId, site);
-                    QueryRequest queryRequest = new QueryRequestImpl(createAnyTagMetacardIdQuery(
+                    QueryRequest queryRequest = new QueryRequestImpl(createMetacardIdQuery(
                             metacardId),
                             isEnterprise,
                             Collections.singletonList(site == null ? this.getId() : site),
@@ -2687,22 +2687,6 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
     protected Query createPropertyIsEqualToQuery(String propertyName, String literal) {
         return new QueryImpl(new PropertyIsEqualToLiteral(new PropertyNameImpl(propertyName),
                 new LiteralImpl(literal)));
-    }
-
-    protected Query createAnyTagMetacardIdQuery(String metacardId) {
-        Filter tagsFilter = frameworkProperties.getFilterBuilder()
-                .attribute(Metacard.TAGS)
-                .is()
-                .like()
-                .text(FilterDelegate.WILDCARD_CHAR);
-        Filter idFilter = frameworkProperties.getFilterBuilder()
-                .attribute(Metacard.ID)
-                .is()
-                .equalTo()
-                .text(metacardId);
-
-        return new QueryImpl(frameworkProperties.getFilterBuilder()
-                .allOf(idFilter, tagsFilter));
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
Fixes compatibility issues by removing the anytag query from inside catalogframework and instead uses a flag in caching federation strategy
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr 
@ryeats 
@tbatie 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
@stustison


