### PR TITLE
DDF-2271- Adds Registry app to install profiles

### DIFF
--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -36,6 +36,7 @@
         <feature>spatial-app</feature>
         <feature>resourcemanagement-app</feature>
         <feature>geowebcache-app</feature>
+        <feature>registry-app</feature>
     </feature>
 
 </features>


### PR DESCRIPTION
#### What does this PR do?
Adds registry-app to standard and development install profiles. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote 
@gordocanchola 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison
#### How should this be tested?
Full build, start up the DDF, install with Development setting and make sure registry-app has started.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2271
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

