### PR TITLE
DDF-2278: Turn catalog-core-validationparser on by default

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -360,7 +360,7 @@
         <feature>catalog-plugin-metacard-validation</feature>
     </feature>
 
-    <feature name="catalog-core-validationparser" install="manual" version="${project.version}"
+    <feature name="catalog-core-validationparser" install="auto" version="${project.version}"
              description="Provides the ability to define new metacard types, attributes, attribute validators, and default values via JSON files">
         <feature prerequisite="true">catalog-core-validator</feature>
         <bundle>mvn:ddf.catalog.core/catalog-core-validationparser/${project.version}</bundle>


### PR DESCRIPTION
#### What does this PR do?
Turns catalog-core-validationparser on by default
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@coyotesqrl @pklinef  @jlcsmith @jrnorth 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@stustison 
@kcwire

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2278
