### PR TITLE
DDF-2373 Added itests for FTPS endpoint

### DIFF
--- a/catalog/ftp/src/test/java/ddf/catalog/ftp/FtpServerStarterTest.java
+++ b/catalog/ftp/src/test/java/ddf/catalog/ftp/FtpServerStarterTest.java
@@ -18,6 +18,11 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static ddf.catalog.ftp.FtpServerStarter.CLIENT_AUTH;
+import static ddf.catalog.ftp.FtpServerStarter.NEED;
+import static ddf.catalog.ftp.FtpServerStarter.PORT;
+import static ddf.catalog.ftp.FtpServerStarter.WANT;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -80,7 +85,7 @@ public class FtpServerStarterTest {
     public void updateConfigurationWithoutActiveConnectionsTest() {
         FtpStatistics stats = mock(FtpStatistics.class);
 
-        Map<String, Object> properties = createProperties(8022, "need");
+        Map<String, Object> properties = createProperties(8022, NEED);
 
         when(ftpServerFactory.createServer()).thenReturn(server);
         when(server.getListener(DEFAULT_LISTENER)).thenReturn(defaultListener);
@@ -100,7 +105,7 @@ public class FtpServerStarterTest {
     public void updateConfigurationWithActiveConnectionsTest() {
         FtpStatistics stats = mock(FtpStatistics.class);
 
-        Map<String, Object> properties = createProperties(8022, "need");
+        Map<String, Object> properties = createProperties(8022, NEED);
 
         when(ftpServerFactory.createServer()).thenReturn(server);
         when(server.getListener(DEFAULT_LISTENER)).thenReturn(defaultListener);
@@ -148,21 +153,21 @@ public class FtpServerStarterTest {
 
     @Test
     public void testSetClientAuthWant() {
-        ftpServerStarter.setClientAuth("want");
+        ftpServerStarter.setClientAuth(WANT);
         assertEquals(ClientAuth.WANT, ftpServerStarter.getClientAuthMode());
     }
 
     @Test
     public void testSetClientAuthNeed() {
-        ftpServerStarter.setClientAuth("need");
+        ftpServerStarter.setClientAuth(NEED);
         assertEquals(ClientAuth.NEED, ftpServerStarter.getClientAuthMode());
     }
 
     private Map<String, Object> createProperties(int port, String clientAuth) {
         Map<String, Object> properties = new HashMap<>();
 
-        properties.put("port", Integer.toString(port));
-        properties.put("clientAuth", clientAuth);
+        properties.put(PORT, Integer.toString(port));
+        properties.put(CLIENT_AUTH, clientAuth);
 
         return properties;
     }


### PR DESCRIPTION
#### What does this PR do?
This PR adds itests for the FTPS endpoint, specifically testing that changing the clientAuth configuration for the ftp-endpoint feature causes the FTP server to close connections with clients as expected.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @peterhuffer @troymohl @tbatie
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
#### How should this be tested?
Confirm that TestFtp itests pass.
#### Any background context you want to provide?
The FTP endpoint will shut down the connection if the client does not have a valid certificate (or does not have a certificate set) when the clientAuth configuration for the ftp-endpoint feature is set to `need`. The four cases can be tested by using the `curl` command and changing the clientAuth configuration (See https://github.com/codice/ddf/pull/926):

1. Set `clientAuth = want` on Admin UI, then `curl --insecure -v -S --ftp-ssl -ftp-method singlecwd -E /path/to/client/cert:certPassword ftp://admin:admin@localhost:8021`
2. Set `clientAuth = want` on Admin UI, then `curl --insecure -v -S --ftp-ssl -ftp-method singlecwd ftp://admin:admin@localhost:8021`
3. Set `clientAuth = need` on Admin UI, then `curl --insecure -v -S --ftp-ssl -ftp-method singlecwd -E /path/to/client/cert:certPassword ftp://admin:admin@localhost:8021`
4. Set `clientAuth = need` on Admin UI, then `curl --insecure -v -S --ftp-ssl -ftp-method singlecwd ftp://admin:admin@localhost:8021`

Only in the last case should the FTP shut down the connection before log in. FTPSClient extends FTPClient, so after a successful log in, FTPSClient will be able to search and put like an FTPClient. Therefore, these new itests only test if an FTPSClient can successfully log in when expected with different clientAuth configurations with/without a client certificate.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2373
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
