### PR TITLE
DDF-2296: Fixed local resource query to include anytag search

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/ResourceOperationsTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/ResourceOperationsTest.groovy
@@ -16,6 +16,7 @@ package ddf.catalog.impl.operations
 import ddf.catalog.data.Metacard
 import ddf.catalog.data.Result
 import ddf.catalog.event.retrievestatus.DownloadStatusInfo
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder
 import ddf.catalog.impl.FrameworkProperties
 import ddf.catalog.operation.QueryResponse
 import ddf.catalog.operation.ResourceRequest
@@ -58,6 +59,7 @@ class ResourceOperationsTest extends Specification {
         queryOperations.query(_, _, _, _) >> queryResponse
 
         frameworkProperties = new FrameworkProperties()
+        frameworkProperties.setFilterBuilder(new GeotoolsFilterBuilder())
 
         opsSecurity = new OperationsSecuritySupport()
         resourceOperations = new ResourceOperations(frameworkProperties, queryOperations, opsSecurity)

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -311,7 +311,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
         getCatalogBundle().setDownloadRetryDelayInSeconds(1);
 
-        getCatalogBundle().setupCaching(true);
+        getCatalogBundle().setupCaching(false);
         urlResourceReaderConfigurator = getUrlResourceReaderConfigurator();
 
         if (fatalError) {
@@ -571,8 +571,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
         // Perform Test and Verify
         // @formatter:off
-        when().get(restUrl).then().log().all().assertThat().contentType("text/plain")
-                .body(is(SAMPLE_DATA));
+        when().get(restUrl).then().log().all().assertThat().body(is(SAMPLE_DATA));
         // @formatter:on
     }
 
@@ -1492,6 +1491,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testDownloadFromCacheIfAvailable() throws Exception {
+        getCatalogBundle().setupCaching(true);
         cometDClient = setupCometDClient(Arrays.asList(NOTIFICATIONS_CHANNEL, ACTIVITIES_CHANNEL));
 
         String filename = "product4.txt";
@@ -1619,6 +1619,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testFileCachesCorrectlyWhenRangeHeadersAreSupported() throws Exception {
+        getCatalogBundle().setupCaching(true);
         cometDClient = setupCometDClient(Arrays.asList(NOTIFICATIONS_CHANNEL, ACTIVITIES_CHANNEL));
         String filename = "product2.txt";
         String metacardId = generateUniqueMetacardId();
@@ -1681,7 +1682,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @Test
     public void testProductDownloadListWithOneActiveDownload() throws IOException {
-
+        getCatalogBundle().setupCaching(true);
         String filename = "product.txt";
         String metacardId = generateUniqueMetacardId();
         String resourceData = getResourceData(metacardId);
@@ -1718,7 +1719,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testProductDownloadListWithTwoActiveDownloads() throws IOException {
-
+        getCatalogBundle().setupCaching(true);
         String filename1 = "product1.txt";
         String metacardId1 = generateUniqueMetacardId();
         String resourceData1 = getResourceData(metacardId1);
@@ -1785,7 +1786,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testProductDownloadListWithTwoActiveDownloadsOneFails() throws Exception {
-
+        getCatalogBundle().setupCaching(true);
         cometDClient = setupCometDClient(Arrays.asList(ACTIVITIES_CHANNEL));
 
         String filename1 = "product1.txt";
@@ -1927,6 +1928,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @Test
     public void testCancelDownload() throws Exception {
+        getCatalogBundle().setupCaching(true);
         getSecurityPolicy().configureWebContextPolicy(null,
                 "/=SAML|basic,/solr=SAML|PKI|basic",
                 null,
@@ -2214,6 +2216,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @Test
     public void testSingleUserDownloadSameProductSyncAndAsync() throws Exception {
+        getCatalogBundle().setupCaching(true);
         getSecurityPolicy().configureWebContextPolicy(null,
                 "/=SAML|basic,/solr=SAML|PKI|basic",
                 null,
@@ -2275,6 +2278,7 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @Test
     public void testSingleUserDownloadSameProductAsync() throws Exception {
+        getCatalogBundle().setupCaching(true);
         getSecurityPolicy().configureWebContextPolicy(null,
                 "/=SAML|basic,/solr=SAML|PKI|basic",
                 null,
@@ -2440,7 +2444,7 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testAsyncDownloadActionPresentUsingCometDClient() throws Exception {
-
+        getCatalogBundle().setupCaching(true);
         String src = "ddf.distribution";
         String metacardId = ingestXmlWithProduct(String.format("%s.txt", testName.getMethodName()));
         String responseChannelId = "0193d9e7f9ed4f8f8bd02103143c41d6";


### PR DESCRIPTION
*This is a re-pullrequest since catalogframework rework*

#### What does this PR do?
Adds back the anytag search into the catalog framework queries while getting resources

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@djblue 
@ryeats 
@stustison 
@kcwire 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@pklinef


