### PR TITLE
DDF-2317 Set metacard.created and metacard.modified dates in Metacard Groomer Plugin to align to new taxonomy

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -27,8 +27,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.plugin.groomer.AbstractMetacardGroomerPlugin;
@@ -72,6 +74,15 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
             aMetacard.setAttribute(new AttributeImpl(Metacard.TAGS,
                     Collections.singletonList(Metacard.DEFAULT_TAG)));
         }
+
+        if (isDateAttributeEmpty(aMetacard, Core.METACARD_CREATED)) {
+            aMetacard.setAttribute(new AttributeImpl(Core.METACARD_CREATED, now));
+            logMetacardAttributeUpdate(aMetacard, Core.METACARD_CREATED, now);
+        }
+
+        aMetacard.setAttribute(new AttributeImpl(Core.METACARD_MODIFIED, now));
+        logMetacardAttributeUpdate(aMetacard, Core.METACARD_MODIFIED, now);
+
     }
 
     private boolean isCatalogResourceUri(URI uri) {
@@ -109,6 +120,13 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
             aMetacard.setAttribute(new AttributeImpl(Metacard.CREATED, now));
         }
 
+        if (isDateAttributeEmpty(aMetacard, Core.METACARD_CREATED)) {
+            aMetacard.setAttribute(new AttributeImpl(Core.METACARD_CREATED, now));
+            LOGGER.debug(
+                    "{} date should not be null on an update operation. Changing date to current timestamp so it is at least not null.",
+                    Core.METACARD_CREATED);
+        }
+
         if (aMetacard.getModifiedDate() == null) {
             aMetacard.setAttribute(new AttributeImpl(Metacard.MODIFIED, now));
         }
@@ -122,6 +140,19 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
                     Collections.singletonList(Metacard.DEFAULT_TAG)));
         }
 
+        // upon an update operation, the metacard modified time should be updated
+        aMetacard.setAttribute(new AttributeImpl(Core.METACARD_MODIFIED, now));
+        logMetacardAttributeUpdate(aMetacard, Core.METACARD_MODIFIED, now);
+    }
+
+    private void logMetacardAttributeUpdate(Metacard metacard, String attribute, Object value) {
+        LOGGER.debug("Applying {} attribute with value {} to metacard [{}].",
+                attribute, value, metacard.getId());
+    }
+    
+    private boolean isDateAttributeEmpty(Metacard metacard, String attribute) {
+        Attribute origAttribute = metacard.getAttribute(attribute);
+        return (origAttribute == null || !(origAttribute.getValue() instanceof Date));
     }
 
 }


### PR DESCRIPTION
#### What does this PR do?
To support the new DDF taxonomy, the Metadata Groomer pre-ingest plugin was updated to set the Metacard.CREATED and Metacard.MODIFIED fields upon ingest to the current date/time for the new ddf.catalog.data.types.Metacard class. Additionally, the Metacard.MODIFIED field is updated to the current date/time for an update operation. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining
@jrnorth
@brendan-hofmann
@coyotesqrl

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Build and run DDF.
Verify that after ingest, the metacard reflects the current date/time for both `metacard.created` and `metacard.modified` date/time values.

**_Note: The transformers in their current state do not support the new taxonomy. Please use the following as a definitions.json file to dynamically apply these attributes across all metacard types for testing._**

```
{
    "attributeTypes": {
        "metacard.created": {
            "type": "DATE_TYPE",
            "stored": true,
            "indexed": true,
            "tokenized": false,
            "multivalued": false
        },
        "metacard.modified": {
            "type": "DATE_TYPE",
            "stored": true,
            "indexed": true,
            "tokenized": false,
            "multivalued": false
        }
    },
    "inject": [
        {
            "attribute": "metacard.created"
        },
        {
            "attribute": "metacard.modified"
        }
    ]
}  
```

#### Any background context you want to provide?
This capability supports the Expiration Date Plugin by setting the `metacard.created` attribute, which is used to calculate the expiration date for the metacard. 

#### What are the relevant tickets?
_Metacard created and modified dates should be set during ingest to reflect the new taxonomy mappings_
https://codice.atlassian.net/browse/DDF-2317

_As an administrator, I want data purged based on its age so that I can control the size of the catalog_
https://codice.atlassian.net/browse/DDF-2274

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
