### PR TITLE
DDF-2287: Added integration tests for download interrupt scenarios.

### DIFF
--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -95,14 +95,20 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <artifactId>httpcore-osgi</artifactId>
+            <version>4.4.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <artifactId>httpclient-osgi</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient-osgi</artifactId>
+            <version>4.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/AsynchronousClientDownloader.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/AsynchronousClientDownloader.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.test.itests.common.downloads;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.message.BasicHttpResponse;
+
+/**
+ * Provides an asynchronous handle to the asynchronous request and synchronous retrieval of a
+ * product utilizing both endpoints in the process.
+ */
+class AsynchronousClientDownloader extends ClientDownloader {
+    private Future downloadRequestFuture = null;
+
+    private String metacardId = null;
+
+    @Override
+    public void startDownload(String metacardId) {
+        client.start();
+        this.metacardId = metacardId;
+        downloadRequestFuture = client.execute(new HttpGet(ClientDownloader.getAsyncDownloadUrl(
+                metacardId)), null);
+        try {
+            HttpResponse response = (BasicHttpResponse) downloadRequestFuture.get();
+            int responseCode = response.getStatusLine()
+                    .getStatusCode();
+            assertThat("Asynchronous request was not successful (responseCode != 200)",
+                    responseCode,
+                    is(200));
+        } catch (InterruptedException e) {
+            Thread.currentThread()
+                    .interrupt();
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Exception occurred in future's thread", e);
+        }
+
+        if (downloadRequestFuture.isCancelled()) {
+            throw new IllegalStateException("Future was cancelled");
+        }
+        if (!downloadRequestFuture.isDone()) {
+            throw new IllegalStateException("Future has not finished");
+        }
+    }
+
+    @Override
+    public void stopDownload() {
+        // TODO: [DDF-2287] Cannot implement until async cancel is available
+        throw new NotImplementedException(
+                "API currently does not support the cancellation of async downloads");
+    }
+
+    @Override
+    protected String processResults() throws ExecutionException {
+        if (downloadRequestFuture == null) {
+            throw new IllegalStateException("Download was never started, so no future exists");
+        }
+
+        Future future =
+                client.execute(new HttpGet(ClientDownloader.getSyncDownloadUrl(this.metacardId)),
+                        null);
+
+        try {
+            HttpResponse response = (BasicHttpResponse) future.get();
+            return IOUtils.toString(response.getEntity()
+                    .getContent(), "UTF-8");
+        } catch (InterruptedException e) {
+            Thread.currentThread()
+                    .interrupt();
+            throw new RuntimeException("Thread interrupted while obtaining results", e);
+        } catch (IOException e) {
+            throw new RuntimeException("IO failed when obtaining results", e);
+        }
+    }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/ClientDownloader.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/ClientDownloader.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.test.itests.common.downloads;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.http.ConnectionClosedException;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.hamcrest.Matchers;
+
+import ddf.test.itests.AbstractIntegrationTest;
+
+/**
+ * Download client abstraction for code re-use within integration tests.
+ */
+public abstract class ClientDownloader {
+    private static final String CSW_STUB_SOURCE_ID = "cswStubServer";
+
+    final CloseableHttpAsyncClient client = HttpAsyncClients.createDefault();
+
+    private Throwable caughtException = null;
+
+    Future future = null;
+
+    public static SynchronousClientDownloader createSynchronous() {
+        return new SynchronousClientDownloader();
+    }
+
+    public static AsynchronousClientDownloader createAsynchronous() {
+        return new AsynchronousClientDownloader();
+    }
+
+    protected abstract String processResults() throws ExecutionException;
+
+    public abstract void startDownload(String metacardId);
+
+    public abstract void stopDownload();
+
+    public CloseableHttpAsyncClient getClient() {
+        return client;
+    }
+
+    public String getResults() {
+        try {
+            return processResults();
+        } catch (ExecutionException e) {
+            Throwable causeOfException = e.getCause();
+            assertThat("Execution failed for a reason other than the connection being closed",
+                    causeOfException instanceof ConnectionClosedException,
+                    Matchers.is(Boolean.TRUE));
+            return causeOfException.toString();
+        }
+    }
+
+    public static String getSyncDownloadUrl(String metacardId) {
+        return String.format("%s/catalog/sources/%s/%s?transform=resource",
+                AbstractIntegrationTest.SERVICE_ROOT.getUrl(),
+                CSW_STUB_SOURCE_ID,
+                metacardId);
+    }
+
+    public static String getAsyncDownloadUrl(String metacardId) {
+        return String.format("%s?source=%s&metacard=%s",
+                AbstractIntegrationTest.RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl(),
+                CSW_STUB_SOURCE_ID,
+                metacardId);
+    }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/SynchronousClientDownloader.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/downloads/SynchronousClientDownloader.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.test.itests.common.downloads;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.message.BasicHttpResponse;
+
+/**
+ * Provides an asynchronous handle to the synchronous retrieval and download endpoint of a product.
+ */
+class SynchronousClientDownloader extends ClientDownloader {
+    @Override
+    public void startDownload(String metacardId) {
+        client.start();
+        future = client.execute(new HttpGet(ClientDownloader.getSyncDownloadUrl(metacardId)), null);
+    }
+
+    @Override
+    public void stopDownload() {
+        try {
+            client.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Client encountered an error when closing.", e);
+        }
+    }
+
+    @Override
+    protected String processResults() throws ExecutionException {
+        if (future == null) {
+            throw new IllegalStateException("Download was never started, so no future exists");
+        }
+        try {
+            HttpResponse response = (BasicHttpResponse) future.get();
+            return IOUtils.toString(response.getEntity()
+                    .getContent(), "UTF-8");
+        } catch (InterruptedException e) {
+            Thread.currentThread()
+                    .interrupt();
+            throw new RuntimeException("Interrupted test", e);
+        } catch (IOException e) {
+            throw new RuntimeException("IO failed when obtaining results", e);
+        }
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds a set of integration tests to the `TestFederation` class for ensuring interruptions to parallel downloads do not cause corruption of product retrieval. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@garrettfreibott 
@oconnormi 
@cmthom10 
@pklinef 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@figliold 
@shaundmorris

#### How should this be tested?
Validate a full build and that `TestFederation` completely passes. 

#### Any background context you want to provide?
These are tests to provide a reliable harness for tweaking resource download code in the standard framework. 

#### What are the relevant tickets?
DDF-2287

##### Change set

* Created the `ClientDownloader` classes for parallel integration testing
* Updated async http libraries in test
* Fix pom dependency to OSGI version

##### Details

Within `TestFederation`, the actual test method is `runParallelInterruptDownloadTest(...)` which can be configured with the caller's choice of objects implementing `ClientDownloader`, which is the base used to abstract the details of how a particular client can be cancelled, interrupted, or abruptly closed. These classes can be found in `ddf.test.itests.common.downloads` and future implementations should live there as well. 

The actual test methods call variations of `runParallelInterruptDownloadTest(...)` and the current state of the test matrix can be found in the next section. Note that some methods are included but are labeled as `@Ignore`, which are necessary test cases but cannot currently be implemented. These cases are also in the matrix labeled as such. 

The `org.apache.http` async client libraries were necessary so that downloads could actually be started and continue to progress in parallel. Blocking calls would render the tests worthless. Optionally, a custom stream consumer could be injected into the client to provide custom callback logic for handling characters as they are received. This strategy was attempted with the creation of `InterruptableAsyncCharConsumer` but failed when _the underlying `IOControl` instance was redundant to just closing the original client object_ and catching the exception. Furthermore, once an event was fired and the consumer started working, it would continue to the end of the stream and always yield a valid cancelled product. 

As it stands, _this custom consumer is pending removal from this PR_ without replacement, but that means the tests will never know the degree of progress made on the partial product before interruption because _abruptly closing the socket means forfeiting the resultant data_. 

These circumstances might be acceptable for this set of tests and is pending feedback. Source has been pre-commented for key responses that are needed. 

##### Parallel Test Matrix

Case | Description | Client 1 | Client 2 | Flip Start Order
---- | ----- | ----- | ----- | -----
1 | Two synchronous clients and one shuts down | Synchronous | Synchronous | N/A (Negligible)
2 | Async starts followed by sync and sync shuts down | Synchronous | Asynchronous | false
3 | Sync starts followed by async and sync shuts down | Synchronous | Asynchronous | true
4 | Async starts followed by sync and async cancels (TODO) | Asynchronous | Synchronous | true
5 | Sync starts followed by async and async cancels (TODO) | Asynchronous | Synchronous | false
6 | Two asynchronous clients start and one cancels (TODO) | Asynchronous | Asynchronous | N/A (Negligible)


##### Pending

* Implementation of asynchronous cancellation (another ticket TBD)
