### PR TITLE
DDF-2356 Added configuration to distinguish between filtering metacards with errors or warnings

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityFilterPlugin.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -38,6 +38,10 @@ import ddf.catalog.plugin.impl.PolicyResponseImpl;
 public class MetacardValidityFilterPlugin implements PolicyPlugin {
 
     private static Map<String, List<String>> attributeMap = new HashMap<>();
+
+    private boolean filterErrors = true;
+
+    private boolean filterWarnings = false;
 
     public Map<String, List<String>> getAttributeMap() {
         return attributeMap;
@@ -104,20 +108,21 @@ public class MetacardValidityFilterPlugin implements PolicyPlugin {
         Metacard metacard = input.getMetacard();
         HashMap<String, Set<String>> securityMap = new HashMap<>();
 
-        if ((metacard.getAttribute(Validation.VALIDATION_ERRORS) != null && metacard.getAttribute(
-                Validation.VALIDATION_ERRORS)
-                .getValues() != null) || (
-                metacard.getAttribute(Validation.VALIDATION_WARNINGS) != null &&
-                        metacard.getAttribute(Validation.VALIDATION_WARNINGS)
-                                .getValues() != null)) {
+        if (isMarkedForFilter(filterErrors, metacard, Validation.VALIDATION_ERRORS)
+                || isMarkedForFilter(filterWarnings, metacard, Validation.VALIDATION_WARNINGS)) {
             for (Map.Entry<String, List<String>> attributeMapping : attributeMap.entrySet()) {
                 securityMap.put(attributeMapping.getKey(),
                         new HashSet<>(attributeMapping.getValue()));
             }
-
         }
 
         return new PolicyResponseImpl(new HashMap<>(), securityMap);
+    }
+
+    private boolean isMarkedForFilter(boolean filterFlag, Metacard metacard, String attribute) {
+        return filterFlag && metacard.getAttribute(attribute) != null && metacard.getAttribute(
+                attribute)
+                .getValues() != null;
     }
 
     @Override
@@ -130,5 +135,21 @@ public class MetacardValidityFilterPlugin implements PolicyPlugin {
     public PolicyResponse processPostResource(ResourceResponse resourceResponse, Metacard metacard)
             throws StopProcessingException {
         return new PolicyResponseImpl();
+    }
+
+    public void setFilterErrors(boolean filterErrors) {
+        this.filterErrors = filterErrors;
+    }
+
+    public boolean getFilterErrors() {
+        return filterErrors;
+    }
+
+    public void setFilterWarnings(boolean filterWarnings) {
+        this.filterWarnings = filterWarnings;
+    }
+
+    public boolean getFilterWarnings() {
+        return filterWarnings;
     }
 }

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -53,6 +53,8 @@
         <property name="attributeMap">
             <list/>
         </property>
+        <property name="filterErrors" value="true"/>
+        <property name="filterWarnings" value="false"/>
     </bean>
 
 

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,6 +22,14 @@
                 description="Mapping of Metacard SECURITY attribute to user attribute."
                 name="Attribute map" id="attributeMap" required="false" type="String"
                 default="invalid-state=system-admin" cardinality="100"/>
+        <AD
+                description="Sets whether metacards with validation errors are filtered."
+                name="Show errors" id="showErrors" required="false" type="Boolean"
+                default="true" cardinality="1"/>
+        <AD
+                description="Sets whether metacards with validation warnings are filtered."
+                name="Show warnings" id="showWarnings" required="false" type="Boolean"
+                default="false" cardinality="1"/>
     </OCD>
 
     <OCD name="Metacard Validation Marker Plugin"

--- a/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
+++ b/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
@@ -26,7 +26,11 @@ import ddf.catalog.validation.ValidationException;
 import ddf.catalog.validation.impl.ValidationExceptionImpl;
 
 public class SampleMetacardValidator implements MetacardValidator, Describable {
-    private Set<String> validWords = Sets.newHashSet("test", "default", "sample");
+    private Set<String> validWords = Sets.newHashSet("clean", "test", "default", "sample");
+
+    private Set<String> warningWords = Sets.newHashSet("warning");
+
+    private Set<String> errorWords = Sets.newHashSet("error");
 
     private String id = "sample-validator";
 
@@ -61,7 +65,20 @@ public class SampleMetacardValidator implements MetacardValidator, Describable {
 
     @Override
     public void validate(Metacard metacard) throws ValidationException {
-        if (!checkMetacard(metacard.getTitle())) {
+        if (checkMetacardForWarningWords(metacard.getTitle())) {
+            ValidationExceptionImpl validationException = new ValidationExceptionImpl(
+                    "Metacard title contains one of the warning words: " + validWords);
+            validationException.setWarnings(Collections.singletonList("sampleWarnings"));
+            throw validationException;
+        }
+        if (checkMetacardForErrorWords(metacard.getTitle())) {
+            ValidationExceptionImpl validationException = new ValidationExceptionImpl(
+                    "Metacard title does not contain any of: " + validWords);
+            validationException.setErrors(Collections.singletonList("sampleError"));
+            validationException.setWarnings(Collections.singletonList("sampleWarnings"));
+            throw validationException;
+        }
+        if (!checkMetacardForValidWords(metacard.getTitle())) {
             ValidationExceptionImpl validationException = new ValidationExceptionImpl(
                     "Metacard title does not contain any of: " + validWords);
             validationException.setErrors(Collections.singletonList("sampleError"));
@@ -70,8 +87,18 @@ public class SampleMetacardValidator implements MetacardValidator, Describable {
         }
     }
 
-    private boolean checkMetacard(String title) {
+    private boolean checkMetacardForValidWords(String title) {
         return validWords.stream()
+                .anyMatch(title::contains);
+    }
+
+    private boolean checkMetacardForWarningWords(String title) {
+        return warningWords.stream()
+                .anyMatch(title::contains);
+    }
+
+    private boolean checkMetacardForErrorWords(String title) {
+        return errorWords.stream()
                 .anyMatch(title::contains);
     }
 
@@ -81,7 +108,27 @@ public class SampleMetacardValidator implements MetacardValidator, Describable {
         }
     }
 
+    public void setWarningWords(Set<String> warningWords) {
+        if (warningWords != null) {
+            this.warningWords = warningWords;
+        }
+    }
+
+    public void setErrorWords(Set<String> errorWords) {
+        if (errorWords != null) {
+            this.errorWords = errorWords;
+        }
+    }
+
     public Set<String> getValidWords() {
         return validWords;
+    }
+
+    public Set<String> getWarningWords() {
+        return warningWords;
+    }
+
+    public Set<String> getErrorWords() {
+        return errorWords;
     }
 }

--- a/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
+++ b/distribution/sdk/sample-metacard-validator/src/main/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidator.java
@@ -67,15 +67,14 @@ public class SampleMetacardValidator implements MetacardValidator, Describable {
     public void validate(Metacard metacard) throws ValidationException {
         if (checkMetacardForWarningWords(metacard.getTitle())) {
             ValidationExceptionImpl validationException = new ValidationExceptionImpl(
-                    "Metacard title contains one of the warning words: " + validWords);
+                    "Metacard title contains one of the warning words: " + warningWords);
             validationException.setWarnings(Collections.singletonList("sampleWarnings"));
             throw validationException;
         }
         if (checkMetacardForErrorWords(metacard.getTitle())) {
             ValidationExceptionImpl validationException = new ValidationExceptionImpl(
-                    "Metacard title does not contain any of: " + validWords);
+                    "Metacard title contains one of the error words: " + errorWords);
             validationException.setErrors(Collections.singletonList("sampleError"));
-            validationException.setWarnings(Collections.singletonList("sampleWarnings"));
             throw validationException;
         }
         if (!checkMetacardForValidWords(metacard.getTitle())) {

--- a/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/sdk/sample-metacard-validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,11 +14,22 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <!-- Register in the OSGi Service Registry -->
-    <service interface="ddf.catalog.validation.MetacardValidator" >
+    <service interface="ddf.catalog.validation.MetacardValidator">
         <bean class="org.codice.ddf.sdk.validation.metacard.SampleMetacardValidator">
             <property name="validWords">
                 <set value-type="java.lang.String">
                     <value>Metacard-1</value>
+                    <value>clean</value>
+                </set>
+            </property>
+            <property name="warningWords">
+                <set value-type="java.lang.String">
+                    <value>warning</value>
+                </set>
+            </property>
+            <property name="errorWords">
+                <set value-type="java.lang.String">
+                    <value>error</value>
                 </set>
             </property>
         </bean>

--- a/distribution/sdk/sample-metacard-validator/src/test/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidatorTest.java
+++ b/distribution/sdk/sample-metacard-validator/src/test/java/org/codice/ddf/sdk/validation/metacard/SampleMetacardValidatorTest.java
@@ -16,6 +16,8 @@ package org.codice.ddf.sdk.validation.metacard;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.validation.ValidationException;
 
@@ -26,14 +28,35 @@ public class SampleMetacardValidatorTest {
         MetacardImpl metacard = new MetacardImpl();
         metacard.setTitle("sample");
         SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.setValidWords(ImmutableSet.of("sample"));
+        validator.setWarningWords(ImmutableSet.of("warning"));
         validator.validate(metacard);
     }
 
     @Test(expected = ValidationException.class)
-    public void testValidateInvalidMetacard() throws ValidationException {
+    public void testValidateNoValidWordsMetacard() throws ValidationException {
         MetacardImpl metacard = new MetacardImpl();
         metacard.setTitle("invalid");
         SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.setValidWords(ImmutableSet.of("sample"));
+        validator.validate(metacard);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateWarningMetacard() throws ValidationException {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("warning");
+        SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.setWarningWords(ImmutableSet.of("warning"));
+        validator.validate(metacard);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testValidateErrorMetacard() throws ValidationException {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle("error");
+        SampleMetacardValidator validator = new SampleMetacardValidator();
+        validator.setErrorWords(ImmutableSet.of("error"));
         validator.validate(metacard);
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -611,6 +611,22 @@ public abstract class AbstractIntegrationTest {
         config.update(properties);
     }
 
+    protected void configureFilterInvalidMetacards(String filterErrors, String filterWarnings)
+            throws IOException {
+        Configuration config = configAdmin.getConfiguration(
+                "ddf.catalog.metacard.validation.MetacardValidityFilterPlugin",
+                null);
+
+        Dictionary properties = new Hashtable<>();
+        properties.put("filterErrors", filterErrors);
+        properties.put("filterWarnings", filterWarnings);
+        config.update(properties);
+    }
+
+    protected void configureFilterInvalidMetacardsReset() throws IOException {
+        configureFilterInvalidMetacards("true", "false");
+    }
+
     /**
      * Allows extending classes to add any custom options to the configuration.
      */

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -1053,10 +1053,21 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "catalog-plugin-metacard-validation",
                 "sample-validator");
 
+        //Configure not enforcing validators so invalid metacards can ingest
+        configureEnforcedMetacardValidators(Collections.singletonList(""));
+
+        // Configure invalid filtering
+        configureMetacardValidityFilterPlugin(Arrays.asList("invalid-state=system-admin"));
+
+        // Configure query to request invalid metacards
+        configureShowInvalidMetacards("true", "true");
+
+        //Configure to filter metacards with validation warnings but not validation errors
         configureFilterInvalidMetacards("false", "true");
 
         String id1 = ingestXmlFromResource("/FilterPluginRes/sampleWarningMetacard.xml");
         String id2 = ingestXmlFromResource("/FilterPluginRes/sampleCleanMetacard.xml");
+        String id3 = ingestXmlFromResource("/FilterPluginRes/sampleErrorMetacard.xml");
 
         try {
             String query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_LIKE,
@@ -1072,15 +1083,18 @@ public class TestCatalog extends AbstractIntegrationTest {
             //clean metacard should be in results but not invalid one
             response.body(not(containsString("warning metacard")));
             response.body(containsString("clean metacard"));
+            response.body(containsString("error metacard"));
 
         } finally {
             deleteMetacard(id1);
             deleteMetacard(id2);
-            configureEnforcedMetacardValidators(Collections.singletonList(""));
+            deleteMetacard(id3);
             getServiceManager().stopFeature(true,
                     "catalog-plugin-metacard-validation",
                     "sample-validator");
             configureFilterInvalidMetacardsReset();
+            configureMetacardValidityFilterPlugin(Arrays.asList(""));
+            configureShowInvalidMetacards("true", "false");
         }
     }
 
@@ -1090,10 +1104,21 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "catalog-plugin-metacard-validation",
                 "sample-validator");
 
+        //Configure not enforcing validators so invalid metacards can ingest
+        configureEnforcedMetacardValidators(Collections.singletonList(""));
+
+        // Configure invalid filtering
+        configureMetacardValidityFilterPlugin(Arrays.asList("invalid-state=system-admin"));
+
+        // Configure query to request invalid metacards
+        configureShowInvalidMetacards("true", "true");
+
+        //Configure to filter metacards with validation errors but not validation warnings
         configureFilterInvalidMetacards("true", "false");
 
         String id1 = ingestXmlFromResource("/FilterPluginRes/sampleErrorMetacard.xml");
         String id2 = ingestXmlFromResource("/FilterPluginRes/sampleCleanMetacard.xml");
+        String id3 = ingestXmlFromResource("/FilterPluginRes/sampleWarningMetacard.xml");
 
         try {
             String query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_LIKE,
@@ -1109,15 +1134,19 @@ public class TestCatalog extends AbstractIntegrationTest {
             //clean metacard should be in results but not invalid one
             response.body(not(containsString("error metacard")));
             response.body(containsString("clean metacard"));
+            response.body(containsString("warning metacard"));
 
         } finally {
             deleteMetacard(id1);
             deleteMetacard(id2);
+            deleteMetacard(id3);
             configureEnforcedMetacardValidators(Collections.singletonList(""));
             getServiceManager().stopFeature(true,
                     "catalog-plugin-metacard-validation",
                     "sample-validator");
             configureFilterInvalidMetacardsReset();
+            configureMetacardValidityFilterPlugin(Arrays.asList(""));
+            configureShowInvalidMetacards("true", "false");
         }
     }
 
@@ -1127,6 +1156,16 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "catalog-plugin-metacard-validation",
                 "sample-validator");
 
+        //Configure not enforcing validators so invalid metacards can ingest
+        configureEnforcedMetacardValidators(Collections.singletonList(""));
+
+        // Configure invalid filtering
+        configureMetacardValidityFilterPlugin(Arrays.asList("invalid-state=system-admin"));
+
+        // Configure query to request invalid metacards
+        configureShowInvalidMetacards("true", "true");
+
+        //configure to filter both metacards with validation errors and validation warnings
         configureFilterInvalidMetacards("true", "true");
 
         String id1 = ingestXmlFromResource("/FilterPluginRes/sampleErrorMetacard.xml");
@@ -1158,6 +1197,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "catalog-plugin-metacard-validation",
                     "sample-validator");
             configureFilterInvalidMetacardsReset();
+            configureMetacardValidityFilterPlugin(Arrays.asList(""));
+            configureShowInvalidMetacards("true", "false");
         }
     }
 
@@ -1167,6 +1208,16 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "catalog-plugin-metacard-validation",
                 "sample-validator");
 
+        //Configure not enforcing validators so invalid metacards can ingest
+        configureEnforcedMetacardValidators(Collections.singletonList(""));
+
+        // Configure invalid filtering
+        configureMetacardValidityFilterPlugin(Arrays.asList("invalid-state=system-admin"));
+
+        // Configure query to request invalid metacards
+        configureShowInvalidMetacards("true", "true");
+
+        //Configure to not filter metacard with validation errors or warnings
         configureFilterInvalidMetacards("false", "false");
 
         String id1 = ingestXmlFromResource("/FilterPluginRes/sampleErrorMetacard.xml");
@@ -1198,6 +1249,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                     "catalog-plugin-metacard-validation",
                     "sample-validator");
             configureFilterInvalidMetacardsReset();
+            configureMetacardValidityFilterPlugin(Arrays.asList(""));
+            configureShowInvalidMetacards("true", "false");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleCleanMetacard.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleCleanMetacard.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+          xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/"
+          xmlns:ns5="http://www.w3.org/2001/SMIL20/Language">
+    <type>ddf.metacard</type>
+    <source>ddf.distribution</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>clean metacard</value>
+    </string>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=</value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleErrorMetacard.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleErrorMetacard.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard"
+>
+    <type>ddf.metacard</type>
+    <source>ddf.distribution</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>error metacard</value>
+    </string>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>
+            /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=
+        </value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>

--- a/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleWarningMetacard.xml
+++ b/distribution/test/itests/test-itests-ddf/src/test/resources/FilterPluginRes/sampleWarningMetacard.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+          xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/"
+          xmlns:ns5="http://www.w3.org/2001/SMIL20/Language">
+    <type>ddf.metacard</type>
+    <source>ddf.distribution</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>warning metacard</value>
+    </string>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=</value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>


### PR DESCRIPTION
#### What does this PR do?
Added a configuration in MetacardValidityFilterPlugin to distinguish between filtering metacards with validation errors, validation warnings, or neither.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@AzGoalie 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [X] Update / Add Integration Tests
