### PR TITLE
DDF-2303: Add authentication support to CometD client used in integra…

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventPublisher.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventPublisher.java
@@ -78,11 +78,11 @@ public class DownloadsStatusEventPublisher {
     /**
      * Send notification and activity with current retrieval status.
      *
-     * @param resourceResponse the response from the product retrieval containing the actual @Resource
-     * @param status the status of the product retrieval, e.g., IN_PROGRESS, STARTED, etc.
-     * @param metacard the @Metacard associated with the product being downloaded
-     * @param detail detailed message to be displayed in the notification and/or activity
-     * @param bytes the number of bytes read thus far during the product download
+     * @param resourceResponse   the response from the product retrieval containing the actual @Resource
+     * @param status             the status of the product retrieval, e.g., IN_PROGRESS, STARTED, etc.
+     * @param metacard           the @Metacard associated with the product being downloaded
+     * @param detail             detailed message to be displayed in the notification and/or activity
+     * @param bytes              the number of bytes read thus far during the product download
      * @param downloadIdentifier unique ID for this product download
      */
     public void postRetrievalStatus(final ResourceResponse resourceResponse,
@@ -101,14 +101,14 @@ public class DownloadsStatusEventPublisher {
     /**
      * Based on the input parameters send notification and/or activity with current retrieval status.
      *
-     * @param resourceResponse the response from the product retrieval containing the actual @Resource
-     * @param status the status of the product retrieval, e.g., IN_PROGRESS, STARTED, etc.
-     * @param metacard the @Metacard associated with the product being downloaded
-     * @param detail detailed message to be displayed in the notification and/or activity
-     * @param bytes the number of bytes read thus far during the product download
+     * @param resourceResponse   the response from the product retrieval containing the actual @Resource
+     * @param status             the status of the product retrieval, e.g., IN_PROGRESS, STARTED, etc.
+     * @param metacard           the @Metacard associated with the product being downloaded
+     * @param detail             detailed message to be displayed in the notification and/or activity
+     * @param bytes              the number of bytes read thus far during the product download
      * @param downloadIdentifier unique ID for this product download
-     * @param sendNotification true indicates a notification with current retrieval status is to be sent
-     * @param sendActivity true indicates an activity with current retrieval status is to be sent
+     * @param sendNotification   true indicates a notification with current retrieval status is to be sent
+     * @param sendActivity       true indicates an activity with current retrieval status is to be sent
      */
     public void postRetrievalStatus(final ResourceResponse resourceResponse,
             ProductRetrievalStatus status, Metacard metacard, String detail, Long bytes,
@@ -128,12 +128,18 @@ public class DownloadsStatusEventPublisher {
 
         // Add user information to the request properties.
         org.apache.shiro.subject.Subject shiroSubject = null;
+
         try {
             shiroSubject = SecurityUtils.getSubject();
         } catch (Exception e) {
             LOGGER.debug("Could not determine current user, using session id.");
         }
+
         String user = SubjectUtils.getName(shiroSubject, "");
+
+        LOGGER.debug("User: {}, session: {}",
+                user,
+                getProperty(resourceResponse, ActivityEvent.SESSION_ID_KEY));
 
         if (notificationEnabled && sendNotification && (status
                 != ProductRetrievalStatus.IN_PROGRESS) && (status

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/AbstractEventController.java
@@ -71,7 +71,6 @@ public abstract class AbstractEventController implements EventHandler {
 
     ConcurrentHashMap<String, ServerSession> userSessionMap = new ConcurrentHashMap<>();
 
-
     /**
      * Establishes {@code AbstractEventController} as a listener to events published by the OSGi
      * eventing framework on the event's root topic
@@ -111,7 +110,8 @@ public abstract class AbstractEventController implements EventHandler {
      */
     public ServerSession getSessionBySessionId(String sessionId) {
         return userSessionMap.searchValues(1, value -> {
-            if (value.getId().equals(sessionId)) {
+            if (value.getId()
+                    .equals(sessionId)) {
                 return value;
             }
             return null;
@@ -127,7 +127,7 @@ public abstract class AbstractEventController implements EventHandler {
      */
     public ServerSession getSessionById(String userId, String sessionId) {
         ServerSession session = null;
-        if (userId != null){
+        if (userId != null) {
             session = getSessionByUserId(userId);
         }
         if (session == null && sessionId != null) {
@@ -230,7 +230,9 @@ public abstract class AbstractEventController implements EventHandler {
 
         userSessionMap.put(userId, serverSession);
 
-        LOGGER.debug("Added ServerSession to userSessionMap - New map: {}", userSessionMap);
+        LOGGER.debug("Added ServerSession for user {} to userSessionMap - New map: {}",
+                userId,
+                userSessionMap);
     }
 
     protected void queuePersistedMessages(final ServerSession serverSession,

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/NotificationController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/NotificationController.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 @Service
 public class NotificationController extends AbstractEventController {
-    // CometD requires prepending the topic name with a '/' character, whereas
+    // CometD requires pre-pending the topic name with a '/' character, whereas
     // the OSGi Event Admin doesn't allow it.
     protected static final String NOTIFICATION_TOPIC_DOWNLOADS_COMETD =
             "/" + Notification.NOTIFICATION_TOPIC_DOWNLOADS;
@@ -59,12 +59,12 @@ public class NotificationController extends AbstractEventController {
     }
 
     /**
-     * Implementation of {@link org.osgi.service.event.EventHandler#handleEvent(Event)} that receives notifications
-     * published on the {@link #NOTIFICATIONS_TOPIC_NAME} topic from the OSGi eventing framework and
-     * forwards them to their intended recipients.
+     * Implementation of {@link org.osgi.service.event.EventHandler#handleEvent(Event)} that
+     * receives notifications published on the {@link Notification#NOTIFICATION_TOPIC_ROOT} topic
+     * from the OSGi eventing framework and forwards them to their intended recipients.
      *
-     * @throws IllegalArgumentException when any of the following required properties are either missing from the Event
-     *                                  or contain empty values:
+     * @throws IllegalArgumentException when any of the following required properties are either
+     *                                  missing from the Event or contain empty values:
      *                                  <p>
      *                                  <ul>
      *                                  <li>{@link Notification#NOTIFICATION_KEY_APPLICATION}</li>
@@ -81,41 +81,52 @@ public class NotificationController extends AbstractEventController {
                 || event.getProperty(Notification.NOTIFICATION_KEY_APPLICATION)
                 .toString()
                 .isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Event \"" + Notification.NOTIFICATION_KEY_APPLICATION
-                            + "\" property is null or empty");
+            String message = "Event [" + Notification.NOTIFICATION_KEY_APPLICATION
+                    + "] property is null or empty";
+            LOGGER.warn(message);
+            throw new IllegalArgumentException(message);
         }
 
         if (null == event.getProperty(Notification.NOTIFICATION_KEY_MESSAGE) || event.getProperty(
                 Notification.NOTIFICATION_KEY_MESSAGE)
                 .toString()
                 .isEmpty()) {
-            throw new IllegalArgumentException("Event \"" + Notification.NOTIFICATION_KEY_MESSAGE
-                    + "\" property is null or empty");
+            String message = "Event [" + Notification.NOTIFICATION_KEY_MESSAGE
+                    + "] property is null or empty";
+            LOGGER.warn(message);
+            throw new IllegalArgumentException(message);
         }
 
         if (null == event.getProperty(Notification.NOTIFICATION_KEY_TIMESTAMP)) {
-            throw new IllegalArgumentException(
-                    "Event \"" + Notification.NOTIFICATION_KEY_TIMESTAMP + "\" property is null");
+            String message =
+                    "Event [" + Notification.NOTIFICATION_KEY_TIMESTAMP + "] property is null";
+            LOGGER.warn(message);
+            throw new IllegalArgumentException(message);
         }
 
         if (null == event.getProperty(Notification.NOTIFICATION_KEY_TITLE) || event.getProperty(
                 Notification.NOTIFICATION_KEY_TITLE)
                 .toString()
                 .isEmpty()) {
-            throw new IllegalArgumentException("Event \"" + Notification.NOTIFICATION_KEY_TITLE
-                    + "\" property is null or empty");
+            String message =
+                    "Event [" + Notification.NOTIFICATION_KEY_TITLE + "] property is null or empty";
+            LOGGER.warn(message);
+            throw new IllegalArgumentException(message);
         }
 
         String sessionId = (String) event.getProperty(Notification.NOTIFICATION_KEY_SESSION_ID);
         String userId = (String) event.getProperty(Notification.NOTIFICATION_KEY_USER_ID);
 
         if (StringUtils.isBlank(userId) && StringUtils.isBlank(sessionId)) {
-            throw new IllegalArgumentException("No user information was provided in the event object. userId and sessionId properties were null");
+            String message =
+                    "No user information was provided in the event object. userId and sessionId properties were null";
+            LOGGER.error(message);
+            throw new IllegalArgumentException(message);
         }
 
-        ServerSession recipient = null;
-        LOGGER.debug("Getting ServerSession for userId/sessionId {}", userId);
+        ServerSession recipient;
+
+        LOGGER.debug("Getting ServerSession for userId/sessionId [{}]/[{}]", userId, sessionId);
         recipient = getSessionById(userId, sessionId);
 
         if (null != recipient) {
@@ -132,8 +143,8 @@ public class NotificationController extends AbstractEventController {
                     NOTIFICATION_TOPIC_DOWNLOADS_COMETD,
                     propMap);
         } else {
-            LOGGER.debug("Session with ID \"{}\" is not connected to the server. "
-                    + "Ignnoring notification", sessionId);
+            LOGGER.debug("Session with ID [{}] is not connected to the server. "
+                    + "Ignoring notification", sessionId);
         }
     }
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds basic authentication support the the CometDClient used in itests.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bantillo 
@Lambeaux 
@garrettfreibott 
@oconnormi 
@cmthom10 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris 
#### How should this be tested?
Run hero build
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2303
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

…tion tests