### PR TITLE
DDF-2421: Enabled filtering of schematron validation properties

### DIFF
--- a/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,6 +19,9 @@
             id="ddf.services.schematron.SchematronValidationService"
             factory-pid="ddf.services.schematron.SchematronValidationService"
             interface="ddf.catalog.validation.MetacardValidator">
+        <service-properties>
+            <cm:cm-properties persistent-id="ddf.services.schematron.SchematronValidationService"/>
+        </service-properties>
         <cm:managed-component class="ddf.services.schematron.SchematronValidationService"
                               init-method="init" destroy-method="destroy">
             <cm:managed-properties persistent-id="" update-strategy="container-managed"/>


### PR DESCRIPTION
#### What does this PR do?
Enables the properties of a SchematronValidationService to be filterable.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr @brendan-hofmann @ahoffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

