### PR TITLE
DDF-2334 Null values displayed in metacard organization attributes

### DIFF
--- a/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
@@ -121,7 +121,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/test/resources/csw-null-metacard-attributes.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/test/resources/csw-null-metacard-attributes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:Organization xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                  id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                  objectType="urn:registry:organization">
+
+    <rim:Name>
+        <rim:LocalizedString xml:lang="en-US" charset="UTF-8" value="Codice"/>
+    </rim:Name>
+    <rim:Address country="USA" postalCode="85037"
+                 stateOrProvince="AZ" street="1234 Some Street"/>
+    <rim:TelephoneNumber number="555-5555" extension="1234"/>
+    <rim:TelephoneNumber number="123-4567"/>
+    <rim:EmailAddress address="emailaddress@something.com"/>
+
+</rim:Organization>


### PR DESCRIPTION
#### What does this PR do?
Provides null checks within metacard attributes. For instance, the phone number area code would return "(null) 123-4353" instead of "123-4353". The phone number and address metacard attributes now have more null checks. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @vinamartin @gordocanchola @clockard @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@stustison
#### How should this be tested?
Build and check it passed 
#### Any background context you want to provide?
Bug was found while working on [DDF-2251](https://github.com/codice/ddf/pull/1053). Since the summary report pulled attribute values from the metacard, parts of these values such as the phone area code or the country of an address would show null if not provided. 
#### What are the relevant tickets?
DDF-2334 
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

