### PR TITLE
DDF-2422: TestFederation iTest Intermittent Failures

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -253,6 +253,7 @@ public class TestFederation extends AbstractIntegrationTest {
             CswSourceProperties cswStubServerProperties =
                     new CswSourceProperties(CSW_STUB_SOURCE_ID);
             cswStubServerProperties.put("cswUrl", CSW_STUB_SERVER_PATH.getUrl());
+            cswStubServerProperties.put(POLL_INTERVAL, CSW_SOURCE_POLL_INTERVAL);
             getServiceManager().createManagedService(CswSourceProperties.FACTORY_PID,
                     cswStubServerProperties);
 
@@ -1835,10 +1836,9 @@ public class TestFederation extends AbstractIntegrationTest {
                 .body(is(resourceData1));
         // @formatter:on
 
-        List<String> activities = cometDClient.getMessagesInAscOrder(ACTIVITIES_CHANNEL);
-
         expect("Waiting for activities").within(10, SECONDS)
                 .until(() -> {
+                    List<String> activities = cometDClient.getMessagesInAscOrder(ACTIVITIES_CHANNEL);
                     if (foundExpectedActivity(activities, filename1, ACTIVITES_STARTED_MESSAGE)
                             && foundExpectedActivity(activities,
                             failFilename,


### PR DESCRIPTION
### What does this PR do?

Fixes the TestFederation intermittent itests failures that have been occurring recently with the bamboo nightly master build and bamboo PR builds.

### Who is reviewing it?

@emanns95 
@brendan-hofmann 
@figliold 

### Choose 2 committers to review/merge the PR.

@kcwire 
@coyotesqrl 

### How should this be tested?

Bamboo PR tests passed a few times in a row, but the master build and other PR builds should be watched after this gets merged in to make sure that the issue is completely gone.
