### PR TITLE
DDF-2368: Fixed resource usage not counting user's first download

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
@@ -411,6 +411,8 @@ public class ResourceOperations extends DescribableImpl {
                 LOGGER.info("Unable to download resource", e);
             }
 
+            resourceResponse = putPropertiesInResponse(resourceRequest, resourceResponse);
+
             resourceResponse = validateFixGetResourceResponse(resourceResponse, resourceReq);
 
             HashMap<String, Set<String>> responsePolicyMap = new HashMap<>();
@@ -450,6 +452,21 @@ public class ResourceOperations extends DescribableImpl {
             throw new ResourceNotSupportedException(FAILED_BY_GET_RESOURCE_PLUGIN + e.getMessage());
         }
 
+        return resourceResponse;
+    }
+
+    private ResourceResponse putPropertiesInResponse(ResourceRequest resourceRequest,
+            ResourceResponse resourceResponse) {
+        if (resourceResponse != null) {
+            // must add the request properties into response properties in case the source forgot to
+            Map<String, Serializable> properties =
+                    new HashMap<>(resourceResponse.getProperties());
+            resourceRequest.getProperties()
+                    .forEach(properties::putIfAbsent);
+            resourceResponse = new ResourceResponseImpl(resourceResponse.getRequest(),
+                    properties,
+                    resourceResponse.getResource());
+        }
         return resourceResponse;
     }
 


### PR DESCRIPTION
#### What does this PR do?
fixes resource usage not counting against first users downloads

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @lcrosenbu @jrnorth @codice/core-api (which doesn't exist but should :) )

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@lessarderic 

#### Checklist:


 - This was caused by the sources not putting the resource request properties into the response.