### PR TITLE
DDF-2314 Make IdentificationPlugin run last so groomers don't undo…

### DIFF
--- a/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,6 +31,6 @@
         <property name="filterBuilder" ref="filterBuilder"/>
     </bean>
 
-    <service ref="identificationPlugin" auto-export="interfaces" ranking="0"/>
+    <service ref="identificationPlugin" auto-export="interfaces" ranking="-1000"/>
 
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
This PR changes the service ranking of the IdentificationPlugin so it will run last
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @brianfelix @ani6gup @ryeats @lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@pklinef
#### How should this be tested?
Verify the build. Start ddf
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Make IdentificationPlugin run last so groomers don't undo id work.