### PR TITLE
DDF-2188-2.9.X Updates the MetacardAttributeSecurityPolicyPlugin to support unions and intersections

### DIFF
--- a/catalog/security/catalog-security-metacardattributeplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/security/catalog-security-metacardattributeplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,8 +18,21 @@
          name="Metacard Attribute Security Policy Plugin"
          id="org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin">
 
-        <AD name="Metacard Attributes:" id="metacardAttributes"
-            description="Metacard attributes that will be collected and mapped to security information. Example: security.classification=classification"
+        <AD name="Metacard Intersect Attributes:" id="intersectMetacardAttributes"
+            description="Metacard attributes that will be collected and mapped to security information. Example: security.classification=classification
+            Any duplicate destinations in this group will result in an intersection of values. E.g. source1=dest and source2=val
+            where source1 is the set of ['a', 'b', 'c'] and source2 is the set ['a', 'c', 'd'] will result in
+            a dest of ['a', 'c']. Note: duplicate destinations for Intersect and Union attributes will
+            behave unpredictably."
+            required="true" type="String" cardinality="1000"
+            default=""/>
+
+        <AD name="Metacard Union Attributes:" id="unionMetacardAttributes"
+            description="Metacard attributes that will be collected and mapped to security information. Example: security.classification=classification
+            Any duplicate destinations in this group will result in a union of values. E.g. source1=dest and source2=val
+            where source1 is the set of ['a', 'b', 'c'] and source2 is the set ['a', 'c', 'd'] will result in
+            a dest of ['a', 'b', 'c', 'd']. Note: duplicate destinations for Intersect and Union attributes will
+            behave unpredictably."
             required="true" type="String" cardinality="1000"
             default=""/>
 

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
 
+import com.google.common.collect.Sets;
 import com.google.common.html.HtmlEscapers;
 import com.google.common.io.FileBackedOutputStream;
 import com.google.common.net.MediaType;
@@ -56,6 +57,7 @@ import com.google.common.net.MediaType;
 import ddf.catalog.content.operation.ContentMetadataExtractor;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
@@ -181,7 +183,8 @@ public class PdfInputTransformer implements InputTransformer {
                             .getName())
                     .collect(Collectors.joining("_"));
 
-            metacard = new MetacardImpl(new MetacardTypeImpl(typeName, attributes));
+            metacard = new MetacardImpl(new MetacardTypeImpl(typeName,
+                    Sets.union(BasicTypes.BASIC_METACARD.getAttributeDescriptors(), attributes)));
             for (ContentMetadataExtractor contentMetadataExtractor : contentMetadataExtractors.values()) {
                 contentMetadataExtractor.process(contentInput, metacard);
             }

--- a/distribution/docs/src/main/resources/_contents/securing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/securing-contents.adoc
@@ -1603,7 +1603,9 @@ While the *Security Attributes (intersection)* field will computer the intersect
 
 The *Metacard Attribute Security Policy Plugin* will pull attributes directly off of a metacard and combine these attributes into a security field for the metacard.
 This plugin assumes that the pertinent information has already been parsed out of the metadata and placed directly on the metacard itself.
-The plugin supports mapping attributes from their names on the metacard to a different security policy name.
+The plugin supports mapping attributes from their names on the metacard to a different security policy name. Attributes can be mapped by union or intersection. E.g.
+A union mapping of `src1=dest` and `src2=dest` will result in `dest` containing the union of all attributes from `src1` and `src2`; an intersection
+ mapping of `src1=dest` and `src2=dest` will result in `dest` containing the intersection of common attributes from `src1` and `src2`.
 
 To configure these policy plugins:
 . Open the ${admin-console} at \${secure_url}/admin


### PR DESCRIPTION
#### What does this PR do?
Multiple source attributes can target the same destination security attribute. This can be accomplished by getting a union of the values or the intersection. This supports both configurations.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @tbatie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested?
Full build and test. Installing DDF and configuring the MetacardAttributeSecurityPolicyPlugin should display two separate lists of mappings that can be added, one for intersections and one for unions.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2188

#### Screenshots (if appropriate)
<img width="450" alt="screen shot 2016-06-29 at 2 24 57 pm" src="https://cloud.githubusercontent.com/assets/1469860/16469356/62b8562c-3e05-11e6-8793-65a674d435c8.png">

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
