### PR TITLE
DDF-2245: Updated frames per second and bits per second to support double value instead of integer.

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/MediaAttributes.java
@@ -52,7 +52,7 @@ public class MediaAttributes implements Media, MetacardType {
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
-                BasicTypes.INTEGER_TYPE));
+                BasicTypes.DOUBLE_TYPE));
         descriptors.add(new AttributeDescriptorImpl(BITS_PER_SAMPLE,
                 true /* indexed */,
                 true /* stored */,
@@ -82,7 +82,7 @@ public class MediaAttributes implements Media, MetacardType {
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,
-                BasicTypes.INTEGER_TYPE));
+                BasicTypes.DOUBLE_TYPE));
         descriptors.add(new AttributeDescriptorImpl(HEIGHT,
                 true /* indexed */,
                 true /* stored */,


### PR DESCRIPTION
#### What does this PR do?
Changes frames per second and bits per second to be double instead of integer.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?

#### Any background context you want to provide?
Bits per second and frames per second are not necessarily always integers.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2245

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated (Taxonomy Wiki)
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests