### PR TITLE
DDF-2281 Add automated tests for simultaneous downloads

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -150,6 +150,7 @@ public class ReliableResourceDownloadManager {
     }
 
     public void setDelayBetweenAttempts(int delayBetweenAttempts) {
+        LOGGER.debug("Delay between attempts set to {} second(s)", delayBetweenAttempts);
         downloaderConfig.setDelayBetweenAttemptsMS(delayBetweenAttempts * ONE_SECOND_IN_MS);
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadEndpoint.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceDownloadEndpoint.java
@@ -182,8 +182,6 @@ public class ResourceDownloadEndpoint {
      * @return response object containing the list of all the currently active downloads
      * @throws DownloadToCacheOnlyException thrown if the product download couldn't be started
      */
-    @GET
-    @Produces(APPLICATION_JSON)
     public Response getDownloadList() throws DownloadToCacheOnlyException {
         try {
             List<DownloadInfo> downloadsInProgress = downloadManager.getDownloadsInProgress();

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
@@ -45,8 +45,6 @@ public class FederatedCswMockServer {
     private final String httpRoot;
 
     private final int port;
-    
-    private String metacardId;
 
     private StubServer cswStubServer;
 
@@ -205,15 +203,10 @@ public class FederatedCswMockServer {
                     .then(ok(), contentType("text/xml"), bytesContent(document.getBytes()));
         }
     }
-    
-    public void setMetacardId(String metacardId) {
-        this.metacardId = metacardId;
-    }
 
     private String substituteTags(String document) {
         String resultDocument = substituteSourceId(document);
         resultDocument = substitutePortNumber(resultDocument);
-        resultDocument = substituteMetacardId(resultDocument);
         return substituteHttpRoot(resultDocument);
     }
 
@@ -227,9 +220,5 @@ public class FederatedCswMockServer {
 
     private String substituteHttpRoot(String document) {
         return document.replaceAll("\\$httpRoot\\$", httpRoot);
-    }
-    
-    private String substituteMetacardId(String document) {
-        return document.replaceAll("\\$metacardId\\$", metacardId);
     }
 }

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/mock/csw/FederatedCswMockServer.java
@@ -45,6 +45,8 @@ public class FederatedCswMockServer {
     private final String httpRoot;
 
     private final int port;
+    
+    private String metacardId;
 
     private StubServer cswStubServer;
 
@@ -203,10 +205,15 @@ public class FederatedCswMockServer {
                     .then(ok(), contentType("text/xml"), bytesContent(document.getBytes()));
         }
     }
+    
+    public void setMetacardId(String metacardId) {
+        this.metacardId = metacardId;
+    }
 
     private String substituteTags(String document) {
         String resultDocument = substituteSourceId(document);
         resultDocument = substitutePortNumber(resultDocument);
+        resultDocument = substituteMetacardId(resultDocument);
         return substituteHttpRoot(resultDocument);
     }
 
@@ -220,5 +227,9 @@ public class FederatedCswMockServer {
 
     private String substituteHttpRoot(String document) {
         return document.replaceAll("\\$httpRoot\\$", httpRoot);
+    }
+    
+    private String substituteMetacardId(String document) {
+        return document.replaceAll("\\$metacardId\\$", metacardId);
     }
 }


### PR DESCRIPTION
#### What does this PR do?

Adds two new tests to TestFederation, testProductDownloadListWithTwoActiveDownloads and  testProductDownloadListWithTwoActiveDownloadsOneFails, to confirm that downloading two products at once performs as expected. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@Lambeaux 
@garrettfreibott 
@oconnormi 
@bantillo

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@figliold
@lessarderic

#### How should this be tested?

Run TestFederation tests.

#### Any background context you want to provide?

Updated some files outside of TestFederation.

Commit Messages: 

- -New itests to determine that two products can be downloaded at once.
Includes an itest for  if one download fails the other continues to download.
- -testProductDownloadListWithTwoActiveDownloadsOneFails now working as expected in TestFederation.
Cleaned up testProductDownloadListWithTwoActiveDownloadsOneFails and testProductDownloadListWithTwoActiveDownloads.
- -testProductDownloadListWithTwoActiveDownloadsOneFails and testProductDownloadListWithTwoActiveDownloads work as intended in TestFederation.
Now includes helper methods for both of the above tests.