### PR TITLE
DDF-2420 Removed local node from sources tab table and made disabled sources show no status.

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
@@ -16,7 +16,6 @@
         <th class="name">Name</th>
         <th class="active-binding">Active Binding</th>
         <th class="status">Status</th>
-        <th class="type">Type</th>
         <th><a href="#" class="addSourceLink fa fa-plus"></a></th>
         <th><a href="#" class="removeSourceLink fa fa-trash-o"></a></th>
         <th><a href="#" class="refreshButton fa fa-refresh"></a></th>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
@@ -42,9 +42,11 @@
     </div>
 </td>
 <td colspan="4">
-    {{#if available}}
-        <span class='label label-success'>Available</span>
-    {{else}}
-        <span class='label label-warning'>Unavailable</span>
+    {{#if currentConfiguration}}
+        {{#if available}}
+            <span class='label label-success'>Available</span>
+        {{else}}
+            <span class='label label-warning'>Unavailable</span>
+        {{/if}}
     {{/if}}
 </td>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.parser.ParserException;
-import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
 import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminService;
@@ -138,8 +137,8 @@ public class SourceConfigurationHandler implements EventHandler {
     @Override
     public void handleEvent(Event event) {
         Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
-        if (mcard == null || !mcard.getTags()
-                .contains(RegistryConstants.REGISTRY_TAG)) {
+        if (mcard == null || !RegistryUtility.isRegistryMetacard(mcard)
+                || RegistryUtility.isIdentityNode(mcard)) {
             return;
         }
 
@@ -583,8 +582,10 @@ public class SourceConfigurationHandler implements EventHandler {
         }
 
         String propertyValue = null;
-        if (config.getProperties().get(property) instanceof String) {
-            propertyValue = (String) config.getProperties().get(property);
+        if (config.getProperties()
+                .get(property) instanceof String) {
+            propertyValue = (String) config.getProperties()
+                    .get(property);
         }
 
         if (propertyValue == null) {

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
@@ -146,7 +146,7 @@ public class SourceConfigurationHandlerTest {
         mcard.setId("2014ca7f59ac46f495e32b4a67a51276");
         mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
-        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true);
+
         mcard.setMetadata(getMetadata("/csw-rim-node-csw-binding.xml"));
         mcard.setTitle("TestRegNode");
 
@@ -155,6 +155,8 @@ public class SourceConfigurationHandlerTest {
         createEvent = new Event("ddf/catalog/event/CREATED", eventProperties);
         updateEvent = new Event("ddf/catalog/event/UPDATED", eventProperties);
         deleteEvent = new Event("ddf/catalog/event/DELETED", eventProperties);
+
+        System.setProperty(RegistryConstants.REGISTRY_ID_PROPERTY, "myRegId");
 
     }
 
@@ -181,6 +183,8 @@ public class SourceConfigurationHandlerTest {
     public void testRegistryMetacardExecutorCall() {
         MetacardImpl mcard = new MetacardImpl();
         mcard.setAttribute(Metacard.TAGS, RegistryConstants.REGISTRY_TAG);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID,
+                "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         Dictionary<String, Object> eventProperties = new Hashtable<>();
         eventProperties.put("ddf.catalog.event.metacard", mcard);
         Event event = new Event("ddf/catalog/event/CREATED", eventProperties);
@@ -190,6 +194,23 @@ public class SourceConfigurationHandlerTest {
         event = new Event("ddf/catalog/event/DELETED", eventProperties);
         sch.handleEvent(event);
         verify(executorService, times(3)).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testIdentityNode() {
+        MetacardImpl mcard = new MetacardImpl();
+        mcard.setAttribute(Metacard.TAGS, RegistryConstants.REGISTRY_TAG);
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, "myRegId");
+        mcard.setAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true);
+        Dictionary<String, Object> eventProperties = new Hashtable<>();
+        eventProperties.put("ddf.catalog.event.metacard", mcard);
+        Event event = new Event("ddf/catalog/event/CREATED", eventProperties);
+        sch.handleEvent(event);
+        event = new Event("ddf/catalog/event/UPDATED", eventProperties);
+        sch.handleEvent(event);
+        event = new Event("ddf/catalog/event/DELETED", eventProperties);
+        sch.handleEvent(event);
+        verify(executorService, never()).execute(any(Runnable.class));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Removed local node from sources tab table and made disabled sources show no status.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison
#### How should this be tested?
Startup an instance and add a csw service binding to the identity node. 
Verify that there are no sources created in the sources tab
Create a secondary local node with a csw service binding. Verify that it comes up in the sources tab and when it is disabled the status column is empty.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2420 
#### Screenshots (if appropriate)
![screen shot 2016-08-19 at 9 05 02 am](https://cloud.githubusercontent.com/assets/5248090/17822595/df317e5c-660c-11e6-9657-97f605680468.png)

![screen shot 2016-08-19 at 9 09 10 am](https://cloud.githubusercontent.com/assets/5248090/17820165/3df907aa-6600-11e6-8548-150c01ca9043.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

