### PR TITLE
DDF-2275 Return immutable attribute sets

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -14,6 +14,7 @@
 package ddf.catalog.data.impl;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -101,59 +102,75 @@ public class BasicTypes {
 
     public static final String VALIDATION_ERRORS = "validation-errors";
 
-    private static final Map<String, AttributeType> ATTRIBUTE_TYPE_MAP = new HashMap<>();
+    private static final Map<String, AttributeType> ATTRIBUTE_TYPE_MAP;
+
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     static {
-        DATE_TYPE = addAttributeType("DATE_TYPE", AttributeFormat.DATE, Date.class);
+        Map<String, AttributeType> attributeTypeMap = new HashMap<>();
 
-        STRING_TYPE = addAttributeType("STRING_TYPE", AttributeFormat.STRING, String.class);
+        DATE_TYPE = addAttributeType("DATE_TYPE",
+                AttributeFormat.DATE,
+                Date.class,
+                attributeTypeMap);
 
-        XML_TYPE = addAttributeType("XML_TYPE", AttributeFormat.XML, String.class);
+        STRING_TYPE = addAttributeType("STRING_TYPE",
+                AttributeFormat.STRING,
+                String.class,
+                attributeTypeMap);
 
-        LONG_TYPE = addAttributeType("LONG_TYPE", AttributeFormat.LONG, Long.class);
+        XML_TYPE = addAttributeType("XML_TYPE",
+                AttributeFormat.XML,
+                String.class,
+                attributeTypeMap);
 
-        BINARY_TYPE = addAttributeType("BINARY_TYPE", AttributeFormat.BINARY, byte[].class);
+        LONG_TYPE = addAttributeType("LONG_TYPE",
+                AttributeFormat.LONG,
+                Long.class,
+                attributeTypeMap);
 
-        GEO_TYPE = addAttributeType("GEO_TYPE", AttributeFormat.GEOMETRY, String.class);
+        BINARY_TYPE = addAttributeType("BINARY_TYPE",
+                AttributeFormat.BINARY,
+                byte[].class,
+                attributeTypeMap);
 
-        BOOLEAN_TYPE = addAttributeType("BOOLEAN_TYPE", AttributeFormat.BOOLEAN, Boolean.class);
+        GEO_TYPE = addAttributeType("GEO_TYPE",
+                AttributeFormat.GEOMETRY,
+                String.class,
+                attributeTypeMap);
 
-        DOUBLE_TYPE = addAttributeType("DOUBLE_TYPE", AttributeFormat.DOUBLE, Double.class);
+        BOOLEAN_TYPE = addAttributeType("BOOLEAN_TYPE",
+                AttributeFormat.BOOLEAN,
+                Boolean.class,
+                attributeTypeMap);
 
-        FLOAT_TYPE = addAttributeType("FLOAT_TYPE", AttributeFormat.FLOAT, Float.class);
+        DOUBLE_TYPE = addAttributeType("DOUBLE_TYPE",
+                AttributeFormat.DOUBLE,
+                Double.class,
+                attributeTypeMap);
 
-        INTEGER_TYPE = addAttributeType("INTEGER_TYPE", AttributeFormat.INTEGER, Integer.class);
+        FLOAT_TYPE = addAttributeType("FLOAT_TYPE",
+                AttributeFormat.FLOAT,
+                Float.class,
+                attributeTypeMap);
 
-        OBJECT_TYPE = addAttributeType("OBJECT_TYPE", AttributeFormat.OBJECT, Serializable.class);
+        INTEGER_TYPE = addAttributeType("INTEGER_TYPE",
+                AttributeFormat.INTEGER,
+                Integer.class,
+                attributeTypeMap);
 
-        SHORT_TYPE = addAttributeType("SHORT_TYPE", AttributeFormat.SHORT, Short.class);
+        OBJECT_TYPE = addAttributeType("OBJECT_TYPE",
+                AttributeFormat.OBJECT,
+                Serializable.class,
+                attributeTypeMap);
 
-        BASIC_METACARD = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME,
-                getBasicAttributeDescriptors());
-    }
+        SHORT_TYPE = addAttributeType("SHORT_TYPE",
+                AttributeFormat.SHORT,
+                Short.class,
+                attributeTypeMap);
 
-    private static <T extends Serializable> AttributeType<T> addAttributeType(final String typeName,
-            final AttributeFormat format, final Class<T> bindingClass) {
-        final AttributeType<T> attributeType = new AttributeType<T>() {
-            private static final long serialVersionUID = 1L;
+        ATTRIBUTE_TYPE_MAP = Collections.unmodifiableMap(attributeTypeMap);
 
-            @Override
-            public Class<T> getBinding() {
-                return bindingClass;
-            }
-
-            @Override
-            public AttributeFormat getAttributeFormat() {
-                return format;
-            }
-        };
-
-        ATTRIBUTE_TYPE_MAP.put(typeName, attributeType);
-
-        return attributeType;
-    }
-
-    private static Set<AttributeDescriptor> getBasicAttributeDescriptors() {
         Set<AttributeDescriptor> descriptors = new HashSet<>();
         descriptors.add(new AttributeDescriptorImpl(Metacard.MODIFIED,
                 true /* indexed */,
@@ -311,7 +328,36 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
-        return descriptors;
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
+
+        BASIC_METACARD = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME,
+                getBasicAttributeDescriptors());
+    }
+
+    private static <T extends Serializable> AttributeType<T> addAttributeType(final String typeName,
+            final AttributeFormat format, final Class<T> bindingClass,
+            Map<String, AttributeType> map) {
+        final AttributeType<T> attributeType = new AttributeType<T>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Class<T> getBinding() {
+                return bindingClass;
+            }
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return format;
+            }
+        };
+
+        map.put(typeName, attributeType);
+
+        return attributeType;
+    }
+
+    private static Set<AttributeDescriptor> getBasicAttributeDescriptors() {
+        return DESCRIPTORS;
     }
 
     public static AttributeType getAttributeType(String type) {

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/AssociationsAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/AssociationsAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,23 +27,25 @@ import ddf.catalog.data.types.Associations;
  * This class provides attributes that represent associations between products.
  */
 public class AssociationsAttributes implements Associations, MetacardType {
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "associations";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(DERIVED,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(DERIVED,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(RELATED,
+        descriptors.add(new AttributeDescriptorImpl(RELATED,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/ContactAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/ContactAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,107 +30,109 @@ import ddf.catalog.data.types.Contact;
  */
 public class ContactAttributes implements Contact, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "contact";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CONTRIBUTOR_ADDRESS,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(CONTRIBUTOR_ADDRESS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CONTRIBUTOR_EMAIL,
+        descriptors.add(new AttributeDescriptorImpl(CONTRIBUTOR_EMAIL,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CONTRIBUTOR_NAME,
+        descriptors.add(new AttributeDescriptorImpl(CONTRIBUTOR_NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CONTRIBUTOR_PHONE,
+        descriptors.add(new AttributeDescriptorImpl(CONTRIBUTOR_PHONE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CREATOR_ADDRESS,
+        descriptors.add(new AttributeDescriptorImpl(CREATOR_ADDRESS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CREATOR_EMAIL,
+        descriptors.add(new AttributeDescriptorImpl(CREATOR_EMAIL,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CREATOR_NAME,
+        descriptors.add(new AttributeDescriptorImpl(CREATOR_NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CREATOR_PHONE,
+        descriptors.add(new AttributeDescriptorImpl(CREATOR_PHONE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_ADDRESS,
+        descriptors.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_ADDRESS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_EMAIL,
+        descriptors.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_EMAIL,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_NAME,
+        descriptors.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_PHONE,
+        descriptors.add(new AttributeDescriptorImpl(POINT_OF_CONTACT_PHONE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(PUBLISHER_ADDRESS,
+        descriptors.add(new AttributeDescriptorImpl(PUBLISHER_ADDRESS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(PUBLISHER_EMAIL,
+        descriptors.add(new AttributeDescriptorImpl(PUBLISHER_EMAIL,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(PUBLISHER_NAME,
+        descriptors.add(new AttributeDescriptorImpl(PUBLISHER_NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(PUBLISHER_PHONE,
+        descriptors.add(new AttributeDescriptorImpl(PUBLISHER_PHONE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,149 +27,151 @@ import ddf.catalog.data.types.Core;
  * This class provides attributes that reflect core attributes expected to be relevant to all metacard types
  */
 public class CoreAttributes implements Core, MetacardType {
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "core";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CHECKSUM,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(CHECKSUM,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CHECKSUM_ALGORITHM,
+        descriptors.add(new AttributeDescriptorImpl(CHECKSUM_ALGORITHM,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CREATED,
+        descriptors.add(new AttributeDescriptorImpl(CREATED,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(DESCRIPTION,
+        descriptors.add(new AttributeDescriptorImpl(DESCRIPTION,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(EXPIRATION,
+        descriptors.add(new AttributeDescriptorImpl(EXPIRATION,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(ID,
+        descriptors.add(new AttributeDescriptorImpl(ID,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(LANGUAGE,
+        descriptors.add(new AttributeDescriptorImpl(LANGUAGE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(LOCATION,
+        descriptors.add(new AttributeDescriptorImpl(LOCATION,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.GEO_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METADATA,
+        descriptors.add(new AttributeDescriptorImpl(METADATA,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.XML_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(MODIFIED,
+        descriptors.add(new AttributeDescriptorImpl(MODIFIED,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(DERIVED_RESOURCE_DOWNLOAD_URL,
+        descriptors.add(new AttributeDescriptorImpl(DERIVED_RESOURCE_DOWNLOAD_URL,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(DERIVED_RESOURCE_URI,
+        descriptors.add(new AttributeDescriptorImpl(DERIVED_RESOURCE_URI,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(RESOURCE_DOWNLOAD_URL,
+        descriptors.add(new AttributeDescriptorImpl(RESOURCE_DOWNLOAD_URL,
                 true /* indexed */,
                 false /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(RESOURCE_SIZE,
+        descriptors.add(new AttributeDescriptorImpl(RESOURCE_SIZE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(RESOURCE_URI,
+        descriptors.add(new AttributeDescriptorImpl(RESOURCE_URI,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(SOURCE_ID,
+        descriptors.add(new AttributeDescriptorImpl(SOURCE_ID,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(THUMBNAIL,
+        descriptors.add(new AttributeDescriptorImpl(THUMBNAIL,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.BINARY_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(TITLE,
+        descriptors.add(new AttributeDescriptorImpl(TITLE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METACARD_CREATED,
+        descriptors.add(new AttributeDescriptorImpl(METACARD_CREATED,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METACARD_MODIFIED,
+        descriptors.add(new AttributeDescriptorImpl(METACARD_MODIFIED,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METACARD_OWNER,
+        descriptors.add(new AttributeDescriptorImpl(METACARD_OWNER,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METACARD_TAGS,
+        descriptors.add(new AttributeDescriptorImpl(METACARD_TAGS,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.OBJECT_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(METACARD_PERMISSIONS,
+        descriptors.add(new AttributeDescriptorImpl(METACARD_PERMISSIONS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.XML_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/DateTimeAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/DateTimeAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,29 +30,31 @@ import ddf.catalog.data.types.DateTime;
  */
 public class DateTimeAttributes implements DateTime, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "datetime";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(START,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(START,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(END,
+        descriptors.add(new AttributeDescriptorImpl(END,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(DateTime.NAME,
+        descriptors.add(new AttributeDescriptorImpl(DateTime.NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/LocationAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/LocationAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -28,35 +29,37 @@ import ddf.catalog.data.types.Location;
  */
 public class LocationAttributes implements Location, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "location";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(ALTITUDE,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(ALTITUDE,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.DOUBLE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(COUNTRY_CODE,
+        descriptors.add(new AttributeDescriptorImpl(COUNTRY_CODE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(COORDINATE_REFERENCE_SYSTEM_CODE,
+        descriptors.add(new AttributeDescriptorImpl(COORDINATE_REFERENCE_SYSTEM_CODE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(COORDINATE_REFERENCE_SYSTEM_NAME,
+        descriptors.add(new AttributeDescriptorImpl(COORDINATE_REFERENCE_SYSTEM_NAME,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -28,89 +29,91 @@ import ddf.catalog.data.types.Media;
  */
 public class MediaAttributes implements Media, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "media";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(FORMAT,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(FORMAT,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(FORMAT_VERSION,
+        descriptors.add(new AttributeDescriptorImpl(FORMAT_VERSION,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(BITS_PER_SECOND,
+        descriptors.add(new AttributeDescriptorImpl(BITS_PER_SECOND,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(BITS_PER_SAMPLE,
+        descriptors.add(new AttributeDescriptorImpl(BITS_PER_SAMPLE,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(COMPRESSION,
+        descriptors.add(new AttributeDescriptorImpl(COMPRESSION,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(ENCODING,
+        descriptors.add(new AttributeDescriptorImpl(ENCODING,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(FRAME_CENTER,
+        descriptors.add(new AttributeDescriptorImpl(FRAME_CENTER,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(FRAMES_PER_SECOND,
+        descriptors.add(new AttributeDescriptorImpl(FRAMES_PER_SECOND,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(HEIGHT,
+        descriptors.add(new AttributeDescriptorImpl(HEIGHT,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(NUMBER_OF_BANDS,
+        descriptors.add(new AttributeDescriptorImpl(NUMBER_OF_BANDS,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(SCANNING_MODE,
+        descriptors.add(new AttributeDescriptorImpl(SCANNING_MODE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(TYPE,
+        descriptors.add(new AttributeDescriptorImpl(TYPE,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(WIDTH,
+        descriptors.add(new AttributeDescriptorImpl(WIDTH,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.INTEGER_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/TopicAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/TopicAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -27,29 +28,31 @@ import ddf.catalog.data.types.Topic;
  */
 public class TopicAttributes implements Topic, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "topic";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(CATEGORY,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(CATEGORY,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(KEYWORD,
+        descriptors.add(new AttributeDescriptorImpl(KEYWORD,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(VOCABULARY,
+        descriptors.add(new AttributeDescriptorImpl(VOCABULARY,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/ValidationAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/ValidationAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -27,23 +28,25 @@ import ddf.catalog.data.types.Validation;
  */
 public class ValidationAttributes implements Validation, MetacardType {
 
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "validation";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(VALIDATION_ERRORS,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(VALIDATION_ERRORS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(VALIDATION_WARNINGS,
+        descriptors.add(new AttributeDescriptorImpl(VALIDATION_WARNINGS,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/VersionAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/VersionAttributes.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.data.impl.types;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,53 +27,55 @@ import ddf.catalog.data.types.Version;
  * This class provides attributes that describe the history/versioning of the metacard
  */
 public class VersionAttributes implements Version, MetacardType {
-    private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
 
     private static final String NAME = "history";
 
     static {
-        DESCRIPTORS.add(new AttributeDescriptorImpl(ACTION,
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(ACTION,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(EDITED_BY,
+        descriptors.add(new AttributeDescriptorImpl(EDITED_BY,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(ID,
+        descriptors.add(new AttributeDescriptorImpl(ID,
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(TAGS,
+        descriptors.add(new AttributeDescriptorImpl(TAGS,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
-                BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(TYPE,
+                BasicTypes.STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(TYPE,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
-                BasicTypes.DATE_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(TYPE_BINARY,
+                BasicTypes.STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(TYPE_BINARY,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.BINARY_TYPE));
-        DESCRIPTORS.add(new AttributeDescriptorImpl(VERSIONED_BY,
+        descriptors.add(new AttributeDescriptorImpl(VERSIONED_BY,
                 true /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 true /* multivalued */,
-                BasicTypes.DATE_TYPE));
+                BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 
     @Override


### PR DESCRIPTION
#### What does this PR do?
Fixes new metacard types to return immutable sets of attributes instead of mutable sets.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@pklinef
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2275
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

