### PR TITLE
DDF-2249: Refactored the FTP endpoint default port to be configurable in system.properties

### DIFF
--- a/catalog/ftp/src/main/java/ddf/catalog/ftp/FtpServerStarter.java
+++ b/catalog/ftp/src/main/java/ddf/catalog/ftp/FtpServerStarter.java
@@ -29,6 +29,7 @@ import org.apache.ftpserver.listener.Listener;
 import org.apache.ftpserver.listener.ListenerFactory;
 import org.apache.ftpserver.ssl.ClientAuth;
 import org.apache.ftpserver.ssl.SslConfigurationFactory;
+import org.codice.ddf.configuration.PropertyResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ public class FtpServerStarter {
 
     private static int resetWaitTimeMillis = 5000;
 
-    private int port = 8021;
+    private int port;
 
     private ClientAuth clientAuth = ClientAuth.WANT;
 
@@ -117,7 +118,10 @@ public class FtpServerStarter {
         LOGGER.debug("Updating FTP Endpoint configuration");
 
         if (properties != null) {
-            int port = (Integer) properties.get("port");
+            //using PropertyResolver in case properties.get("port") is ${org.codice.ddf.catalog.ftp.port}
+            PropertyResolver propertyResolver = new PropertyResolver((String) properties.get("port"));
+            int port = Integer.parseInt(propertyResolver.getResolvedString());
+
             String clientAuth = ((String) properties.get("clientAuth")).toLowerCase();
 
             if ((this.port != port) || (!this.clientAuth.toString()
@@ -253,7 +257,7 @@ public class FtpServerStarter {
     }
 
     public void setClientAuth(String newClientAuth) {
-        switch (newClientAuth) {
+        switch (newClientAuth.toLowerCase()) {
         case "want":
             clientAuth = ClientAuth.WANT;
             break;

--- a/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
         <cm:managed-properties persistent-id="ddf.catalog.ftp.FtpServerStarter"
                                update-strategy="component-managed"
                                update-method="updateConfiguration"/>
-        <property name="port" value="8021"/>
+        <property name="port" value="${org.codice.ddf.catalog.ftp.port}"/>
         <property name="clientAuth" value="want"/>
         <property name="keyStoreFile" value="${javax.net.ssl.keyStore}"/>
         <property name="keyStorePassword" value="${javax.net.ssl.keyStorePassword}"/>

--- a/catalog/ftp/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ftp/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,8 +18,8 @@
 
         <AD
                 description="The port number for the FTP server to listen on."
-                name="FTP Port Number" id="port" min="0" max="65535"
-                required="true" type="Integer" default="8021"/>
+                name="FTP Port Number" id="port"
+                required="true" type="String" default="${org.codice.ddf.catalog.ftp.port}"/>
 
         <AD
                 description='Whether or not client authentication is required or wanted. A value of "Need" requires client auth, a value of "Want" leaves it up to the client.'

--- a/catalog/ftp/src/test/java/ddf/catalog/ftp/FtpServerStarterTest.java
+++ b/catalog/ftp/src/test/java/ddf/catalog/ftp/FtpServerStarterTest.java
@@ -148,14 +148,20 @@ public class FtpServerStarterTest {
 
     @Test
     public void testSetClientAuthWant() {
-        ftpServerStarter.setClientAuth(ClientAuth.WANT.toString());
+        ftpServerStarter.setClientAuth("want");
         assertEquals(ClientAuth.WANT, ftpServerStarter.getClientAuthMode());
+    }
+
+    @Test
+    public void testSetClientAuthNeed() {
+        ftpServerStarter.setClientAuth("need");
+        assertEquals(ClientAuth.NEED, ftpServerStarter.getClientAuthMode());
     }
 
     private Map<String, Object> createProperties(int port, String clientAuth) {
         Map<String, Object> properties = new HashMap<>();
 
-        properties.put("port", port);
+        properties.put("port", Integer.toString(port));
         properties.put("clientAuth", clientAuth);
 
         return properties;

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -74,6 +74,9 @@ bad.mime.types=text/html,text/javascript,text/x-javascript,application/x-shellsc
 # done in a test environment. These events will be audited.
 org.codice.allowBasicAuthOverHttp=false
 
+# Set the default port number for the catalog-ftp feature FTP endpoint
+org.codice.ddf.catalog.ftp.port=8021
+
 javax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
 #javax.xml.transform.TransformerFactory=org.apache.xalan.processor.TransformerFactoryImpl
 

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/integrating-catalog-contents.adoc
@@ -1119,7 +1119,7 @@ The configurable properties for the FTP Endpoint are accessed from the *FTP Endp
 |`port`
 |Integer
 |Specifies the port for the server to listen on for connections.
-|8021
+|${org.codice.ddf.catalog.ftp.port}
 |Yes
 
 |Client Authentication
@@ -1144,7 +1144,7 @@ After creating a custom Ftplet, it needs to be added to the FTP server’s Ftple
 
 ====== From an FTP client:
 
-The FTP endpoint can be accessed from any FTP client of choice. Some common clients are FileZilla, PuTTY, or the FTP client provided in the terminal. The default port number is *8021*. If FTPS is enabled with 2-way TLS, a client that supports client authentication is required.
+The FTP endpoint can be accessed from any FTP client of choice. Some common clients are FileZilla, PuTTY, or the FTP client provided in the terminal. The default port number is *${org.codice.ddf.catalog.ftp.port}*. If FTPS is enabled with 2-way TLS, a client that supports client authentication is required.
 
 ===== Implementation Details
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
@@ -53,7 +53,9 @@ public class TestFtp extends AbstractIntegrationTest {
 
     private static final String FTP_SERVER = "localhost";
 
-    private static final int FTP_DEFAULT_PORT = 8021;
+    private static final String FTP_PORT_PROPERTY = "org.codice.ddf.catalog.ftp.port";
+
+    private static final DynamicPort FTP_PORT = new DynamicPort(FTP_PORT_PROPERTY, 6);
 
     private static final String FTP_ENDPOINT_FEATURE = "catalog-ftp";
 
@@ -75,6 +77,7 @@ public class TestFtp extends AbstractIntegrationTest {
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();
 
+            System.setProperty(FTP_PORT_PROPERTY, FTP_PORT.getPort());
             getServiceManager().startFeature(true, FTP_ENDPOINT_FEATURE);
 
         } catch (Exception e) {
@@ -155,7 +158,7 @@ public class TestFtp extends AbstractIntegrationTest {
     private FTPClient createInsecureClient() throws Exception {
         FTPClient ftp = new FTPClient();
 
-        ftp.connect(FTP_SERVER, FTP_DEFAULT_PORT);
+        ftp.connect(FTP_SERVER, Integer.parseInt(FTP_PORT.getPort()));
         showServerReply(ftp);
         int connectionReply = ftp.getReplyCode();
         if (!FTPReply.isPositiveCompletion(connectionReply)) {


### PR DESCRIPTION
#### What does this PR do?
This PR refactors the default port for the FTP endpoint so that it is configurable in system.properties. The FTP endpoint port in TestFtp itest is now set to a DynamicPort.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @peterhuffer @troymohl @mweser
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@kcwire
#### How should this be tested?
1. Ensure FtpServerStarterTest and TestFtp itest pass.
2. Confirm that the FTP endpoint port number is configurable in system.properties:
   1. Build DDF.
   2. Change `org.codice.ddf.catalog.ftp.port` in $DDF_HOME/etc/system.properties file to a new port.
   3. Start DDF, and start the FTP Endpoint feature (see https://github.com/codice/ddf/pull/784).
   4. Using a FTP client of your choice (see https://github.com/codice/ddf/pull/784), confirm that the default port number for the FTP endpoint is now the new port that you set in the system.properties file.
   5. Confirm that "${org.codice.ddf.catalog.ftp.port}" appears in the modal to configure the FTP endpoint on the Admin UI. You should be able to `Save changes` with "${org.codice.ddf.catalog.ftp.port}" as the port number, and the server should start on the new port that you set in the system.properties file.
   6. Confirm that the FTP endpoint port is still configurable from the Admin UI (see https://github.com/codice/ddf/pull/846).

#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2249
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests