### PR TITLE
DDF-2254 Added ablility to switch between remote registry types when adding a remote in the registry-app

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
@@ -29,16 +29,7 @@ function (Q, Service, Backbone, _) {
     });
 
     Registry.Model = Backbone.AssociatedModel.extend({
-        defaults: {
-                registryConfiguration : []
-        },
         configUrl: "/admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui",
-        idAttribute: 'name',
-        remoteId: 'remoteName',
-        pullAttribute: 'pullAllowed',
-        pushAttribute: 'pushAllowed',
-        autoPushAttribute: 'autoPush',
-        pidAttribute: 'pid',
         initialize: function() {
             this.set('registryConfiguration', new Registry.ConfigurationList());
         },
@@ -48,7 +39,7 @@ function (Q, Service, Backbone, _) {
            
         },
         removeRegistry: function(registry) {
-            this.get("registryConfigurations").remove(registry);
+            this.get("registryConfiguration").remove(registry);
         },
         size: function() {
             return this.get('registryConfiguration').length;
@@ -58,32 +49,18 @@ function (Q, Service, Backbone, _) {
     Registry.Collection = Backbone.Collection.extend({
         model: Registry.Model,
         addRegistry: function(configuration) {
-            var registry;
-            var registryId = configuration.get("properties").get('shortname');
-            if(!registryId){
-                registryId = configuration.get("properties").get('id');
-            }
-            var remoteIdName = configuration.get("properties").get('remoteName');
-            var allowPull = configuration.get("properties").get('pullAllowed');
-            var allowPush = configuration.get("properties").get('pushAllowed');
-            var pushAuto = configuration.get("properties").get('autoPush');
-            var id = configuration.get('id');
-            if(this.get(registryId)) {
-                registry = this.get(registryId);
-            } else {
-                registry = new Registry.Model({name: registryId, remoteName: remoteIdName, pullAllowed: allowPull, pushAllowed: allowPush, autoPush: pushAuto, pid: id});
-                this.add(registry);
-            }
 
+            var registry = new Registry.Model(configuration.get("properties"));
             registry.addRegistryConfiguration(configuration);
 
+            this.add(registry);
             registry.trigger('change');
         },
         removeRegistry: function(registry) {
             this.remove(registry);
         },
         comparator: function(model) {
-            var str = model.get('name') || '';
+            var str = model.get('id') || '';
             return str.toLowerCase();
         }
     });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/ModalConfig.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/ModalConfig.view.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/** Main view page for add. */
+define([
+    'icanhaz',
+    'marionette',
+    'backbone',
+    'js/view/ModalRegistry.view.js',
+    'wreqr',
+    'underscore',
+    'jquery',
+    'js/view/Utils.js',
+    'js/model/Service.js',
+    'text!templates/configModal.handlebars'
+],
+function (ich,Marionette,Backbone,ModalRegistry,wreqr,_,$,Utils,Service,modalConfig) {
+
+    ich.addTemplate('modalConfig', modalConfig);
+
+    var ModalConfig = {};
+
+    ModalConfig.View = Marionette.Layout.extend({
+        template: 'modalConfig',
+        className: 'modal',
+        events: {
+            "click .submit-button": "submitData"
+        },
+        regions: {
+            details: '.modal-details'
+        },
+        initialize: function(options){
+            _.bindAll(this);
+            this.registry = options.registry;
+            this.modelBinder = new Backbone.ModelBinder();
+        },
+        serializeData: function(){
+            var data = {};
+
+            if(this.model) {
+                data = this.model.toJSON();
+            }
+            var configNames = [];
+            var regConfigs = this.model.get('registryConfiguration');
+            regConfigs.forEach(function(config){
+                var service = config.get('service').get('name');
+                if(configNames.indexOf(service) === -1){
+                    configNames.push(service);
+                }
+            });
+            data.configNames = configNames;
+            return data;
+        },
+        onClose: function() {
+            this.modelBinder.unbind();
+            this.$el.off('hidden.bs.modal');
+            this.$el.off('shown.bs.modal');
+        },
+        closeAndUnbind: function() {
+            this.modelBinder.unbind();
+            this.$el.modal("hide");
+        },
+        submitData: function (event) {
+            this.closeAndUnbind();
+            var configSelected = event.currentTarget.id;
+            wreqr.vent.trigger("showModal",
+                new ModalRegistry.View({
+                    model: this.model,
+                    registry: this.registry,
+                    mode: 'add',
+                    registryType: configSelected
+                })
+            );
+        }
+    });
+
+    return ModalConfig;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/Registry.view.js
@@ -19,6 +19,7 @@ define([
     'underscore',
     'jquery',
     'q',
+    'js/view/ModalConfig.view.js',
     'js/view/ModalRegistry.view.js',
     'js/view/EmptyView.js',
     'wreqr',
@@ -32,7 +33,7 @@ define([
     'js/model/RemoteStatus.js',
     'js/model/Status.js'
 ],
-function (ich,Marionette,_,$,Q,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistryModal,deleteRegistry,registryPage,registryList,registryRow,poller,RemoteStatus,Status) {
+function (ich,Marionette,_,$,Q,ModalConfig,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistryModal,deleteRegistry,registryPage,registryList,registryRow,poller,RemoteStatus,Status) {
 
     var RegistryView ={};
 
@@ -195,14 +196,26 @@ function (ich,Marionette,_,$,Q,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistr
             });
         },
         addRegistry: function(){
-            if(this.model) {
-                wreqr.vent.trigger("showModal",
-                    new ModalRegistry.View({
-                        model: this.model.getRegistryModel(),
-                        registry: this.model,
-                        mode: 'add'
-                    })
-                );
+            var self = this.model;
+            if(self) {
+                var regConfigs = self.getRegistryModel().get('registryConfiguration');
+                if(regConfigs.size() > 1) {
+                    wreqr.vent.trigger("showModal",
+                        new ModalConfig.View({
+                            model:self.getRegistryModel(),
+                            registry: self
+                        })
+                    );
+                } else {
+                    wreqr.vent.trigger("showModal",
+                        new ModalRegistry.View({
+                            model: self.getRegistryModel(),
+                            registry: self,
+                            mode: 'add',
+                            registryType: self.getRegistryModel().type
+                        })
+                    );
+                }
             }
         },
         removeRegistry: function() {
@@ -216,11 +229,13 @@ function (ich,Marionette,_,$,Q,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistr
             }
         },
         editRegistry: function(service) {
+            var self = this.model;
             wreqr.vent.trigger("showModal",
                 new ModalRegistry.View({
-                    model: this.model.getRegistryModel(service),
-                    registry: this.model,
-                    mode: 'edit'
+                    model: self.getRegistryModel(service),
+                    registry: self,
+                    mode: 'edit',
+                    registryType: service.get('type')
                 })
             );
         }

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/less/styles.less
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/less/styles.less
@@ -93,6 +93,10 @@ table.align-middle{
   float: right;
 }
 
+.button-config {
+  margin:5px 5px;
+}
+
 .newLink {
   text-decoration: none!important;
   width: 100%;

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/configModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/configModal.handlebars
@@ -1,4 +1,3 @@
-
 {{!--
 /**
  * Copyright (c) Codice Foundation
@@ -12,6 +11,22 @@
  *
  **/
  --}}
-<div class="delete-registry-name">
-    <input class="selectRegistryDelete" type="checkbox" value="{{id}}"> {{id}}
+
+<div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal"
+                    aria-hidden="true">&times;</button>
+            <h4 class="modal-title">
+                Select Configuration of Registry to Add
+            </h4>
+        </div>
+        <div class="modal-body">
+            <form class="form-horizontal add-registry container-fluid">
+                {{#each configNames}}
+                    <button type="button" class="btn btn-success button-config submit-button" id="{{this}}">{{this}}</button>
+                {{/each}}
+            </form>
+        </div>
+    </div>
 </div>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryModal.handlebars
@@ -19,7 +19,7 @@
                     aria-hidden="true">&times;</button>
             <h4 class="modal-title">
                 {{#is mode 'edit'}}
-                    Edit {{name}}
+                    Edit {{id}}
                 {{else}}
                     Add Registry
                 {{/is}}

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryRow.handlebars
@@ -13,8 +13,8 @@
  --}}
 <td>
     <a href='#{{id}}' class='newLink' data-toggle="modal">
-        {{#if name}}
-            {{name}}
+        {{#if id}}
+            {{id}}
         {{else}}
             <span class='label label-danger'>[No Title]</span>
         {{/if}}
@@ -35,12 +35,12 @@
     {{/if}}
 </td>
 <td>
-    {{#if pushAllowed}}
+    {{#if attributes.pushAllowed}}
         <span class="fa fa-check"></span>
     {{/if}}
 </td>
 <td colspan="4">
-    {{#if pullAllowed}}
+    {{#if attributes.pullAllowed}}
         <span class="fa fa-check"></span>
     {{/if}}
 </td>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/textType.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/textType.handlebars
@@ -19,12 +19,8 @@
         </a>
     {{/if}}
     <div class="controls">
-        {{#if optionValues}}
-            <select id="{{id}}" name="{{id}}" class="form-control input-sm">
-                {{#each optionLabels}}
-                    <option value="{{lookup ../optionValues @index}}" {{#is @index 0}}selected="selected" {{/is}}>{{.}}</option>
-                {{/each}}
-            </select>
+        {{#if id}}
+            <input type='text' class='{{id}} metatype form-control input-sm' name='{{id}}' id='{{id}}' value='{{id}}'>
         {{else}}
             <input type='text' class='{{id}} metatype form-control input-sm' name='{{id}}' id='{{id}}' value='{{#defaultValue}}{{.}}{{/defaultValue}}'>
         {{/if}}

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -14,7 +14,7 @@
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-    <OCD name="Registry Store" id="Csw_Registry_Store" description="Registry CSW Store">
+    <OCD name="CSW Registry Store" id="Csw_Registry_Store" description="Registry CSW Store">
 
         <AD description="The unique name of the store" name="Registry ID" id="id" required="true"
             type="String"/>


### PR DESCRIPTION
#### What does this PR do?
As a user, I want to be able to switch between registry types when adding a remote registry in the registry-app.

If multiple registry configurations are present at the time a new remote registry is added, a modal will pop up allowing the user to select the type before continuing to the standard add dialog.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@gordocanchola 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
@stustison
#### How should this be tested?
Implement a second type of registry store, then run DDF and add a remote registry in the Registry-App. Please note, the extra button(s) will only be displayed if more than one registry store is available when a remote is added.

I will be more than happy to demo/assist with a hero of the changes if interested. Please see me for instructions on how to make these changes appear.
#### Any background context you want to provide?
Please see me for further details about how to test this PR.

Currently the ui selects a single configuration for the user, but this should be changed so that the user can select the registry type upon creation.
#### What are the relevant tickets?
DDF-2254

#### Screenshots (if appropriate)
![](https://cloud.githubusercontent.com/assets/11355332/16710032/9708f48a-45d6-11e6-8f94-d66e2a2d816f.jpg)
![](https://cloud.githubusercontent.com/assets/11355332/16710023/379e94e6-45d6-11e6-919b-c987cf37b0ac.jpg)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

This PR was approved on the master branch -> https://github.com/codice/ddf/pull/982