### PR TITLE
DDF-2293: Invalid caching status reported to user due to resource cac…

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -311,12 +311,6 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(Metacard.RESOURCE_CACHE_STATUS,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BOOLEAN_TYPE));
         return descriptors;
     }
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/Metacard.java
@@ -237,12 +237,6 @@ public interface Metacard extends Serializable {
     String DERIVED_RESOURCE_DOWNLOAD_URL = "resource.derived-download-url";
 
     /**
-     * {@link Attribute} name for accessing the resources cache status for the products of this
-     * {@link Metacard}. <br/>
-     */
-    String RESOURCE_CACHE_STATUS = "resource.cached";
-
-    /**
      * Returns {@link Attribute} for given attribute name.
      *
      * @param name name of attribute

--- a/catalog/core/catalog-core-resourcestatusplugin/pom.xml
+++ b/catalog/core/catalog-core-resourcestatusplugin/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -66,7 +71,8 @@
                             notifications,
                             activities,
                             hazelcast;scope=runtime|compile,
-                            catalog-core-api-impl;scope=!test
+                            catalog-core-api-impl;scope=!test,
+                            common-system
                         </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.cache.impl,
@@ -96,22 +102,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.97</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>1.00</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-resourcestatusplugin/src/main/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatus.java
+++ b/catalog/core/catalog-core-resourcestatusplugin/src/main/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatus.java
@@ -14,7 +14,10 @@
 package ddf.catalog.core.resourcestatus.metacard;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
+import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +43,10 @@ public class MetacardResourceStatus implements PostQueryPlugin {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetacardResourceStatus.class);
 
+    private static final String INTERNAL_LOCAL_RESOURCE = "internal.local-resource";
+
+    private static final String LOCAL_CONTENT_SCHEME = "content:";
+
     private ResourceCacheInterface cache;
 
     public MetacardResourceStatus(ResourceCacheInterface cache) {
@@ -53,29 +60,69 @@ public class MetacardResourceStatus implements PostQueryPlugin {
 
         results.stream()
                 .map(Result::getMetacard)
-                .filter(metacard -> metacard != null)
-                .forEach(this::addResourceCachedAttribute);
+                .filter(Objects::nonNull)
+                .forEach(this::addResourceLocalAttribute);
 
         return input;
     }
 
-    private void addResourceCachedAttribute(Metacard metacard) {
-        metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_CACHE_STATUS,
-                isResourceCached(metacard, new ResourceRequestById(metacard.getId()))));
+    private void addResourceLocalAttribute(Metacard metacard) {
+        boolean isResourceLocal = false;
+        if (!hasResourceUri(metacard)) {
+            isResourceLocal = false;
+        } else {
+            isResourceLocal = isResourceLocal(metacard);
+        }
+        metacard.setAttribute(
+                new AttributeImpl(INTERNAL_LOCAL_RESOURCE, isResourceLocal));
     }
 
+    private boolean isResourceLocal(Metacard metacard) {
+        return (doesSourceIdMatchLocalSiteName(metacard) && isResourceUriLocal(metacard))
+                || isResourceCached(metacard, new ResourceRequestById(metacard.getId()));
+    }
+    
     private boolean isResourceCached(Metacard metacard, ResourceRequest resourceRequest) {
         String key = getCacheKey(metacard, resourceRequest);
-
         ReliableResource cachedResource = (ReliableResource) cache.getValid(key, metacard);
-        if (cachedResource != null) {
-            return true;
+        return cachedResource != null;
+    }
+
+    private boolean hasResourceUri(Metacard metacard) {
+        Optional<String> resourceUri = Optional.ofNullable(metacard.getResourceURI())
+                .map(uri -> uri.toString());
+        return resourceUri.isPresent();
+    }
+
+    private boolean isResourceUriLocal(Metacard metacard) {
+        return hasResourceUri(metacard) && metacard.getResourceURI()
+                .toString()
+                .startsWith(LOCAL_CONTENT_SCHEME);
+    }
+
+    private boolean doesSourceIdMatchLocalSiteName(Metacard metacard) {
+        Optional<String> sourceId = Optional.ofNullable(metacard.getSourceId());
+
+        if (sourceId.isPresent()) {
+            String sourceIdLowerCase = sourceId.get()
+                    .toLowerCase();
+            return sourceIdLowerCase.equals(getLocalSiteName());
+        } else {
+            LOGGER.warn(
+                    "Unable to determine if the source id in metacard {} matches the local site name because the " +
+                    " metacard did not contain a source id attribute.",
+                    metacard.getId());
+            return false;
         }
-        return false;
     }
 
     private String getCacheKey(Metacard metacard, ResourceRequest resourceRequest) {
         CacheKey cacheKey = new CacheKey(metacard, resourceRequest);
         return cacheKey.generateKey();
+    }
+
+    String getLocalSiteName() {
+        return SystemInfo.getSiteName()
+                .toLowerCase();
     }
 }

--- a/catalog/core/catalog-core-resourcestatusplugin/src/test/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatusTest.java
+++ b/catalog/core/catalog-core-resourcestatusplugin/src/test/java/ddf/catalog/core/resourcestatus/metacard/MetacardResourceStatusTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,12 +40,29 @@ import ddf.catalog.resource.data.ReliableResource;
 
 public class MetacardResourceStatusTest {
 
+    private static final String INTERNAL_LOCAL_RESOURCE = "internal.local-resource";
+
+    private static final String LOCAL_SITE_NAME = "local-ddf";
+
+    private static final String REMOTE_SITE_NAME = "remote-ddf";
+
+    private static final String CONTENT_RESOURCE_URI = "content:f74e48380d9347b28a6b4fd88ffe024b";
+
+    private static final String REMOTE_RESOURCE_URI = "https://remote-ddf:20002/services/catalog/sources/ddf.distribution/ce4de61db5da46bdbf6dad8fe6394663?transform=resource";
+
+    private static final String METACARD_ID = "f74e48380d9347b28a6b4fd88ffe024b";
+
+    private static final String RESOURCE_SIZE = "354";
+
     @Mock
     private ResourceCacheInterface cache;
+
     @Mock
     private ReliableResource cachedResource;
+
     @Mock
     private QueryResponse queryResponse;
+
     @Mock
     private MetacardImpl basicMetacard;
 
@@ -52,54 +71,163 @@ public class MetacardResourceStatusTest {
         MockitoAnnotations.initMocks(this);
     }
 
+    /**
+     * Metacard source id is local, Metacard contains no resource uri, Metacard resource is not cached
+     */
     @Test
-    public void testMetacardDisplaysCachedProduct() throws Exception {
-
-        setupCachedMock(getBasicMetacard());
-
-        MetacardResourceStatus plugin = new MetacardResourceStatus(cache);
-
-        Attribute resourceStatusAttribute = getReourceStatusAttribute(plugin.process(queryResponse));
-
-        assertThat(resourceStatusAttribute.getValue(), is(true));
-    }
-
-    @Test
-    public void testMetacardDisplaysNonCachedProduct() throws Exception {
-        setupNonCachedMock(getBasicMetacard());
-
-        MetacardResourceStatus plugin = new MetacardResourceStatus(cache);
-        QueryResponse queryResponse = plugin.process(this.queryResponse);
-
-        Attribute resourceStatusAttribute = getReourceStatusAttribute(plugin.process(queryResponse));
-
+    public void testMetacardResourceIsNotLocal1() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(LOCAL_SITE_NAME, null));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
         assertThat(resourceStatusAttribute.getValue(), is(false));
     }
 
-    private MetacardImpl getBasicMetacard() {
-        MetacardImpl metacard = new MetacardImpl();
-        metacard.setId("abc123");
-        metacard.setSourceId("ddf-1");
-        metacard.setResourceSize("N/A");
+    /**
+     * Metacard source id is local, Metacard contains remote resource uri, Metacard resource is not
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsNotLocal2() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(LOCAL_SITE_NAME, REMOTE_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(false));
+    }
 
+    /**
+     * Metacard source id is remote, Metacard contains content resource uri, Metacard resource is not
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsNotLocal3() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(REMOTE_SITE_NAME, CONTENT_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(false));
+    }
+
+    /**
+     * Metacard source id is remote, Metacard contains remote resource uri, Metacard resource is not
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsNotLocal4() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(REMOTE_SITE_NAME, REMOTE_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(false));
+    }
+
+    /**
+     * Metacard contains no source id, Metacard contains remote resource uri, Metacard resource is not
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsNotLocal5() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(null, REMOTE_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(false));
+    }
+
+    /**
+     * Metacard source id is local, Metacard contains content resource uri, Metacard resource is not
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsLocal1() throws Exception {
+        setupCache(false);
+        setupSingleResultResponseMock(getBasicMetacard(LOCAL_SITE_NAME, CONTENT_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(true));
+    }
+
+    /**
+     * Metacard source id is local, Metacard contains remote resource uri, Metacard resource is cached
+     */
+    @Test
+    public void testMetacardResourceIsLocal2() throws Exception {
+        setupCache(true);
+        setupSingleResultResponseMock(getBasicMetacard(LOCAL_SITE_NAME, REMOTE_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(true));
+    }
+
+    /**
+     * Metacard source id is remote, Metacard contains content resource uri, Metacard resource is
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsLocal3() throws Exception {
+        setupCache(true);
+        setupSingleResultResponseMock(getBasicMetacard(REMOTE_SITE_NAME, CONTENT_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(true));
+    }
+
+    /**
+     * Metacard source id is remote, Metacard contains remote resource uri, Metacard resource is
+     * cached
+     */
+    @Test
+    public void testMetacardResourceIsLocal4() throws Exception {
+        setupCache(true);
+        setupSingleResultResponseMock(getBasicMetacard(REMOTE_SITE_NAME, REMOTE_RESOURCE_URI));
+        MetacardResourceStatus plugin = getMetacardResourceStatusPlugin();
+        Attribute resourceStatusAttribute = getInternalLocalResurceAttribute(
+                plugin.process(queryResponse));
+        assertThat(resourceStatusAttribute.getValue(), is(true));
+    }
+
+    private MetacardImpl getBasicMetacard(String sourceId, String resourceUri)
+        throws URISyntaxException {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId(METACARD_ID);
+        if (sourceId != null) {
+            metacard.setSourceId(sourceId);
+        }
+        metacard.setResourceSize(RESOURCE_SIZE);
+        if (resourceUri != null) {
+            metacard.setResourceURI(new URI(resourceUri));
+        }
         return metacard;
     }
 
-    private void setupCachedMock(MetacardImpl metacard) {
-        when(cachedResource.getSize()).thenReturn(999L);
-        when(cachedResource.hasProduct()).thenReturn(true);
-        when(cache.getValid(anyString(), anyObject())).thenReturn(cachedResource);
+    private MetacardResourceStatus getMetacardResourceStatusPlugin() {
+        MetacardResourceStatus plugin = new MetacardResourceStatus(cache) {
+            @Override
+            String getLocalSiteName() {
+                return LOCAL_SITE_NAME;
+            }
+        };
 
-        setupSingleResultResponseMock(metacard);
+        return plugin;
     }
 
-    private void setupNonCachedMock(MetacardImpl metacard) {
-
-        when(cachedResource.getSize()).thenReturn(0L);
-        when(cachedResource.hasProduct()).thenReturn(false);
-        when(cache.getValid(anyString(), anyObject())).thenReturn(null);
-
-        setupSingleResultResponseMock(metacard);
+    private void setupCache(boolean isResourceCached) {
+        when(cachedResource.getSize()).thenReturn(999L);
+        when(cachedResource.hasProduct()).thenReturn(true);
+        if (isResourceCached) {
+            when(cache.getValid(anyString(), anyObject())).thenReturn(cachedResource);
+        } else {
+            when(cache.getValid(anyString(), anyObject())).thenReturn(null);
+        }
     }
 
     private void setupSingleResultResponseMock(MetacardImpl metacard) {
@@ -110,10 +238,10 @@ public class MetacardResourceStatusTest {
         when(queryResponse.getResults()).thenReturn(results);
     }
 
-    private Attribute getReourceStatusAttribute(QueryResponse queryResponse) {
+    private Attribute getInternalLocalResurceAttribute(QueryResponse queryResponse) {
         Metacard resultMetacard = queryResponse.getResults()
                 .get(0)
                 .getMetacard();
-        return resultMetacard.getAttribute(Metacard.RESOURCE_CACHE_STATUS);
+        return resultMetacard.getAttribute(INTERNAL_LOCAL_RESOURCE);
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
@@ -72,8 +72,7 @@ class CachedResourceMetacardComparator {
             Metacard.EFFECTIVE,
             Metacard.CREATED,
             Metacard.EXPIRATION,
-            Metacard.CONTENT_TYPE,
-            Metacard.RESOURCE_CACHE_STATUS);
+            Metacard.CONTENT_TYPE);
 
     private CachedResourceMetacardComparator() {
     }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
@@ -75,13 +75,6 @@ public class CachedResourceMetacardComparatorTest {
     }
 
     @Test
-    public void isSameMetacardWithDifferentResourceCacheStatus() {
-        updatedMetacard.setAttribute(Metacard.RESOURCE_CACHE_STATUS, Boolean.TRUE);
-
-        assertThat(isSame(cachedMetacard, updatedMetacard), is(true));
-    }
-
-    @Test
     public void isSameWhenBothMetacardTypesNull() {
         cachedMetacard.setType(null);
         updatedMetacard.setType(null);
@@ -293,7 +286,6 @@ public class CachedResourceMetacardComparatorTest {
                 deriverResourceUrl));
         metacard.setAttribute(new AttributeImpl(Metacard.DERIVED_RESOURCE_URI, derivedResourceUri));
         metacard.setAttribute(new AttributeImpl(Metacard.RELATED, "otherMetacardId"));
-        metacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_CACHE_STATUS, Boolean.FALSE));
         return metacard;
     }
 }

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/model/Search.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/model/Search.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
@@ -101,6 +102,10 @@ public class Search {
     public static final String ELAPSED = "elapsed";
 
     public static final String CACHED = "cached";
+
+    private static final String INTERNAL_LOCAL_RESOURCE = "internal.local-resource";
+
+    private static final String IS_RESOURCE_LOCAL = "is-resource-local";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Search.class);
 
@@ -360,6 +365,11 @@ public class Search {
         } else {
             metacard.put(CACHED, ISO_8601_DATE_FORMAT.print(new DateTime()));
         }
+
+        metacard.put(IS_RESOURCE_LOCAL, Optional.ofNullable(result.getMetacard()
+                .getAttribute(INTERNAL_LOCAL_RESOURCE))
+                .map(Attribute::getValue)
+                .orElse(Boolean.FALSE));
 
         addObject(transformedResult, METACARD, metacard);
 

--- a/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/integrating-contents.adoc
@@ -831,7 +831,7 @@ The response is returned as a data map that contains an internal map with the fo
 |GeoJson-formatted value
 |This format is defined by the GeoJSON Metacard Transformer.
 
-|results/metacard/properties/resource.cached
+|results/metacard/is-resource-local
 |A property indicating whether a metacard's associated resource is cached
 |Boolean
 |true, false
@@ -892,61 +892,70 @@ The response is returned as a data map that contains an internal map with the fo
 [source,json,xml]
 ----
 {
-    "data": {
-        "hits": 1,
-        "metacard-types": {
-            "ddf.metacard": {...}
-        },
-        "id": "857f76c0-da8c-72f5-09cd-536b69e427af",
-        "results": [
-           {
-                "metacard": {
-                    "cached": "2016-06-09T22:46:57.258+0000",
-                    "geometry": {
-                        "coordinates": [
-                            -97.03125,
-                            35.173808
-                        ],
-                        "type": "Point"
-                    },
-                    "type": "Feature",
-                    "actions": [ ... ],
-                    "properties": {
-                        "thumbnail": "..."
-                        "metadata": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><metadata> ... </metadata>",
-                        "resource-size": "92314",
-                        "created": "2016-06-09T22:46:37.707+0000",
-                        "metacard-tags": [
-                            "resource"
-                        ],
-                        "resource-uri": "content:1a83781dd56a4050afc420016d078e22",
-                        "checksum-algorithm": "Adler32",
-                        "metadata-content-type": "image/jpeg",
-                        "metacard-type": "ddf.metacard",
-                        "title": "fixTheBugs_geotagged.jpg",
-                        "resource-download-url": "${secure_url}services/catalog/sources/ddf.distribution/1a83781dd56a4050afc420016d078e22?transform=resource",
-                        "source-id": "ddf.distribution",
-                        "effective": "2016-06-09T22:46:37.707+0000",
-                        "point-of-contact": "",
-                        "checksum": "edfa1836",
-                        "modified": "2016-06-09T22:46:37.707+0000",
-                        "id": "1a83781dd56a4050afc420016d078e22"
-                    }
-                }
+   "data": {
+      "hits": 1,
+      "metacard-types": {
+         "ddf.metacard": {...}
+      },
+      "id": "6f0e04e9-acd1-4935-b9dd-c83e770a36d5",
+      "results": [
+         {
+            "metacard": {
+               "is-resource-local": false,
+               "cached": "2016-07-13T19:22:18.220+0000",
+               "geometry": {
+                  "coordinates": [
+                     -84.415337,
+                     42.729925
+                  ],
+                  "type": "Point"
+               },
+               "type": "Feature",
+               "actions": [...],
+               "properties": {
+                  "thumbnail": "...",
+                  "metadata": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><metadata>...</metadata>",
+                  "resource-size": "362417",
+                  "created": "2010-06-10T12:07:26.000+0000",
+                  "resource-uri": "content:faade630a2a247468ca9a9b57303b437",
+                  "metacard-tags": [
+                     "resource"
+                  ],
+                  "checksum-algorithm": "Adler32",
+                  "metadata-content-type": "image/jpeg",
+                  "metacard-type": "ddf.metacard",
+                  "resource-download-url": "${secure_url}services/catalog/sources/ddf.distribution/faade630a2a247468ca9a9b57303b437?transform=resource",
+                  "title": "example.jpg",
+                  "source-id": "ddf.distribution",
+                  "effective": "2016-07-13T19:22:06.966+0000",
+                  "point-of-contact": "",
+                  "checksum": "dc7337c5",
+                  "modified": "2010-06-10T12:07:26.000+0000",
+                  "id": "faade630a2a247468ca9a9b57303b437"
+               }
             }
-        ],
-        "status": [
-           {
-                "hits": 1,
-                "elapsed": 432,
-                "reasons": [],
-                "id": "ddf.distribution",
-                "state": "SUCCEEDED",
-                "results": 1
-            }
-        ],
-        "successful": true
-    },
-    "channel": "/857f76c0-da8c-72f5-09cd-536b69e427af"
+         }
+      ],
+      "status": [
+         {
+            "hits": 1,
+            "elapsed": 453,
+            "reasons": [],
+            "id": "ddf.distribution",
+            "state": "SUCCEEDED",
+            "results": 1
+         }
+      ],
+      "successful": true
+   },
+   "channel": "/6f0e04e9-acd1-4935-b9dd-c83e770a36d5"
+},
+{
+   "successful": true
+},
+{
+   "channel": "/service/query",
+   "id": "142",
+   "successful": true
 }
 ----

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -964,49 +964,6 @@ public class TestCatalog extends AbstractIntegrationTest {
         deleteMetacard(metacardId);
     }
 
-    @Test
-    public void testGetMetacardResourceStatusNotCached()
-            throws IOException, XPathExpressionException {
-        String fileName = testName.getMethodName() + ".txt";
-        String metacardId = ingestXmlWithProduct(fileName);
-
-        String productDirectory = new File(fileName).getAbsoluteFile()
-                .getParent();
-        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
-                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
-
-        String url = REST_PATH.getUrl() + "sources/ddf.distribution/" + metacardId;
-        String resourceCachedXpath = String.format("//*[@name='%s']/*/text()",
-                Metacard.RESOURCE_CACHE_STATUS);
-
-        get(url).then()
-                .body(hasXPath(resourceCachedXpath, is("false")));
-
-        deleteMetacard(metacardId);
-    }
-
-    @Test
-    public void testGetMetacardResourceStatusCached() throws IOException, XPathExpressionException {
-        String fileName = testName.getMethodName() + ".txt";
-        String metacardId = ingestXmlWithProduct(fileName);
-
-        String productDirectory = new File(fileName).getAbsoluteFile()
-                .getParent();
-        urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
-                DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory});
-
-        String url = REST_PATH.getUrl() + "sources/ddf.distribution/" + metacardId;
-        String resourceCachedXpath = String.format("//*[@name='%s']/*/text()",
-                Metacard.RESOURCE_CACHE_STATUS);
-
-        get(url + "?transform=resource").then();
-
-        get(url).then()
-                .body(hasXPath(resourceCachedXpath, is("true")));
-
-        deleteMetacard(metacardId);
-    }
-
     private void verifyGetRecordByIdResponse(final ValidatableResponse response,
             final String... ids) {
         final String xPathGetRecordWithId = "//GetRecordByIdResponse/Record[identifier=\"%s\"]";


### PR DESCRIPTION
#### What does this PR do?
Removes the `resource.cached` attribute from the `Metacard` interface. A new attribute `internal.local-resource` is added to each metacard in the `MetacardResourceStatus` `PostQueryPlugin` which reflects the cache status of resources associated with metacards.  When performing a query via the search endpoint, each metacard result has the attribute `is-resource-local` which indicates its cache status.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann 
@oconnormi
@lessarderic 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@pklinef 
#### How should this be tested?
Hero build. Manually testing will require two DDFs.
1) Setup DDF1 with an opensearch federated source pointing to DDF2.
2) Upload image2 to DDF2.
3) Perform an enterprise query on DDF1.
4) Capture the cometd query response on DDF1 and verify that the is-resource-local attribute is set to false for the metacard associated with image2.
5) Download the resource on DDF1 (image2).  
6) Perform another enterprise query on DDF1.
7) Capture the cometd query response on DDF1 and verify that the is-resource-local attribute is set to true for the metacard associated with image2.


#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2293
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…hing flag being set as a basic type metacard attribute