### PR TITLE
DDF-1940: Fixes NullPointerException when trying to add sourceQueries in SolrCache when SourceIds is null

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -391,7 +391,7 @@ public class SolrCache implements SolrCacheMBean {
         @Override
         protected SolrQuery postAdapt(QueryRequest request, SolrFilterDelegate filterDelegate,
                 SolrQuery query) throws UnsupportedQueryException {
-            if (!request.isEnterprise()) {
+            if (request.getSourceIds() != null) {
                 List<SolrQuery> sourceQueries = new ArrayList<>();
                 for (String source : request.getSourceIds()) {
                     sourceQueries.add(filterDelegate.propertyIsEqualTo(StringUtils.removeEnd(


### PR DESCRIPTION
#### What does this PR do?
Fixes this NullPointerException when performing a search via the Search UI:
```bash
16:19:23,417 | WARN  | ool-51-thread-17 | talog.cache.solr.impl.SortedQueryMonitor  161 | re-standardframework | Couldn't get results from completed federated query. ddf.catalog.cache.solr.impl.SolrCacheSource, null
java.lang.NullPointerException
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)[:1.8.0_73]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)[:1.8.0_73]
	at ddf.catalog.cache.solr.impl.SortedQueryMonitor.run(SortedQueryMonitor.java:135)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)[:1.8.0_73]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_73]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_73]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_73]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_73]
Caused by: java.lang.NullPointerException
	at ddf.catalog.cache.solr.impl.SolrCache$CacheSolrMetacardClient.postAdapt(SolrCache.java:396)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.source.solr.SolrMetacardClient.getSolrQuery(SolrMetacardClient.java:261)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.source.solr.SolrMetacardClient.query(SolrMetacardClient.java:94)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.cache.solr.impl.SolrCache.query(SolrCache.java:135)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.cache.solr.impl.SolrCacheSource.query(SolrCacheSource.java:73)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.cache.solr.impl.CachingFederationStrategy$CallableSourceResponse.call(CachingFederationStrategy.java:545)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at ddf.catalog.cache.solr.impl.CachingFederationStrategy$CallableSourceResponse.call(CachingFederationStrategy.java:531)[329:catalog-core-standardframework:2.10.0.SNAPSHOT]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_73]
	... 5 more
```
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@peterhuffer @troymohl
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@coyotesqrl
#### How should this be tested?
Click Search on the Search UI (you don't need to configure any sources), and you should not see the NullPointerException warning in the log. Searches should still produce expected results.
#### Any background context you want to provide?
The warning was logged each time that the Search button was clicked.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-1940
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests