### PR TITLE
DDF-2335 Disable the Hazelcast version check on startup.

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -173,3 +173,8 @@ karaf.secured.services=(&(osgi.command.scope=*)(osgi.command.function=*))
 #org.osgi.framework.trust.repositories=${karaf.home}/etc/trustStore.ks
 ws-security.subject.cert.constraints = .*
 security.audit.roles=group,admin,manager,viewer,system-admin,system-history,systembundles
+
+#
+# Disable Hazelcast version check
+#
+hazelcast.version.check.enabled=false


### PR DESCRIPTION
#### What does this PR do?
Disables the remote version check

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ryeats, @stustison 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested?
Build and unzip; run a full install of the app and see that the erroneous `fatal error` message no longer appears.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2335

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

