### PR TITLE
DDF-2316: Force commons-fileupload to 1.3.2 in solr pom to fix OWASP. 

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -52,7 +52,6 @@
         <lucene.version>5.1.0</lucene.version>
         <!-- Mina version is not the latest version due to Apache FTPServer 1.0.6 not supporting newer releases properly -->
         <mina.version>2.0.6</mina.version>
-        <commons.fileupload.version>1.3.2</commons.fileupload.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <commons-beanutils.version>1.9.2</commons-beanutils.version>
         <netty.version>4.0.32.Final</netty.version>
         <qpid-jms.version>0.9.0</qpid-jms.version>
+        <commons.fileupload.version>1.3.2</commons.fileupload.version>
         <!--Documentation Replacements-->
         <branding>DDF</branding>
         <branding-lowercase>ddf</branding-lowercase>
@@ -200,6 +201,11 @@
                 <artifactId>groovy-all</artifactId>
                 <version>2.4.5</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>${commons.fileupload.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?
OWASP will now pass. Some transitive dependency was bringing in a bad version of commons-fileupload that was not even being used. 

#### Who is reviewing it?
@tbatie 
@adimka 
@stustison 

#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@shaundmorris

#### How should this be tested?
Invoke an OWASP-only check on a clean quick-build and ensure it passes. Can be done on Jenkins if desired. 