### PR TITLE
DDF-2289 Gracefully handle null/empty metadata in schematron validator

### DIFF
--- a/catalog/schematron/catalog-schematron-plugin/pom.xml
+++ b/catalog/schematron/catalog-schematron-plugin/pom.xml
@@ -13,7 +13,9 @@
  **/
 
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>catalog-schematron-pom</artifactId>
@@ -48,6 +50,10 @@
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -34,6 +34,7 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.platform.util.XMLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,11 +234,8 @@ public class SchematronValidationService implements MetacardValidator, Describab
     public void validate(Metacard metacard) throws ValidationException {
         for (Templates validator : validators) {
             String metadata = metacard.getMetadata();
-            if (metadata == null) {
-                throw new SchematronValidationException(
-                        "The Metacard.METADATA attribute must not be null to run schematron validation against the Metacard");
-            }
-            if (namespace != null && !namespace.equals(XMLUtils.getRootNamespace(metadata))) {
+            if (StringUtils.isEmpty(metadata) || (namespace != null
+                    && !namespace.equals(XMLUtils.getRootNamespace(metadata)))) {
                 return;
             }
             schematronReport = generateReport(metadata, validator);
@@ -275,11 +273,13 @@ public class SchematronValidationService implements MetacardValidator, Describab
 
     /**
      * Replace tabs, literal carriage returns, and newlines with a single whitespace
+     *
      * @param input
      * @return
      */
     static String sanitize(final String input) {
-        return input.replaceAll("[\t \r\n]+", " ").trim();
+        return input.replaceAll("[\t \r\n]+", " ")
+                .trim();
     }
 
     @Override

--- a/catalog/schematron/catalog-schematron-plugin/src/test/java/ddf/services/schematron/SchematronValidationServiceTest.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/test/java/ddf/services/schematron/SchematronValidationServiceTest.java
@@ -65,6 +65,17 @@ public class SchematronValidationServiceTest {
         getService("dog_legs.sch").validate(getMetacard("dog_4leg_3paw.xml"));
     }
 
+    @Test
+    public void testNullorEmptyMetadata()
+            throws ValidationException, IOException, SchematronInitializationException {
+        MetacardImpl card = new MetacardImpl();
+        SchematronValidationService service = getService("dog_legs.sch");
+        service.validate(card);
+        card.setMetadata("");
+        service.validate(card);
+        assertThat("No exceptions were thrown validating null/empty metadata", true, is(true));
+    }
+
     @Test(expected = ValidationException.class)
     public void testMultipleSchematron()
             throws ValidationException, IOException, SchematronInitializationException {
@@ -200,8 +211,7 @@ public class SchematronValidationServiceTest {
     public void testSanitizationChangesNothing() {
         String str = "ontattoinewerunfromsandpeople";
         // verify that nothing changes
-        assertThat(str,
-                is(SchematronValidationService.sanitize(str)));
+        assertThat(str, is(SchematronValidationService.sanitize(str)));
         str = "princess leia";
         // verify that nothing changes again
         assertThat(str, is(SchematronValidationService.sanitize(str)));


### PR DESCRIPTION
#### What does this PR do?
Fix schematron marking null/empty metadata as invalid, potentially causing it to get lost from ingest/query.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@spearskw @djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
#### How should this be tested?
Create an enforced schematron validator configuration, then verify that it is still possible to ingest metacards with null/empty metadata.
#### Any background context you want to provide?
This issue was discovered while playing with the new catalog search ui. Attempting to store workspace data was failing when an enforced schematron validator was configured.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2289
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

