### PR TITLE
DDF-2308 2.9.X Updates the Tika and Pdf InputTransformers to use Basic MetacardType with or without content extractors present.

### DIFF
--- a/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
+++ b/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
@@ -62,15 +62,13 @@ public class MetacardCreator {
      *                           generated {@code Metacard}, may be null
      * @param metadataXml        the XML for the {@link Metacard#METADATA} attribute that should be set in
      *                           the generated {@code Metacard}, may be null
-     * @param typeName           the name to give to the dynamically created {@link MetacardType}
      * @param extendedAttributes the extra attributes (on top of those already present in
      *                           {@link BasicTypes#BASIC_METACARD}) that will be available in the metacard
      * @return a new {@code Metacard}
      */
     public static Metacard createEnhancedMetacard(final Metadata metadata, final String id,
-            final String metadataXml, final String typeName,
-            final Set<AttributeDescriptor> extendedAttributes) {
-        MetacardTypeImpl metacardType = new MetacardTypeImpl(typeName,
+            final String metadataXml, final Set<AttributeDescriptor> extendedAttributes) {
+        MetacardTypeImpl metacardType = new MetacardTypeImpl(BasicTypes.BASIC_METACARD.getName(),
                 Sets.union(BasicTypes.BASIC_METACARD.getAttributeDescriptors(),
                         extendedAttributes));
         return createMetacard(metadata, id, metadataXml, metacardType);

--- a/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
+++ b/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Set;
 import java.util.TimeZone;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.junit.Test;
@@ -54,16 +55,16 @@ public class MetacardCreatorTest {
 
     @Test
     public void testBasicMetacard() {
-        Metacard metacard = testMetacard(null, null);
+        Metacard metacard = testMetacard(null);
         assertThat(metacard.getMetacardType(), is(BasicTypes.BASIC_METACARD));
     }
 
     @Test
     public void testMetacardExtended() {
-        Metacard metacard = testMetacard("test_metacard1",
-                ImmutableSet.of(createObjectAttr("attr1"), createObjectAttr("attr2")));
+        Metacard metacard = testMetacard(ImmutableSet.of(createObjectAttr("attr1"),
+                createObjectAttr("attr2")));
         assertThat(metacard.getMetacardType()
-                .getName(), is("test_metacard1"));
+                .getName(), is(BasicTypes.BASIC_METACARD.getName()));
 
         ImmutableSet<String> attrNames = ImmutableSet.of("attr1", "attr2");
         int count = (int) metacard.getMetacardType()
@@ -76,11 +77,15 @@ public class MetacardCreatorTest {
     }
 
     private AttributeDescriptorImpl createObjectAttr(String name) {
-        return new AttributeDescriptorImpl(name, false, false, false, false,
+        return new AttributeDescriptorImpl(name,
+                false,
+                false,
+                false,
+                false,
                 BasicTypes.OBJECT_TYPE);
     }
 
-    private Metacard testMetacard(String typeName, Set<AttributeDescriptor> extraAttributes) {
+    private Metacard testMetacard(Set<AttributeDescriptor> extraAttributes) {
         final Metadata metadata = new Metadata();
 
         final String title = "title";
@@ -101,10 +106,12 @@ public class MetacardCreatorTest {
         final String metadataXml = "<xml>test</xml>";
 
         final Metacard metacard;
-        if (typeName == null) {
+        if (CollectionUtils.isEmpty(extraAttributes)) {
             metacard = MetacardCreator.createBasicMetacard(metadata, id, metadataXml);
         } else {
-            metacard = MetacardCreator.createEnhancedMetacard(metadata, id, metadataXml, typeName,
+            metacard = MetacardCreator.createEnhancedMetacard(metadata,
+                    id,
+                    metadataXml,
                     extraAttributes);
         }
 

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -174,16 +174,7 @@ public class PdfInputTransformer implements InputTransformer {
                     .flatMap(Collection::stream)
                     .collect(Collectors.toSet());
 
-            // TODO RAP 14 Jun 16: Might need to add service method to extract
-            // name/id type info from the extractor. Those would then be
-            // concatted together to form a name for the metacardtype.
-            String typeName = contentMetadataExtractors.values()
-                    .stream()
-                    .map(v -> v.getClass()
-                            .getName())
-                    .collect(Collectors.joining("_"));
-
-            metacard = new MetacardImpl(new MetacardTypeImpl(typeName,
+            metacard = new MetacardImpl(new MetacardTypeImpl(BasicTypes.BASIC_METACARD.getName(),
                     Sets.union(BasicTypes.BASIC_METACARD.getAttributeDescriptors(), attributes)));
             for (ContentMetadataExtractor contentMetadataExtractor : contentMetadataExtractors.values()) {
                 contentMetadataExtractor.process(contentInput, metacard);
@@ -269,8 +260,11 @@ public class PdfInputTransformer implements InputTransformer {
 
     private void addXmlElement(String name, String value, StringBuilder metadata) {
         if (StringUtils.isNotBlank(value)) {
-            metadata.append(String.format("<%s>%s</%s>", name, HtmlEscapers.htmlEscaper()
-                    .escape(value), name));
+            metadata.append(String.format("<%s>%s</%s>",
+                    name,
+                    HtmlEscapers.htmlEscaper()
+                            .escape(value),
+                    name));
         }
     }
 
@@ -297,7 +291,8 @@ public class PdfInputTransformer implements InputTransformer {
         int scaledHeight = (int) (image.getHeight() * scalingFactor);
         int scaledWidth = (int) (image.getWidth() * scalingFactor);
 
-        BufferedImage scaledImage = new BufferedImage(scaledWidth, scaledHeight,
+        BufferedImage scaledImage = new BufferedImage(scaledWidth,
+                scaledHeight,
                 BufferedImage.TYPE_INT_RGB);
         Graphics2D graphics = scaledImage.createGraphics();
         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
@@ -306,7 +301,10 @@ public class PdfInputTransformer implements InputTransformer {
         graphics.dispose();
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            ImageIOUtil.writeImage(scaledImage, FORMAT_NAME, outputStream, RESOLUTION_DPI,
+            ImageIOUtil.writeImage(scaledImage,
+                    FORMAT_NAME,
+                    outputStream,
+                    RESOLUTION_DPI,
                     IMAGE_QUALITY);
             return outputStream.toByteArray();
         }

--- a/catalog/transformer/catalog-transformer-pdf/src/test/groovy/ddf/catalog/transformer/input/pdf/PdfInputTransformerSpecTest.groovy
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/groovy/ddf/catalog/transformer/input/pdf/PdfInputTransformerSpecTest.groovy
@@ -173,7 +173,7 @@ class PdfInputTransformerSpecTest extends Specification {
                 [new AttributeDescriptorImpl('attr1', false, false, false, false, BasicTypes.OBJECT_TYPE),
                  new AttributeDescriptorImpl('attr2', false, false, false, false, BasicTypes.OBJECT_TYPE)]
 
-        metacard.metacardType.name != BasicTypes.BASIC_METACARD.name
+        metacard.metacardType.name == BasicTypes.BASIC_METACARD.name
         def attrNames = metacard.metacardType.attributeDescriptors*.name
         attrNames.containsAll(['attr1', 'attr2'])
     }

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -112,11 +112,11 @@ public class TikaInputTransformer implements InputTransformer {
         try {
             Thread.currentThread()
                     .setContextClassLoader(getClass().getClassLoader());
-            templates = TransformerFactory.newInstance(
-                    net.sf.saxon.TransformerFactoryImpl.class.getName(),
-                    net.sf.saxon.TransformerFactoryImpl.class.getClassLoader())
-                    .newTemplates(new StreamSource(
-                            TikaMetadataExtractor.class.getResourceAsStream("/metadata.xslt")));
+            templates =
+                    TransformerFactory.newInstance(net.sf.saxon.TransformerFactoryImpl.class.getName(),
+                            net.sf.saxon.TransformerFactoryImpl.class.getClassLoader())
+                            .newTemplates(new StreamSource(TikaMetadataExtractor.class.getResourceAsStream(
+                                    "/metadata.xslt")));
         } catch (TransformerConfigurationException e) {
             LOGGER.warn("Couldn't create XML transformer", e);
         } finally {
@@ -194,17 +194,10 @@ public class TikaInputTransformer implements InputTransformer {
                         .flatMap(Collection::stream)
                         .collect(Collectors.toSet());
 
-                // TODO RAP 14 Jun 16: Might need to add service method to extract
-                // name/id type info from the extractor. Those would then be
-                // concatted together to form a name for the metacardtype.
-                String typeName = contentMetadataExtractors.values()
-                        .stream()
-                        .map(v -> v.getClass()
-                                .getName())
-                        .collect(Collectors.joining("_"));
-
-                metacard = MetacardCreator.createEnhancedMetacard(metadata, id, metadataText,
-                        typeName, attributes);
+                metacard = MetacardCreator.createEnhancedMetacard(metadata,
+                        id,
+                        metadataText,
+                        attributes);
                 for (ContentMetadataExtractor contentMetadataExtractor : contentMetadataExtractors.values()) {
                     contentMetadataExtractor.process(plainText, metacard);
                 }
@@ -232,7 +225,8 @@ public class TikaInputTransformer implements InputTransformer {
     private void registerService(BundleContext bundleContext) {
         LOGGER.debug("Registering {} as an osgi service.",
                 TikaInputTransformer.class.getSimpleName());
-        bundleContext.registerService(ddf.catalog.transform.InputTransformer.class, this,
+        bundleContext.registerService(ddf.catalog.transform.InputTransformer.class,
+                this,
                 getServiceProperties());
     }
 
@@ -271,7 +265,8 @@ public class TikaInputTransformer implements InputTransformer {
 
             if (null != image) {
                 BufferedImage bufferedImage = new BufferedImage(image.getWidth(null),
-                        image.getHeight(null), BufferedImage.TYPE_INT_RGB);
+                        image.getHeight(null),
+                        BufferedImage.TYPE_INT_RGB);
                 Graphics2D graphics = bufferedImage.createGraphics();
                 graphics.drawImage(image, null, null);
                 graphics.dispose();

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -16,7 +16,6 @@ package ddf.catalog.transformer.input.tika;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -56,12 +55,12 @@ public class TikaInputTransformerTest {
         BundleContext mockBundleContext = mock(BundleContext.class);
         TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(mockBundleContext);
         verify(mockBundleContext).registerService(eq(InputTransformer.class),
-                eq(tikaInputTransformer), any(Hashtable.class));
+                eq(tikaInputTransformer),
+                any(Hashtable.class));
     }
 
     @Test
-    public void testTransformWithContentExtractor()
-            throws Exception {
+    public void testTransformWithContentExtractor() throws Exception {
         InputStream stream = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("testPDF.pdf");
@@ -73,11 +72,19 @@ public class TikaInputTransformerTest {
 
         when(bundleMock.getBundleContext()).thenReturn(bundleCtx);
         when(bundleCtx.getService(any())).thenReturn(cme);
-        ImmutableSet<AttributeDescriptor> attributeDescriptors = ImmutableSet.of(
-                new AttributeDescriptorImpl("attr1", false, false, false, false,
-                        BasicTypes.OBJECT_TYPE),
-                new AttributeDescriptorImpl("attr2", false, false, false, false,
-                        BasicTypes.OBJECT_TYPE));
+        ImmutableSet<AttributeDescriptor> attributeDescriptors =
+                ImmutableSet.of(new AttributeDescriptorImpl("attr1",
+                                false,
+                                false,
+                                false,
+                                false,
+                                BasicTypes.OBJECT_TYPE),
+                        new AttributeDescriptorImpl("attr2",
+                                false,
+                                false,
+                                false,
+                                false,
+                                BasicTypes.OBJECT_TYPE));
         when(cme.getMetacardAttributes()).thenReturn(attributeDescriptors);
 
         TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx) {
@@ -89,7 +96,8 @@ public class TikaInputTransformerTest {
         tikaInputTransformer.addContentMetadataExtractors(serviceRef);
         Metacard metacard = tikaInputTransformer.transform(stream);
 
-        assertThat(metacard.getMetacardType().getName(), not(BasicTypes.BASIC_METACARD.getName()));
+        assertThat(metacard.getMetacardType()
+                .getName(), is(BasicTypes.BASIC_METACARD.getName()));
         int matchedAttrs = (int) metacard.getMetacardType()
                 .getAttributeDescriptors()
                 .stream()
@@ -100,8 +108,7 @@ public class TikaInputTransformerTest {
     }
 
     @Test
-    public void testContentExtractorRemoval()
-        throws Exception {
+    public void testContentExtractorRemoval() throws Exception {
         InputStream stream = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("testPDF.pdf");
@@ -113,11 +120,19 @@ public class TikaInputTransformerTest {
 
         when(bundleMock.getBundleContext()).thenReturn(bundleCtx);
         when(bundleCtx.getService(any())).thenReturn(cme);
-        ImmutableSet<AttributeDescriptor> attributeDescriptors = ImmutableSet.of(
-                new AttributeDescriptorImpl("attr1", false, false, false, false,
-                        BasicTypes.OBJECT_TYPE),
-                new AttributeDescriptorImpl("attr2", false, false, false, false,
-                        BasicTypes.OBJECT_TYPE));
+        ImmutableSet<AttributeDescriptor> attributeDescriptors =
+                ImmutableSet.of(new AttributeDescriptorImpl("attr1",
+                                false,
+                                false,
+                                false,
+                                false,
+                                BasicTypes.OBJECT_TYPE),
+                        new AttributeDescriptorImpl("attr2",
+                                false,
+                                false,
+                                false,
+                                false,
+                                BasicTypes.OBJECT_TYPE));
         when(cme.getMetacardAttributes()).thenReturn(attributeDescriptors);
 
         TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx) {
@@ -130,7 +145,8 @@ public class TikaInputTransformerTest {
         tikaInputTransformer.removeContentMetadataExtractor(serviceRef);
         Metacard metacard = tikaInputTransformer.transform(stream);
 
-        assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));
+        assertThat(metacard.getMetacardType()
+                .getName(), is(BasicTypes.BASIC_METACARD.getName()));
         int matchedAttrs = (int) metacard.getMetacardType()
                 .getAttributeDescriptors()
                 .stream()
@@ -263,8 +279,8 @@ public class TikaInputTransformerTest {
         Metacard metacard = transform(stream);
         assertNotNull(metacard);
         assertNotNull(metacard.getMetadata());
-        assertThat(metacard.getMetadata(), containsString(
-                "<meta name=\"Compression CompressionTypeName\" content=\"BI_RGB\"/>"));
+        assertThat(metacard.getMetadata(),
+                containsString("<meta name=\"Compression CompressionTypeName\" content=\"BI_RGB\"/>"));
         assertThat(metacard.getContentTypeName(), is("image/x-ms-bmp"));
     }
 
@@ -453,8 +469,8 @@ public class TikaInputTransformerTest {
         assertThat(convertDate(metacard.getCreatedDate()), is("2010-05-04 06:43:54 UTC"));
         assertThat(convertDate(metacard.getModifiedDate()), is("2010-06-29 06:34:35 UTC"));
         assertNotNull(metacard.getMetadata());
-        assertThat(metacard.getMetadata(), containsString(
-                "content as every other file being tested for tika content parsing"));
+        assertThat(metacard.getMetadata(),
+                containsString("content as every other file being tested for tika content parsing"));
         assertThat(metacard.getContentTypeName(),
                 is("application/vnd.openxmlformats-officedocument.presentationml.presentation"));
     }
@@ -470,8 +486,8 @@ public class TikaInputTransformerTest {
         assertThat(convertDate(metacard.getCreatedDate()), is("2007-10-01 16:13:56 UTC"));
         assertThat(convertDate(metacard.getModifiedDate()), is("2007-10-01 16:31:43 UTC"));
         assertNotNull(metacard.getMetadata());
-        assertThat(metacard.getMetadata(), containsString(
-                "Written and saved in Microsoft Excel X for Mac Service Release 1."));
+        assertThat(metacard.getMetadata(),
+                containsString("Written and saved in Microsoft Excel X for Mac Service Release 1."));
         assertThat(metacard.getContentTypeName(), is("application/vnd.ms-excel"));
     }
 
@@ -512,8 +528,8 @@ public class TikaInputTransformerTest {
         assertThat(convertDate(metacard.getCreatedDate()), is("2007-09-14 11:06:08 UTC"));
         assertThat(convertDate(metacard.getModifiedDate()), is("2013-02-13 06:52:10 UTC"));
         assertNotNull(metacard.getMetadata());
-        assertThat(metacard.getMetadata(), containsString(
-                "This is a sample Open Office document, written in NeoOffice 2.2.1"));
+        assertThat(metacard.getMetadata(),
+                containsString("This is a sample Open Office document, written in NeoOffice 2.2.1"));
         assertThat(metacard.getContentTypeName(), is("application/vnd.oasis.opendocument.text"));
 
         // Reset timezone back to local time zone.


### PR DESCRIPTION
#### What does this PR do?
Instead of creating a new type on the fly, inject the additional attributes from the content extractors into the Basic MetacardType.

This cherry pick required some massaging to work with 2.9.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @ryeats 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested?
Full build/test run should be sufficient.

#### Any background context you want to provide?
When initially implemented, new metacard types were being generated on the fly. The correct solution is to add attributes to the Basic type so the two input transformers produce metacards of the same type whether or not content extractors are deployed to the system.

#### What are the relevant tickets?
DDF-2308

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests