### PR TITLE
DDF-2332: Add data type attribute to Core taxonomy

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
@@ -171,6 +171,12 @@ public class CoreAttributes implements Core, MetacardType {
                 true /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.XML_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(DATATYPE,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                true /* multivalued */,
+                BasicTypes.STRING_TYPE));
         DESCRIPTORS = Collections.unmodifiableSet(descriptors);
     }
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
@@ -120,6 +120,11 @@ public interface Core {
     String TITLE = "title";
 
     /**
+     * {@link ddf.catalog.data.Attribute} name for accessing the generic type of the {@link Metacard} resource. <br/>
+     */
+    String DATATYPE = "datatype";
+
+    /**
      * {@link ddf.catalog.data.Attribute} name for accessing the creation date of the {@link Metacard}. <br/>
      */
     String METACARD_CREATED = "metacard.created";

--- a/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
@@ -1,0 +1,22 @@
+{
+  "validators": {
+    "datatype": [
+      {
+        "validator": "enumeration",
+        "arguments": [
+          "Collection",
+          "Dataset",
+          "Event",
+          "Image",
+          "Interactive Resource",
+          "Service",
+          "Software",
+          "Sound",
+          "Text",
+          "Video",
+          "Document"
+        ]
+      }
+    ]
+  }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/customtypedefinitions.json
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/customtypedefinitions.json
@@ -1,0 +1,24 @@
+{
+  "metacardTypes": [
+    {
+      "type": "customtype1",
+      "attributes": {
+        "title": {
+          "required": true
+        },
+        "datatype": {
+          "required": false
+        }
+      }
+    }
+  ],
+  "attributeTypes": {
+    "datatype": {
+      "type": "STRING_TYPE",
+      "indexed": true,
+      "stored": true,
+      "tokenized": true,
+      "multivalued": true
+    }
+  }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/metacard-datatype-validation.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/metacard-datatype-validation.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+          xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/"
+          xmlns:ns5="http://www.w3.org/2001/SMIL20/Language">
+    <type>customtype1</type>
+    <source>ddf.distribution</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>Datatype Validation Test Card</value>
+    </string>
+    <geometry name="location">
+        <value>
+            <ns2:Point>
+                <ns2:pos>-74.0452177 40.6898329</ns2:pos>
+            </ns2:Point>
+        </value>
+    </geometry>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=</value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+    <string name="datatype">
+        <value>Invalid Type</value>
+    </string>
+</metacard>


### PR DESCRIPTION
#### What does this PR do?
Adds the DataType attribute to the Core Taxonomy to describe at a high level the type of data being cataloged.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire 

#### How should this be tested?
Run the integration tests.

#### Any background context you want to provide?
Added the attribute as well as default validation rules that enforce the valid values. Additional changes were made to the integration tests where a default feature no longer needs to be started. Added cleanup to content directory test.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2332

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests

