### PR TITLE
DDF-2416 Fix ip validation of guest tokens

### DIFF
--- a/platform/security/sts/security-sts-guestvalidator/src/main/java/org/codice/ddf/security/validator/guest/GuestValidator.java
+++ b/platform/security/sts/security-sts-guestvalidator/src/main/java/org/codice/ddf/security/validator/guest/GuestValidator.java
@@ -13,8 +13,9 @@
  */
 package org.codice.ddf.security.validator.guest;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.cxf.sts.request.ReceivedToken;
 import org.apache.cxf.sts.token.validator.TokenValidator;
@@ -32,15 +33,6 @@ import ddf.security.principal.GuestPrincipal;
 public class GuestValidator implements TokenValidator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GuestValidator.class);
-
-    private static final Pattern IPV4_PATTERN = Pattern.compile(
-            "^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$");
-
-    private static final Pattern IPV6_HEX_COMPRESSED_PATTERN = Pattern.compile(
-            "^\\[((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)\\]$");
-
-    private static final Pattern IPV6_STD_PATTERN = Pattern.compile(
-            "^\\[(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\\]$");
 
     private List<String> supportedRealm;
 
@@ -65,10 +57,11 @@ public class GuestValidator implements TokenValidator {
     }
 
     private boolean validIpAddress(String address) {
-        return IPV4_PATTERN.matcher(address)
-                .matches() || IPV6_STD_PATTERN.matcher(address)
-                .matches() || IPV6_HEX_COMPRESSED_PATTERN.matcher(address)
-                .matches();
+        try {
+            return InetAddress.getByName(address) != null;
+        } catch (UnknownHostException e) {
+            return false;
+        }
     }
 
     @Override

--- a/platform/security/sts/security-sts-guestvalidator/src/test/java/org/codice/ddf/security/validator/guest/GuestValidatorTest.java
+++ b/platform/security/sts/security-sts-guestvalidator/src/test/java/org/codice/ddf/security/validator/guest/GuestValidatorTest.java
@@ -52,6 +52,8 @@ public class GuestValidatorTest {
 
     ReceivedToken receivedAnyRealmToken;
 
+    ReceivedToken receivedTokenIpv6Reachability;
+
     @Before
     public void setup() {
         validator = new GuestValidator();
@@ -64,6 +66,9 @@ public class GuestValidatorTest {
 
         GuestAuthenticationToken guestAuthenticationTokenIpv6 = new GuestAuthenticationToken("*",
                 "0:0:0:0:0:0:0:1");
+
+        GuestAuthenticationToken guestAuthenticationTokenIpv6Reachability =
+                new GuestAuthenticationToken("*", "0:0:0:0:0:0:0:1%4");
 
         GuestAuthenticationToken guestAuthenticationTokenBadIp = new GuestAuthenticationToken("*",
                 "123.abc.45.def");
@@ -80,60 +85,75 @@ public class GuestValidatorTest {
                         BinarySecurityTokenType.class,
                         binarySecurityTokenType);
 
-        BinarySecurityTokenType binarySecurityTokenType2 = new BinarySecurityTokenType();
-        binarySecurityTokenType2.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
-        binarySecurityTokenType2.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
-        binarySecurityTokenType2.setId(GuestAuthenticationToken.BST_GUEST_LN);
-        binarySecurityTokenType2.setValue(Base64.getEncoder()
+        BinarySecurityTokenType binarySecurityTokenTypeBadToken = new BinarySecurityTokenType();
+        binarySecurityTokenTypeBadToken.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
+        binarySecurityTokenTypeBadToken.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
+        binarySecurityTokenTypeBadToken.setId(GuestAuthenticationToken.BST_GUEST_LN);
+        binarySecurityTokenTypeBadToken.setValue(Base64.getEncoder()
                 .encodeToString("NotGuest".getBytes()));
-        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElement2 =
+        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElementBadToken =
                 new JAXBElement<BinarySecurityTokenType>(new QName(
                         "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
                         "BinarySecurityToken"),
                         BinarySecurityTokenType.class,
-                        binarySecurityTokenType2);
+                        binarySecurityTokenTypeBadToken);
 
-        BinarySecurityTokenType binarySecurityTokenType3 = new BinarySecurityTokenType();
-        binarySecurityTokenType3.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
-        binarySecurityTokenType3.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
-        binarySecurityTokenType3.setId(GuestAuthenticationToken.BST_GUEST_LN);
-        binarySecurityTokenType3.setValue(guestAuthenticationTokenAnyRealm.getEncodedCredentials());
-        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElement3 =
+        BinarySecurityTokenType binarySecurityTokenTypeAnyRealm = new BinarySecurityTokenType();
+        binarySecurityTokenTypeAnyRealm.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
+        binarySecurityTokenTypeAnyRealm.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
+        binarySecurityTokenTypeAnyRealm.setId(GuestAuthenticationToken.BST_GUEST_LN);
+        binarySecurityTokenTypeAnyRealm.setValue(guestAuthenticationTokenAnyRealm.getEncodedCredentials());
+        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElementAnyRealm =
                 new JAXBElement<BinarySecurityTokenType>(new QName(
                         "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
                         "BinarySecurityToken"),
                         BinarySecurityTokenType.class,
-                        binarySecurityTokenType3);
+                        binarySecurityTokenTypeAnyRealm);
 
-        BinarySecurityTokenType binarySecurityTokenType4 = new BinarySecurityTokenType();
-        binarySecurityTokenType4.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
-        binarySecurityTokenType4.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
-        binarySecurityTokenType4.setId(GuestAuthenticationToken.BST_GUEST_LN);
-        binarySecurityTokenType4.setValue(guestAuthenticationTokenIpv6.getEncodedCredentials());
-        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElement4 =
+        BinarySecurityTokenType binarySecurityTokenTypeIpv6 = new BinarySecurityTokenType();
+        binarySecurityTokenTypeIpv6.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
+        binarySecurityTokenTypeIpv6.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
+        binarySecurityTokenTypeIpv6.setId(GuestAuthenticationToken.BST_GUEST_LN);
+        binarySecurityTokenTypeIpv6.setValue(guestAuthenticationTokenIpv6.getEncodedCredentials());
+        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElementIpv6 =
                 new JAXBElement<BinarySecurityTokenType>(new QName(
                         "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
                         "BinarySecurityToken"),
                         BinarySecurityTokenType.class,
-                        binarySecurityTokenType4);
+                        binarySecurityTokenTypeIpv6);
 
-        BinarySecurityTokenType binarySecurityTokenType5 = new BinarySecurityTokenType();
-        binarySecurityTokenType5.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
-        binarySecurityTokenType5.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
-        binarySecurityTokenType5.setId(GuestAuthenticationToken.BST_GUEST_LN);
-        binarySecurityTokenType5.setValue(guestAuthenticationTokenBadIp.getEncodedCredentials());
-        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElement5 =
+        BinarySecurityTokenType binarySecurityTokenTypeIpv6Reachability =
+                new BinarySecurityTokenType();
+        binarySecurityTokenTypeIpv6Reachability.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
+        binarySecurityTokenTypeIpv6Reachability.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
+        binarySecurityTokenTypeIpv6Reachability.setId(GuestAuthenticationToken.BST_GUEST_LN);
+        binarySecurityTokenTypeIpv6Reachability.setValue(guestAuthenticationTokenIpv6Reachability.getEncodedCredentials());
+        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElementIpv6Reachability =
                 new JAXBElement<BinarySecurityTokenType>(new QName(
                         "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
                         "BinarySecurityToken"),
                         BinarySecurityTokenType.class,
-                        binarySecurityTokenType5);
+                        binarySecurityTokenTypeIpv6Reachability);
+
+        BinarySecurityTokenType binarySecurityTokenTypeBadIp = new BinarySecurityTokenType();
+        binarySecurityTokenTypeBadIp.setValueType(GuestAuthenticationToken.GUEST_TOKEN_VALUE_TYPE);
+        binarySecurityTokenTypeBadIp.setEncodingType(BSTAuthenticationToken.BASE64_ENCODING);
+        binarySecurityTokenTypeBadIp.setId(GuestAuthenticationToken.BST_GUEST_LN);
+        binarySecurityTokenTypeBadIp.setValue(guestAuthenticationTokenBadIp.getEncodedCredentials());
+        JAXBElement<BinarySecurityTokenType> binarySecurityTokenElementBadIp =
+                new JAXBElement<BinarySecurityTokenType>(new QName(
+                        "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
+                        "BinarySecurityToken"),
+                        BinarySecurityTokenType.class,
+                        binarySecurityTokenTypeBadIp);
 
         receivedToken = new ReceivedToken(binarySecurityTokenElement);
-        receivedAnyRealmToken = new ReceivedToken(binarySecurityTokenElement3);
-        receivedBadToken = new ReceivedToken(binarySecurityTokenElement2);
-        receivedTokenIpv6 = new ReceivedToken(binarySecurityTokenElement4);
-        receivedTokenBadIp = new ReceivedToken(binarySecurityTokenElement5);
+        receivedAnyRealmToken = new ReceivedToken(binarySecurityTokenElementAnyRealm);
+        receivedBadToken = new ReceivedToken(binarySecurityTokenElementBadToken);
+        receivedTokenIpv6 = new ReceivedToken(binarySecurityTokenElementIpv6);
+        receivedTokenIpv6Reachability =
+                new ReceivedToken(binarySecurityTokenElementIpv6Reachability);
+        receivedTokenBadIp = new ReceivedToken(binarySecurityTokenElementBadIp);
         parameters = new TokenValidatorParameters();
         parameters.setToken(receivedToken);
     }
@@ -179,6 +199,17 @@ public class GuestValidatorTest {
     public void testCanValidateIpv6Token() {
         TokenValidatorParameters params = new TokenValidatorParameters();
         params.setToken(receivedTokenIpv6);
+        TokenValidatorResponse response = validator.validateToken(params);
+
+        assertEquals(ReceivedToken.STATE.VALID,
+                response.getToken()
+                        .getState());
+    }
+
+    @Test
+    public void testCanValidateIpv6ReachabilityToken() {
+        TokenValidatorParameters params = new TokenValidatorParameters();
+        params.setToken(receivedTokenIpv6Reachability);
         TokenValidatorResponse response = validator.validateToken(params);
 
         assertEquals(ReceivedToken.STATE.VALID,


### PR DESCRIPTION
#### What does this PR do?
Fix scoped ipv6 addresses in guest tokens.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard 
@glenhein 
@harrison-tarr 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
Verify that your computer asks for a guest token with a scoped ipv6 address. I was able to reliably produce this by using `?dev=true` to change my cert. Make sure (in a private session) that you can access guest pages like the login page.
#### Any background context you want to provide?
This should be backported to 2.9.x and the same fix applied to videographer in alliance.
#### What are the relevant tickets?
DDF-2416
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

