### PR TITLE
DDF-2260 Added support for GeoPDF WGS84 location parsing

### DIFF
--- a/catalog/transformer/catalog-transformer-pdf/pom.xml
+++ b/catalog/transformer/catalog-transformer-pdf/pom.xml
@@ -171,22 +171,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.35</minimum>
+                                            <minimum>0.48</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.94</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -197,5 +197,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParser.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParser.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSBoolean;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSDocument;
+import org.apache.pdfbox.cos.COSFloat;
+import org.apache.pdfbox.cos.COSInteger;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSNull;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.cos.ICOSVisitor;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GeoPdfParser {
+
+    public static final String GEOGRAPHIC = "GEOGRAPHIC";
+
+    public static final String LGIDICT = "LGIDict";
+
+    public static final String PROJECTION = "Projection";
+
+    public static final String PROJECTION_TYPE = "ProjectionType";
+
+    public static final String NEATLINE = "Neatline";
+
+    public static final String CTM = "CTM";
+
+    private static final String POLYGON = "POLYGON ((";
+
+    private static final String MULTIPOLYGON = "MULTIPOLYGON (";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoPdfParser.class);
+
+    private static final int CTM_SIZE = 6;
+
+    /**
+     * Generates a WKT compliant String from a PDF Document if it contains GeoPDF information.
+     * Currently, only WGS84 Projections are supported (GEOGRAPHIC GeoPDF ProjectionType).
+     *
+     * @param pdfDocument - The PDF document
+     * @return the WKT String
+     * @throws IOException
+     */
+    public String getWktFromPDF(PDDocument pdfDocument) throws IOException {
+        ToDoubleVisitor toDoubleVisitor = new ToDoubleVisitor();
+        LinkedList<String> polygons = new LinkedList<>();
+
+        for (PDPage pdPage : pdfDocument.getPages()) {
+            COSDictionary cosObject = pdPage.getCOSObject();
+
+
+            COSBase lgiDictObject = cosObject.getObjectFromPath(LGIDICT);
+
+            // Handle Multiple Map Frames
+            if (lgiDictObject instanceof COSArray) {
+                for (int i = 0; i < ((COSArray) lgiDictObject).size(); i++) {
+                    COSDictionary lgidict = (COSDictionary) cosObject.getObjectFromPath(
+                            LGIDICT + "/[" + i + "]");
+
+                    COSDictionary projectionArray = (COSDictionary) lgidict.getDictionaryObject(
+                            PROJECTION);
+                    if (projectionArray != null) {
+                        String projectionType =
+                                ((COSString) projectionArray.getItem(PROJECTION_TYPE)).getString();
+                        if (GEOGRAPHIC.equals(projectionType)) {
+                            COSArray neatlineArray = (COSArray) cosObject.getObjectFromPath(
+                                    LGIDICT + "/[" + i + "]/" + NEATLINE);
+                            String wktString = getWktFromNeatLine(lgidict,
+                                    neatlineArray,
+                                    toDoubleVisitor);
+                            polygons.add(wktString);
+                        } else {
+                            LOGGER.debug(
+                                    "Unsupported projection type {}.  Map Frame will be skipped.",
+                                    projectionType);
+                        }
+                    } else {
+                        LOGGER.debug(
+                                "No projection array found on the map frame.  Map Frame will be skipped.");
+                    }
+                }
+            // Handle One Map Frame
+            } else if (lgiDictObject instanceof COSDictionary) {
+                COSDictionary lgidict = (COSDictionary) lgiDictObject;
+                COSDictionary projectionArray = (COSDictionary) lgidict.getDictionaryObject(
+                        PROJECTION);
+                if (projectionArray != null) {
+                    String projectionType =
+                            ((COSString) projectionArray.getItem(PROJECTION_TYPE)).getString();
+                    if (GEOGRAPHIC.equals(projectionType)) {
+                        COSArray neatlineArray = (COSArray) cosObject.getObjectFromPath(
+                                LGIDICT + "/" + NEATLINE);
+                        if (neatlineArray == null) {
+                            neatlineArray = generateNeatLineFromPDFDimensions(pdPage);
+
+                        }
+                        polygons.add(getWktFromNeatLine(lgidict, neatlineArray, toDoubleVisitor));
+
+                    } else {
+                        LOGGER.debug("Unsupported projection type {}.  Map Frame will be skipped.",
+                                projectionType);
+                    }
+                } else {
+                    LOGGER.debug(
+                            "No projection array found on the map frame.  Map Frame will be skipped.");
+                }
+            }
+        }
+
+        if (polygons.size() == 0) {
+            LOGGER.debug(
+                    "No GeoPDF information found on PDF during transformation.  Metacard location will not be set.");
+            return null;
+        }
+
+        StringBuilder wkt = new StringBuilder();
+        if (polygons.size() == 1) {
+            wkt.append(POLYGON);
+            wkt.append(polygons.get(0));
+            wkt.append("))");
+            return wkt.toString();
+        } else {
+            return polygons.stream()
+                    .map(polygon -> "((" + polygon + "))")
+                    .collect(Collectors.joining(",", MULTIPOLYGON, ")"));
+        }
+    }
+
+    /**
+     * A PDF Neatline defines the area of a PDF image with relation to the PDF page.  If no neatline is given
+     * it is assumed that the image encompasses the entire page.  This functiong generates a NeatLine
+     * in this fashion.
+     * @param pdPage the page to generate the NeatLine
+     * @return an array of points representing the NeatLine
+     */
+    private COSArray generateNeatLineFromPDFDimensions(PDPage pdPage) {
+        COSArray neatLineArray = new COSArray();
+
+        String width = pdPage.getMediaBox().getWidth() + "";
+        String height = pdPage.getMediaBox().getHeight() + "";
+
+        neatLineArray.add(new COSString("0"));
+        neatLineArray.add(new COSString("0"));
+
+        neatLineArray.add(new COSString(width));
+        neatLineArray.add(new COSString("0"));
+
+        neatLineArray.add(new COSString(width));
+        neatLineArray.add(new COSString(height));
+
+        neatLineArray.add(new COSString("0"));
+        neatLineArray.add(new COSString(height));
+
+        return neatLineArray;
+    }
+
+    /**
+     * Convert a Point2d into WKT Lat/Lon
+     *
+     * @param point2D
+     * @return a String representation of a WKT Lat/Lon pair
+     */
+    private String point2dToWkt(Point2D point2D) {
+        return point2D.getX() + " " + point2D.getY();
+    }
+
+    /**
+     * Parses a given NeatLine and Transformation matrix into a WKT String
+     *
+     * @param lgidict         - The PDF's LGIDict object
+     * @param neatLineArray   - The NeatLine array of points for the PDF
+     * @param toDoubleVisitor - A visitor that converts PDF Strings / Ints / Longs into doubles.
+     * @return the generated WKT Lat/Lon set
+     * @throws IOException
+     */
+    private String getWktFromNeatLine(COSDictionary lgidict, COSArray neatLineArray,
+            ICOSVisitor toDoubleVisitor) throws IOException {
+        List<Double> neatline = new LinkedList<>();
+        StringBuilder wktString = new StringBuilder();
+        List<String> coordinateList = new LinkedList<>();
+        String firstCoordinate = null;
+
+        double[] points = new double[CTM_SIZE];
+        for (int i = 0; i < CTM_SIZE; i++) {
+            points[i] = (Double) lgidict.getObjectFromPath(CTM + "/[" + i + "]")
+                    .accept(toDoubleVisitor);
+        }
+        AffineTransform affineTransform = new AffineTransform(points);
+
+        for (int i = 0; i < neatLineArray.size(); i++) {
+            neatline.add((Double) neatLineArray.get(i)
+                    .accept(toDoubleVisitor));
+        }
+
+        for (int i = 0; i < neatline.size(); i += 2) {
+            double x = neatline.get(i);
+            double y = neatline.get(i + 1);
+
+            Point2D p = new Point2D.Double(x, y);
+
+            Point2D pprime = affineTransform.transform(p, null);
+
+            String xySet = point2dToWkt(pprime);
+
+            if (firstCoordinate == null) {
+                firstCoordinate = xySet;
+            }
+            coordinateList.add(xySet);
+        }
+        coordinateList.add(firstCoordinate);
+        wktString.append(StringUtils.join(coordinateList, ", "));
+        LOGGER.debug("{}", wktString);
+        return wktString.toString();
+    }
+
+    /**
+     * This visitor class converts parsable COS Objects into {@link Double}s
+     */
+    private static class ToDoubleVisitor implements ICOSVisitor {
+
+        @Override
+        public Object visitFromArray(COSArray cosArray) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromBoolean(COSBoolean cosBoolean) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromDictionary(COSDictionary cosDictionary) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromDocument(COSDocument cosDocument) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromFloat(COSFloat cosFloat) throws IOException {
+            return cosFloat.doubleValue();
+        }
+
+        @Override
+        public Object visitFromInt(COSInteger cosInteger) throws IOException {
+            return (double) cosInteger.longValue();
+        }
+
+        @Override
+        public Object visitFromName(COSName cosName) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromNull(COSNull cosNull) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromStream(COSStream cosStream) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromString(COSString cosString) throws IOException {
+            return Double.valueOf(cosString.getString());
+        }
+    }
+}

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParser.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParser.java
@@ -140,12 +140,8 @@ public class GeoPdfParser {
             return null;
         }
 
-        StringBuilder wkt = new StringBuilder();
         if (polygons.size() == 1) {
-            wkt.append(POLYGON);
-            wkt.append(polygons.get(0));
-            wkt.append("))");
-            return wkt.toString();
+            return POLYGON + polygons.get(0) + "))";
         } else {
             return polygons.stream()
                     .map(polygon -> "((" + polygon + "))")
@@ -163,8 +159,8 @@ public class GeoPdfParser {
     private COSArray generateNeatLineFromPDFDimensions(PDPage pdPage) {
         COSArray neatLineArray = new COSArray();
 
-        String width = pdPage.getMediaBox().getWidth() + "";
-        String height = pdPage.getMediaBox().getHeight() + "";
+        String width = String.valueOf(pdPage.getMediaBox().getWidth());
+        String height = String.valueOf(pdPage.getMediaBox().getHeight());
 
         neatLineArray.add(new COSString("0"));
         neatLineArray.add(new COSString("0"));
@@ -203,7 +199,6 @@ public class GeoPdfParser {
     private String getWktFromNeatLine(COSDictionary lgidict, COSArray neatLineArray,
             ICOSVisitor toDoubleVisitor) throws IOException {
         List<Double> neatline = new LinkedList<>();
-        StringBuilder wktString = new StringBuilder();
         List<String> coordinateList = new LinkedList<>();
         String firstCoordinate = null;
 
@@ -235,7 +230,7 @@ public class GeoPdfParser {
             coordinateList.add(xySet);
         }
         coordinateList.add(firstCoordinate);
-        wktString.append(StringUtils.join(coordinateList, ", "));
+        String wktString = StringUtils.join(coordinateList, ", ");
         LOGGER.debug("{}", wktString);
         return wktString.toString();
     }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -75,6 +76,8 @@ public class PdfInputTransformer implements InputTransformer {
     private static final float IMAGE_HEIGHTWIDTH = 128;
 
     private static final String FORMAT_NAME = "jpg";
+
+    private static final GeoPdfParser GEO_PDF_PARSER = new GeoPdfParser();
 
     private static final FastDateFormat DATE_FORMAT = FastDateFormat.getInstance(
             "yyyy-MM-dd'T'HH:mm:ssZZ");
@@ -214,6 +217,9 @@ public class PdfInputTransformer implements InputTransformer {
         extractPdfMetadata(pdfDocument, metacard);
 
         metacard.setThumbnail(generatePdfThumbnail(pdfDocument));
+
+        Optional.ofNullable(GEO_PDF_PARSER.getWktFromPDF(pdfDocument)).ifPresent(metacard::setLocation);
+
         return metacard;
     }
 

--- a/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfDocumentGenerator.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfDocumentGenerator.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+
+public class GeoPdfDocumentGenerator {
+
+    public static PDDocument generateEmptyPdf() {
+        PDDocument pdDocument = new PDDocument();
+        pdDocument.addPage(new PDPage());
+        return pdDocument;
+    }
+
+    public static PDDocument generateGeoPdf(int numberOfPages, int numberOfFramesPerPage,
+            String projectionType) {
+        PDDocument pdDocument = new PDDocument();
+        for (int i = 0; i < numberOfPages; i++) {
+            pdDocument.addPage(generateGeoPdfPage(numberOfFramesPerPage, projectionType));
+        }
+        return pdDocument;
+    }
+
+    public static PDDocument generateGeoPdf(int numberOfPages, String projectionType,
+            boolean generateNeatLine) {
+        PDDocument pdDocument = new PDDocument();
+        for (int i = 0; i < numberOfPages; i++) {
+            pdDocument.addPage(generateGeoPdfPage(projectionType, generateNeatLine));
+        }
+        return pdDocument;
+    }
+
+    private static PDPage generateGeoPdfPage(int numberOfFramesPerPage, String projectionType) {
+        PDPage pdPage = new PDPage();
+        COSDictionary cosDictionary = pdPage.getCOSObject();
+        cosDictionary.setItem(GeoPdfParser.LGIDICT, generateLGIDictArray(numberOfFramesPerPage,
+                projectionType));
+        return pdPage;
+    }
+
+    private static PDPage generateGeoPdfPage(String projectionType, boolean generateNeatLine) {
+        PDPage pdPage = new PDPage();
+        COSDictionary cosDictionary = pdPage.getCOSObject();
+        cosDictionary.setItem(GeoPdfParser.LGIDICT, generateMapFrameDictionary(projectionType,
+                generateNeatLine));
+        return pdPage;
+    }
+
+    private static COSArray generateLGIDictArray(int numberOfFrames, String projectionType) {
+        COSArray cosArray = new COSArray();
+        for (int i = 0; i < numberOfFrames; i++) {
+            cosArray.add(generateMapFrameDictionary(projectionType));
+        }
+        return cosArray;
+    }
+
+    private static COSDictionary generateMapFrameDictionary(String projectionType) {
+        COSDictionary cosDictionary = new COSDictionary();
+        if (StringUtils.isNotBlank(projectionType)) {
+            cosDictionary.setItem(GeoPdfParser.PROJECTION, generateProjectionDictionary(
+                    projectionType));
+        }
+
+        cosDictionary.setItem(GeoPdfParser.NEATLINE, generateNeatLineArray());
+        cosDictionary.setItem(GeoPdfParser.CTM, generateCTMArray());
+        return cosDictionary;
+    }
+
+    private static COSDictionary generateMapFrameDictionary(String projectionType,
+            boolean generateNeatLine) {
+        COSDictionary cosDictionary = new COSDictionary();
+        if (StringUtils.isNotBlank(projectionType)) {
+            cosDictionary.setItem(GeoPdfParser.PROJECTION, generateProjectionDictionary(
+                    projectionType));
+        }
+
+        if (generateNeatLine) {
+            cosDictionary.setItem(GeoPdfParser.NEATLINE, generateNeatLineArray());
+        }
+
+        cosDictionary.setItem(GeoPdfParser.CTM, generateCTMArray());
+        return cosDictionary;
+    }
+
+    private static COSArray generateNeatLineArray() {
+        COSArray neatLineArray = new COSArray();
+        neatLineArray.add(new COSString("1563.749999999969"));
+        neatLineArray.add(new COSString("1992.384698215686"));
+        neatLineArray.add(new COSString("1563.75000000011"));
+        neatLineArray.add(new COSString("239.6265517842302"));
+        neatLineArray.add(new COSString("74.23874999988999"));
+        neatLineArray.add(new COSString("239.6265517846492"));
+        neatLineArray.add(new COSString("74.23875000008906"));
+        neatLineArray.add(new COSString("1992.38469821535"));
+        neatLineArray.add(new COSString("1563.749999999969"));
+        neatLineArray.add(new COSString("1992.384698215686"));
+        return neatLineArray;
+    }
+
+    private static COSArray generateCTMArray() {
+        COSArray ctmArray = new COSArray();
+        ctmArray.add((new COSString("0.003591954022988553")));
+        ctmArray.add((new COSString("7.868785750012534e-017")));
+        ctmArray.add((new COSString("-7.868785750012534e-017")));
+        ctmArray.add((new COSString("0.003591954022988553")));
+        ctmArray.add((new COSString("-80.77532309213824")));
+        ctmArray.add((new COSString("36.77844766314338")));
+        return ctmArray;
+    }
+
+    private static COSDictionary generateProjectionDictionary(String projectionType) {
+        COSDictionary projectionDictionary = new COSDictionary();
+        projectionDictionary.setString(GeoPdfParser.PROJECTION_TYPE, projectionType);
+        return projectionDictionary;
+    }
+}

--- a/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/TestGeoPdfParser.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/TestGeoPdfParser.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.junit.Test;
+
+public class TestGeoPdfParser {
+
+    public static final String WKT_POLYGON =
+            "POLYGON ((-75.15840498869015 43.93500189524018, -75.15840498868951 37.63917521983974, -80.50866091541451 37.639175219841135, -80.50866091541393 43.93500189523885, -75.15840498869015 43.93500189524018, -75.15840498869015 43.93500189524018))";
+
+    public static final String WKT_MULTIPOLYGON =
+            "MULTIPOLYGON (((-75.15840498869015 43.93500189524018, -75.15840498868951 37.63917521983974, -80.50866091541451 37.639175219841135, -80.50866091541393 43.93500189523885, -75.15840498869015 43.93500189524018, -75.15840498869015 43.93500189524018)),((-75.15840498869015 43.93500189524018, -75.15840498868951 37.63917521983974, -80.50866091541451 37.639175219841135, -80.50866091541393 43.93500189523885, -75.15840498869015 43.93500189524018, -75.15840498869015 43.93500189524018)))";
+
+    public static final String WKT_POLYGON_NO_NEATLINE =
+            "POLYGON ((-80.77532309213824 36.77844766314338, -78.57704723006924 36.77844766314343, -78.5770472300693 39.623275249350364, -80.7753230921383 39.623275249350314, -80.77532309213824 36.77844766314338))";
+
+    private static final GeoPdfParser GEO_PDF_PARSER = new GeoPdfParser();
+
+    @Test
+    public void testEmptyPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateEmptyPdf();
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, nullValue());
+    }
+
+    @Test
+    public void testSinglePageMultiFrameGeographicGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
+                2,
+                GeoPdfParser.GEOGRAPHIC);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, is(WKT_MULTIPOLYGON));
+    }
+
+    @Test
+    public void testSinglePageSingleMultiFrameGeographicGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
+                1,
+                GeoPdfParser.GEOGRAPHIC);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, is(WKT_POLYGON));
+    }
+
+    @Test
+    public void testSinglePageMultiFrameNonGeographicGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, 2, "UT");
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, nullValue());
+    }
+
+    @Test
+    public void testSinglePageMultiFrameNoProjectionGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, 2, "");
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, nullValue());
+    }
+
+    @Test
+    public void testSinglePageSingleFrameGeographicGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
+                GeoPdfParser.GEOGRAPHIC,
+                true);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, is(WKT_POLYGON));
+    }
+
+    @Test
+    public void testSinglePageSingleFrameNonGeographicGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, "UT", true);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, nullValue());
+    }
+
+    @Test
+    public void testSinglePageSingleFrameNoProjectionGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, "", true);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, nullValue());
+    }
+
+    @Test
+    public void testSinglePageSingleFrameNoNeatLineGeoPdf() throws Exception {
+        PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
+                GeoPdfParser.GEOGRAPHIC,
+                false);
+        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        assertThat(wktString, is(WKT_POLYGON_NO_NEATLINE));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
This PR adds support to parse WGS84 locations from GeoPDF files when present.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein @jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire 
#### How should this be tested?
Install DDF, Ingest GeoPDFs that contain `GEOGRAPHIC` projection types, and observe the location is properly set via the Standard Search UI (contact me for example data)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2260
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

