### PR TITLE
DDF-2334 Null values displayed in metacard organization attributes

### DIFF
--- a/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
@@ -119,7 +119,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/converter/RegistryPackageConverter.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/converter/RegistryPackageConverter.java
@@ -76,7 +76,8 @@ public class RegistryPackageConverter {
 
     private static final Map<String, String> METACARD_XML_NAME_MAP;
 
-    private static final InternationalStringTypeHelper INTERNATIONAL_STRING_TYPE_HELPER = new InternationalStringTypeHelper();
+    private static final InternationalStringTypeHelper INTERNATIONAL_STRING_TYPE_HELPER =
+            new InternationalStringTypeHelper();
 
     private static final SlotTypeHelper SLOT_TYPE_HELPER = new SlotTypeHelper();
 
@@ -263,7 +264,7 @@ public class RegistryPackageConverter {
         if (person.isSetTelephoneNumber()) {
             List<TelephoneNumberType> phoneNumbers = person.getTelephoneNumber();
             if (CollectionUtils.isNotEmpty(phoneNumbers)) {
-                phone = getPhoneNumberString(phoneNumbers.get(0));
+                phone = getPhoneNumber(phoneNumbers.get(0));
             }
         }
 
@@ -449,36 +450,48 @@ public class RegistryPackageConverter {
         return multiValued;
     }
 
-    private static String getPhoneNumberString(TelephoneNumberType digits) {
-        String phoneNumber;
-        if (StringUtils.isBlank(digits.getExtension())) {
-            phoneNumber = String.format("(%s) %s", digits.getAreaCode(), digits.getNumber());
-        } else {
-            phoneNumber = String.format("(%s) %s extension %s",
-                    digits.getAreaCode(),
-                    digits.getNumber(),
-                    digits.getExtension());
+    private static String getPhoneNumber(TelephoneNumberType digits) {
+        if (digits.getNumber()
+                .isEmpty()) {
+            return "N/A";
         }
 
-        return phoneNumber;
+        StringBuilder phoneNumberBuilder = new StringBuilder();
+
+        phoneNumberBuilder = buildNonNullString(phoneNumberBuilder,
+                digits.getCountryCode(),
+                "",
+                "+%s");
+
+        phoneNumberBuilder = buildNonNullString(phoneNumberBuilder,
+                digits.getAreaCode(),
+                " ",
+                "(%s)");
+        phoneNumberBuilder = buildNonNullString(phoneNumberBuilder, digits.getNumber(), " ");
+        phoneNumberBuilder = buildNonNullString(phoneNumberBuilder,
+                digits.getExtension(),
+                " ",
+                "ext %s");
+        return phoneNumberBuilder.toString();
     }
 
     private static void setMetacardAddressAttribute(List<PostalAddressType> addresses,
             String metacardAttribute, MetacardImpl metacard) {
+
         if (CollectionUtils.isNotEmpty(addresses)) {
+            StringBuilder addressString = new StringBuilder();
             PostalAddressType address = addresses.get(0);
 
-            String metacardAddress = String.format("%s, %s, %s %s, %s",
-                    address.getStreet(),
-                    address.getCity(),
-                    address.getStateOrProvince(),
-                    address.getPostalCode(),
-                    address.getCountry());
-
-            if (StringUtils.isNotBlank(metacardAddress)) {
-                metacard.setAttribute(metacardAttribute, metacardAddress);
+            addressString = buildNonNullString(addressString, address.getStreet(), " ");
+            addressString = buildNonNullString(addressString, address.getCity(), ", ");
+            addressString = buildNonNullString(addressString, address.getStateOrProvince(), ", ");
+            addressString = buildNonNullString(addressString, address.getPostalCode(), " ");
+            addressString = buildNonNullString(addressString, address.getCountry(), ", ");
+            if (StringUtils.isNotBlank(addressString.toString())) {
+                metacard.setAttribute(metacardAttribute, addressString.toString());
             }
         }
+
     }
 
     private static void setMetacardStringAttribute(String value, String metacardAttribute,
@@ -502,24 +515,35 @@ public class RegistryPackageConverter {
 
     private static void setMetacardPhoneNumberAttribute(List<TelephoneNumberType> phoneNumbers,
             String metacardAttribute, MetacardImpl metacard) {
-        List<String> metacardPhoneNumbers = new ArrayList<>();
 
-        for (TelephoneNumberType digits : phoneNumbers) {
-
-            if (StringUtils.isBlank(digits.getExtension())) {
-                metacardPhoneNumbers.add(String.format("(%s) %s",
-                        digits.getAreaCode(),
-                        digits.getNumber()));
-            } else {
-                metacardPhoneNumbers.add(String.format("(%s) %s extension %s",
-                        digits.getAreaCode(),
-                        digits.getNumber(),
-                        digits.getExtension()));
-            }
-        }
-        if (CollectionUtils.isNotEmpty(metacardPhoneNumbers)) {
+        if (phoneNumbers != null) {
+            List<String> metacardPhoneNumbers = phoneNumbers.stream()
+                    .map(RegistryPackageConverter::getPhoneNumber)
+                    .collect(Collectors.toList());
             metacard.setAttribute(metacardAttribute, (Serializable) metacardPhoneNumbers);
         }
+    }
+
+    private static StringBuilder buildNonNullString(StringBuilder stringBuilder,
+            String attributeValue, String delimiterBefore, String format) {
+        if (StringUtils.isNotBlank(attributeValue)) {
+            if (stringBuilder.length() > 0) {
+                stringBuilder.append(delimiterBefore);
+            }
+            if (StringUtils.isNotEmpty(format)) {
+                stringBuilder.append(String.format(format, attributeValue));
+            } else {
+                stringBuilder.append(attributeValue);
+            }
+        }
+        return stringBuilder;
+    }
+
+    private static StringBuilder buildNonNullString(StringBuilder stringBuilder,
+            String attributeValue, String delimiterBefore) {
+
+        return (buildNonNullString(stringBuilder, attributeValue, delimiterBefore, null));
+
     }
 
     private static void setAttributeFromMap(String metacardAttributeName,

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/test/java/org/codice/ddf/registry/transformer/RegistryTransformerTest.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/test/java/org/codice/ddf/registry/transformer/RegistryTransformerTest.java
@@ -67,7 +67,6 @@ public class RegistryTransformerTest {
         parser = new XmlParser();
         registryTransformer.setParser(parser);
         System.setProperty(RegistryConstants.REGISTRY_ID_PROPERTY, "identityRegistryId");
-
     }
 
     @Test(expected = CatalogTransformerException.class)
@@ -141,7 +140,28 @@ public class RegistryTransformerTest {
                 hasItem("1234 Some Street, Phoenix, AZ 85037, USA"));
         assertThat(RegistryUtility.getListOfStringAttribute(metacard,
                 RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER),
-                hasItem("(555) 555-5555 extension 1234"));
+                hasItem("(555) 555-5555 ext 1234"));
+        assertThat(RegistryUtility.getListOfStringAttribute(metacard,
+                RegistryObjectMetacardType.ORGANIZATION_EMAIL),
+                hasItem("emailaddress@something.com"));
+    }
+
+    @Test
+    public void testNullMetacardAttributeValues() throws Exception {
+        MetacardImpl metacard = convert("/csw-null-metacard-attributes.xml");
+        assertRegistryMetacard(metacard);
+
+        assertThat(RegistryUtility.getStringAttribute(metacard,
+                RegistryObjectMetacardType.ORGANIZATION_NAME,
+                null), is("Codice"));
+        assertThat(RegistryUtility.getListOfStringAttribute(metacard,
+                RegistryObjectMetacardType.ORGANIZATION_ADDRESS),
+                hasItem("1234 Some Street, AZ 85037, USA"));
+        assertThat(RegistryUtility.getListOfStringAttribute(metacard,
+                RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER),
+                hasItem("555-5555 ext 1234"));
+        assertThat(RegistryUtility.getListOfStringAttribute(metacard,
+                RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER), hasItem("123-4567"));
         assertThat(RegistryUtility.getListOfStringAttribute(metacard,
                 RegistryObjectMetacardType.ORGANIZATION_EMAIL),
                 hasItem("emailaddress@something.com"));
@@ -237,7 +257,7 @@ public class RegistryTransformerTest {
     }
 
     @Test
-    public void testPersonNoExtension() throws Exception {
+    public void testPersonNoext() throws Exception {
         MetacardImpl metacard = convert("/csw-person-info.xml");
 
         assertThat(RegistryUtility.getStringAttribute(metacard, Metacard.POINT_OF_CONTACT, null),
@@ -335,12 +355,12 @@ public class RegistryTransformerTest {
                 hasItem("1234 Some Street, Phoenix, AZ 85037, USA"));
         assertThat(RegistryUtility.getListOfStringAttribute(metacard,
                 RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER),
-                hasItem("(555) 555-5555 extension 1234"));
+                hasItem("(555) 555-5555 ext 1234"));
         assertThat(RegistryUtility.getListOfStringAttribute(metacard,
                 RegistryObjectMetacardType.ORGANIZATION_EMAIL),
                 hasItem("emailaddress@something.com"));
         assertThat(RegistryUtility.getStringAttribute(metacard, Metacard.POINT_OF_CONTACT, null),
-                is("john doe, (111) 111-1111 extension 1234, emailaddress@something.com"));
+                is("john doe, (111) 111-1111 ext 1234, emailaddress@something.com"));
     }
 
     @Test

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/test/resources/csw-null-metacard-attributes.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/test/resources/csw-null-metacard-attributes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:Organization xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                  id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                  objectType="urn:registry:organization">
+
+    <rim:Name>
+        <rim:LocalizedString xml:lang="en-US" charset="UTF-8" value="Codice"/>
+    </rim:Name>
+    <rim:Address country="USA" postalCode="85037"
+                 stateOrProvince="AZ" street="1234 Some Street"/>
+    <rim:TelephoneNumber number="555-5555" extension="1234"/>
+    <rim:TelephoneNumber number="123-4567"/>
+    <rim:EmailAddress address="emailaddress@something.com"/>
+
+</rim:Organization>

--- a/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilderTest.java
+++ b/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilderTest.java
@@ -125,11 +125,11 @@ public class RegistryReportBuilderTest {
                 .text();
 
         assertThat(organizationName, is("Codice"));
-        assertThat(phoneNumbers, is("(555) 555-5555 extension 1234"));
+        assertThat(phoneNumbers, is("(555) 555-5555 ext 1234"));
         assertThat(emailAddresses, is("emailaddress@something.com"));
         assertThat(address, is("1234 Some Street, Phoenix, AZ 85037, USA"));
         assertThat(pointOfContact,
-                is("foo bar, (111) 111-1111 extension 1234, emailaddress@something.com"));
+                is("foo bar, +country (111) 111-1111 ext 1234, emailaddress@something.com"));
     }
 
     private void assertSparseSummaryReportValues(Document document) {


### PR DESCRIPTION
https://github.com/codice/ddf/pull/1109

Provides null checks within metacard attributes. For instance, the phone number area code would return "(null) 123-4353" instead of "123-4353". The phone number and address metacard attributes now have more null checks.

@coyotesqrl
@lessarderic

