### PR TITLE
DDF-2307 fixed issues with search ui map layers with saving search ui config and messing up proxies for users with saved preferences

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.controller.js
@@ -22,29 +22,30 @@ define(['application',
         'js/view/cesium.metacard',
         'jquery',
         'drawHelper',
-        'js/controllers/cesium.layerCollection.controller'
+        'js/controllers/cesium.layerCollection.controller',
+        'js/model/user'
     ], function (Application, _, Marionette, Cesium, Q, wreqr, properties, CesiumMetacard, $, DrawHelper,
-                 LayerCollectionController) {
+                 LayerCollectionController, User) {
         "use strict";
 
         var imageryProviderTypes = LayerCollectionController.imageryProviderTypes;
 
         var CesiumLayerCollectionController = LayerCollectionController.extend({
             initialize: function () {
-                this.listenTo(wreqr.vent, 'preferencesModal:reorder:bigMap', this.reIndexAll);
+                this.listenTo(wreqr.vent, 'preferencesModal:reorder:bigMap', this.reIndexLayers);
 
                 // there is no automatic chaining of initialize.
                 LayerCollectionController.prototype.initialize.apply(this, arguments);
             }
         });
 
-        var Controller = Marionette.Controller.extend({
-            initialize: function () {
-                this.overlays = {};
+    var Controller = Marionette.Controller.extend({
+        initialize: function () {
+            this.overlays = {};
 
-                Cesium.BingMapsApi.defaultKey = properties.bingKey || 0;
-                this.mapViewer = this.createMap();
-                this.drawHelper = new DrawHelper(this.mapViewer);
+            Cesium.BingMapsApi.defaultKey = properties.bingKey || 0;
+            this.mapViewer = this.createMap();
+            this.drawHelper = new DrawHelper(this.mapViewer);
 
                 this.scene = this.mapViewer.scene;
                 this.ellipsoid = this.mapViewer.scene.globe.ellipsoid;
@@ -65,6 +66,10 @@ define(['application',
             },
             createMap: function () {
                 var layerPrefs = Application.UserModel.get('user>preferences>mapLayers');
+                var layersToRemove = [];
+                var index = 0;
+                User.updateMapLayers(layerPrefs, layersToRemove, index);
+
                 var layerCollectionController = new CesiumLayerCollectionController({
                     collection: layerPrefs
                 });

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -80,9 +80,10 @@ define(['underscore',
              removing/re-adding the layers causes visible "re-render" of entire map;
              raising/lowering is smoother.
              */
-            this.collection.forEach(function (model) {
+            this.collection.forEach(function (model, index) {
                 var layer = this.layerForCid[model.cid];
-                var indexChange = model.get('index') - model.previous('index');
+                var prevIndex = this.map.imageryLayers.indexOf(layer);
+                var indexChange = index - prevIndex;
                 var count = Math.abs(indexChange);
                 var method = indexChange > 0 ? "raise" : "lower";
                 _.times(count, function () {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/common.layerCollection.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/common.layerCollection.controller.js
@@ -27,40 +27,6 @@ define([
 
             // subclasses must implement reIndexLayers()
             this.listenTo(this.collection, 'sort', this.reIndexLayers);
-        },
-        move: function (model) {
-            /*
-             moving a layer will move other layers, so re-index all models
-             then move all layers in batch. This logic supports moving a
-             model "anywhere" within the list of models.
-             */
-            var newIndex = model.get('index');
-            var oldIndex = model.previous('index');
-
-            if (newIndex < oldIndex) { // lower model, perhaps raise other models.
-                this.collection.each(function (otherModel) {
-                    if (otherModel.cid !== model.cid) {
-                        var otherIndex = otherModel.get('index');
-                        if (otherIndex < oldIndex && otherIndex >= newIndex) {
-                            otherModel.set('index', otherIndex + 1);
-                        }
-                    }
-                });
-            }
-            else if (newIndex > oldIndex) { // raise model, perhaps lower other models.
-                this.collection.each(function (otherModel) {
-                    if (otherModel.cid !== model.cid) {
-                        var otherIndex = otherModel.get('index');
-                        if (otherIndex > oldIndex && otherIndex <= newIndex) {
-                            otherModel.set('index', otherIndex - 1);
-                        }
-                    }
-                });
-            }
-        },
-        onBeforeDestroy: function () {
-            this.collection = null;
-            this.layerForCid = null;
         }
     });
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/openlayers.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/openlayers.controller.js
@@ -23,14 +23,15 @@ define(['application',
         'js/model/Metacard',
         'jquery',
         'js/controllers/ol.layerCollection.controller',
-        'js/view/openlayers.geocoder'
+        'js/view/openlayers.geocoder',
+        'js/model/user'
     ], function (Application, _, Marionette, ol, Q, wreqr, properties, OpenlayersMetacard, Metacard, $,
-                 LayerCollectionController, geocoder) {
+                 LayerCollectionController, geocoder, User) {
         "use strict";
 
         var OpenLayerCollectionController = LayerCollectionController.extend({
             initialize: function () {
-                this.listenTo(wreqr.vent, 'preferencesModal:reorder:bigMap', this.reIndexAll);
+                this.listenTo(wreqr.vent, 'preferencesModal:reorder:bigMap', this.reIndexLayers);
 
                 // there is no automatic chaining of initialize.
                 LayerCollectionController.prototype.initialize.apply(this, arguments);
@@ -47,6 +48,9 @@ define(['application',
                 }
 
                 var layerPrefs = Application.UserModel.get('user>preferences>mapLayers');
+                var layersToRemove = [];
+                var index = 0;
+                User.updateMapLayers(layerPrefs, layersToRemove, index);
                 var layerCollectionController = new OpenLayerCollectionController({collection: layerPrefs});
                 this.mapViewer = layerCollectionController.makeMap({
                     zoom: 3,

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/preferences/PreferencesModal.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/preferences/PreferencesModal.view.js
@@ -204,7 +204,7 @@ define([
                 this.viewMapLayers = new User.MapLayers(viewLayerModels);
 
                 // listen to any change on all models in collection.
-                this.viewMapLayers.on('change', this.onEdit, this);
+                this.listenTo(this.viewMapLayers, 'change', this.onEdit);
 
                 if (maptype.is3d()) {
                     this.widgetController = new PrefsModalView.CesiumLayersController({
@@ -260,14 +260,12 @@ define([
                         if (viewLayer.get('show') !== layer.get('show')) {
                             layer.set('show', viewLayer.get('show'));
                         }
-                        if (viewLayer.get('index') !== layer.get('index')) {
-                            layer.set('index', viewLayer.get('index'));
-                        }
                     });
-                    wreqr.vent.trigger('preferencesModal:reorder:bigMap');
+                    this.model.sort();
                     this.model.savePreferences();
                     this.isEdited = false;
                     this.layerButtons.ui.save.toggleClass('btn-default').toggleClass('btn-primary');
+                    wreqr.vent.trigger('preferencesModal:reorder:bigMap');
                 }
             },
             resetDefaults: function () {
@@ -319,70 +317,32 @@ define([
         PrefsModalView.LayerPickerTable = Marionette.CompositeView.extend({
             template: 'layerListTemplate',
             childViewContainer: '#pickerList',
-            /*
-             "reverse" the sort order of the picker rows, so that the lowest layer
-             is represented by the "lowest" row in the table, and "raising/lowering" rows
-             makes sense with raising/lowering map layers.
-             */
-            viewComparator: function (model) {
-                return this.getReverseIndex(model.get('index'));
-            },
-            getReverseIndex: function (index) {
-                return this.collection.length - 1 - index;
-            },
-            reorderOnSort: true, // do not override resortView(), else defeat default reorderOnSort.
             ui: {
                 tbody: 'tbody'
             },
-            onAttach: function () {
-                var pickerList = this;
-                this.ui.tbody.sortable({
-                    axis: 'y',
-                    containment: 'parent',
-                    handle: '.sortHandle',
-                    cursor: 'move',
-                    forceHelperSize: true,
-                    tolerance: 'pointer',
-                    forcePlaceholderSize: true,
-                    placeholder: 'sortable-placeholder',
-                    helper: function (e, tr) {
-                        var $originals = tr.children();
-                        var $helper = tr.clone();
-                        $helper.addClass('layerPickerHelper'); // color helper.
-
-                        // prevent "helper" resizing while dragging.
-                        $helper.children().each(function (index) {
-                            $(this).width($originals.eq(index).outerWidth());
-                        });
-                        return $helper;
-                    },
-                    update: function (event, ui) {
-                        // the ui index is the "reverse" of how the models are indexed.
-                        var layerPicker = ui.item.data('layerPicker');
-                        var viewIndex = ui.item.index();
-                        var newIndex = pickerList.getReverseIndex(viewIndex);
-                        layerPicker.changeIndex(newIndex);
-
-                        /*
-                            update the marionette composite view indexes so that it's
-                            reorder on sort works correctly.
-                         */
-                        pickerList.collection.forEach(function (model) {
-                            var view = this.children.findByModel(model);
-                            var viewIndex = pickerList.getReverseIndex(model.get('index'));
-                            view._index = viewIndex;
-                        }, pickerList);
-
-                        pickerList.collection.sort(); // triggers view reorder and layers reorder.
-                    },
-                    start: function (event, ui) {
-                        /*
-                         default placeholder height is too small.
-                         prevent visible widget resizing on drag/drop
-                         */
-                        ui.placeholder.height(ui.helper.outerHeight());
+            initialize: function() {
+                this.collection.each(function(model) {
+                    this.listenTo(model, 'change', this.updateSort);
+                }, this);
+            },
+            updateSort: function() {
+                var sort = false;
+                var prevAlpha = 0;
+                for (var index=0;index<this.collection.models.length;index++) {
+                    if (index !== 0) {
+                        if (this.collection.at(index).get('alpha') > prevAlpha) {
+                            sort = true;
+                            break;
+                        } else {
+                            prevAlpha = this.collection.at(index).get('alpha');
+                        }
+                    } else {
+                        prevAlpha = this.collection.at(index).get('alpha');
                     }
-                });
+                }
+                if (sort) {
+                    this.collection.sort();
+                }
             }
         });
 
@@ -408,10 +368,6 @@ define([
             },
             changeShow: function (model) {
                 this.ui.range.prop('disabled', !model.get('show'));
-            },
-            changeIndex: function (newIndex) {
-                this.model.set('index', newIndex);
-                this.widgetController.move(this.model);
             },
             onDestroy: function () {
                 this.modelBinder.unbind();

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/preferences/layer.list.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/preferences/layer.list.handlebars
@@ -14,7 +14,6 @@
 <table class="table scrollable">
     <thead>
     <tr id="header">
-        <th>Order</th>
         <th>Visible</th>
         <th>Name</th>
         <th>Transparency</th>

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/preferences/layerPicker.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/preferences/layerPicker.handlebars
@@ -11,9 +11,6 @@
 *
 **/
 --}}
-<td class="sortHandle">
-    <i class="fa fa-arrows-v fa-1x"></i>
-</td>
 <td>
     <input name="show" type="checkbox"/>
 </td>


### PR DESCRIPTION
#### What does this PR do?
 - saving the search ui config no longer starts/stops proxies unless they change
 - users with saved preferences will no longer lose map tiles after a config change
 - fixed issue with search ui layers not updating correctly after preferences are saved
 - fixed layer ordering to use alpha instead of arbitrary indexes so that all layers are visible without manual reordering

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@andrewkfiedler @djblue @coyotesqrl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
