### PR TITLE
DDF-2243 Changed ZipCompression to prevent duplicating history metacards and did some refactoring

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -97,7 +97,7 @@ public class IngestCommand extends CatalogCommands {
 
     private static final String ZIP_DECOMPRESSION = "zipDecompression";
 
-    private static final String METACARD_PATH = "metacards" + File.separator;
+    private static final String CONTENT_PATH = CONTENT + File.separator;
 
     private final PeriodFormatter timeFormatter = new PeriodFormatterBuilder().printZeroRarelyLast()
             .appendDays()
@@ -491,7 +491,7 @@ public class IngestCommand extends CatalogCommands {
                     List<Metacard> metacardList = zipDecompression.transform(inputStream,
                             arguments);
                     if (metacardList.size() != 0) {
-                        metacardFileMapping = generateFileMap(new File(inputFile.getParent(), METACARD_PATH));
+                        metacardFileMapping = generateFileMap(new File(inputFile.getParent(), CONTENT_PATH));
                         fileCount.set(metacardList.size());
                         metacardQueue.addAll(metacardList);
                     }
@@ -646,7 +646,6 @@ public class IngestCommand extends CatalogCommands {
     }
 
     private Map<String, List<File>> generateFileMap(File inputFile) throws IOException {
-
         if (!inputFile.exists()) {
             return null;
         }
@@ -666,7 +665,6 @@ public class IngestCommand extends CatalogCommands {
                 return FileVisitResult.CONTINUE;
             }
         });
-
         return fileMap;
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resourceretriever/LocalResourceRetriever.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resourceretriever/LocalResourceRetriever.java
@@ -60,7 +60,7 @@ public class LocalResourceRetriever implements ResourceRetriever {
             throw new ResourceNotFoundException("Unable to find resource due to null URI");
         }
 
-        Map<String, Serializable> props = new HashMap<String, Serializable>(properties);
+        Map<String, Serializable> props = new HashMap<>(properties);
 
         if (bytesToSkip > 0) {
             props.put(BYTES_TO_SKIP, Long.valueOf(bytesToSkip));
@@ -84,15 +84,9 @@ public class LocalResourceRetriever implements ResourceRetriever {
                                     reader.getId(),
                                     resourceUri);
                         }
-                    } catch (ResourceNotFoundException e) {
+                    } catch (ResourceNotFoundException | ResourceNotSupportedException | IOException e) {
                         LOGGER.debug("Product not found using resource reader with name {}",
-                                reader.getId());
-                    } catch (ResourceNotSupportedException e) {
-                        LOGGER.debug("Product not found using resource reader with name {}",
-                                reader.getId());
-                    } catch (IOException ioe) {
-                        LOGGER.debug("Product not found using resource reader with name {}",
-                                reader.getId());
+                                reader.getId(), e);
                     }
                 }
             }

--- a/catalog/transformer/catalog-transformer-zip/pom.xml
+++ b/catalog/transformer/catalog-transformer-zip/pom.xml
@@ -92,22 +92,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.49</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipValidationException.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipValidationException.java
@@ -25,14 +25,4 @@ public class ZipValidationException extends Exception {
     public ZipValidationException(final String message) {
         super(message);
     }
-
-    /**
-     * Instantiates a new exception with the provided message and {@link Throwable}.
-     *
-     * @param message   the message
-     * @param throwable the throwable
-     */
-    public ZipValidationException(final String message, final Throwable throwable) {
-        super(message, throwable);
-    }
 }

--- a/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/TestZipValidator.java
+++ b/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/TestZipValidator.java
@@ -15,29 +15,20 @@ package org.codice.ddf.catalog.transformer.zip;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.cert.CertificateException;
 import java.util.Properties;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.wss4j.common.crypto.Merlin;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import ddf.security.PropertiesLoader;
 import ddf.security.SecurityConstants;
 
 public class TestZipValidator {
 
     private ZipValidator zipValidator;
-
-    private Merlin merlin;
 
     private static Properties properties;
 
@@ -101,26 +92,12 @@ public class TestZipValidator {
                 "/signature.properties")
                 .getPath());
         zipValidator.init();
+    }
 
-        try {
-            KeyStore trustStore = KeyStore.getInstance(System.getProperty(
-                    "javax.net.ssl.keyStoreType"));
-            InputStream trustFIS =
-                    TestZipValidator.class.getResourceAsStream("/serverKeystore.jks");
-            try {
-                trustStore.load(trustFIS, "changeit".toCharArray());
-            } catch (CertificateException e) {
-                fail(e.getMessage());
-            } finally {
-                IOUtils.closeQuietly(trustFIS);
-            }
-
-            merlin = new Merlin(PropertiesLoader.loadProperties(TestZipValidator.class.getResource(
-                    "/signature.properties")
-                    .getPath()), ZipValidator.class.getClassLoader(), null);
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
+    @Test
+    public void testGetSignaturePropertiesPath() {
+        assertThat(TestZipValidator.class.getResource("/signature.properties")
+                .getPath(), is(zipValidator.getSignaturePropertiesPath()));
     }
 
     @Test(expected = ZipValidationException.class)


### PR DESCRIPTION
#### What does this PR do?
This PR updates the catalog:ingest --include-content functionality to prevent duplicating content generated from history metacards, as well as refactoring and code coverage.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein @dcruver 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
     Build DDF
     Turn on Versioning Plugin and Configure the Historian
     Deploy sdk-sample-storageplugin
     Ingest some images
     Update some of the metacards using Postman or the Catalog UI
     Dump Images using `catalog:dump --include-content`
     Observe that `Update` history metacards are not duplicating content within the Zip file
     Sign the zip file using jarsigner (or optionally use the catalog-dump script in `/bin`)
     Build a new DDF
     Ingest the zip using `catalog:ingest --include-content` and verify all metadata and content is preserved.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2243
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests