### PR TITLE
DDF-2131 Moved Historian call in CatalogFrameworkImpl

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -1078,9 +1078,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                             .size());
             if (Requests.isLocal(createRequest)) {
                 createResponse = catalog.create(createRequest);
+                createResponse = historian.version(createResponse);
             }
-
-            createResponse = historian.version(createResponse);
 
             if (catalogStoreRequest) {
                 CreateResponse remoteCreateResponse = doRemoteCreate(createRequest);
@@ -1490,9 +1489,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
 
             if (Requests.isLocal(updateReq)) {
                 updateResponse = catalog.update(updateReq);
+                updateResponse = historian.version(updateResponse);
             }
-
-            updateResponse = historian.version(updateResponse);
 
             if (catalogStoreRequest) {
                 UpdateResponse remoteUpdateResponse = doRemoteUpdate(updateReq);
@@ -1644,9 +1642,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                             e);
                 }
                 deleteResponse = catalog.delete(deleteRequest);
+                historian.version(deleteResponse);
             }
-
-            historian.version(deleteResponse);
 
             if (catalogStoreRequest) {
                 DeleteResponse remoteDeleteResponse = doRemoteDelete(deleteRequest);


### PR DESCRIPTION
#### What does this PR do?
Fixes issue with Historian trying to version metacards that are being created/updated/deleted on remote systems.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef

#### How should this be tested?
#### Any background context you want to provide?
https://github.com/codice/ddf/pull/964
#### What are the relevant tickets?
DDF-2131
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Moved Historian call in CatalogFrameworkImpl inside Request.isLocal block to prevent it from trying version remote Create/Update/Delte operations

(cherry picked from commit e8df529)