### PR TITLE
DDF-2345 Update Registry Node Info screen to handle invalid dates

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -119,11 +119,13 @@ define([
                 return data;
             },
             getNodeName: function() {
-                var node = this.model.get("RegistryObjectList").ExtrinsicObject.find(function(extObj) {
-                    return extObj.objectType === "urn:registry:federation:node";
+                var extName;
+                this.model.get("RegistryObjectList").ExtrinsicObject.forEach( function (extObj) {
+                    if (extObj.objectType === "urn:registry:federation:node") {
+                        extName = extObj.Name;
+                    }
                 });
-
-                return node.Name;
+                return extName;
             },
             onRender: function () {
                 this.$el.attr('role', "dialog");

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
@@ -48,7 +48,9 @@
             css: 'lib/require-css/css',
 
             // default admin ui
-            app: 'js/application'
+            app: 'js/application',
+
+            moment: 'lib/moment/min/moment.min'
         },
 
 
@@ -81,6 +83,10 @@
             icanhaz: {
                 deps: ['handlebars', 'jquery'],
                 exports: 'ich'
+            },
+
+            moment: {
+                exports: 'moment'
             },
 
             perfectscrollbar: ['jquery'],

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
@@ -14,7 +14,7 @@
 <table class='table table-striped align-middle'>
     <thead>
     <th class="name">Name</th>
-    <th class="created">Created On</th>
+    <th class="created">Live Date</th>
     <th class="modified">Last Modified</th>
     <th/>
     <th>


### PR DESCRIPTION
#### What does this PR do?

The Registry Node Information screen will not display information if an invalid date is in any node's information. This would result in node modals not being accessable and not being displayed in the UI. 

This PR fixes the issue by replacing any invalid dates/times with a valid date/time representing now. These new valid values are not saved to the node unless the user chooses to do so.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@vinamartin @clockard @gordocanchola @brianfelix @ani6gup @andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
1. Verify Invalid Dates are not accepted from the User
Boot up the Registry-App an attempt to enter an invalid date/time (can only be performed on FireFox or IE) for any of the date fields, and more specifically the custom fields.
Invalid dates should not be saved to the node.

2. Verify Invalid Dates from another Node do not break your node
Boot up the Registry-App and add a Remote Node with invalid date/time information. Once the node is connected, verify that the remote node is present in the node information tab and that the node modal can be opened/navigated. 

**Should be tested in Chrome, Firefox and IE**
#### Any background context you want to provide?
This PR also addresses a minor IE syntax issue.

Notes from the ticket:
"When not using a chrome browser, the date fields in the Node Information modal are not forced to be any particular format. This can cause errors if a date is entered in an invalid format.
Need to add a regular expression to enforce the format of dates so they will always be correct. 

An additional check should also be done within the javascript that normalizes the dates on the registry node information screen. (Segment.js, line 44) In the case where there is an invalid date, put a blank date or another string to show that the format is invalid. This will make sure that even if bad data is coming from remote nodes, it will fail more gracefully. "

#### What are the relevant tickets?
DDF-2345 Registry Node Information screen will not display information if an invalid date is in any node's information 
#### Screenshots (if appropriate)
![ddf-2345](https://cloud.githubusercontent.com/assets/11355332/17524537/e5e2e7c8-5e13-11e6-9d45-88b061a5603a.png)
![screen shot 2016-08-09 at 10 02 31 am](https://cloud.githubusercontent.com/assets/11355332/17525673/9499627a-5e18-11e6-9390-9695c2214e91.png)



#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

