### PR TITLE
DDF-2284 use new SessionFactory from karaf

### DIFF
--- a/platform/platform-scheduler/pom.xml
+++ b/platform/platform-scheduler/pom.xml
@@ -150,7 +150,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.31</minimum>
+                                            <minimum>0.28</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>


### PR DESCRIPTION
#### What does this PR do?
Use the new SessionFactory in karaf for getting a command session and executing a command.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth 
@kcwire 
@stustison 
@bdeining 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@jlcsmith
#### How should this be tested?
Build. Go to config -> ddf platform -> configuration -> platform command scheduler. Configure a command, such as "log:get" for with a reasonable interval, such as 10 seconds. Watch the log file for the output from the command.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2284
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
