### PR TITLE
DDF-2307 Fix map preferences restore button

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/user.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/user.js
@@ -94,14 +94,15 @@ define([
             };
         },
         parse: function(resp) {
-            resp.label = 'Type: ' + resp.type;
-            if (resp.layer) {
-                resp.label += ' Layer: ' + resp.layer;
+            var layer = _.clone(resp);
+            layer.label = 'Type: ' + layer.type;
+            if (layer.layer) {
+                layer.label += ' Layer: ' + layer.layer;
             }
-            if (resp.layers) {
-                resp.label += ' Layers: ' + resp.layers.join(', ');
+            if (layer.layers) {
+                layer.label += ' Layers: ' + layer.layers.join(', ');
             }
-            return resp;
+            return layer;
         }
     });
 


### PR DESCRIPTION
#### What does this PR do?
Fixes regressions caused by the original DDF-2307 commit.

- Fix restore button to use properties
- Sort views by label instead of alpha
- Fix render order to avoid model binder errors when sorting the
  collection
- Fix user model to not modify the original layer from properties

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@djblue 
@andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
Use the restore defaults button in the Standard UI map preferences.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2307

#### Screenshots (if appropriate)

#### Checklist:
- [ n/a ] Documentation Updated
- [ n/a ] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests
