### PR TITLE
DDF-2262 Fix default subscription polling interval

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEvent.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEvent.java
@@ -82,8 +82,7 @@ public class SendEvent implements DeliveryMethod, Pingable {
 
     public static final double JITTER_PERCENT = 0.25;
 
-    public static final long DEFAULT_PING_PERIOD = TimeUnit.MINUTES.convert(30,
-            TimeUnit.MILLISECONDS);
+    public static final long DEFAULT_PING_PERIOD = TimeUnit.MINUTES.toMillis(30L);
 
     private final TransformerManager transformerManager;
 

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEventTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/SendEventTest.java
@@ -46,7 +46,6 @@ import org.codice.ddf.spatial.ogc.csw.catalog.common.CswException;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSubscribe;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
@@ -235,9 +234,7 @@ public class SendEventTest {
         assertNotEquals(lastPing, sendEvent.getLastPing());
     }
 
-    //fix this test its failing intermittently
     @Test
-    @Ignore
     public void testIsAvailableNoExperation() throws Exception {
         long lastPing = sendEvent.getLastPing();
         when(webclient.invoke(eq("HEAD"), isNull())).thenReturn(response);


### PR DESCRIPTION
#### What does this PR do?
fix the default polling interval which was getting set to 0 to be for 30 minutes instead
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @bcwaters @adimka
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris
#### How should this be tested?
run the unit tests
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

