### PR TITLE
DDF-2365: updated recommended Java version in DDF docs

### DIFF
--- a/distribution/docs/src/main/resources/_contents/installing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/installing-contents.adoc
@@ -20,6 +20,7 @@ Restrict access to sensitive files by ensuring that the only users with access p
 . Delete any other groups or users listed with access to `INSTALLATION_HOME/etc` and `INSTALLATION_HOME/deploy`.
 
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
+** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 * Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
@@ -77,7 +78,7 @@ For the change to take effect, a restart is required.
 init 6
 ----
 
-===== Directory Permissions on *NIX
+====== Directory Permissions on *NIX
 
 Protect the ${ddf-branding} from unauthorized access.
 

--- a/distribution/docs/src/main/resources/_contents/quickstart-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/quickstart-contents.adoc
@@ -10,6 +10,7 @@ These steps will demonstrate:
 ==== Prerequisites
 
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
+** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 * Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.


### PR DESCRIPTION
#### What does this PR do?

Adds a recommendation to use a Java version of 8u60 or higher.

#### Who is reviewing it?

@vinamartin @Lambeaux @jrnorth 

#### Choose 2 committers to review/merge the PR.

@shaundmorris
@stustison

#### How should this be tested?

review documentation

#### What are the relevant tickets?

[DDF-2365](https://codice.atlassian.net/browse/DDF-2365)

#### Screenshots (if appropriate)

![screen shot 2016-08-05 at 9 11 19 am](https://cloud.githubusercontent.com/assets/10619999/17442929/e9ebc1c0-5aec-11e6-877f-8d993c41c157.png)
![screen shot 2016-08-05 at 9 15 57 am](https://cloud.githubusercontent.com/assets/10619999/17443028/4a7319b2-5aed-11e6-9feb-51cb01dbc98a.png)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

