### PR TITLE
DDF-1940 Creates a new internal-only SolrCacheSource to extract and reduce customizations in the CachingFederationStrategy.

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -485,5 +485,10 @@
             <artifactId>ftp</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-tagsfilterplugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -66,6 +66,7 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-standardframework/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcestatusplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-tagsfilterplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.security/catalog-security-logging/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-attribute/${project.version}</bundle>

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -449,7 +449,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -464,7 +464,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 
 import ddf.catalog.cache.SolrCacheMBean;
+import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardCreationException;
 import ddf.catalog.data.Result;
@@ -330,6 +332,10 @@ public class SolrCache implements SolrCacheMBean {
 
         SourceResponse response = client.query(queryRequest);
         return getMetacardsFromResponse(response);
+    }
+
+    Set<ContentType> getContentTypes() {
+        return client.getContentTypes();
     }
 
     private List<Metacard> getMetacardsFromResponse(SourceResponse sourceResponse) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCacheSource.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCacheSource.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.cache.solr.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.ContentType;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.impl.ProcessingDetailsImpl;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceMonitor;
+import ddf.catalog.source.UnsupportedQueryException;
+
+/**
+ * Source used internally by the {@link CachingFederationStrategy} to encapsulate interaction with
+ * the cache.
+ */
+public class SolrCacheSource implements Source {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolrCacheSource.class);
+
+    private static final String DESCRIBABLE_PROPERTIES_FILE = "/describable.properties";
+
+    private static Properties describableProperties = new Properties();
+
+    private final SolrCache cache;
+
+    static {
+        try (InputStream propertiesStream = ddf.catalog.source.solr.SolrCatalogProvider.class.getResourceAsStream(
+                DESCRIBABLE_PROPERTIES_FILE)) {
+            describableProperties.load(propertiesStream);
+        } catch (IOException e) {
+            LOGGER.info("IO exception loading describable properties", e);
+        }
+    }
+
+    SolrCacheSource(SolrCache cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public boolean isAvailable(SourceMonitor callback) {
+        return true;
+    }
+
+    @Override
+    public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
+        final QueryResponseImpl queryResponse = new QueryResponseImpl(request);
+        try {
+            SourceResponse result = cache.query(request);
+            queryResponse.setHits(result.getHits());
+            queryResponse.setProperties(result.getProperties());
+            queryResponse.addResults(result.getResults(), true);
+        } catch (UnsupportedQueryException e) {
+            queryResponse.getProcessingDetails()
+                    .add(new ProcessingDetailsImpl(getId(), e));
+            queryResponse.closeResultQueue();
+        }
+        return queryResponse;
+    }
+
+    @Override
+    public Set<ContentType> getContentTypes() {
+        return cache.getContentTypes();
+    }
+
+    @Override
+    public String getVersion() {
+        return describableProperties.getProperty("version");
+    }
+
+    @Override
+    public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public String getTitle() {
+        return describableProperties.getProperty("name");
+    }
+
+    @Override
+    public String getDescription() {
+        return describableProperties.getProperty("description");
+    }
+
+    @Override
+    public String getOrganization() {
+        return describableProperties.getProperty("organization");
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -261,8 +261,6 @@
         <argument ref="postFederatedQuerySortedList"/>
         <argument ref="solrCatalogCache"/>
         <argument ref="cacheThreadPool"/>
-        <argument ref="filterAdapter"/>
-        <argument ref="filterBuilder"/>
         <argument ref="validationQueryFactory"/>
         <property name="maxStartIndex" value="50000"/>
     </bean>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/describable.properties
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/describable.properties
@@ -1,0 +1,4 @@
+version=${version}
+description=${description}
+organization=${organization.name}
+name=${artifactId}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SolrCacheSourceTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SolrCacheSourceTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.cache.solr.impl;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import ddf.catalog.data.ContentType;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.source.UnsupportedQueryException;
+
+public class SolrCacheSourceTest {
+
+    private ContentType contentType;
+
+    private QueryRequest queryRequest;
+
+    private SourceResponse sourceResponse;
+
+    private SolrCache solrCache;
+
+    private SolrCacheSource solrCacheSource;
+
+    private List<Result> results;
+
+    @Before
+    public void setup() throws Exception {
+        contentType = mock(ContentType.class);
+        when(contentType.getName()).thenReturn("Content-Type");
+        when(contentType.getVersion()).thenReturn("1.0");
+        when(contentType.getNamespace()).thenReturn(URI.create("http://foo.bar"));
+
+        queryRequest = mock(QueryRequest.class);
+        sourceResponse = mock(SourceResponse.class);
+        when(sourceResponse.getHits()).thenReturn(5L);
+        when(sourceResponse.getProperties()).thenReturn(ImmutableMap.of("key1",
+                "val1",
+                "key2",
+                "val2"));
+        results = IntStream.rangeClosed(1, 5)
+                .mapToObj(i -> mock(Result.class))
+                .collect(Collectors.toList());
+        when(sourceResponse.getResults()).thenReturn(results);
+
+        solrCache = mock(SolrCache.class);
+        when(solrCache.getContentTypes()).thenReturn(ImmutableSet.of(contentType));
+        when(solrCache.query(queryRequest)).thenReturn(sourceResponse);
+
+        solrCacheSource = new SolrCacheSource(solrCache);
+    }
+
+    @Test
+    public void testDescribableProperties() {
+        assertThat(solrCacheSource.getId(), is(SolrCacheSource.class.getName()));
+        assertThat(solrCacheSource.getVersion(), is("1.0-TEST"));
+        assertThat(solrCacheSource.getTitle(), is("SolrCacheSource"));
+        assertThat(solrCacheSource.getDescription(), is("SolrCacheSource Test"));
+        assertThat(solrCacheSource.getOrganization(), is("Codice"));
+    }
+
+    @Test
+    public void testContentTypes() {
+        assertThat(solrCacheSource.getContentTypes(), containsInAnyOrder(contentType));
+    }
+
+    @Test
+    public void goodQuery() throws Exception {
+        SourceResponse queryResponse = solrCacheSource.query(queryRequest);
+        assertThat(queryResponse.getHits(), is(sourceResponse.getHits()));
+        assertThat(queryResponse.getProperties()
+                        .size(),
+                is(sourceResponse.getProperties()
+                        .size()));
+        queryResponse.getProperties()
+                .entrySet()
+                .stream()
+                .forEach(e -> assertThat(e.getValue(),
+                        is(sourceResponse.getProperties()
+                                .get(e.getKey()))));
+
+        assertThat(queryResponse.getResults()
+                        .size(),
+                is(sourceResponse.getResults()
+                        .size()));
+        queryResponse.getResults()
+                .stream()
+                .forEach(r -> assertTrue(sourceResponse.getResults()
+                        .contains(r)));
+    }
+
+    @Test
+    public void badQuery() throws Exception {
+        when(solrCache.query(queryRequest)).thenThrow(new UnsupportedQueryException("Failed"));
+        SourceResponse queryResponse = solrCacheSource.query(queryRequest);
+        assertThat(queryResponse.getProcessingDetails()
+                .size(), greaterThan(0));
+        ProcessingDetails processingDetail = queryResponse.getProcessingDetails()
+                .stream()
+                .filter(ProcessingDetails.class::isInstance)
+                .map(ProcessingDetails.class::cast)
+                .filter(pd -> pd.getSourceId()
+                        .equals(solrCacheSource.getId()))
+                .findFirst()
+                .orElse(null);
+        assertThat(processingDetail, notNullValue());
+        assertThat(processingDetail.getException(), instanceOf(UnsupportedQueryException.class));
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/test/resources/describable.properties
+++ b/catalog/core/catalog-core-standardframework/src/test/resources/describable.properties
@@ -1,0 +1,4 @@
+version=1.0-TEST
+description=SolrCacheSource Test
+organization=Codice
+name=SolrCacheSource

--- a/catalog/core/catalog-core-tagsfilterplugin/pom.xml
+++ b/catalog/core/catalog-core-tagsfilterplugin/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.catalog.core</groupId>
+        <artifactId>core</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog-core-tagsfilterplugin</artifactId>
+    <name>DDF :: Catalog :: Core :: Tags Filter Plugin</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.94</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.98</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.98</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.92</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-tagsfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPlugin.java
+++ b/catalog/core/catalog-core-tagsfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPlugin.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.tagsfilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opengis.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.delegate.TagsFilterDelegate;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PreFederatedQueryPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.source.CatalogProvider;
+import ddf.catalog.source.Source;
+import ddf.catalog.source.UnsupportedQueryException;
+
+/**
+ * When no {@code tags} filter is present on a query, adds a default tag of {@code resource}.
+ * A filter will also be added to include metacards without any tags attribute to support
+ * backwards compatibility.
+ */
+public class TagsFilterQueryPlugin implements PreFederatedQueryPlugin {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TagsFilterQueryPlugin.class);
+
+    private final List<CatalogProvider> catalogProviders;
+
+    private final FilterAdapter filterAdapter;
+
+    private final FilterBuilder filterBuilder;
+
+    public TagsFilterQueryPlugin(List<CatalogProvider> catalogProviders,
+            FilterAdapter filterAdapter, FilterBuilder filterBuilder) {
+        this.catalogProviders = catalogProviders;
+        this.filterAdapter = filterAdapter;
+        this.filterBuilder = filterBuilder;
+    }
+
+    @Override
+    public QueryRequest process(Source source, QueryRequest input)
+            throws PluginExecutionException, StopProcessingException {
+        if (catalogProviders.stream()
+                .noneMatch(cp -> cp.getId()
+                        .equals(source.getId()))) {
+            return input;
+        }
+
+        QueryRequest request = input;
+        try {
+            Query query = request.getQuery();
+            if (filterAdapter.adapt(query, new TagsFilterDelegate())) {
+                return request;
+            }
+
+            List<Filter> filters = new ArrayList<>();
+            //no tags filter given in props or in query. Add the default ones.
+            filters.add(filterBuilder.attribute(Metacard.TAGS)
+                    .is()
+                    .like()
+                    .text(Metacard.DEFAULT_TAG));
+            filters.add(filterBuilder.attribute(Metacard.TAGS)
+                    .empty());
+            Filter newFilter = filterBuilder.allOf(filterBuilder.anyOf(filters), query);
+
+            QueryImpl newQuery = new QueryImpl(newFilter,
+                    query.getStartIndex(),
+                    query.getPageSize(),
+                    query.getSortBy(),
+                    query.requestsTotalResultsCount(),
+                    query.getTimeoutMillis());
+            request = new QueryRequestImpl(newQuery,
+                    request.isEnterprise(),
+                    request.getSourceIds(),
+                    request.getProperties());
+        } catch (UnsupportedQueryException uqe) {
+            LOGGER.error("Unable to update query with default tags filter");
+        }
+        return request;
+    }
+}

--- a/catalog/core/catalog-core-tagsfilterplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-tagsfilterplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="catalogProviderSortedList" class="ddf.catalog.util.impl.SortedServiceList"/>
+
+    <reference-list id="catalogProviders" interface="ddf.catalog.source.CatalogProvider"
+                    availability="optional">
+        <reference-listener
+                ref="catalogProviderSortedList"
+                bind-method="bindPlugin"
+                unbind-method="unbindPlugin"/>
+    </reference-list>
+
+    <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
+
+    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+
+    <bean id="tagsFilterPlugin"
+          class="org.codice.ddf.catalog.plugin.tagsfilter.TagsFilterQueryPlugin">
+        <argument ref="catalogProviderSortedList"/>
+        <argument ref="filterAdapter"/>
+        <argument ref="filterBuilder"/>
+    </bean>
+
+    <service ref="tagsFilterPlugin" interface="ddf.catalog.plugin.PreFederatedQueryPlugin"/>
+</blueprint>

--- a/catalog/core/catalog-core-tagsfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPluginTest.java
+++ b/catalog/core/catalog-core-tagsfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPluginTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.tagsfilter;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.filter.And;
+import org.opengis.filter.Filter;
+import org.opengis.filter.Or;
+
+import com.google.common.collect.ImmutableList;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.filter.AttributeBuilder;
+import ddf.catalog.filter.ContextualExpressionBuilder;
+import ddf.catalog.filter.ExpressionBuilder;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.source.CatalogProvider;
+import ddf.catalog.source.Source;
+
+public class TagsFilterQueryPluginTest {
+    private TagsFilterQueryPlugin plugin;
+
+    private QueryRequest queryRequest;
+
+    private Source source;
+
+    private FilterAdapter filterAdapter;
+
+    private FilterBuilder filterBuilder;
+
+    private Query query;
+
+    @Before
+    public void setup() {
+        CatalogProvider catProvider1 = mock(CatalogProvider.class);
+        CatalogProvider catProvider2 = mock(CatalogProvider.class);
+        CatalogProvider catProvider3 = mock(CatalogProvider.class);
+        when(catProvider1.getId()).thenReturn("cat1");
+        when(catProvider2.getId()).thenReturn("cat2");
+        when(catProvider3.getId()).thenReturn("cat3");
+
+        ImmutableList<CatalogProvider> catalogProviders = ImmutableList.of(catProvider1,
+                catProvider2,
+                catProvider3);
+        filterAdapter = mock(FilterAdapter.class);
+        filterBuilder = mock(FilterBuilder.class);
+
+        plugin = new TagsFilterQueryPlugin(catalogProviders, filterAdapter, filterBuilder);
+
+        source = mock(Source.class);
+        when(source.getId()).thenReturn("cat2");
+
+        queryRequest = mock(QueryRequest.class);
+        query = mock(Query.class);
+        when(queryRequest.getQuery()).thenReturn(query);
+    }
+
+    @Test
+    public void notACatalogProvider() throws Exception {
+        when(source.getId()).thenReturn("not a catalog provider");
+        QueryRequest process = plugin.process(source, queryRequest);
+
+        assertThat(process, is(queryRequest));
+        verify(filterAdapter, never()).adapt(any(), any());
+    }
+
+    @Test
+    public void adapterTrue() throws Exception {
+        when(filterAdapter.adapt(any(), any())).thenReturn(true);
+        QueryRequest process = plugin.process(source, queryRequest);
+
+        assertThat(process, is(queryRequest));
+        verify(filterBuilder, never()).attribute(anyString());
+    }
+
+    @Test
+    public void addTags() throws Exception {
+        AttributeBuilder attributeBuilder = mock(AttributeBuilder.class);
+        ExpressionBuilder expressionBuilder = mock(ExpressionBuilder.class);
+        ContextualExpressionBuilder contextualExpressionBuilder =
+                mock(ContextualExpressionBuilder.class);
+        Filter emptyFilter = mock(Filter.class);
+        Filter defaultTagFilter = mock(Filter.class);
+
+        when(attributeBuilder.empty()).thenReturn(emptyFilter);
+        when(attributeBuilder.is()).thenReturn(expressionBuilder);
+        when(expressionBuilder.like()).thenReturn(contextualExpressionBuilder);
+        when(contextualExpressionBuilder.text(Metacard.DEFAULT_TAG)).thenReturn(defaultTagFilter);
+        Or anyOf = mock(Or.class);
+        when(filterBuilder.anyOf(ImmutableList.of(defaultTagFilter, emptyFilter))).thenReturn(anyOf);
+        when(filterBuilder.allOf(anyOf, query)).thenReturn(mock(And.class));
+
+        when(filterAdapter.adapt(any(), any())).thenReturn(false);
+        when(filterBuilder.attribute(Metacard.TAGS)).thenReturn(attributeBuilder);
+        QueryRequest process = plugin.process(source, queryRequest);
+
+        assertThat(process, not(queryRequest));
+    }
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -118,5 +118,6 @@
         <module>catalog-core-attribute-registry</module>
         <module>catalog-core-defaultvalues</module>
         <module>catalog-core-resourcestatusplugin</module>
+        <module>catalog-core-tagsfilterplugin</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?

Also moves the addition of the default filter tag to a new `PreFederatedQueryPlugin` now that it can take advantage of the existance of the new Source.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@rzwiefel @clockard @tbatie @kcwire 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
Full build and test. Execute queries with and without tag filters.

#### Any background context you want to provide?
We have been adding properties to queries and updating the `CachingFederationStrategy` with branching logic based on those properties instead of creating `PreFederatedQueryPlugin`s to isolate that work. By adding the new `SolrCacheSource` we can stop corrupting the strategy's code.

#### What are the relevant tickets?
DDF-1940

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
