### PR TITLE
DDF-2131: Set historian to be on by default

### DIFF
--- a/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
+++ b/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
@@ -146,7 +146,9 @@ public class FederationStrategyTest {
         props.setDefaultAttributeValueRegistry(new DefaultAttributeValueRegistryImpl());
         CatalogFrameworkImpl framework = new CatalogFrameworkImpl(props);
         framework.bind(provider);
-        framework.setHistorian(new Historian());
+        Historian historian = new Historian();
+        historian.setHistoryEnabled(false);
+        framework.setHistorian(historian);
 
         List<Metacard> metacards = new ArrayList<Metacard>();
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -79,7 +79,7 @@ public class Historian {
 
     private final Map<String, List<Callable<Boolean>>> staged = new ConcurrentHashMap<>();
 
-    private boolean historyEnabled = false;
+    private boolean historyEnabled = true;
 
     private List<StorageProvider> storageProviders;
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -349,9 +349,10 @@ public class CatalogFrameworkImplTest {
         };
         framework.bind(provider);
         framework.bind(storageProvider);
-
-        framework.setHistorian(new Historian());
-        resourceFramework.setHistorian(new Historian());
+        Historian historian = new Historian();
+        historian.setHistoryEnabled(false);
+        framework.setHistorian(historian);
+        resourceFramework.setHistorian(historian);
 
         ThreadContext.bind(mock(Subject.class));
     }
@@ -2542,7 +2543,9 @@ public class CatalogFrameworkImplTest {
         CatalogFrameworkImpl framework = new CatalogFrameworkImpl(frameworkProperties);
         framework.bind(provider);
         framework.bind(storageProvider);
-        framework.setHistorian(new Historian());
+        Historian historian = new Historian();
+        historian.setHistoryEnabled(false);
+        framework.setHistorian(historian);
         return framework;
 
     }


### PR DESCRIPTION
#### What does this PR do?
Enables the historian to be on by default. 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
@shaundmorris 


 - this was originally supposed to be on by default but there was some discord between the initialized value and metatype default