### PR TITLE
DDF-2333 Add a command for seeding the metacard and product caches

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -101,6 +101,10 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util-unavailableurls</artifactId>
             <version>${project.version}</version>

--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -97,17 +97,13 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util-unavailableurls</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SeedCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SeedCommand.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import static java.util.AbstractMap.SimpleEntry;
+import static java.util.Map.Entry;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static ddf.catalog.data.Metacard.ANY_TEXT;
+import static ddf.catalog.filter.FilterDelegate.WILDCARD_CHAR;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.apache.felix.gogo.commands.Command;
+import org.apache.felix.gogo.commands.Option;
+import org.fusesource.jansi.Ansi;
+import org.geotools.filter.text.cql2.CQL;
+import org.opengis.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.ResourceRequestById;
+import ddf.catalog.resource.ResourceNotFoundException;
+import ddf.catalog.resource.ResourceNotSupportedException;
+
+@Command(scope = CatalogCommands.NAMESPACE, name = "seed", description =
+        "Seeds the local metacard and product caches from the enterprise or from specific federated sources.\n\n"
+                + "\tThis command will query the enterprise or the specified sources for metacards in increments "
+                + "the size of the `--product-limit` argument (default 20) until that number of product downloads "
+                + "have started or until there are no more results. Local products will not be added to the cache. "
+                + "This command will not re-download products that are up-to-date in the cache, so subsequent runs "
+                + "of the command will attempt to cache metacards and products that have not already been cached.\n\n"
+                + "\tNote that this command will begin the product downloads and some may still be in progress "
+                + "by the time it completes. Also, product caching must be enabled in the catalog framework for "
+                + "this command to seed the product cache.")
+public class SeedCommand extends SubjectCommands {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeedCommand.class);
+
+    private static final Map<String, Serializable> CACHE_UPDATE_PROPERTIES =
+            Collections.singletonMap("mode", "update");
+
+    private static final String RESOURCE_CACHE_STATUS = "internal.local-resource";
+
+    @Option(name = "--source", multiValued = true, aliases = {
+            "-s"}, description = "Source(s) to query (e.g., -s source1 -s source2). Default is to query the entire enterprise.")
+    List<String> sources;
+
+    @Option(name = "--cql", description = "CQL expression specifying the metacards to seed.\n"
+            + "CQL Examples:\n" + "\tTextual:   seed --cql \"title like 'some text'\"\n"
+            + "\tTemporal:  seed --cql \"modified before 2012-09-01T12:30:00Z\"\n"
+            + "\tSpatial:   seed --cql \"DWITHIN(location, POINT (1 2), 10, kilometers)\"\n"
+            + "\tComplex:   seed --cql \"title like 'some text' AND modified before 2012-09-01T12:30:00Z\"")
+    String cql;
+
+    @Option(name = "--product-limit", aliases = {"-pl"}, description =
+            "The maximum number of products to download to the cache. The number of metacards cached "
+                    + "might not be equal to this number because some metacards may not have associated "
+                    + "products.")
+    int productLimit = 20;
+
+    private final Predicate<Metacard> isNonCachedResource = metacard -> {
+        Attribute cached = metacard.getAttribute(RESOURCE_CACHE_STATUS);
+        return cached == null || !((Boolean) cached.getValue());
+    };
+
+    private Filter createFilter() throws Exception {
+        if (isNotBlank(cql)) {
+            return CQL.toFilter(cql);
+        } else {
+            final FilterBuilder builder = getService(FilterBuilder.class);
+            if (builder != null) {
+                return builder.attribute(ANY_TEXT)
+                        .is()
+                        .like()
+                        .text(WILDCARD_CHAR);
+            } else {
+                throw new RuntimeException("Could not retrieve the FilterBuilder service.");
+            }
+        }
+    }
+
+    @Override
+    protected Object executeWithSubject() throws Exception {
+        if (productLimit <= 0) {
+            printErrorMessage("A limit of " + productLimit
+                    + " was supplied. The limit must be greater than 0.");
+            return null;
+        }
+
+        final Filter filter = createFilter();
+
+        final long start = System.currentTimeMillis();
+        int productDownloads = 0;
+        int downloadErrors = 0;
+        int pageCount = 0;
+
+        while (productDownloads < productLimit) {
+            final QueryImpl query = new QueryImpl(filter);
+            query.setPageSize(productLimit);
+            query.setStartIndex(pageCount * productLimit + 1);
+            ++pageCount;
+
+            final QueryRequestImpl queryRequest;
+            if (sources != null && !sources.isEmpty()) {
+                queryRequest = new QueryRequestImpl(query, sources);
+            } else {
+                queryRequest = new QueryRequestImpl(query, true);
+            }
+            queryRequest.setProperties(new HashMap<>(CACHE_UPDATE_PROPERTIES));
+
+            final CatalogFramework framework = getService(CatalogFramework.class);
+
+            final QueryResponse queryResponse;
+            if (framework != null) {
+                queryResponse = framework.query(queryRequest);
+            } else {
+                throw new RuntimeException("Could not retrieve the CatalogFramework service.");
+            }
+
+            if (queryResponse.getResults()
+                    .isEmpty()) {
+                break;
+            }
+
+            final List<Entry<? extends ResourceRequest, String>> resourceRequests =
+                    queryResponse.getResults()
+                            .stream()
+                            .map(Result::getMetacard)
+                            .filter(isNonCachedResource)
+                            .map(metacard -> new SimpleEntry<>(new ResourceRequestById(metacard.getId()),
+                                    metacard.getSourceId()))
+                            .collect(toList());
+
+            for (Entry<? extends ResourceRequest, String> requestAndSourceId : resourceRequests) {
+                final ResourceRequest request = requestAndSourceId.getKey();
+                try {
+                    framework.getResource(request, requestAndSourceId.getValue());
+                    ++productDownloads;
+                } catch (IOException | ResourceNotFoundException | ResourceNotSupportedException e) {
+                    ++downloadErrors;
+                    LOGGER.warn("Could not download product for metacard [id={}]",
+                            request.getAttributeValue(),
+                            e);
+                }
+
+                printProgressAndFlush(start, productLimit, productDownloads);
+
+                if (productDownloads == productLimit) {
+                    break;
+                }
+            }
+        }
+
+        printProgressAndFlush(start, productDownloads, productDownloads);
+
+        console.println();
+        if (downloadErrors > 0) {
+            printColor(Ansi.Color.YELLOW,
+                    downloadErrors
+                            + " product download(s) had errors. Check the logs for details.");
+        }
+        printSuccessMessage("Done seeding. " + productDownloads + " product download(s) started.");
+
+        return null;
+    }
+}

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SeedCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SeedCommand.java
@@ -53,14 +53,14 @@ import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 
 @Service
-@Command(scope = CatalogCommands.NAMESPACE, name = "seed", description =
-        "Seeds the local metacard and product caches from the enterprise or from specific federated sources.\n\n"
-                + "\tThis command will query the enterprise or the specified sources for metacards in increments "
+@Command(scope = CatalogCommands.NAMESPACE, name = "seed", description = "Seeds the local metacard "
+        + "and product caches from the enterprise or from specific federated sources.", detailedDescription =
+        "This command will query the enterprise or the specified sources for metacards in increments "
                 + "the size of the `--product-limit` argument (default 20) until that number of product downloads "
                 + "have started or until there are no more results. Local products will not be added to the cache. "
                 + "This command will not re-download products that are up-to-date in the cache, so subsequent runs "
                 + "of the command will attempt to cache metacards and products that have not already been cached.\n\n"
-                + "\tNote that this command will begin the product downloads and some may still be in progress "
+                + "Note that this command will begin the product downloads and some may still be in progress "
                 + "by the time it completes. Also, product caching must be enabled in the catalog framework for "
                 + "this command to seed the product cache.")
 public class SeedCommand extends SubjectCommands implements Action {

--- a/catalog/core/catalog-core-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,7 +3,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
+ * version 3 of the License, or any later version. 
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -50,7 +50,7 @@
 		<command name="catalog/describe">
 			<action class="org.codice.ddf.commands.catalog.DescribeCommand"/>
 		</command>
-
+		
 		<command name="catalog/dump">
 			<action class="org.codice.ddf.commands.catalog.DumpCommand"/>
 		</command>
@@ -58,17 +58,13 @@
 		<command name="catalog/range">
 			<action class="org.codice.ddf.commands.catalog.RangeCommand"/>
 		</command>
-
+		
 		<command name="catalog/replicate">
 			<action class="org.codice.ddf.commands.catalog.ReplicationCommand"/>
 		</command>
-
+		
 		<command name="catalog/migrate">
 			<action class="org.codice.ddf.commands.catalog.MigrateCommand"/>
-		</command>
-
-		<command name="catalog/seed">
-			<action class="org.codice.ddf.commands.catalog.SeedCommand"/>
 		</command>
 	</command-bundle>
 

--- a/catalog/core/catalog-core-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-commands/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,7 +3,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -50,7 +50,7 @@
 		<command name="catalog/describe">
 			<action class="org.codice.ddf.commands.catalog.DescribeCommand"/>
 		</command>
-		
+
 		<command name="catalog/dump">
 			<action class="org.codice.ddf.commands.catalog.DumpCommand"/>
 		</command>
@@ -58,13 +58,17 @@
 		<command name="catalog/range">
 			<action class="org.codice.ddf.commands.catalog.RangeCommand"/>
 		</command>
-		
+
 		<command name="catalog/replicate">
 			<action class="org.codice.ddf.commands.catalog.ReplicationCommand"/>
 		</command>
-		
+
 		<command name="catalog/migrate">
 			<action class="org.codice.ddf.commands.catalog.MigrateCommand"/>
+		</command>
+
+		<command name="catalog/seed">
+			<action class="org.codice.ddf.commands.catalog.SeedCommand"/>
 		</command>
 	</command-bundle>
 

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestSeedCommand.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestSeedCommand.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doReturn;
@@ -47,7 +46,6 @@ import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
@@ -66,21 +64,12 @@ public class TestSeedCommand extends TestAbstractCommand {
         consoleOutput = new ConsoleOutput();
         consoleOutput.interceptSystemOut();
 
-        framework = mock(CatalogFramework.class);
+        seedCommand = new SeedCommand();
 
-        seedCommand = new SeedCommand() {
-            @Override
-            protected <T> T getService(Class<T> clazz) {
-                if (clazz.equals(CatalogFramework.class)) {
-                    return clazz.cast(framework);
-                } else if (clazz.equals(FilterBuilder.class)) {
-                    return clazz.cast(new GeotoolsFilterBuilder());
-                } else {
-                    fail("getService() should not have been called with " + clazz.getName());
-                    return null;
-                }
-            }
-        };
+        framework = mock(CatalogFramework.class);
+        seedCommand.framework = framework;
+
+        seedCommand.filterBuilder = new GeotoolsFilterBuilder();
     }
 
     @After

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestSeedCommand.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TestSeedCommand.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import org.geotools.filter.text.cql2.CQL;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+
+public class TestSeedCommand extends TestAbstractCommand {
+    private SeedCommand seedCommand;
+
+    private ConsoleOutput consoleOutput;
+
+    private CatalogFramework framework;
+
+    @Before
+    public void setUp() {
+        consoleOutput = new ConsoleOutput();
+        consoleOutput.interceptSystemOut();
+
+        framework = mock(CatalogFramework.class);
+
+        seedCommand = new SeedCommand() {
+            @Override
+            protected <T> T getService(Class<T> clazz) {
+                if (clazz.equals(CatalogFramework.class)) {
+                    return clazz.cast(framework);
+                } else if (clazz.equals(FilterBuilder.class)) {
+                    return clazz.cast(new GeotoolsFilterBuilder());
+                } else {
+                    fail("getService() should not have been called with " + clazz.getName());
+                    return null;
+                }
+            }
+        };
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        consoleOutput.resetSystemOut();
+        consoleOutput.closeBuffer();
+    }
+
+    @Test
+    public void testBadProductLimit() throws Exception {
+        seedCommand.productLimit = 0;
+        seedCommand.executeWithSubject();
+        assertThat(consoleOutput.getOutput(), containsString("The limit must be greater than 0."));
+    }
+
+    @Test
+    public void testEnterprise() throws Exception {
+        mockQueryResponse(1, new String[0], new boolean[0]);
+        runCommandAndVerifyQueryRequest(request -> assertThat(request.isEnterprise(), is(true)));
+    }
+
+    @Test
+    public void testSources() throws Exception {
+        final String source1 = "source1";
+        final String source2 = "source2";
+        seedCommand.sources = newArrayList(source1, source2);
+
+        mockQueryResponse(1, new String[0], new boolean[0]);
+
+        runCommandAndVerifyQueryRequest(request -> {
+            assertThat(request.isEnterprise(), is(false));
+            assertThat(request.getSourceIds(), is(newHashSet(source1, source2)));
+        });
+    }
+
+    @Test
+    public void testCql() throws Exception {
+        final String cql = "modified AFTER 2016-07-21T00:00:00Z";
+        seedCommand.cql = cql;
+
+        mockQueryResponse(1, new String[0], new boolean[0]);
+
+        runCommandAndVerifyQueryRequest(request -> {
+            Query query = request.getQuery();
+            assertThat(CQL.toCQL(query), is(cql));
+        });
+    }
+
+    @Test
+    public void testNoCql() throws Exception {
+        mockQueryResponse(1, new String[0], new boolean[0]);
+
+        runCommandAndVerifyQueryRequest(request -> {
+            Query query = request.getQuery();
+            assertThat(CQL.toCQL(query), is("anyText ILIKE '*'"));
+        });
+    }
+
+    @Test
+    public void testCacheMetacards() throws Exception {
+        mockQueryResponse(1, new String[0], new boolean[0]);
+
+        runCommandAndVerifyQueryRequest(request -> assertThat(request.getProperties(),
+                hasEntry("mode", "update")));
+    }
+
+    private void runCommandAndVerifyQueryRequest(Consumer<QueryRequest> queryRequestAssertions)
+            throws Exception {
+        seedCommand.executeWithSubject();
+
+        ArgumentCaptor<QueryRequest> queryCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(framework).query(queryCaptor.capture());
+
+        QueryRequest request = queryCaptor.getValue();
+        queryRequestAssertions.accept(request);
+    }
+
+    @Test
+    public void testProductLimit() throws Exception {
+        final int limit = 2;
+        seedCommand.productLimit = limit;
+
+        final String id1 = "1";
+        final String id2 = "2";
+        mockQueryResponse(limit * 2 + 1, new String[] {id1, id2}, new boolean[] {false, false});
+
+        runCommandAndVerifyResourceRequests(limit, resourceRequests -> {
+            assertThat(resourceRequests, hasSize(limit));
+            verifyResourceRequest(resourceRequests.get(0), id1);
+            verifyResourceRequest(resourceRequests.get(1), id2);
+        }, siteNames -> assertThat(siteNames, is(newArrayList(id1, id2))));
+
+        verify(framework, times(1)).query(any(QueryRequest.class));
+    }
+
+    @Test
+    public void testFewerProductsThanLimit() throws Exception {
+        final int limit = 10;
+        seedCommand.productLimit = limit;
+
+        final String id1 = "1";
+        final String id2 = "2";
+        final String id3 = "3";
+        mockQueryResponse(limit + 1,
+                new String[] {id1, id2, id3},
+                new boolean[] {false, false, false});
+
+        final int expectedResourceRequests = 3;
+        runCommandAndVerifyResourceRequests(expectedResourceRequests, resourceRequests -> {
+            assertThat(resourceRequests, hasSize(expectedResourceRequests));
+            verifyResourceRequest(resourceRequests.get(0), id1);
+            verifyResourceRequest(resourceRequests.get(1), id2);
+            verifyResourceRequest(resourceRequests.get(2), id3);
+        }, siteNames -> assertThat(siteNames, is(newArrayList(id1, id2, id3))));
+
+        verify(framework, times(2)).query(any(QueryRequest.class));
+    }
+
+    @Test
+    public void testDoesNotDownloadCachedProduct() throws Exception {
+        final int limit = 3;
+        seedCommand.productLimit = limit;
+
+        final String id1 = "1";
+        final String id2 = "2";
+        mockQueryResponse(limit * 2 + 1,
+                new String[] {id1, id2, "3"},
+                new boolean[] {false, false, true});
+        final int expectedResourceRequests = 3;
+
+        runCommandAndVerifyResourceRequests(expectedResourceRequests, resourceRequests -> {
+            assertThat(resourceRequests, hasSize(expectedResourceRequests));
+            verifyResourceRequest(resourceRequests.get(0), id1);
+            verifyResourceRequest(resourceRequests.get(1), id2);
+            verifyResourceRequest(resourceRequests.get(2), id1);
+        }, siteNames -> assertThat(siteNames, is(newArrayList(id1, id2, id1))));
+
+        verify(framework, times(2)).query(any(QueryRequest.class));
+    }
+
+    private void runCommandAndVerifyResourceRequests(int expectedResourceRequests,
+            Consumer<List<ResourceRequest>> requestAssertions,
+            Consumer<List<String>> siteNameAssertions) throws Exception {
+        seedCommand.executeWithSubject();
+
+        ArgumentCaptor<ResourceRequest> resourceRequestCaptor = ArgumentCaptor.forClass(
+                ResourceRequest.class);
+        ArgumentCaptor<String> siteNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(framework,
+                times(expectedResourceRequests)).getResource(resourceRequestCaptor.capture(),
+                siteNameCaptor.capture());
+
+        List<ResourceRequest> resourceRequests = resourceRequestCaptor.getAllValues();
+        requestAssertions.accept(resourceRequests);
+
+        List<String> siteNames = siteNameCaptor.getAllValues();
+        siteNameAssertions.accept(siteNames);
+    }
+
+    private void mockQueryResponse(int stopReturningResultsAtIndex, String[] ids, boolean[] cached)
+            throws Exception {
+        List<Result> results = new ArrayList<>();
+        for (int i = 0; i < ids.length; ++i) {
+            String id = ids[i];
+            Result mockResult = mock(Result.class);
+            MetacardImpl metacard = new MetacardImpl();
+            metacard.setId(id);
+            metacard.setSourceId(id);
+            metacard.setAttribute("internal.local-resource", cached[i]);
+            when(mockResult.getMetacard()).thenReturn(metacard);
+            results.add(mockResult);
+        }
+
+        QueryResponse response = mock(QueryResponse.class);
+        when(response.getResults()).thenReturn(results);
+        doReturn(response).when(framework)
+                .query(argThat(isQueryWithStartIndex(request -> request.getQuery()
+                        .getStartIndex() < stopReturningResultsAtIndex)));
+
+        QueryResponse noResults = mock(QueryResponse.class);
+        when(noResults.getResults()).thenReturn(Collections.emptyList());
+        doReturn(noResults).when(framework)
+                .query(argThat(isQueryWithStartIndex(request -> request.getQuery()
+                        .getStartIndex() >= stopReturningResultsAtIndex)));
+    }
+
+    private IsQueryWithStartIndex isQueryWithStartIndex(Predicate<QueryRequest> test) {
+        return new IsQueryWithStartIndex(test);
+    }
+
+    private class IsQueryWithStartIndex extends ArgumentMatcher<QueryRequest> {
+        private final Predicate<QueryRequest> test;
+
+        private IsQueryWithStartIndex(Predicate<QueryRequest> test) {
+            this.test = test;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            return test.test((QueryRequest) o);
+        }
+    }
+
+    private void verifyResourceRequest(ResourceRequest request, String expectedAttributeValue) {
+        assertThat(request.getAttributeName(), is(Metacard.ID));
+        assertThat(request.getAttributeValue(), is(expectedAttributeValue));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds a `catalog:seed` command that allows the user to seed the local metacard and product caches from the enterprise or from specific federated sources.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@glenhein 
@rzwiefel 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@coyotesqrl 

#### How should this be tested?
Set up two DDFs. Ingest some products on DDF-1. On DDF-2, add DDF-1 as a federated source.

Run the `catalog:seed` command on DDF-2 with different values for the `--cql`, `--product-limit`, and `--source` options and verify that the expected metacards and products are added to the local caches.

#### What are the relevant tickets?
[DDF-2333](https://codice.atlassian.net/browse/DDF-2333)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
