### PR TITLE
DDF-2276 Added the option to restrict local sources during data usage monitoring, changed the default to only track remote sources, and updated unit tests

### DIFF
--- a/catalog/resourcemanagement/resourcemanagement-usage-plugin/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-usage-plugin/pom.xml
@@ -86,22 +86,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/resourcemanagement/resourcemanagement-usage-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/resourcemanagement/resourcemanagement-usage-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,11 +11,15 @@
  *
  **/
 -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
 
     <bean id="plugin"
           class="org.codice.ddf.resourcemanagement.usage.ResourceUsagePlugin">
         <argument ref="attributesStore"/>
+        <cm:managed-properties persistent-id="org.codice.ddf.resourcemanagement.usage"
+                               update-strategy="container-managed"/>
+        <property name="monitorLocalSources" value="false"/>
     </bean>
 
     <!-- Register in the OSGi Service Registry -->

--- a/catalog/resourcemanagement/resourcemanagement-usage-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/resourcemanagement/resourcemanagement-usage-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Data Usage" id="org.codice.ddf.resourcemanagement.usage">
+        <AD description="When checked, the Data Usage Plugin will also consider data usage from local sources."
+            name="Monitor Local Sources" id="monitorLocalSources" required="true" type="Boolean"
+            default="false"/>
+    </OCD>
+
+    <Designate pid="org.codice.ddf.resourcemanagement.usage">
+        <Object ocdref="org.codice.ddf.resourcemanagement.usage"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/css/index.css
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/css/index.css
@@ -68,6 +68,7 @@ select {
     border: 1px solid red;
 }
 
-.data-limit-all {
-
+.glyphicon {
+    margin-left: 10px;
 }
+

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/js/model/DataUsage.js
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/js/model/DataUsage.js
@@ -20,6 +20,8 @@ define(['backbone',
 
         var MB_SIZE = (1000 * 1000);
 
+        var CONFIGURATION_ADMIN_URL = "/admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/";
+
         var DataUsage = {};
 
         DataUsage.UsageModel = Backbone.Model.extend({
@@ -38,6 +40,13 @@ define(['backbone',
                     dataType: 'json',
                     success: function(data) {
                         that.set({'users' : that.parseDataModel(data.value)});
+                    }
+                });
+                $.ajax({
+                    url: CONFIGURATION_ADMIN_URL + "getProperties/org.codice.ddf.resourcemanagement.usage",
+                    dataType: 'json',
+                    success: function(data) {
+                        that.set({ 'monitorLocalSources' : data.value.monitorLocalSources});
                     }
                 });
             },
@@ -169,6 +178,18 @@ define(['backbone',
                          usageRemaining = "0 MB";
                     }
                 return usageRemaining;
+            },
+            updateMonitorLocalSources: function(updateMonitorLocalSources) {
+                var properties = {monitorLocalSources : updateMonitorLocalSources};
+                var that = this;
+                $.ajax({
+                    url: CONFIGURATION_ADMIN_URL + "update/org.codice.ddf.resourcemanagement.usage/" + JSON.stringify(properties),
+                    dataType: 'json',
+                    success : function() {
+                        that.set(properties);
+                    }
+                });
+
             }
         });
 

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/js/view/DataUsage.view.js
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/js/view/DataUsage.view.js
@@ -81,10 +81,12 @@ define([
                 _.bindAll(this);
                this.listenTo(this.model, 'change:saving', this.render);
                this.listenTo(this.model, 'change:cronTime', this.render);
+               this.listenTo(this.model, 'change:monitorLocalSources', this.render);
             },
             onRender : function() {
                this.setupPopOver('[data-toggle="update-all-popover"]', 'Updates the Data Limit for all users in the table.  If there are individual fields set in the table, the limit for all fields takes precedence.');
-               this.setupPopOver('[data-toggle="cron-time-popover"]', 'Sets the time for the Data Usage for each user to reset.  The system must be restarted for this new time to take effect. ');
+               this.setupPopOver('[data-toggle="cron-time-popover"]', 'Sets the time for the Data Usage for each user to reset.  The system must be restarted for this new time to take effect.');
+               this.setupPopOver('[data-toggle="monitor-local-sources"]', 'When checked, the Data Usage Plugin will also consider data usage from local sources.');
             },
             updateUsers : function () {
                 var userData = this.model.get('users');
@@ -131,10 +133,15 @@ define([
                 if(updateTime !== this.model.get('cronTime')) {
                     this.model.updateCronTime(updateTime);
                 }
+                var updateMonitorLocalSources = $('.monitor-checkbox').prop('checked');
+                if(updateMonitorLocalSources !== this.model.get('monitorLocalSources')) {
+                    this.model.updateMonitorLocalSources(updateMonitorLocalSources);
+                }
             },
             refreshUsers : function() {
                 this.model.getUsageData();
                 this.model.trigger('change:users', this.model);
+                this.model.trigger('change:monitorLocalSources', this.model);
             },
             notifyAllData : function(e) {
                 var value = $(e.target).val();

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/templates/dataUsageControl.handlebars
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/templates/dataUsageControl.handlebars
@@ -24,6 +24,10 @@
             Data usage resets at <input type="time" class="input-time" value={{cronTime}}><i class="glyphicon glyphicon-question-sign" data-toggle="cron-time-popover"></i>
         </div>
 
+        <div class="update-limit">
+            Monitor data from local sources : <input type="checkbox" class="monitor-checkbox" {{#if monitorLocalSources}}checked{{/if}}><i class="glyphicon glyphicon-question-sign" data-toggle="monitor-local-sources"></i>
+        </div>
+
        <div class="button-div">
            <i class="fa fa-refresh refresh"></i>
            <button class="btn btn-primary save">Save</button>


### PR DESCRIPTION
#### What does this PR do?
This PR adds the ability to optionally choose to consider local sources when monitoring a user's data usage.  It also changes data monitoring to only monitor remote sources by default, adds additional unit tests, and adds functionality to toggle and save the configuration in the Data Usage Admin Plugin.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth  @glenhein  
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build DDF, Install Resource Management App, Fiddle with the new checkbox in the Data Usage plugin and observe correct behavior when downloading local and remote sources.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2276
#### Screenshots (if appropriate)
https://codice.atlassian.net/browse/DDF-2276
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests