### PR TITLE
DDF-1940 Fixes issue with fanout queries passing query tags to legacy systems.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -2146,6 +2146,9 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
 
         LOGGER.debug("Calling strategy.federate()");
 
+        if (fanoutEnabled) {
+            queryRequest.getProperties().put("no-default-tags", true);
+        }
         QueryResponse response = strategy.federate(sourcesToQuery, queryRequest);
         frameworkProperties.getQueryResponsePostProcessor()
                 .processResponse(response);


### PR DESCRIPTION
#### What does this PR do?
In a fanout system, all source ids match the system id and if one of the legacy federated sources that are also providers is being used, the query being sent to it will incorrectly be modified with the tag information.

This change checks the `fanoutEnabled` flag and if it is true, sets the `no-default-tags` property on the query request to true. That property is checked by the `CachingFederationStrategy` and if true, skips adding the query tags.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @rzwiefel @bcwaters 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef

#### How should this be tested?

1. Configure a set of sources and execute a query with tags. Verify they are still passed to the federated sources.
2. Then, set one of the DDF instances as a fanout instance and execute the same query through it. Verify that the tags are not passed through.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-1940

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests