### PR TITLE
DDF-2360 Updated documentation to reflect move to JDK 8 and to

### DIFF
--- a/distribution/docs/src/main/resources/_contents/running-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/running-contents.adoc
@@ -91,19 +91,24 @@ to:
 RUN_AS_USER=<${ddf-branding-lowercase}-user>
 ----
 +
-. Set the memory in the wrapper config to match with ${branding} default memory setting.
-.. Add the setting for PermGen space under the JVM Parameters section.
-.. Update heap space to 2048.
+. Set the memory in the wrapper config to match with ${branding} default memory setting and set additional required parameters.
 +
 .INSTALLATION_HOME/etc/${branding-lowercase}-wrapper.conf
 [source,java,linenums]
 ----
 #Add the following:
-wrapper.java.additional.11=-Dderby.system.home="..\data\derby"
-wrapper.java.additional.12=-Dderby.storage.fileSyncTransactionLog=true
-wrapper.java.additional.13=-Dcom.sun.management.jmxremote
-wrapper.java.additional.14=-Dfile.encoding=UTF8
-wrapper.java.additional.15=-D${ddf-branding-lowercase}.home=%${branding}_HOME%
+wrapper.java.additional.10=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
+wrapper.java.additional.11=-server
+wrapper.java.additional.12=-Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.13=-Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.14=-Dkaraf.restart.jvm.supported=true
+wrapper.java.additional.15=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
+wrapper.java.additional.16=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
+wrapper.java.additional.17=-Dfile.encoding=UTF8
+wrapper.java.additional.18=-XX:+UnlockDiagnosticVMOptions
+wrapper.java.additional.19=-XX:+UnsyncloadClass
+wrapper.java.additional.20=-Dderby.system.home=%KARAF_HOME%/data/derby
+wrapper.java.additional.21=-Dderby.storage.fileSyncTransactionLog=true
 
 #Update the following:
 wrapper.java.maxmemory=2048
@@ -113,7 +118,7 @@ wrapper.java.maxmemory=2048
 +
 .INSTALLATION_HOME/etc/${branding-lowercase}-wrapper.conf
 ----
-set.default.${branding}_HOME="%KARAF_HOME%"
+set.default.${branding}_HOME=%KARAF_HOME%
 ----
 +
 . Install the wrapper startup/shutdown scripts.


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a problem with the documentation that was described in 
ddf-2360.  There were undocumented environment vars that were required to run the ddf as a service .

Also removed a reference to PermGen memory (since it is no longer used in the now required JDK 8)

Also removed some quotation marks around an env var prevented proper evaluation of a path.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ricklarsen @oconnormi 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@michaelmenousek
@shaundmorris
#### How should this be tested?
Review documentation.  

Install the DDF as a service on Linux.  Make sure it works.

#### Any background context you want to provide?
Tested Environment:  Centos7 standard installation with oracle JDK 8.

#### What are the relevant tickets?
ddf-2360

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Insert missing environment vars needed to run the ddf as a linux service

