### PR TITLE
DDF-2267 Registry UI to Display All Nodes

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/java/org/codice/ddf/registry/admin/plugin/RegistryPlugin.java
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/java/org/codice/ddf/registry/admin/plugin/RegistryPlugin.java
@@ -26,7 +26,7 @@ public class RegistryPlugin extends AbstractApplicationPlugin {
      * Constructor.
      */
     public RegistryPlugin() {
-        this.displayName = "Local Node Information";
+        this.displayName = "Node Information";
         this.iframeLocation = URI.create("/admin/registry/local/index.html");
         List<String> apps = new ArrayList<>();
         apps.add("registry-app");

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/FieldDescriptors.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/FieldDescriptors.js
@@ -66,10 +66,10 @@ define(['underscore'], function (_) {
             _.each(custom, function(field){
                     base[field.key] = field;
                     base[field.key].isSlot = _.isUndefined(field.isSlot)? true : field.isSlot;
-                    if(field.constructTitle){
+                    if(field.constructTitle &&  typeof field.constructTitle !== 'function' ){
                         base[field.key].constructTitle = that[field.constructTitle];
                     }
-                    if(field.autoPopulateFunction){
+                    if(field.autoPopulateFunction &&  typeof field.autoPopulateFunction !== 'function'){
                         base[field.key].autoPopulateFunction = that[field.autoPopulateFunction];
                     }
 

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
@@ -223,7 +223,7 @@ define([
 
     Node.Models = Backbone.Collection.extend({
         model: Node.Model,
-        url: '/admin/jolokia/read/org.codice.ddf.registry:type=FederationAdminMBean/LocalNodes',
+        url: '/admin/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/allRegistryMetacards',
         deleteUrl: '/admin/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/deleteLocalEntry',
 
         parse: function (raw) {
@@ -246,6 +246,12 @@ define([
                 return array[0];
             }
             return undefined;
+        },
+        getRemoteNodes: function(){
+            return this.models.filter(function(model){
+                var transValues = model.get('TransientValues');
+                return !transValues || (!transValues['registry-identity-node'] && !transValues['registry-local-node']);
+            });
         },
         deleteNodes: function (nodes) {
             var mbean = 'org.codice.ddf.registry:type=FederationAdminMBean';

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
@@ -250,7 +250,7 @@ define([
         getRemoteNodes: function(){
             return this.models.filter(function(model){
                 var transValues = model.get('TransientValues');
-                return !transValues || (!transValues['registry-identity-node'] && !transValues['registry-local-node']);
+                return !transValues || !transValues['registry-local-node'];
             });
         },
         deleteNodes: function (nodes) {

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Association.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Association.view.js
@@ -38,8 +38,21 @@ define([
             events: {
                 "click .remove-association": 'removeAssociation'
             },
+            initialize: function(options) {
+                this.readOnly = options.readOnly;
+            },
             removeAssociation: function () {
                 wreqr.vent.trigger('removeAssociation:' + this.model.get('sourceId'), this.model.get('id'));
+            },
+            serializeData: function() {
+                var data = {};
+
+                if (this.model) {
+                    data = this.model.toJSON();
+                }
+                data.readOnly = this.readOnly;
+
+                return data;
             }
         });
         Association.AssociationCollectionView = Marionette.CompositeView.extend({
@@ -50,6 +63,7 @@ define([
                 "click .add-association": 'addAssociation'
             },
             initialize: function (options) {
+                this.readOnly = options.readOnly;
                 this.parentId = options.parentId;
                 this.simpleId = this.parentId.split(':').join('-');
                 this.listenTo(wreqr.vent, 'removeAssociation:' + this.parentId, this.removeAssociation);
@@ -66,6 +80,7 @@ define([
                 var data = {};
                 data.availableAssociation = this.model.getAvailableAssociationSegments(this.parentId);
                 data.simpleId = this.simpleId;
+                data.readOnly = this.readOnly;
                 return data;
             },
             removeAssociation: function (associationId) {
@@ -98,6 +113,13 @@ define([
                     trigger: 'hover'
                 };
                 view.$(selector).popover(options);
+            },
+            buildItemView: function (item, ItemViewType, itemViewOptions) {
+                var options = _.extend({
+                    model: item,
+                    readOnly: this.readOnly
+                }, itemViewOptions);
+                return new ItemViewType(options);
             }
 
 

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/CustomizableField.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/CustomizableField.view.js
@@ -37,7 +37,8 @@ define([
             events: {
                 "click .add-custom-field": 'addField'
             },
-            initialize: function () {
+            initialize: function (options) {
+                this.readOnly = options.readOnly;
                 this.listenTo(wreqr.vent, 'removeField:' + this.model.get('segmentId'), this.removeField);
             },
             onRender: function () {
@@ -47,7 +48,8 @@ define([
                     });
                 this.customFieldsRegion.show(new Field.FieldCollectionView({
                     collection: new Backbone.Collection(customFields),
-                    parentId: this.model.get("segmentId")
+                    parentId: this.model.get("segmentId"),
+                    readOnly: this.readOnly
                 }));
             },
             addField: function (event) {
@@ -88,6 +90,7 @@ define([
                     data = this.model.toJSON();
                 }
                 data.customFieldError = this.customFieldError;
+                data.readOnly = this.readOnly;
                 return data;
             }
         });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
@@ -42,7 +42,8 @@ define([
                 "change:error": "showHideError",
                 "change": "fieldChanged"
             },
-            initialize: function () {
+            initialize: function (options) {
+                this.readOnly = options.readOnly;
                 this.modelBinder = new Backbone.ModelBinder();
                 if(this.model.get('inlineGroup')){
                     this.$el.css('display','inline-block');
@@ -81,6 +82,9 @@ define([
                     data = this.model.toJSON();
                     data.validationError = this.model.get('error');
                     data.errorIndices = this.model.errorIndices;
+                    if (this.readOnly) {
+                        data.editable = false;
+                    }
                 }
                 return data;
             },
@@ -93,6 +97,7 @@ define([
             itemView: Field.FieldView,
             tagName: 'tr',
             initialize: function (options) {
+                this.readOnly = options.readOnly;
                 this.listenTo(wreqr.vent, 'addedField:' + options.parentId, this.addedField);
                 this.listenTo(wreqr.vent, 'removedField:' + options.parentId, this.removedField);
 
@@ -100,7 +105,8 @@ define([
             buildItemView: function (item, ItemViewType, itemViewOptions) {
                 var options = _.extend({
                     model: item,
-                    parentId: this.options.parentId
+                    parentId: this.options.parentId,
+                    readOnly: this.readOnly
                 }, itemViewOptions);
                 return new ItemViewType(options);
             },

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -58,6 +58,7 @@ define([
              */
             initialize: function (options) {
                 this.mode = options.mode;
+                this.readOnly = options.readOnly;
                 this.model.refreshData();
                 this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.generalInfo.get('segmentId'), this.updateGeneralTabError);
                 this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.organizationInfo.get('segmentId'), this.updateOrgTabError);
@@ -68,27 +69,32 @@ define([
                 this.generalInfoView = new Segment.SegmentCollectionView({
                     model: this.model.generalInfo,
                     collection: this.model.generalInfo.get('segments'),
-                    showHeader: true
+                    showHeader: true,
+                    readOnly: this.readOnly
                 });
                 this.organizationInfoView = new Segment.SegmentCollectionView({
                     model: this.model.organizationInfo,
                     collection: this.model.organizationInfo.get('segments'),
-                    showHeader: true
+                    showHeader: true,
+                    readOnly: this.readOnly
                 });
                 this.contactInfoView = new Segment.SegmentCollectionView({
                     model: this.model.contactInfo,
                     collection: this.model.contactInfo.get('segments'),
-                    showHeader: true
+                    showHeader: true,
+                    readOnly: this.readOnly
                 });
                 this.serviceInfoView = new Segment.SegmentCollectionView({
                     model: this.model.serviceInfo,
                     collection: this.model.serviceInfo.get('segments'),
-                    showHeader: true
+                    showHeader: true,
+                    readOnly: this.readOnly
                 });
                 this.contentInfoView = new Segment.SegmentCollectionView({
                     model: this.model.contentInfo,
                     collection: this.model.contentInfo.get('segments'),
-                    showHeader: true
+                    showHeader: true,
+                    readOnly: this.readOnly
                 });
 
             },
@@ -106,6 +112,7 @@ define([
                 data.saveErrors = this.saveErrors;
                 data.validationErrors = this.model.validationError;
                 data.mode = this.mode;
+                data.readOnly = this.readOnly;
 
                 return data;
             },

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -114,7 +114,16 @@ define([
                 data.mode = this.mode;
                 data.readOnly = this.readOnly;
 
+                data.name = this.getNodeName();
+
                 return data;
+            },
+            getNodeName: function() {
+                var node = this.model.get("RegistryObjectList").ExtrinsicObject.find(function(extObj) {
+                    return extObj.objectType === "urn:registry:federation:node";
+                });
+
+                return node.Name;
             },
             onRender: function () {
                 this.$el.attr('role', "dialog");

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
@@ -8,7 +8,7 @@ table.align-middle{
   }
 }
 
-#localIdentityNodeRegion,#localAdditionalNodeRegion {
+#localIdentityNodeRegion,#localAdditionalNodeRegion,#remoteNodeRegion {
   a {
     padding-left: 5px;
     text-decoration: none;
@@ -19,7 +19,7 @@ table.align-middle{
         text-align: right;
       }
       th {
-        width: 25%;
+        width: 20%;
       }
     }
   }
@@ -45,7 +45,10 @@ table.align-middle{
       }
     }
     td {
-      width: 25%;
+      width: 20%;
+    }
+    td:last-child {
+      text-align: right;
     }
   }
   .add-segment{

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationList.handlebars
@@ -18,14 +18,16 @@
            data-content="Associations link different parts of the registry together. This is usually done to associate a particular organization or contact with a certain service, collection, or endpoint but is not limited to just those.">
             <i class='fa fa-question-circle fa-lg'></i>
         </a>
-        <select class="association-selector" {{#lt availableAssociation.length 1}}disabled{{/lt}}>
-            {{#each availableAssociation}}
-                <option name="{{this.segmentId}}"
-                        value="{{this.segmentName}}">{{this.segmentName}}</option>
-            {{/each}}
-        </select>
-        <a href="#"
-           class="add-association fa fa-plus-square fa-lg plus-button {{#lt availableAssociation.length 1}}disabled-link{{/lt}}"></a>
+        {{#unless readOnly}}
+            <select class="association-selector" {{#lt availableAssociation.length 1}}disabled{{/lt}}>
+                {{#each availableAssociation}}
+                    <option name="{{this.segmentId}}"
+                            value="{{this.segmentName}}">{{this.segmentName}}</option>
+                {{/each}}
+            </select>
+            <a href="#"
+               class="add-association fa fa-plus-square fa-lg plus-button {{#lt availableAssociation.length 1}}disabled-link{{/lt}}"></a>
+        {{/unless}}
     </div>
     <label>The following entities are associated with this entity:</label>
     <table class='association-table table align-middle'>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/associationRow.handlebars
@@ -18,7 +18,9 @@
 <td>
     <label class="association-name">{{targetType}}</label>
 </td>
-<td>
-    <a href="#" name="{{id}}"
-       class="remove-association fa fa-trash-o fa-lg minus-button"></a>
-</td>
+{{#unless readOnly}}
+    <td>
+        <a href="#" name="{{id}}"
+           class="remove-association fa fa-trash-o fa-lg minus-button"></a>
+    </td>
+{{/unless}}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/customFieldList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/customFieldList.handlebars
@@ -15,17 +15,19 @@
 <div class="customizable-fields">
     <div class="customizable-header">
         <label class="nested-label2">Custom Fields</label>
-        <input type="text" class="field-name" name="customName"
-               placeholder="Field Name">
-        <select class="field-type-selector">
-            <option value="string">string</option>
-            <option value="boolean">boolean</option>
-            <option value="number">number</option>
-            <option value="date">date</option>
-            <option value="point">point</option>
-            <option value="bounds">bounds</option>
-        </select>
-        <a href="#" class="add-custom-field fa fa-plus-square fa-lg plus-button"></a>
+        {{#unless readOnly}}
+            <input type="text" class="field-name" name="customName"
+                   placeholder="Field Name">
+            <select class="field-type-selector">
+                <option value="string">string</option>
+                <option value="boolean">boolean</option>
+                <option value="number">number</option>
+                <option value="date">date</option>
+                <option value="point">point</option>
+                <option value="bounds">bounds</option>
+            </select>
+            <a href="#" class="add-custom-field fa fa-plus-square fa-lg plus-button"></a>
+        {{/unless}}
     </div>
     {{#if customFieldError}}
         <div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
@@ -18,12 +18,13 @@
         <i class='fa fa-question-circle fa-lg'></i>
     </a>
 {{/unless}}
-{{#if multiValued}}
-    <a href="#" class="add-value fa fa-plus-square fa-lg plus-button"></a>
-{{/if}}
-{{#if custom}}
-    <a href="#" class="remove-field fa fa-minus-square fa-lg minus-button"></a>
-
+{{#if editable}}
+    {{#if multiValued}}
+        <a href="#" class="add-value fa fa-plus-square fa-lg plus-button"></a>
+    {{/if}}
+    {{#if custom}}
+        <a href="#" class="remove-field fa fa-minus-square fa-lg minus-button"></a>
+    {{/if}}
 {{/if}}
 <div class="input-area">
     {{#is type "string"}}
@@ -41,10 +42,12 @@
                                    name="value{{@index}}" value="{{this}}"
                                    {{#unless ../../editable}}readonly{{/unless}}/>
                         </td>
-                        <td>
-                            <a href="#" name="{{@index}}"
-                               class="remove-value fa fa-minus-square fa-lg minus-button"></a>
-                        </td>
+                        {{#if editable}}
+                            <td>
+                                <a href="#" name="{{@index}}"
+                                   class="remove-value fa fa-minus-square fa-lg minus-button"></a>
+                            </td>
+                        {{/if}}
                     </tr>
                 {{/each}}
             </table>
@@ -67,7 +70,7 @@
                name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
     {{/is}}
     {{#is type "boolean"}}
-        <input type="checkbox" name="value" value="{{value}}"/>
+        <input type="checkbox" name="value" value="{{value}}" {{#unless editable}}disabled{{/unless}}/>
     {{/is}}
     {{#is type "date"}}
         <input type="date" name="valueDate" value="{{valueDate}}"

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
@@ -16,9 +16,12 @@
     <th class="name">Name</th>
     <th class="created">Created On</th>
     <th class="modified">Last Modified</th>
+    <th/>
     <th>
         {{#if multiValued}}
-            <a href="#" class="button-icon add-node-link fa fa-plus"></a>
+            {{#unless readOnly}}
+                <a href="#" class="button-icon add-node-link fa fa-plus"></a>
+            {{/unless}}
             <a href="#" class="button-icon refresh-button fa fa-refresh"></a>
         {{/if}}
     </th>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
@@ -20,12 +20,12 @@
             <h4 class="modal-title">
                 {{#unless readOnly}}
                     {{#is mode 'edit'}}
-                        Edit {{name}}
+                        Edit: {{name}}
                     {{else}}
                         Add Local Node
                     {{/is}}
                 {{else}}
-                    Read Only
+                    {{name}} (Read Only)
                 {{/unless}}
             </h4>
         </div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeModal.handlebars
@@ -18,11 +18,15 @@
             <button type="button" class="close" data-dismiss="modal"
                     aria-hidden="true">&times;</button>
             <h4 class="modal-title">
-                {{#is mode 'edit'}}
-                    Edit {{name}}
+                {{#unless readOnly}}
+                    {{#is mode 'edit'}}
+                        Edit {{name}}
+                    {{else}}
+                        Add Local Node
+                    {{/is}}
                 {{else}}
-                    Add Local Node
-                {{/is}}
+                    Read Only
+                {{/unless}}
             </h4>
         </div>
         <div class="modal-body">
@@ -75,14 +79,20 @@
                 </div>
             {{/if}}
             <div class="btn-group">
-                {{#is mode 'edit'}}
-                    <button type="button" class="btn btn-primary submit-button">Save</button>
-                {{else}}
-                    <button type="button" class="btn btn-primary submit-button">Add</button>
-                {{/is}}
-                <button type="button" class="btn btn-default cancel-button" data-dismiss="modal">
-                    Cancel
-                </button>
+                {{#unless readOnly}}
+                    {{#is mode 'edit'}}
+                        <button type="button" class="btn btn-primary submit-button">Save</button>
+                    {{else}}
+                        <button type="button" class="btn btn-primary submit-button">Add</button>
+                    {{/is}}
+                {{/unless}}
+                    <button type="button" class="btn btn-default cancel-button" data-dismiss="modal">
+                        {{#unless readOnly}}
+                            Cancel
+                        {{else}}
+                            Close
+                        {{/unless}}
+                    </button>
             </div>
         </div>
     </div><!-- /.modal-content -->

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/registryPage.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/registryPage.handlebars
@@ -19,6 +19,9 @@
 
         <h4 class="node-table-label">Additional Local Nodes</h4>
         <div id="localAdditionalNodeRegion"></div>
+
+        <h4 class="node-table-label">Remote Nodes</h4>
+        <div id="remoteNodeRegion"></div>
     </div>
 </div>
 <div id="IframeModalDOM" class="IframeModalDOM"></div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentList.handlebars
@@ -5,6 +5,7 @@
             <td>
                 <label class="nested-label{{nestedLevel}}">{{segmentName}}</label>
             </td>
+            {{#unless readOnly}}
             {{#if multiValued}}
                 <td>
                     {{#if autoValues}}
@@ -15,9 +16,10 @@
                             {{/each}}
                         </select>
                     {{/if}}
-                    <a href="#" class="button-icon add-segment fa fa-lg fa-plus-square" aria-hidden="true"></a>
+                        <a href="#" class="button-icon add-segment fa fa-lg fa-plus-square" aria-hidden="true"></a>
                 </td>
             {{/if}}
+            {{/unless}}
         </tr>
     </table>
 </div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/segmentRow.handlebars
@@ -33,10 +33,12 @@
                     </div>
                 </td>
                 <td>
+                {{#unless readOnly}}
                     <div class="segment-delete">
                         <a href="#"
                            class="button-icon remove-segment minus-button fa fa-lg fa-trash-o"></a>
                     </div>
+                {{/unless}}
                 </td>
         </table>
     {{/if}}

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
@@ -247,7 +247,7 @@ public class FederationAdmin implements FederationAdminMBean {
         }
 
         List<Metacard> localMetacards =
-                federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids);
+                federationAdminService.getRegistryMetacardsByRegistryIds(ids);
         List<String> metacardIds = new ArrayList<>();
 
         metacardIds.addAll(localMetacards.stream()

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
@@ -442,12 +442,12 @@ public class FederationAdminTest {
                 .map(Metacard::getId)
                 .collect(Collectors.toList()));
 
-        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenReturn(
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(ids)).thenReturn(
                 matchingMetacards);
 
         federationAdmin.deleteLocalEntry(ids);
 
-        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService).getRegistryMetacardsByRegistryIds(ids);
         verify(federationAdminService).deleteRegistryEntriesByMetacardIds(metacardIds);
     }
 


### PR DESCRIPTION
#### What does this PR do?
The remote nodes are now displayed in the local nodes page. The nodes can be opened for inspection but not can't be modified
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @mcalcote @vinamartin @brianfelix @ani6gup @andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@stustison
#### How should this be tested?
Two ddf instances are needed to manually test. Edit the identity node of the remote instance trying to add a value for each section.
In the local ddf, add the remote instance in the remote registries tab.
Verify the node information shows up under the Remote Nodes section
Open the node and verify the information cannot be modified.
Close the modal and click the delete button.
Verify that the node was removed.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2267
#### Screenshots (if appropriate)
![remotenodessection](https://cloud.githubusercontent.com/assets/14877145/16822442/4f684e3a-4911-11e6-9799-84e9e97d141c.png)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Changing FederationAdmin's deleteLocalEntry to call getRegistryMetacardsByIds, updating unit tests

Adding check to see if the construct title is a string or a function
Adding check to see if the autoPopulateFunction  is a string or a function

Changing registry node model url to call allRegistryMetacards instead of localNodes
Adding getRemoteNodes function to get the non local entries from the model

Adding a remoteNodeRegion that will display the non local nodes.
Adding a function to display the NodeModel in readOnly mode
Adding a readOnly flag that is set when NodeTable is created and passed to the necessary views. The readOnly flag is used to prevent modifications to the non local entries.

Changing addSegment in the view to stop the event propagation
Changing the css to add the remoteNodeRegion and line things up

Changing the handlebars files to only allow fields to be editable and display add/remove icons if the readOnly flag is not set