### PR TITLE
DDF-2250 Make SaxEventToXmlConverter handle edge cases

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,18 +26,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.xml.stream.XMLStreamException;
-
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
 import org.junit.Test;
-import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
 import ddf.catalog.data.Attribute;
@@ -200,84 +195,6 @@ public class TestGenericXmlLib {
         assertThat(inputTransformer.getOrganization(), is("foo"));
         assertThat(inputTransformer.getTitle(), is("foo"));
         assertThat(inputTransformer.getVersion(), is("foo"));
-    }
-
-    @Test
-    public void testSaxEventToXmlElementConverter()
-            throws UnsupportedEncodingException, XMLStreamException {
-        SaxEventToXmlElementConverter saxEventToXmlElementConverter =
-                new SaxEventToXmlElementConverter();
-        saxEventToXmlElementConverter.addNamespace("foo", "bar");
-        saxEventToXmlElementConverter.addNamespace("barfoo", "foobar");
-        Attributes attrs = mock(Attributes.class);
-        when(attrs.getLength()).thenReturn(2);
-        when(attrs.getLocalName(0)).thenReturn("foo");
-        when(attrs.getLocalName(1)).thenReturn("bar");
-        when(attrs.getURI(0)).thenReturn("foobar");
-        when(attrs.getURI(1)).thenReturn("");
-        when(attrs.getValue(anyInt())).thenReturn("test");
-        saxEventToXmlElementConverter.toElement("bar", "test", attrs);
-        saxEventToXmlElementConverter.toElement("&lt;chara&gt;cters".toCharArray(), 0, 16);
-        saxEventToXmlElementConverter.toElement("bar", "test");
-        saxEventToXmlElementConverter.toElement("bar", "test", attrs);
-        saxEventToXmlElementConverter.toElement("characters".toCharArray(), 0, 8);
-        saxEventToXmlElementConverter.toElement("bar", "test");
-        assertThat(saxEventToXmlElementConverter.toString(),
-                is("<foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">&amp;lt;chara&amp;gt;cte</foo:test><foo:test xmlns:foo=\"bar\" xmlns:barfoo=\"foobar\" barfoo:foo=\"test\" bar=\"test\">characte</foo:test>"));
-        saxEventToXmlElementConverter.reset();
-        assertThat(saxEventToXmlElementConverter.toString(), is(""));
-    }
-
-    @Test
-    public void testSaxEventToXmlElementConverterEdgeCase()
-            throws UnsupportedEncodingException, XMLStreamException {
-        // set up mock Attribute object
-        Attributes attrs = mock(Attributes.class);
-        when(attrs.getLength()).thenReturn(2);
-        when(attrs.getLocalName(0)).thenReturn("foo");
-        when(attrs.getLocalName(1)).thenReturn("bar");
-        when(attrs.getURI(0)).thenReturn("ns1uri");
-        when(attrs.getURI(1)).thenReturn("");
-        when(attrs.getValue(anyInt())).thenReturn("test");
-        // inner attrs
-        Attributes attrs2 = mock(Attributes.class);
-        when(attrs2.getLength()).thenReturn(2);
-        when(attrs2.getLocalName(0)).thenReturn("foo");
-        when(attrs2.getLocalName(1)).thenReturn("bar");
-        when(attrs2.getURI(0)).thenReturn("ns1uri.v2");
-        when(attrs2.getURI(1)).thenReturn("");
-        when(attrs2.getValue(anyInt())).thenReturn("test");
-
-        SaxEventToXmlElementConverter converter = new SaxEventToXmlElementConverter();
-
-        // Simulate begin reading
-        converter.addNamespace("ns1", "ns1uri");
-        converter.addNamespace("ns2", "ns2uri");
-
-        // Write parent element and characters
-        converter.toElement("ns1uri", "element1", attrs);
-        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
-
-        // Declare new namespace, using same prefix as previous
-        converter.addNamespace("ns1", "ns1uri.v2");
-        converter.toElement("ns1uri.v2", "nestedElement", attrs2);
-        converter.toElement("ns1uri.v2", "nestedElement");
-
-        // Pop prefix
-        converter.removeNamespace("ns1");
-
-        converter.toElement("ns1uri", "element1", attrs);
-        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
-        converter.toElement("ns1uri", "element1");
-
-        // Finish writing parent
-        converter.toElement("ns1uri", "element1");
-
-        converter.toElement("ns1uri", "element1", attrs);
-        converter.toElement("0123456789ABCDEF".toCharArray(), 0, 16);
-        converter.toElement("ns1uri", "element1");
-        assertThat(converter.toString(),
-                is("<ns1:element1 xmlns:ns1=\"ns1uri\" ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF<ns1:nestedElement xmlns:ns1=\"ns1uri.v2\" ns1:foo=\"test\" bar=\"test\"></ns1:nestedElement><ns1:element1 ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF</ns1:element1></ns1:element1><ns1:element1 xmlns:ns1=\"ns1uri\" ns1:foo=\"test\" bar=\"test\">0123456789ABCDEF</ns1:element1>"));
     }
 
     @Test

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxEventToXmlElementConverter.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxEventToXmlElementConverter.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+public class TestSaxEventToXmlElementConverter {
+
+    /*
+     * Some of the "reconstructedExpectations" in this class are different than the input. This is acceptable and expected,
+     * because the output just has to be semantically the same as the input, it doesn't have to be literally the same.
+     * For example, sometimes the namespaces are declared at different scopes, in a different order, comments are removed, etc.
+     */
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredDefaultNamespaceUri()
+            throws XMLStreamException, IOException, SAXException {
+        String doubleDeclaredNamespaceUriSnippet =
+                //@formatter:off
+                  "<x xmlns:ns1='foobar' xmlns='foobar'>"
+                + "    <good1 a='1' b='2' />"
+                + "    <good2 a='1' ns1:a='2' />"
+                + "</x>";
+                //@formatter:on
+
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<x xmlns='foobar'>"
+                + "    <good1 a='1' b='2'></good1>"
+                + "    <good2 a='1' xmlns:ns1='foobar' ns1:a='2'></good2>"
+                + "</x>";
+                //@formatter:on
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(doubleDeclaredNamespaceUriSnippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedXml, is(reconstructedExpectation));
+    }
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredDefaultNamespaceUriVariation()
+            throws XMLStreamException, IOException, SAXException {
+        String doubleDeclaredNamespaceUriSnippet =
+                //@formatter:off
+                  "<x xmlns:ns1='notfoobar' xmlns:ns2='foobar' xmlns='foobar'>"
+                + "    <good1 a='1' b='2' />"
+                + "    <good2 a='1' ns2:a='2' ns1:a='3'/>"
+                + "</x>";
+                //@formatter:on
+
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<x xmlns='foobar'>"
+                + "    <good1 a='1' b='2'></good1>"
+                + "    <good2 a='1' xmlns:ns2='foobar' ns2:a='2' xmlns:ns1='notfoobar' ns1:a='3'></good2>"
+                + "</x>";
+                //@formatter:on
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(doubleDeclaredNamespaceUriSnippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedXml, is(reconstructedExpectation));
+    }
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredNamespaceUriVariation()
+            throws XMLStreamException, IOException, SAXException {
+        String doubleDeclaredNamespaceUriSnippet =
+                //@formatter:off
+                  "<x:y xmlns='default' xmlns:x='www.x.com' x:one='2' x:two='2'>"
+                + "    <y:z xmlns:y='www.x.com' x:one='1' y:two='2'>"
+                + "        <x:z>abcdefg</x:z>"
+                + "    </y:z>"
+                + "</x:y>";
+                //@formatter:on
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<x:y xmlns:x='www.x.com' x:one='2' x:two='2'>"
+                + "    <y:z xmlns:y='www.x.com' y:one='1' y:two='2'>"
+                + "        <y:z>abcdefg</y:z>"
+                + "    </y:z>"
+                + "</x:y>";
+                //@formatter:on
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(doubleDeclaredNamespaceUriSnippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedXml, is(reconstructedExpectation));
+    }
+
+    @Test
+    public void testSaxEventToXmlElementConverterRedeclaredNamespaceUriVariation2()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet =
+                //@formatter:off
+                  "<?xml version='1.0' encoding='UTF-8' ?>"
+                + "<outer xmlns:aaa='whocares' xmlns='http://www.w3.com'>"
+                + "    <aaa:foo name='outside'>"
+                + "        <aaa:bar xmlns:bbb='inside1'>"
+                + "            <bbb:baz xmlns:aaa='inside2'>"
+                + "                <aaa:verybad name='scope matters'/>"
+                + "            </bbb:baz>"
+                + "        </aaa:bar>"
+                + "    </aaa:foo>"
+                + "</outer>";
+                //@formatter:on
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<outer xmlns='http://www.w3.com'>"
+                + "    <aaa:foo xmlns:aaa='whocares' name='outside'>"
+                + "        <aaa:bar>"
+                + "            <bbb:baz xmlns:bbb='inside1'>"
+                + "                <aaa:verybad xmlns:aaa='inside2' name='scope matters'></aaa:verybad>"
+                + "            </bbb:baz>"
+                + "        </aaa:bar>"
+                + "    </aaa:foo>"
+                + "</outer>";
+                //@formatter:on
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedXml, is(reconstructedExpectation));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterNormal()
+            throws XMLStreamException, IOException, SAXException {
+        String normalSnippet =
+                //@formatter:off
+                  "<?xml version='1.0'?>"
+                + "<!-- both namespace prefixes are available throughout -->"
+                + "<bk:book xmlns:bk='urn:loc.gov:books' xmlns:isbn='urn:ISBN:0-395-36341-6'>"
+                + "    <bk:title>Cheaper by the Dozen</bk:title>"
+                + "    <isbn:number>1568491379</isbn:number>"
+                + "</bk:book>";
+                //@formatter:on
+
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<bk:book xmlns:bk='urn:loc.gov:books'>"
+                + "    <bk:title>Cheaper by the Dozen</bk:title>"
+                + "    <isbn:number xmlns:isbn='urn:ISBN:0-395-36341-6'>1568491379</isbn:number>"
+                + "</bk:book>";
+                //@formatter:on
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(normalSnippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterScopedPrefixRedeclaration()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet =
+                //@formatter:off
+                  "<?xml version='1.0'?>"
+                + "<!-- initially, the default namespace is 'books' -->"
+                + "<book xmlns='urn:loc.gov:books' xmlns:isbn='urn:ISBN:0-395-36341-6'>"
+                + "    <title>Cheaper by the Dozen</title>"
+                + "    <isbn:number>1568491379</isbn:number>"
+                + "    <notes><!-- make HTML the default namespace for some commentary -->"
+                + "        <p xmlns='http://www.w3.org/1999/xhtml'>This is a <i>funny</i> book!</p>"
+                + "    </notes>"
+                + "</book>";
+                //@formatter:on
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<book xmlns='urn:loc.gov:books'>"
+                + "    <title>Cheaper by the Dozen</title>"
+                + "    <isbn:number xmlns:isbn='urn:ISBN:0-395-36341-6'>1568491379</isbn:number>"
+                + "    <notes>"
+                + "        <p xmlns='http://www.w3.org/1999/xhtml'>This is a <i>funny</i> book!</p>"
+                + "    </notes>"
+                + "</book>";
+                //@formatter:on
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterScopedPrefixRedeclarationVariation()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet =
+                //@formatter:off
+                  "<?xml version='1.0'?>"
+                + "<!-- initially, the default namespace is 'books' -->"
+                + "<book xmlns='urn:loc.gov:books'>"
+                + "    <title>Cheaper by the Dozen</title>"
+                + "    <isbn:number xmlns:isbn='urn:ISBN:0-395-36341-6'>1568491379</isbn:number>"
+                + "    <notes><!-- make HTML the default namespace for some commentary -->"
+                + "        <p xmlns='http://www.w3.org/1999/xhtml'>This is a <i>funny</i> book!</p>"
+                + "    </notes>"
+                + "    <title xmlns='urn:loc.gov:books'>Cheaper by the Bakers Dozen</title>"
+                + "</book>";
+                //@formatter:on
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<book xmlns='urn:loc.gov:books'>"
+                + "    <title>Cheaper by the Dozen</title>"
+                + "    <isbn:number xmlns:isbn='urn:ISBN:0-395-36341-6'>1568491379</isbn:number>"
+                + "    <notes>"
+                + "        <p xmlns='http://www.w3.org/1999/xhtml'>This is a <i>funny</i> book!</p>"
+                + "    </notes>"
+                + "    <title>Cheaper by the Bakers Dozen</title>"
+                + "</book>";
+                //@formatter:on
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+
+    @Test
+    public void testSaxEventToXmlConverterRedclaredPrefixAndReusedUri()
+            throws XMLStreamException, IOException, SAXException {
+        String snippet =
+                //@formatter:off
+                  "<x:y xmlns='default' xmlns:x='www.x.com' x:one='2' x:two='2'>"
+                + "    <y:z xmlns:y='www.x.com' xmlns:x='dumb.but.possible' x:one='1' y:two='2'>"
+                + "        <x:z>abcdefg</x:z>"
+                + "    </y:z>"
+                + "</x:y>";
+                //@formatter:on
+
+        String reconstructedExpectation =
+                //@formatter:off
+                  "<x:y xmlns:x='www.x.com' x:one='2' x:two='2'>"
+                + "    <y:z xmlns:y='www.x.com' xmlns:x='dumb.but.possible' x:one='1' y:two='2'>"
+                + "        <x:z>abcdefg</x:z>"
+                + "    </y:z>"
+                + "</x:y>";
+                //@formatter:on
+
+        TestSaxParser parser = new TestSaxParser();
+        String reconstructedXml = parser.parseAndReconstruct(snippet);
+        reconstructedExpectation = reconstructedExpectation.replaceAll("'", "\"");
+        assertThat(reconstructedExpectation, is(reconstructedXml));
+    }
+}

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxParser.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestSaxParser.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DefaultHandler2;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+public class TestSaxParser extends DefaultHandler2 {
+
+    private XMLReader reader;
+
+    private SaxEventToXmlElementConverter converter;
+
+    @Override
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
+        try {
+            converter.addNamespace(prefix, uri);
+        } catch (XMLStreamException e) {
+            fail("Failed to add namespace");
+        }
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        converter.removeNamespace(prefix);
+
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts)
+            throws SAXException {
+        try {
+            converter.toElement(uri, localName, atts);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on startElement with pieces: %s %s %s %s", uri, localName, qName, atts));
+        }
+
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        try {
+            converter.toElement(uri, localName);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on endElement with pieces: %s %s %s", uri, localName, qName));
+        }
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        try {
+            converter.toElement(ch, start, length);
+        } catch (XMLStreamException e) {
+            fail(String.format("Failed on endElement with pieces: %s", new String(ch, start, length)));
+        }
+    }
+
+    public String parseAndReconstruct(String xmlSnippet)
+            throws IOException, XMLStreamException, SAXException {
+        converter = new SaxEventToXmlElementConverter();
+        reader = XMLReaderFactory.createXMLReader();
+        reader.setContentHandler(this);
+        reader.setErrorHandler(this);
+        reader.parse(new InputSource(new ByteArrayInputStream(xmlSnippet.getBytes())));
+        return converter.toString();
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds unit tests and makes the SaxEventToXmlElementConverter even more robust
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris
#### How should this be tested?
Unit tests should be enough. If during review we realize we need more, they can be added.
#### Any background context you want to provide?
When this ticket was first being reviewed, we noticed it could use better unit tests with better edge case coverage. This PR intends to add that edge case coverage.
#### What are the relevant tickets?
DDF-2250
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
