### PR TITLE
DDF-2365: updated recommended Java version in DDF docs

### DIFF
--- a/distribution/docs/src/main/resources/_contents/installing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/installing-contents.adoc
@@ -20,6 +20,7 @@ Restrict access to sensitive files by ensuring that the only users with access p
 . Delete any other groups or users listed with access to `INSTALLATION_HOME/etc` and `INSTALLATION_HOME/deploy`.
 
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
+** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 * Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
@@ -77,7 +78,7 @@ For the change to take effect, a restart is required.
 init 6
 ----
 
-===== Directory Permissions on *NIX
+====== Directory Permissions on *NIX
 
 Protect the ${ddf-branding} from unauthorized access.
 

--- a/distribution/docs/src/main/resources/_contents/quickstart-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/quickstart-contents.adoc
@@ -10,6 +10,7 @@ These steps will demonstrate:
 ==== Prerequisites
 
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
+** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 * Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.


### PR DESCRIPTION
#### What does this PR do?

Backport of [PR-1099](https://github.com/codice/ddf/pull/1099/), which updated the recommended Java version in the installing and quick-start docs.

#### Who is reviewing it?

@jrnorth @vinamartin @Lambeaux 
#### Choose 2 committers to review/merge the PR.

@shaundmorris
@stustison

#### How should this be tested?

#### What are the relevant tickets?
[DDF-2365](https://codice.atlassian.net/browse/DDF-2365)
#### Screenshots (if appropriate)
![screen shot 2016-08-05 at 9 15 57 am](https://cloud.githubusercontent.com/assets/10619999/17445922/ca158872-5afb-11e6-8a8d-658238834ae1.png)
![screen shot 2016-08-05 at 9 11 19 am](https://cloud.githubusercontent.com/assets/10619999/17445926/cf56288c-5afb-11e6-82e0-4cd8cfe62ac9.png)


#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

