### PR TITLE
DDF-2359 fix issues ingesting images on a headless server

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -31,6 +31,9 @@ javax.net.ssl.trustStorePassword=changeit
 javax.net.ssl.keyStoreType=jks
 javax.net.ssl.trustStoreType=jks
 
+#force java to run in headless mode for when the server doesn't have a display device
+java.awt.headless=true
+
 # Set the global url properties
 org.codice.ddf.system.protocol=https://
 org.codice.ddf.system.hostname=localhost


### PR DESCRIPTION
#### What does this PR do?
fix issue ingesting images caused by generating thumbnails on headless server
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @adimka @bcwaters 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris
#### How should this be tested?
run a ddf on a headless server and successfully ingest an image and verify that a thumbnail is generated
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests