### PR TITLE
DDF-2326: Fixed issue with no location in nearby/cities/ request on Search UI

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/NearbyLocation.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/NearbyLocation.js
@@ -35,7 +35,7 @@ define([
 
                 initialize: function(attributes) {
                         var geoJson = attributes.geo.toJSON();
-                        this.id = wellknown.stringify(geoJson);
+                        this.set(this.idAttribute, wellknown.stringify(geoJson));
                 }
             });
 


### PR DESCRIPTION
#### What does this PR do?
The PR fixes the issue that the /services/REST/v1/Locations/nearby/cities/ endpoint is returning a 404 when a record on the search results with a location is opened to the Summary tab. These warnings were logged:

```bash
08:59:27,570 | WARN  | tp2056892729-585 | org.apache.cxf.jaxrs.utils.JAXRSUtils     524 | xf-rt-frontend-jaxrs | No operation matching request path "/services/REST/v1/Locations/nearby/cities/" is found, Relative Path: /nearby/cities/, HTTP Method: GET, ContentType: */*, Accept: application/json,text/javascript,*/*;q=0.01,. Please enable FINE/TRACE log level for more details.
08:59:27,571 | WARN  | tp2056892729-585 | jaxrs.impl.WebApplicationExceptionMapper   72 | xf-rt-frontend-jaxrs | javax.ws.rs.ClientErrorException: HTTP 404 Not Found ...
```

This issue was traced to https://github.com/codice/ddf/pull/873/commits/411206bda1c390f5aca4a9ce02cdb17f4c0ece54.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@stustison @troymohl @glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
#### How should this be tested?
Upload a record with a location. Click on this record in the search results, and you should see a nearby city (e.g. 4.281 km SW of New York) above the "Zoom and center" link on the Summary tab. You should not see those warnings in the log.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2326
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests