### PR TITLE
DDF-2245: Removed metacard.permissions and added access control metac…

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.SecurityAttributes;
 
 /**
  * Default implementation of the {@link MetacardType}, used by {@link BasicTypes} to create the
@@ -121,6 +122,7 @@ public class MetacardTypeImpl implements MetacardType {
         this.name = name;
         List<String> attributeNames = new ArrayList<>();
         addAttributeDescriptors(attributeNames, new CoreAttributes().getAttributeDescriptors());
+        addAttributeDescriptors(attributeNames, new SecurityAttributes().getAttributeDescriptors());
 
         if (metacardTypes != null) {
             metacardTypes.forEach(metacardType -> addAttributeDescriptors(attributeNames,

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
@@ -165,12 +165,6 @@ public class CoreAttributes implements Core, MetacardType {
                 false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
-        descriptors.add(new AttributeDescriptorImpl(METACARD_PERMISSIONS,
-                true /* indexed */,
-                true /* stored */,
-                true /* tokenized */,
-                true /* multivalued */,
-                BasicTypes.XML_TYPE));
         descriptors.add(new AttributeDescriptorImpl(DATATYPE,
                 true /* indexed */,
                 true /* stored */,

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/SecurityAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/SecurityAttributes.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.data.impl.types;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.types.Security;
+
+/**
+ * This class defines attributes that provide restrictions on the metacard and/or resource.
+ */
+public class SecurityAttributes implements Security, MetacardType {
+
+    private static final Set<AttributeDescriptor> DESCRIPTORS;
+
+    private static final String NAME = "security";
+
+    static {
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        descriptors.add(new AttributeDescriptorImpl(ACCESS_GROUPS,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                true /* multivalued */,
+                BasicTypes.STRING_TYPE));
+        descriptors.add(new AttributeDescriptorImpl(ACCESS_INDIVIDUALS,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                true /* multivalued */,
+                BasicTypes.STRING_TYPE));
+        DESCRIPTORS = Collections.unmodifiableSet(descriptors);
+    }
+
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return DESCRIPTORS;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor(String name) {
+        for (AttributeDescriptor attributeDescriptor : DESCRIPTORS) {
+            if (attributeDescriptor.getName()
+                    .equals(name)) {
+                return attributeDescriptor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}
+

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
@@ -39,6 +39,7 @@ import ddf.catalog.data.impl.types.CoreAttributes;
 import ddf.catalog.data.impl.types.DateTimeAttributes;
 import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.impl.types.TopicAttributes;
 import ddf.catalog.data.impl.types.ValidationAttributes;
 import ddf.catalog.data.impl.types.VersionAttributes;
@@ -72,6 +73,8 @@ public class MetacardTypeImplTest {
     private static final ValidationAttributes VALIDATION_ATTRIBUTES = new ValidationAttributes();
 
     private static final CoreAttributes CORE_ATTRIBUTES = new CoreAttributes();
+
+    private static final SecurityAttributes SECURITY_ATTRIBUTES = new SecurityAttributes();
 
     @Test
     public void testNullAttributeDescriptors() {
@@ -410,22 +413,26 @@ public class MetacardTypeImplTest {
 
     @Test
     public void testDuplicateAttributes() {
-        MetacardType duplicateAttributeMetacardType = new MetacardTypeImpl("testType", Collections.singleton(new AttributeDescriptorImpl(
-                Core.CHECKSUM,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.SHORT_TYPE)));
+        MetacardType duplicateAttributeMetacardType = new MetacardTypeImpl("testType",
+                Collections.singleton(new AttributeDescriptorImpl(Core.CHECKSUM,
+                        true /* indexed */,
+                        true /* stored */,
+                        false /* tokenized */,
+                        false /* multivalued */,
+                        BasicTypes.SHORT_TYPE)));
         List<MetacardType> metacardTypeList = new ArrayList<>();
         metacardTypeList.add(DATE_TIME_ATTRIBUTES);
         metacardTypeList.add(duplicateAttributeMetacardType);
 
         MetacardType metacardType = new MetacardTypeImpl(TEST_NAME, metacardTypeList);
 
-        int expectedSize = DATE_TIME_ATTRIBUTES.getAttributeDescriptors().size() + CORE_ATTRIBUTES.getAttributeDescriptors().size();
+        int expectedSize = DATE_TIME_ATTRIBUTES.getAttributeDescriptors()
+                .size() + CORE_ATTRIBUTES.getAttributeDescriptors()
+                .size() + SECURITY_ATTRIBUTES.getAttributeDescriptors()
+                .size();
 
-        assertThat(metacardType.getAttributeDescriptors().size(), is(expectedSize));
+        assertThat(metacardType.getAttributeDescriptors()
+                .size(), is(expectedSize));
     }
 
     private void assertMetacardAttributes(MetacardType metacardType,

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
@@ -148,8 +148,4 @@ public interface Core {
      */
     String METACARD_TAGS = Metacard.TAGS;
 
-    /**
-     * {@link ddf.catalog.data.Attribute} name for accessing the security permissions of the {@link Metacard}. <br/>
-     */
-    String METACARD_PERMISSIONS = "metacard.permissions";
 }

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Security.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Security.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.data.types;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface Security {
+
+    /**
+     * {@link ddf.catalog.data.Attribute} name for storing groups to enforce access controls upon
+     */
+    String ACCESS_GROUPS = "security.access-groups";
+
+    /**
+     * {@link ddf.catalog.data.Attribute} name for storing the email addresses of users to enforce access controls upon
+     */
+    String ACCESS_INDIVIDUALS = "security.access-individuals";
+}


### PR DESCRIPTION
#### What does this PR do?
Taxonomy changes including
- Removal of metacard.permissions
- Addition of new DDF Security attribute category
- Addition of security.access-groups and security.access-individuals

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@brendan-hofmann @bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

