### PR TITLE
DDF-2372 Allow metacards to track which validators have been run

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -337,6 +337,18 @@ public class BasicTypes {
                 false /* tokenized */,
                 true /* multivalued */,
                 STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(Validation.FAILED_VALIDATORS_WARNINGS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                true /* multivalued */,
+                STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(Validation.FAILED_VALIDATORS_ERRORS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                true /* multivalued */,
+                STRING_TYPE));
         DESCRIPTORS = Collections.unmodifiableSet(descriptors);
 
         BASIC_METACARD = new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME,

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeType.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeType.java
@@ -20,8 +20,7 @@ import java.io.Serializable;
  * <p>
  * {@link Attribute} values are bound to and the format expected to be used by those values
  *
- * @param <T>
- *            - The class used by values of this {@link AttributeType}
+ * @param <T> - The class used by values of this {@link AttributeType}
  */
 public interface AttributeType<T extends Serializable> extends Serializable {
 
@@ -45,7 +44,6 @@ public interface AttributeType<T extends Serializable> extends Serializable {
      * switch on <code>instanceof</code>, an {@link java.util.Enumeration} is used instead.
      *
      * @author michael.menousek@lmco.com
-     *
      */
     public enum AttributeFormat {
 
@@ -122,7 +120,7 @@ public interface AttributeType<T extends Serializable> extends Serializable {
          * {@link AttributeDescriptor#isIndexed() indexing},
          * {@link AttributeDescriptor#isTokenized() tokenizing}) will not be performed even if
          * indicated by the {@link AttributeDescriptor}. <br>
-         *
+         * <p>
          * <p>
          * <b>NOTE:</b> In order for classes to be deserialized by a {@link ddf.catalog.source.Source}, that class must
          * exist on the classpath of that {@link ddf.catalog.source.Source}. This may require additional parameters to

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Validation.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Validation.java
@@ -22,14 +22,26 @@ package ddf.catalog.data.types;
 public interface Validation {
 
     /**
-     * {@link ddf.catalog.data.Attribute} name for accessing the validation warnings of this {@link Metacard}.
+     * {@link ddf.catalog.data.Attribute} name for accessing the validation warnings of this {@link ddf.catalog.data.Metacard}.
      * Uses original taxonomy to preserve backwards compatibility.
      */
     String VALIDATION_WARNINGS = "validation-warnings";
 
     /**
-     * {@link ddf.catalog.data.Attribute} nname for accessing the validation errors of this {@link Metacard}.
+     * {@link ddf.catalog.data.Attribute} name for accessing the validation errors of this {@link ddf.catalog.data.Metacard}.
      * Uses original taxonomy to preserve backwards compatibility.
      */
     String VALIDATION_ERRORS = "validation-errors";
+
+    /**
+     * {@link ddf.catalog.data.Attribute} name for accessing the validators that were run on this
+     * {@link ddf.catalog.data.Metacard} that had warnings.
+     */
+    String FAILED_VALIDATORS_WARNINGS = "failed-validators-warnings";
+
+    /**
+     * {@link ddf.catalog.data.Attribute} name for accessing the validators that were run on this
+     * {@link ddf.catalog.data.Metacard} that had errors.
+     */
+    String FAILED_VALIDATORS_ERRORS = "failed-validators-errors";
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/AbstractIntegrationTest.java
@@ -611,6 +611,10 @@ public abstract class AbstractIntegrationTest {
         config.update(properties);
     }
 
+    protected void configureShowInvalidMetacardsReset() throws IOException {
+        configureShowInvalidMetacards("false", "true");
+    }
+
     protected void configureFilterInvalidMetacards(String filterErrors, String filterWarnings)
             throws IOException {
         Configuration config = configAdmin.getConfiguration(


### PR DESCRIPTION
#### What does this PR do?
Adds which validators a metacard has been run through and indicates whether there are validation errors or warnings for each validator run.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr 
@AzGoalie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested?
Full Build

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [x] Update / Add Integration Tests
