### PR TITLE
DDF-2321 Add artemis message bus features

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/artemis.xml
+++ b/distribution/ddf-common/src/main/resources/etc/artemis.xml
@@ -1,0 +1,70 @@
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+    <jms xmlns="urn:activemq:jms">
+        <queue name="DLQ"/>
+        <queue name="ExpiryQueue"/>
+    </jms>
+
+    <core xmlns="urn:activemq:core">
+
+        <!-- this could be ASYNCIO or NIO -->
+        <journal-type>NIO</journal-type>
+        <paging-directory>${ddf.home}/data/artemis/paging</paging-directory>
+        <bindings-directory>${ddf.home}/data/artemis/bindings</bindings-directory>
+        <journal-directory>${ddf.home}/data/artemis/journal</journal-directory>
+        <large-messages-directory>${ddf.home}/data/artemis/large-messages</large-messages-directory>
+        <journal-min-files>10</journal-min-files>
+
+        <!--
+         This value was determined through a calculation.
+         Your system could perform 0.63 writes per millisecond
+         on the current journal configuration.
+         That translates as a sync write every 1591999 nanoseconds
+        -->
+        <journal-buffer-timeout>1591999</journal-buffer-timeout>
+
+        <acceptors>
+            <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+            <acceptor name="amqp">tcp://0.0.0.0:${artemis.amqp.port}?sslEnabled=true;keyStorePath=${javax.net.ssl.keyStore};keyStorePassword=${javax.net.ssl.keyStorePassword};enabledCipherSuites=${https.cipherSuites};enabledProtocols=${https.protocols}</acceptor>
+        </acceptors>
+
+        <security-settings>
+            <security-setting match="#">
+                <permission type="createNonDurableQueue" roles="manager"/>
+                <permission type="deleteNonDurableQueue" roles="manager"/>
+                <permission type="createDurableQueue" roles="manager"/>
+                <permission type="deleteDurableQueue" roles="manager"/>
+                <permission type="consume" roles="manager"/>
+                <permission type="send" roles="manager"/>
+                <!-- we need this otherwise ./artemis data imp wouldn't work -->
+                <permission type="manage" roles="manager"/>
+            </security-setting>
+        </security-settings>
+
+        <address-settings>
+            <!--default for catch all-->
+            <address-setting match="#">
+                <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                <redelivery-delay>0</redelivery-delay>
+                <max-size-bytes>10485760</max-size-bytes>
+                <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                <address-full-policy>BLOCK</address-full-policy>
+                <auto-create-jms-queues>true</auto-create-jms-queues>
+            </address-setting>
+        </address-settings>
+    </core>
+</configuration>

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.activemq.artemis.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.activemq.artemis.cfg
@@ -1,0 +1,4 @@
+config=file:etc/artemis.xml
+name=local
+domain=karaf
+rolePrincipalClass=org.apache.karaf.jaas.boot.principal.RolePrincipal

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -185,3 +185,8 @@ security.audit.roles=group,admin,manager,viewer,system-admin,system-history,syst
 # Disable Hazelcast version check
 #
 hazelcast.version.check.enabled=false
+
+#
+# Artemis Message Bus properties
+#
+artemis.amqp.port=5672

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -102,6 +102,9 @@
                                 <descriptor>
                                     mvn:ddf.distribution/install-profiles/${project.version}/xml/features
                                 </descriptor>
+                                <descriptor>
+                                    mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features
+                                </descriptor>
                             </descriptors>
                             <repository>${setup.folder}/${karaf.folder}/system</repository>
                         </configuration>
@@ -339,6 +342,13 @@
             <groupId>org.codice.ddf.resourcemanagement</groupId>
             <artifactId>resourcemanagement-app</artifactId>
             <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>enterprise</artifactId>
+            <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/distribution/ddf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/ddf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -33,7 +33,8 @@ featuresRepositories= \
  mvn:ddf.admin/admin-app/${project.version}/xml/features, \
  mvn:org.codice.ddf.resourcemanagement/resourcemanagement-app/${project.version}/xml/features, \
  mvn:org.codice.ddf.spatial/geowebcache-app/${project.version}/xml/features, \
- mvn:org.codice.ddf.registry/registry-app/${project.version}/xml/features
+ mvn:org.codice.ddf.registry/registry-app/${project.version}/xml/features, \
+ mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features
 
 #
 # Comma separated list of features to install at startup

--- a/distribution/ddf/src/main/filtered-resources/etc/org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl.config
+++ b/distribution/ddf/src/main/filtered-resources/etc/org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl.config
@@ -1,2 +1,2 @@
 service.pid="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl"
-ignoredApplications=["standard","kernel","org.ops4j.pax.web","org.ops4j.pax.cdi","install-profiles","enterprise","spring"]
+ignoredApplications=["standard","kernel","org.ops4j.pax.web","org.ops4j.pax.cdi", "org.ops4j.pax.jdbc", "install-profiles","enterprise","spring"]

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -59,7 +59,7 @@
         <feature version='${camel.version}'>camel-spring</feature>
         <feature version='${camel.version}'>camel-blueprint</feature>
     </feature>
-    <feature name='camel-amqp' version='${project.version}' start-level='50'>
+    <feature name='camel-amqp' version='${camel.version}' start-level='50'>
     <bundle dependency='true'>mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
     <bundle dependency='true'>mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mina/${servicemix.bundles.mina.version}</bundle>
@@ -1042,6 +1042,43 @@
         <feature>platform-migratable-api</feature>
         <feature>platform-migration</feature>
         <feature>platform-migratable</feature>
+    </feature>
+
+    <feature name="artemis-core" install="manual" version="${artemis.version}" description="ActiveMQ Artemis broker libraries">
+        <feature prerequisite="true">transaction</feature>
+        <feature prerequisite="true">netty-core</feature>
+        <feature prerequisite="true">scr</feature>
+        <configfile finalname="etc/org.apache.activemq.artemis.cfg">mvn:org.apache.activemq/artemis-features/${artemis.version}/cfg</configfile>
+        <configfile finalname="etc/artemis.xml">mvn:org.apache.activemq/artemis-features/${artemis.version}/xml/artemis</configfile>
+
+        <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_2.0_spec/${geronimo-jms_2_spec.version}</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+        <bundle>mvn:io.netty/netty-codec-http/${netty.version}</bundle>
+        <bundle>mvn:commons-beanutils/commons-beanutils/${commons-beanutils.version}</bundle>
+        <bundle>mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
+
+        <bundle>mvn:org.jboss.logging/jboss-logging/${jboss-logging.version}</bundle>
+        <bundle>mvn:org.jgroups/jgroups/${jgroups.version}</bundle>
+
+        <bundle>mvn:org.apache.activemq/artemis-native/${artemis.version}</bundle>
+        <bundle>mvn:org.apache.activemq/artemis-server-osgi/${artemis.version}</bundle>
+    </feature>
+
+    <feature name="artemis-amqp" install="manual" version="${artemis.version}" description="ActiveMQ Artemis AMQP protocol libraries">
+        <feature prerequisite="true">wrap</feature>
+        <feature prerequisite="true">artemis-core</feature>
+        <bundle>wrap:mvn:org.apache.qpid/proton-j/${proton.version}</bundle>
+        <bundle>wrap:mvn:org.apache.qpid/qpid-jms-client/${qpid-jms.version}</bundle>
+        <bundle>mvn:org.apache.activemq/artemis-proton-plug/${artemis.version}</bundle>
+        <bundle>mvn:org.apache.activemq/artemis-amqp-protocol/${artemis.version}</bundle>
+    </feature>
+
+    <feature name="netty-core" install="manual" version="${netty.version}" description="Netty libraries">
+        <bundle>mvn:io.netty/netty-common/${netty.version}</bundle>
+        <bundle>mvn:io.netty/netty-transport/${netty.version}</bundle>
+        <bundle>mvn:io.netty/netty-buffer/${netty.version}</bundle>
+        <bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
+        <bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>
     </feature>
 
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,15 @@
         <servicemix.bundles.commons-httpclient.version>3.1_7</servicemix.bundles.commons-httpclient.version>
         <commons-pool.version>1.6</commons-pool.version>
         <servicemix.bundles.junit.version>4.11_2</servicemix.bundles.junit.version>
+        <!-- Artemis dependencies -->
+        <artemis.version>1.3.0</artemis.version>
+        <proton.version>0.12.2</proton.version>
+        <geronimo-jms_2_spec.version>1.0-alpha-2</geronimo-jms_2_spec.version>
+        <jboss-logging.version>3.3.0.Final</jboss-logging.version>
+        <jgroups.version>3.6.9.Final</jgroups.version>
+        <commons-beanutils.version>1.9.2</commons-beanutils.version>
+        <netty.version>4.0.32.Final</netty.version>
+        <qpid-jms.version>0.9.0</qpid-jms.version>
         <!--Documentation Replacements-->
         <branding>DDF</branding>
         <branding-lowercase>ddf</branding-lowercase>


### PR DESCRIPTION
#### What does this PR do?
Adds a message bus application (Apache Artemis) allowing message communication from JMS queues and topics.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@coyotesqrl 
@ryeats 
@pklinef 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
#### How should this be tested?
Install artemis-amqp, and make sure it installs correctly.
Once artemis is installed, do a port scan on port 5672 using localhost to verify the connection to the message bus is open.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2321
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests