### PR TITLE
DDF-2346: Source Modal does not like single quoted names

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Utils.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Utils.js
@@ -62,7 +62,7 @@ function ($,_, Marionette) {
          * Set up the popovers based on if the selector has a description.
          */
         setupPopOvers: function($popoverAnchor, id, title, description) {
-            var selector = ".description[data-title='" + id + "']",
+            var selector = ".description",
                 options = {
                     title: title,
                     content: description,


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issue where the Source modal won't open up if there is a single quote in the source's name.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @clockard @vinamartin @ryeats @ani6gup @brianfelix @djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold 
@shaundmorris
#### How should this be tested?
Start up DDF with registry. 
Open the DDF Catalog app. 
Open the Node Information tab
Open the identity node and rename it to something containing a single quote
Open the Services tab.
Add a service with at least one binding. Save
Open the Sources tab.
Verify a source exists for you identity node, you may have to refresh the list.
Click on the source and verify the modal opens up.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2346
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Updating the popover selector to remove the attribute check for 'data-title'.
An update was made to the backing library JQuery (or Sizzle) where the data-title attribute value containing a single quote is no longer recognized as an attribute.
Selecting on description class itself will add the popover.