### PR TITLE
DDF-2328 Added in runtime exception that was accidentally removed due to ambiguity

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
@@ -63,6 +63,7 @@ import org.xml.sax.SAXException;
 
 import com.google.common.io.ByteSource;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.converters.DataHolder;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.core.TreeMarshaller;
@@ -253,7 +254,7 @@ public class GmdTransformer implements InputTransformer, MetacardTransformer {
             Metacard metacard = toMetacard(pathValueTracker, id);
             metacard.setAttribute(new AttributeImpl(Core.METADATA, xml));
             return metacard;
-        } catch (XMLStreamException | IOException e) {
+        } catch (XStreamException | XMLStreamException | IOException e) {
             throw new CatalogTransformerException(TRANSFORM_EXCEPTION_MSG, e);
         } finally {
             IOUtils.closeQuietly(inputStream);


### PR DESCRIPTION
#### What does this PR do?
This PR adds back in a runtime exception that was accidentally removed. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@peterhuffer  @troymohl  
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
@jaymcnallie 
#### How should this be tested?
Build DDF
#### Any background context you want to provide?
It was observed that some extending projects were having problems on failed ingests because this exception was taken out.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests