### PR TITLE
DDF-2327 Add content uri overwrite protection

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -13,8 +13,9 @@
  **/
 -->
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.catalog</groupId>
@@ -498,6 +499,11 @@
         <dependency>
             <groupId>ddf.catalog.plugin</groupId>
             <artifactId>catalog-plugin-expirationdate</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-content-uri</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -106,6 +106,7 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-contentresourcereader/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf/checksum/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-checksum/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-content-uri/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-videothumbnail/${project.version}</bundle>
     </feature>
 

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/UpdateRequestImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/UpdateRequestImpl.java
@@ -28,7 +28,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.operation.UpdateRequest;
 
 /**
- * The UpdateRequestImpl reprensents the default implementation of {@link UpdateRequest}.
+ * The UpdateRequestImpl represents the default implementation of {@link UpdateRequest}.
  */
 public class UpdateRequestImpl extends OperationImpl implements UpdateRequest {
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/UpdateOperations.java
@@ -82,8 +82,7 @@ public class UpdateOperations {
     private static final Logger INGEST_LOGGER =
             LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
 
-    private static final String PRE_INGEST_ERROR =
-            "Error during pre-ingest:\n\n";
+    private static final String PRE_INGEST_ERROR = "Error during pre-ingest:\n\n";
 
     private Supplier<CatalogProvider> catalogSupplier;
 
@@ -150,7 +149,8 @@ public class UpdateOperations {
 
             setDefaultValues(updateRequest);
 
-            List<Filter> idFilters = new ArrayList<>(updateRequest.getUpdates().size());
+            List<Filter> idFilters = new ArrayList<>(updateRequest.getUpdates()
+                    .size());
             for (Map.Entry<Serializable, Metacard> update : updateRequest.getUpdates()) {
                 idFilters.add(frameworkProperties.getFilterBuilder()
                         .attribute(updateRequest.getAttributeName())
@@ -177,7 +177,12 @@ public class UpdateOperations {
                     query = queryOperations.doQuery(queryRequest,
                             frameworkProperties.getFederationStrategy(),
                             false);
-                    for (Result result : query.getResults()) {
+                    List<Result> results = query.getResults();
+                    if (results.size() != updateRequest.getUpdates()
+                            .size()) {
+                        throw new IngestException("Unable to find all metacards in update request.");
+                    }
+                    for (Result result : results) {
                         metacardMap.put(opsCrudSupport.getAttributeStringValue(result.getMetacard(),
                                 updateRequest.getAttributeName()), result.getMetacard());
                     }

--- a/catalog/plugin/catalog-plugin-content-uri/pom.xml
+++ b/catalog/plugin/catalog-plugin-content-uri/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-plugin-content-uri</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Content URI</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.78</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.42</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.66</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-content-uri/src/main/java/org/codice/ddf/catalog/content/plugin/uri/ContentUriAccessPlugin.java
+++ b/catalog/plugin/catalog-plugin-content-uri/src/main/java/org/codice/ddf/catalog/content/plugin/uri/ContentUriAccessPlugin.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.content.plugin.uri;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.AccessPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+
+public class ContentUriAccessPlugin implements AccessPlugin {
+    @Override
+    public CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public UpdateRequest processPreUpdate(UpdateRequest input,
+            Map<String, Metacard> existingMetacards) throws StopProcessingException {
+        for (Map.Entry<Serializable, Metacard> entry : input.getUpdates()) {
+            Metacard existingMetacard = existingMetacards.get(entry.getKey()
+                    .toString());
+            if (entry.getValue()
+                    .getResourceURI() != null && existingMetacard.getResourceURI() != null
+                    && !existingMetacard.getResourceURI()
+                    .equals(entry.getValue()
+                            .getResourceURI())
+                    && ContentItem.CONTENT_SCHEME.equals(existingMetacard.getResourceURI()
+                    .getScheme())) {
+                throw new StopProcessingException("Cannot overwrite resource URI in content store.");
+            }
+        }
+        return input;
+    }
+
+    @Override
+    public DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public DeleteResponse processPostDelete(DeleteResponse input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public QueryResponse processPostQuery(QueryResponse input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public ResourceRequest processPreResource(ResourceRequest input)
+            throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public ResourceResponse processPostResource(ResourceResponse input, Metacard metacard)
+            throws StopProcessingException {
+        return input;
+    }
+}

--- a/catalog/plugin/catalog-plugin-content-uri/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-content-uri/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+        xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd"
+>
+
+    <bean id="contentUriPlugin"
+          class="org.codice.ddf.catalog.content.plugin.uri.ContentUriAccessPlugin"/>
+
+    <service ref="contentUriPlugin" interface="ddf.catalog.plugin.AccessPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-content-uri/src/test/java/org/codice/ddf/catalog/content/plugin/uri/TestContentUriAccessPlugin.java
+++ b/catalog/plugin/catalog-plugin-content-uri/src/test/java/org/codice/ddf/catalog/content/plugin/uri/TestContentUriAccessPlugin.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.content.plugin.uri;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.StopProcessingException;
+
+public class TestContentUriAccessPlugin {
+
+    public static final String ID_OR_URI = "ID_OR_URI";
+
+    private UpdateRequest input;
+
+    private Metacard updateCard;
+
+    private HashMap<String, Metacard> existingMetacards;
+
+    private Metacard existingMetacard;
+
+    private ContentUriAccessPlugin contentUriAccessPlugin;
+
+    @Before
+    public void setup() {
+        input = mock(UpdateRequest.class);
+        updateCard = mock(Metacard.class);
+        when(input.getUpdates()).thenReturn(Collections.singletonList(new HashMap.SimpleEntry<>(
+                ID_OR_URI,
+                updateCard)));
+        existingMetacards = new HashMap<>();
+        existingMetacard = mock(Metacard.class);
+        existingMetacards.put(ID_OR_URI, existingMetacard);
+        contentUriAccessPlugin = new ContentUriAccessPlugin();
+    }
+
+    @Test
+    public void bothUrisNull() throws StopProcessingException {
+        when(updateCard.getResourceURI()).thenReturn(null);
+        when(existingMetacard.getResourceURI()).thenReturn(null);
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+        assertNoChanges();
+    }
+
+    @Test
+    public void updateUriNull() throws StopProcessingException, URISyntaxException {
+        when(updateCard.getResourceURI()).thenReturn(null);
+        when(existingMetacard.getResourceURI()).thenReturn(new URI(""));
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+        assertNoChanges();
+    }
+
+    @Test
+    public void existingUriNull() throws StopProcessingException, URISyntaxException {
+        when(updateCard.getResourceURI()).thenReturn(new URI(""));
+        when(existingMetacard.getResourceURI()).thenReturn(null);
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+        assertNoChanges();
+    }
+
+    @Test
+    public void existingUriNonContent() throws StopProcessingException, URISyntaxException {
+        when(updateCard.getResourceURI()).thenReturn(new URI(""));
+        when(existingMetacard.getResourceURI()).thenReturn(new URI(""));
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+        assertNoChanges();
+    }
+
+    @Test(expected = StopProcessingException.class)
+    public void existingUriContent() throws StopProcessingException, URISyntaxException {
+        when(updateCard.getResourceURI()).thenReturn(new URI(""));
+        when(existingMetacard.getResourceURI()).thenReturn(new URI(ContentItem.CONTENT_SCHEME,
+                UUID.randomUUID()
+                        .toString(),
+                null));
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+    }
+
+    private void assertNoChanges() {
+        assertThat("Input should not have been modified", input, is(equalTo(input)));
+        assertThat("Existing metacards should not have been modified",
+                existingMetacards,
+                is(equalTo(existingMetacards)));
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -32,5 +32,6 @@
         <module>catalog-plugin-versioning</module>
         <module>catalog-plugin-duplication</module>
         <module>catalog-plugin-expirationdate</module>
+        <module>catalog-plugin-content-uri</module>
     </modules>
 </project>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -835,6 +835,21 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testUpdateContentResourceUri() throws IOException {
+        String fileName = testName.getMethodName() + ".txt";
+        String metacardId = ingestXmlWithProduct(fileName);
+        update(metacardId, Library.getSimpleXml("content:" + metacardId), "text/xml");
+        given().header(HttpHeaders.CONTENT_TYPE, "text/xml")
+                .body(Library.getSimpleXml("foo:bar"))
+                .expect()
+                .log()
+                .all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .when()
+                .put(new DynamicUrl(REST_PATH, metacardId).getUrl());
+    }
+
+    @Test
     public void testCachedContentLengthHeader() throws IOException {
         String fileName = "testCachedContentLengthHeader" + ".jpg";
         File tmpFile = createTemporaryFile(fileName,


### PR DESCRIPTION
#### What does this PR do?
Adds an `AccessPlugin` that prevents resource URIs in the content store from being overwritten.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @ahoffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
Ingest a product to the content store, such as via the search UI. Verify that attempting to overwrite the resource URI of the generated metacard is rejected.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2327
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

