### PR TITLE
DDF-2292 Fixed sdk-app redeploy issue by switching the packaging to pom

### DIFF
--- a/distribution/sdk/sdk-app/pom.xml
+++ b/distribution/sdk/sdk-app/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <artifactId>sdk-app</artifactId>
     <name>DDF :: SDK :: App</name>
-    <packaging>kar</packaging>
+    <packaging>pom</packaging>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
#### What does this PR do?
Fixes maven deploy issue which attempted to deploy the sdk features.xml file twice. This resulted in maven deploy failing overall. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann @coyotesqrl @oconnormi 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie 
@shaundmorris
#### How should this be tested?
Full build. Run maven deploy on the sdk-app with a released/fixed version set in the pom.xml
#### Any background context you want to provide?
This only has been discovered/reproduced during a release with the Nexus repository set to not allow redeployed artifacts
#### What are the relevant tickets?
DDF-2292
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/ddf/1048)
<!-- Reviewable:end -->
