### PR TITLE
DDF-2264 Upgrade Camel to 2.16.3 and add support for camel-amqp

### DIFF
--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -29,10 +29,9 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
-
     <!--
-    Begin Camel Features 2.16.1; All feature definitions come from 3rd party feature file
-        (org.apache.camel.karaf/apache-camel/2.16.1/xml/features)
+    Begin Camel Features ${camel.version}; All feature definitions come from 3rd party feature file
+        (org.apache.camel.karaf/apache-camel/${camel.version}/xml/features)
 
     DO NOT EDIT
     -->
@@ -53,128 +52,135 @@
             <!--mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.6_1-->
         <!--</bundle>-->
     <!--</feature>-->
-    <feature name='camel' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel' install="manual" version='${camel.version}'  start-level='50'>
         <!-- Added cxf as prereq to keep things ordered -->
         <feature prerequisite="true">cxf</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <feature version='2.16.1'>camel-spring</feature>
-        <feature version='2.16.1'>camel-blueprint</feature>
+        <feature version='${camel.version}'>camel-core</feature>
+        <feature version='${camel.version}'>camel-spring</feature>
+        <feature version='${camel.version}'>camel-blueprint</feature>
     </feature>
-    <feature name='camel-core' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel-amqp' version='${project.version}' start-level='50'>
+    <bundle dependency='true'>mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
+    <bundle dependency='true'>mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mina/${servicemix.bundles.mina.version}</bundle>
+    <!-- TODO: Specify version range for qpid-jms-client (0.6.0, 0.10.0] once Karaf 4.0.6 is available -->
+    <bundle dependency='true'>wrap:mvn:org.apache.qpid/qpid-jms-client/${qpid-jms-client.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.apache.qpid/proton-j/${proton-j.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.netty/netty-all/${netty-all.version}</bundle>
+    <feature prerequisite="true" version='${camel.version}'>camel-jms</feature>
+    <bundle>mvn:org.apache.camel/camel-amqp/${camel.version}</bundle>
+</feature>
+    <feature name='camel-core' install="manual" version='${camel.version}'  start-level='50'>
         <feature>cxf-specs</feature>
-        <bundle>mvn:org.apache.camel/camel-core/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-catalog/2.16.1</bundle>
+        <bundle>mvn:org.apache.camel/camel-core/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-catalog/${camel.version}</bundle>
         <conditional>
             <condition>shell</condition>
-            <bundle>mvn:org.apache.camel/camel-commands-core/2.16.1</bundle>
-            <bundle>
-                mvn:org.apache.camel.karaf/camel-karaf-commands/2.16.1
-            </bundle>
+            <bundle>mvn:org.apache.camel/camel-commands-core/${camel.version}</bundle>
+            <bundle>mvn:org.apache.camel.karaf/camel-karaf-commands/${camel.version}</bundle>
         </conditional>
         <!--
          allow camel to access its own mbeans for karaf commands and other needs
         -->
         <config name="jmx.acl.org.apache.camel">* = *</config>
     </feature>
-    <feature name="camel-catalog" install="manual" version="2.16.1"  start-level="50">
-        <feature version="2.16.1">camel-core</feature>
-        <bundle>
-            mvn:org.apache.camel.karaf/camel-karaf-commands-catalog/2.16.1
-        </bundle>
+    <feature name="camel-catalog" install="manual" version="${camel.version}"  start-level="50">
+        <feature version="${camel.version}">camel-core</feature>
+        <bundle>mvn:org.apache.camel.karaf/camel-karaf-commands-catalog/${camel.version}</bundle>
     </feature>
-    <feature name='camel-spring' install="manual" version='2.16.1'
+    <feature name='camel-spring' install="manual" version='${camel.version}'
              start-level='50'>
-        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimo-jta_1.1_spec.version}</bundle>
         <feature version='[3.2,4)'>spring</feature>
         <feature version='[1.2,2)'>spring-dm</feature>
         <feature version='[3.2,4)'>spring-tx</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-spring/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-spring/${camel.version}</bundle>
     </feature>
-    <feature name='camel-blueprint' install="manual" version='2.16.1'
+    <feature name='camel-blueprint' install="manual" version='${camel.version}'
              start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-blueprint/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-blueprint/${camel.version}</bundle>
     </feature>
 
     <!-- the following features are sorted A..Z -->
-    <feature name='camel-context' install="manual" version='2.16.1'
+    <feature name='camel-context' install="manual" version='${camel.version}'
              start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-context/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-context/${camel.version}</bundle>
     </feature>
-    <feature name='camel-cxf' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel-cxf' install="manual" version='${camel.version}'  start-level='50'>
         <feature version='[3.0,4.0)'>cxf-core</feature>
         <feature version='[3.0,4.0)'>cxf-jaxrs</feature>
         <feature version='[3.0,4.0)'>cxf-jaxws</feature>
         <feature version='[3.0,4.0)'>cxf-http-jetty</feature>
         <feature version='[3.0,4.0)'>cxf-databinding-jaxb</feature>
         <feature version='[3.0,4.0)'>cxf-bindings-soap</feature>
-        <feature version="2.16.1">camel-spring</feature>
-        <bundle>mvn:org.apache.camel/camel-cxf-transport/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-cxf/2.16.1</bundle>
+        <feature version="${camel.version}">camel-spring</feature>
+        <bundle>mvn:org.apache.camel/camel-cxf-transport/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-cxf/${camel.version}</bundle>
     </feature>
-    <feature name='camel-eventadmin' install="manual" version='2.16.1'
+    <feature name='camel-eventadmin' install="manual" version='${camel.version}'
              start-level='50'>
         <feature>eventadmin</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-eventadmin/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-eventadmin/${camel.version}</bundle>
     </feature>
-    <feature name='camel-freemarker' install="manual" version='2.16.1'
+    <feature name='camel-freemarker' install="manual" version='${camel.version}'
              start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.freemarker/2.3.23_1</bundle>
-        <bundle>mvn:org.apache.camel/camel-freemarker/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.freemarker/${servicemix.bundles.freemarker.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-freemarker/${camel.version}</bundle>
     </feature>
-    <feature name='camel-http' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel-http' install="manual" version='${camel.version}'  start-level='50'>
         <!-- Added camel as prereq to keep things ordered -->
         <feature prerequisite="true">camel</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/3.1_7</bundle>
-        <bundle dependency='true'>mvn:commons-codec/commons-codec/1.10</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/${servicemix.bundles.commons-httpclient.version}</bundle>
+        <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
         <!--<bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-servlet_3.0_spec/1.0</bundle>-->
-        <bundle>mvn:org.apache.camel/camel-http-common/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-http/2.16.1</bundle>
+        <bundle>mvn:org.apache.camel/camel-http-common/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-http/${camel.version}</bundle>
     </feature>
-    <feature name='camel-jaxb' install="manual" version='2.16.1'  start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-jaxb/2.16.1</bundle>
+    <feature name='camel-jaxb' install="manual" version='${camel.version}'  start-level='50'>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-jaxb/${camel.version}</bundle>
     </feature>
     <!--
-    <feature name='camel-jetty' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel-jetty' install="manual" version='${camel.version}'  start-level='50'>
         <feature>jetty</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-http-common/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-jetty-common/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-jetty8/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-http-common/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-jetty-common/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-jetty8/${camel.version}</bundle>
     </feature>
     -->
-    <feature name='camel-jetty9' version='2.16.1' start-level='50'>
+    <feature name='camel-jetty9' version='${camel.version}' start-level='50'>
         <details>camel-jetty9 intend to work with jetty9, so this feature only works in the karaf container which support jetty9, e.g. karaf 4.x</details>
         <feature prerequisite="true" version="[9,10)">jetty</feature>
-        <feature prerequisite="true" version="2.16.1">camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-http-common/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-jetty-common/2.16.1</bundle>
-        <bundle>mvn:org.apache.camel/camel-jetty9/2.16.1</bundle>
+        <feature prerequisite="true" version="${camel.version}">camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-http-common/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-jetty-common/${camel.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-jetty9/${camel.version}</bundle>
     </feature>
-    <feature name='camel-jms' install="manual" version='2.16.1'  start-level='50'>
+    <feature name='camel-jms' install="manual" version='${camel.version}'  start-level='50'>
         <feature version='[3.2,4)'>spring</feature>
-        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
-        <bundle dependency='true'>mvn:commons-pool/commons-pool/1.6</bundle>
-        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimo-jta_1.1_spec.version}</bundle>
+        <bundle dependency='true'>mvn:commons-pool/commons-pool/${commons-pool.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${geronimo-jms_1.1_spec.version}</bundle>
         <feature version='[3.2,4)'>spring-jms</feature>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-jms/2.16.1</bundle>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-jms/${camel.version}</bundle>
     </feature>
-    <feature name='camel-stax' install="manual" version='2.16.1'  start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <bundle>mvn:org.apache.camel/camel-stax/2.16.1</bundle>
+    <feature name='camel-stax' install="manual" version='${camel.version}'  start-level='50'>
+        <feature version='${camel.version}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel/camel-stax/${camel.version}</bundle>
     </feature>
-    <feature name='camel-test' install="manual" version='2.16.1'  start-level='50'>
-        <feature version='2.16.1'>camel-core</feature>
-        <feature version='2.16.1'>camel-spring</feature>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.junit/4.11_2</bundle>
-        <bundle>mvn:org.apache.camel/camel-test/2.16.1</bundle>
+    <feature name='camel-test' install="manual" version='${camel.version}'  start-level='50'>
+        <feature version='${camel.version}'>camel-core</feature>
+        <feature version='${camel.version}'>camel-spring</feature>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.junit/${servicemix.bundles.junit.version}</bundle>
+        <bundle>mvn:org.apache.camel/camel-test/${camel.version}</bundle>
     </feature>
 
     <!-- End Camel Features -->

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <!-- Properties for the frontend-maven-plugin -->
         <node.version>v4.4.4</node.version>
         <npm.version>2.15.6</npm.version>
-        <camel.version>2.16.1</camel.version>
+        <camel.version>2.16.3</camel.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.1</commons-io.version>
         <cxf.version>3.1.4</cxf.version>
@@ -97,6 +97,16 @@
         <pax.cdi.version>0.12.0</pax.cdi.version>
         <validation.version>1.1.0.Final</validation.version>
         <commons-configuration.version>1.10</commons-configuration.version>
+        <servicemix.bundles.mina.version>1.1.7_6</servicemix.bundles.mina.version>
+        <qpid-jms-client.version>0.6.0</qpid-jms-client.version>
+        <proton-j.version>0.10</proton-j.version>
+        <netty-all.version>4.0.17.Final</netty-all.version>
+        <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>
+        <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
+        <servicemix.bundles.freemarker.version>2.3.23_1</servicemix.bundles.freemarker.version>
+        <servicemix.bundles.commons-httpclient.version>3.1_7</servicemix.bundles.commons-httpclient.version>
+        <commons-pool.version>1.6</commons-pool.version>
+        <servicemix.bundles.junit.version>4.11_2</servicemix.bundles.junit.version>
         <!--Documentation Replacements-->
         <branding>DDF</branding>
         <branding-lowercase>ddf</branding-lowercase>


### PR DESCRIPTION
#### What does this PR do?
Upgrade camel to 2.16.3 and adds the ability to install the camel-amqp component.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats @coyotesqrl
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 
@jaymcnallie
#### How should this be tested?
Make sure integration tests pass and that the camel-amqp feature can install correctly.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2264
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

