### PR TITLE
DDF-2290 updated hardcoded dependency on commons-collection to use pr…

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -278,7 +278,7 @@
         <bundle>
             mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${cxf.xpp3.bundle.version}
         </bundle>
-        <bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle>mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
     </feature>
 
     <feature name="catalog-transformer-zip" install="auto" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
Remove dependency on excluded version of commons-collections v3.2.1 which has been excluded from distro packaging due to vulnerabilties
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@beyelerb @bdeining @Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris 
#### How should this be tested?
As this only exhibited symptoms on a windows host not connected to the internet, recommend testing the fix in the same environment.  

Unzip, start ddf, install standard set of apps.  Verify the all apps install/start and no errors are reported for missing commons-collections jar.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2290
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…operty in root pom