### PR TITLE
DDF-2385 add banner warning to admin console when user session expires

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/models/Alerts.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Alerts.js
@@ -45,6 +45,7 @@ define([
                 var json = {'items': response.stacktrace.split(/\n/)};
                 if (response.stacktrace === 'Forbidden') {
                     json.banner = 'Your session has expired. Please <a href="/login/index.html?prevurl=/admin/">log in</a> again.';
+                    json.items = ['An error was received while trying to contact the server which indicated that you may no longer be logged in.'];
                 }
                 return json;
             } else {

--- a/platform/admin/ui/src/main/webapp/js/util/SessionRefresherUtil.js
+++ b/platform/admin/ui/src/main/webapp/js/util/SessionRefresherUtil.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define, document*/
+define(['jquery', 'underscore'], function ($, _) {
+    "use strict";
+
+    return function (timeDuration) {
+
+        var refresh = _.throttle(function () {
+            $.get("index.html");
+        }, timeDuration);
+
+        $(document).keypress(refresh);
+        $(document).click(refresh);
+    };
+});

--- a/platform/admin/ui/src/main/webapp/main.js
+++ b/platform/admin/ui/src/main/webapp/main.js
@@ -10,7 +10,7 @@
  *
  **/
 /*global require, window */
-/*jslint nomen:false, -W064 */
+/*jslint nomen:false, -W064, browser:true */
 
 (function () {
     'use strict';
@@ -128,12 +128,13 @@
         'js/models/Alerts.js',
         'js/views/Alerts.view',
         'properties',
+        'js/util/SessionRefresherUtil',
         'icanhaz',
         'js/HandlebarsHelpers',
         'modelbinder',
         'bootstrap',
         'templateConfig'
-    ], function ($, Backbone, Marionette, Application, ModuleView, AlertsModel, AlertsView, Properties) {
+    ], function ($, Backbone, Marionette, Application, ModuleView, AlertsModel, AlertsView, Properties, SessionRefresherUtil) {
 
         var app = Application.App;
 
@@ -166,6 +167,20 @@
                 });
             }
         });
+
+        //refresh the session if keypress  or mouse click events occur
+        SessionRefresherUtil(60000);
+
+        //redirect upon session timeout
+        $(document).ajaxError(function (_, jqxhr) {
+                if (jqxhr.status === 401 || jqxhr.status === 403) {
+                    app.addInitializer(function () {
+                        Application.App.alertsRegion.show(new AlertsView.View({'model': AlertsModel.Jolokia({'stacktrace': 'Forbidden'})}));
+                    });
+                }
+
+            }
+        );
 
         //setup the footer
         app.addInitializer(function () {


### PR DESCRIPTION
#### What does this PR do?
Adds a warning banner if the user session expires
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @adimka @djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison
#### How should this be tested?
log in to the admin console with two tabs logout with one of them and then try to do some action on the other and verify the banner changes to a warning about being logged out.


#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
![screen shot 2016-08-11 at 8 44 02 am](https://cloud.githubusercontent.com/assets/14876988/17594930/d82e204c-5f9f-11e6-862e-73a4ca687809.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests