### PR TITLE
DDF-2391: Log Viewer Filtering Includes Higher Severities

### DIFF
--- a/platform/admin/core/admin-core-logviewer/package.json
+++ b/platform/admin/core/admin-core-logviewer/package.json
@@ -24,6 +24,7 @@
     "color": "0.11.1",
     "concat-stream": "1.5.1",
     "event-stream": "3.3.2",
+    "lodash": "4.13.1",
     "moment": "2.13.0",
     "object-hash": "1.1.2",
     "random-item": "1.0.0",

--- a/platform/admin/core/admin-core-logviewer/src/main/resources/index.html
+++ b/platform/admin/core/admin-core-logviewer/src/main/resources/index.html
@@ -15,7 +15,6 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <link href="../lib/bootswatch/flatly/bootstrap.min.css" rel="stylesheet"/>
         <style>
             body {
                 padding: 0;

--- a/platform/admin/core/admin-core-logviewer/src/main/webapp/js/components/log-viewer/log-viewer.less
+++ b/platform/admin/core/admin-core-logviewer/src/main/webapp/js/components/log-viewer/log-viewer.less
@@ -13,7 +13,7 @@
   color: @fg;
   background: @bg;
   width: 100%;
-  height: 90px;
+  height: 60px;
   border-bottom: 1px @border solid;
 }
 
@@ -21,7 +21,7 @@
   position: absolute;
   overflow-y: auto;
   overflow-x: hidden;
-  top: 90px;
+  top: 60px;
   bottom: 0px;
 }
 

--- a/platform/admin/core/admin-core-logviewer/src/main/webapp/js/filter.js
+++ b/platform/admin/core/admin-core-logviewer/src/main/webapp/js/filter.js
@@ -13,6 +13,11 @@
  *
  **/
 
+import includes from 'lodash/includes'
+
+import lvls from './levels'
+const levels = lvls()
+
 const arrayToObject = function (key, array) {
   var o = {}
   array.forEach(function (element) {
@@ -56,7 +61,7 @@ export default (filters, logs) => {
   }
 
   const levelLogs = logs.filter((entry) => {
-    return level === 'ALL' || entry.level === level
+    return level === 'ALL' || includes(levels.slice(levels.indexOf(level)), entry.level)
   }).map(getMarks)
 
   return (fields.length > 0) ? levelLogs.filter(hasMarks) : levelLogs

--- a/platform/admin/core/admin-core-logviewer/src/main/webapp/js/levels.js
+++ b/platform/admin/core/admin-core-logviewer/src/main/webapp/js/levels.js
@@ -15,13 +15,14 @@
 
 // Correspond to classes in log-entry.less
 // Also used to populate level-selector drop down list
+// these should be ordered by severity from lowest to highest
 const levels = {
-  ERROR: 'errorLevel',
-  WARN: 'warnLevel',
-  INFO: 'infoLevel',
-  DEBUG: 'debugLevel',
+  ALL: undefined,
   TRACE: 'traceLevel',
-  ALL: undefined
+  DEBUG: 'debugLevel',
+  INFO: 'infoLevel',
+  WARN: 'warnLevel',
+  ERROR: 'errorLevel'
 }
 
 // log level colors

--- a/platform/admin/core/admin-core-logviewer/src/test/js/filter.js
+++ b/platform/admin/core/admin-core-logviewer/src/test/js/filter.js
@@ -14,46 +14,67 @@
  **/
 
 import test from 'tape'
+
 import filter from '../../main/webapp/js/filter'
 import random from './random-entry'
 
-test('level filter', function (t) {
+const getEntry = (item) => item.entry
+
+test('level filter TRACE', (t) => {
   t.plan(1)
 
-  const logs = [{ level: 'DEBUG' }, { level: 'WARN' }].map(random)
-  const filtered = filter({ level: 'DEBUG' }, logs)
+  const logs = [{ level: 'TRACE' }, { level: 'INFO' }, { level: 'ERROR' }].map(random)
+  const filtered = filter({ level: 'TRACE' }, logs).map(getEntry)
 
-  t.equal(filtered.length, 1)
+  t.deepEqual(filtered, [logs[0], logs[1], logs[2]])
 })
 
-test('text filter', function (t) {
+test('level filter WARN', (t) => {
+  t.plan(1)
+
+  const logs = [{ level: 'INFO' }, { level: 'WARN' }, { level: 'ERROR' }].map(random)
+  const filtered = filter({ level: 'WARN' }, logs).map(getEntry)
+
+  t.deepEqual(filtered, [logs[1], logs[2]])
+})
+
+test('level filter ERROR', (t) => {
+  t.plan(1)
+
+  const logs = [{ level: 'DEBUG' }, { level: 'WARN' }, { level: 'ERROR' }].map(random)
+  const filtered = filter({ level: 'ERROR' }, logs).map(getEntry)
+
+  t.deepEqual(filtered, [logs[2]])
+})
+
+test('text filter', (t) => {
   t.plan(1)
 
   const logs = [{ message: 'first' }, { message: 'second' }].map(random)
-  const filtered = filter({ message: 'first' }, logs)
+  const filtered = filter({ message: 'first' }, logs).map(getEntry)
 
-  t.equal(filtered.length, 1)
+  t.deepEqual(filtered, [logs[0]])
 })
 
-test('text filter (partial match)', function (t) {
+test('text filter (partial match)', (t) => {
   t.plan(1)
 
   const logs = [{ message: 'random' }].map(random)
-  const filtered = filter({ message: 'rand' }, logs)
+  const filtered = filter({ message: 'rand' }, logs).map(getEntry)
 
-  t.equal(filtered.length, 1)
+  t.deepEqual(filtered, [logs[0]])
 })
 
-test('text filter (regex match)', function (t) {
+test('text filter (regex match)', (t) => {
   t.plan(1)
 
   const logs = [{ message: 'one two' }, { message: 'two one' }].map(random)
-  const filtered = filter({ message: '^one' }, logs)
+  const filtered = filter({ message: '^one' }, logs).map(getEntry)
 
-  t.equal(filtered.length, 1)
+  t.deepEqual(filtered, [logs[0]])
 })
 
-test('compound filter (logical AND)', function (t) {
+test('compound filter (logical AND)', (t) => {
   t.plan(1)
 
   const logs = [
@@ -61,7 +82,7 @@ test('compound filter (logical AND)', function (t) {
     { level: 'WARN', message: 'second' }
   ].map(random)
 
-  const filtered = filter({ level: 'DEBUG', message: 'second' }, logs)
+  const filtered = filter({ level: 'DEBUG', message: 'second' }, logs).map(getEntry)
 
-  t.equal(filtered.length, 0)
+  t.deepEqual(filtered, [logs[1]])
 })


### PR DESCRIPTION
#### What does this PR do?
The Log Viewer level filter now shows all logs with a severity higher-than-or-equal to the selected level. Ex, is the user chooses "WARN", it will show all logs with levels WARN and ERROR.

Some formatting bugs introduced in DDF-2270 were also fixed.

#### Who is reviewing it?
@djblue 
@oconnormi 

#### Choose 2 committers to review/merge the PR.
@lessarderic
@shaundmorris

#### How should this be tested?
Unit tests were added, so a full build should be enough.