### PR TITLE
DDF-2275 fix media.frame-center and media.compression

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
@@ -64,7 +64,7 @@ public class MediaAttributes implements Media, MetacardType {
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
-                BasicTypes.INTEGER_TYPE));
+                BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(ENCODING,
                 true /* indexed */,
                 true /* stored */,
@@ -74,9 +74,9 @@ public class MediaAttributes implements Media, MetacardType {
         descriptors.add(new AttributeDescriptorImpl(FRAME_CENTER,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 false /* multivalued */,
-                BasicTypes.STRING_TYPE));
+                BasicTypes.GEO_TYPE));
         descriptors.add(new AttributeDescriptorImpl(FRAMES_PER_SECOND,
                 true /* indexed */,
                 true /* stored */,


### PR DESCRIPTION
#### What does this PR do?
Fix media.frame-center and media.compression. Change media.frame-center to GEO_TYPE and non-tokenized, change media.compression to STRING.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brendan-hofmann 
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Run unit tests.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2275
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

