### PR TITLE
DDF-2369 Add configuration to distinguish between enforcing validation errors and warnings

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,6 +41,8 @@
         <property name="enforcedMetacardValidators">
             <list/>
         </property>
+        <property name="enforceErrors" value="true"/>
+        <property name="enforceWarnings" value="true"/>
 
     </bean>
 

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -39,6 +39,14 @@
                 name="Enforced Validators" id="enforcedMetacardValidators" required="false"
                 type="String"
                 default="" cardinality="100"/>
+        <AD
+                description="Sets whether validation errors are enforced"
+                name="Enforce errors" id="enforceErrors" required="false" type="Boolean"
+                default="true" cardinality="1"/>
+        <AD
+                description="Sets whether validation warnings are enforced"
+                name="Encorce warnings" id="enforceWarnings" required="false" type="Boolean"
+                default="false" cardinality="1"/>
     </OCD>
 
     <Designate

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -627,6 +627,22 @@ public abstract class AbstractIntegrationTest {
         configureFilterInvalidMetacards("true", "false");
     }
 
+    protected void configureEnforceValidityErrorsAndWarnings(String enforceErrors,
+            String enforceWarnings) throws IOException {
+        Configuration config = configAdmin.getConfiguration(
+                "ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin",
+                null);
+
+        Dictionary properties = new Hashtable<>();
+        properties.put("enforceErrors", enforceErrors);
+        properties.put("enforceWarnings", enforceWarnings);
+        config.update(properties);
+    }
+
+    protected void configureEnforceValidityErrorsAndWarningsReset() throws IOException {
+        configureEnforceValidityErrorsAndWarnings("true", "false");
+    }
+
     /**
      * Allows extending classes to add any custom options to the configuration.
      */


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to configure whether to enforce validation warnings, errors, both, or neither out of the enforced validators.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR 
before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested?
Full build with tests

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
