### PR TITLE
DDF-2199 Added null metacard check to RegistryPolicyPlugin

### DIFF
--- a/catalog/spatial/registry/registry-policy-plugin/src/main/java/org/codice/ddf/registry/policy/RegistryPolicyPlugin.java
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/java/org/codice/ddf/registry/policy/RegistryPolicyPlugin.java
@@ -159,7 +159,7 @@ public class RegistryPolicyPlugin implements PolicyPlugin {
 
     private PolicyResponse getWritePolicy(Metacard input, Map<String, Serializable> properties) {
         HashMap<String, Set<String>> operationPolicy = new HashMap<>();
-        if (Requests.isLocal(properties) && RegistryUtility.isRegistryMetacard(input)) {
+        if (Requests.isLocal(properties) && input != null && RegistryUtility.isRegistryMetacard(input)) {
             String registryBaseUrl = RegistryUtility.getStringAttribute(input,
                     RegistryObjectMetacardType.REGISTRY_BASE_URL,
                     null);


### PR DESCRIPTION
#### What does this PR do?

While resolving merge conflicts from the previous 2199 PR, a null check was lost in RegistryPolicyPlugin.getWritePolicy. This PR fixes that.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @gordocanchola @clockard @spearskw 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris
#### How should this be tested?
Build

#### Any background context you want to provide?
https://github.com/codice/ddf/pull/1049

#### What are the relevant tickets?
DDF-2199

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

