### PR TITLE
DDF-2341 update PdfInputTransformer for new taxonomy

### DIFF
--- a/catalog/transformer/catalog-transformer-pdf/pom.xml
+++ b/catalog/transformer/catalog-transformer-pdf/pom.xml
@@ -172,7 +172,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.93</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/CheckedFunction.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/CheckedFunction.java
@@ -13,8 +13,9 @@
  */
 package ddf.catalog.transformer.input.pdf;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
+import java.io.IOException;
 
-public interface GeoPdfParser extends CheckedFunction<PDDocument, String> {
-
+@FunctionalInterface
+public interface CheckedFunction<T, R> {
+    R apply(T t) throws IOException;
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParserImpl.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParserImpl.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSBoolean;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSDocument;
+import org.apache.pdfbox.cos.COSFloat;
+import org.apache.pdfbox.cos.COSInteger;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSNull;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.cos.ICOSVisitor;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GeoPdfParserImpl implements GeoPdfParser {
+
+    public static final String GEOGRAPHIC = "GEOGRAPHIC";
+
+    public static final String LGIDICT = "LGIDict";
+
+    public static final String PROJECTION = "Projection";
+
+    public static final String PROJECTION_TYPE = "ProjectionType";
+
+    public static final String NEATLINE = "Neatline";
+
+    public static final String CTM = "CTM";
+
+    private static final String POLYGON = "POLYGON ((";
+
+    private static final String MULTIPOLYGON = "MULTIPOLYGON (";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoPdfParserImpl.class);
+
+    private static final int CTM_SIZE = 6;
+
+    /**
+     * Generates a WKT compliant String from a PDF Document if it contains GeoPDF information.
+     * Currently, only WGS84 Projections are supported (GEOGRAPHIC GeoPDF ProjectionType).
+     *
+     * @param pdfDocument - The PDF document
+     * @return the WKT String
+     * @throws IOException
+     */
+    @Override
+    public String apply(PDDocument pdfDocument) throws IOException {
+        ToDoubleVisitor toDoubleVisitor = new ToDoubleVisitor();
+        LinkedList<String> polygons = new LinkedList<>();
+
+        for (PDPage pdPage : pdfDocument.getPages()) {
+            COSDictionary cosObject = pdPage.getCOSObject();
+
+
+            COSBase lgiDictObject = cosObject.getObjectFromPath(LGIDICT);
+
+            // Handle Multiple Map Frames
+            if (lgiDictObject instanceof COSArray) {
+                for (int i = 0; i < ((COSArray) lgiDictObject).size(); i++) {
+                    COSDictionary lgidict = (COSDictionary) cosObject.getObjectFromPath(
+                            LGIDICT + "/[" + i + "]");
+
+                    COSDictionary projectionArray = (COSDictionary) lgidict.getDictionaryObject(
+                            PROJECTION);
+                    if (projectionArray != null) {
+                        String projectionType =
+                                ((COSString) projectionArray.getItem(PROJECTION_TYPE)).getString();
+                        if (GEOGRAPHIC.equals(projectionType)) {
+                            COSArray neatlineArray = (COSArray) cosObject.getObjectFromPath(
+                                    LGIDICT + "/[" + i + "]/" + NEATLINE);
+                            String wktString = getWktFromNeatLine(lgidict,
+                                    neatlineArray,
+                                    toDoubleVisitor);
+                            polygons.add(wktString);
+                        } else {
+                            LOGGER.debug(
+                                    "Unsupported projection type {}.  Map Frame will be skipped.",
+                                    projectionType);
+                        }
+                    } else {
+                        LOGGER.debug(
+                                "No projection array found on the map frame.  Map Frame will be skipped.");
+                    }
+                }
+                // Handle One Map Frame
+            } else if (lgiDictObject instanceof COSDictionary) {
+                COSDictionary lgidict = (COSDictionary) lgiDictObject;
+                COSDictionary projectionArray = (COSDictionary) lgidict.getDictionaryObject(
+                        PROJECTION);
+                if (projectionArray != null) {
+                    String projectionType =
+                            ((COSString) projectionArray.getItem(PROJECTION_TYPE)).getString();
+                    if (GEOGRAPHIC.equals(projectionType)) {
+                        COSArray neatlineArray = (COSArray) cosObject.getObjectFromPath(
+                                LGIDICT + "/" + NEATLINE);
+                        if (neatlineArray == null) {
+                            neatlineArray = generateNeatLineFromPDFDimensions(pdPage);
+
+                        }
+                        polygons.add(getWktFromNeatLine(lgidict, neatlineArray, toDoubleVisitor));
+
+                    } else {
+                        LOGGER.debug("Unsupported projection type {}.  Map Frame will be skipped.",
+                                projectionType);
+                    }
+                } else {
+                    LOGGER.debug(
+                            "No projection array found on the map frame.  Map Frame will be skipped.");
+                }
+            }
+        }
+
+        if (polygons.size() == 0) {
+            LOGGER.debug(
+                    "No GeoPDF information found on PDF during transformation.  Metacard location will not be set.");
+            return null;
+        }
+
+        if (polygons.size() == 1) {
+            return POLYGON + polygons.get(0) + "))";
+        } else {
+            return polygons.stream()
+                    .map(polygon -> "((" + polygon + "))")
+                    .collect(Collectors.joining(",", MULTIPOLYGON, ")"));
+        }
+    }
+
+    /**
+     * A PDF Neatline defines the area of a PDF image with relation to the PDF page.  If no neatline is given
+     * it is assumed that the image encompasses the entire page.  This functiong generates a NeatLine
+     * in this fashion.
+     * @param pdPage the page to generate the NeatLine
+     * @return an array of points representing the NeatLine
+     */
+    private COSArray generateNeatLineFromPDFDimensions(PDPage pdPage) {
+        COSArray neatLineArray = new COSArray();
+
+        String width = String.valueOf(pdPage.getMediaBox().getWidth());
+        String height = String.valueOf(pdPage.getMediaBox().getHeight());
+
+        neatLineArray.add(new COSString("0"));
+        neatLineArray.add(new COSString("0"));
+
+        neatLineArray.add(new COSString(width));
+        neatLineArray.add(new COSString("0"));
+
+        neatLineArray.add(new COSString(width));
+        neatLineArray.add(new COSString(height));
+
+        neatLineArray.add(new COSString("0"));
+        neatLineArray.add(new COSString(height));
+
+        return neatLineArray;
+    }
+
+    /**
+     * Convert a Point2d into WKT Lat/Lon
+     *
+     * @param point2D
+     * @return a String representation of a WKT Lat/Lon pair
+     */
+    private String point2dToWkt(Point2D point2D) {
+        return point2D.getX() + " " + point2D.getY();
+    }
+
+    /**
+     * Parses a given NeatLine and Transformation matrix into a WKT String
+     *
+     * @param lgidict         - The PDF's LGIDict object
+     * @param neatLineArray   - The NeatLine array of points for the PDF
+     * @param toDoubleVisitor - A visitor that converts PDF Strings / Ints / Longs into doubles.
+     * @return the generated WKT Lat/Lon set
+     * @throws IOException
+     */
+    private String getWktFromNeatLine(COSDictionary lgidict, COSArray neatLineArray,
+            ICOSVisitor toDoubleVisitor) throws IOException {
+        List<Double> neatline = new LinkedList<>();
+        List<String> coordinateList = new LinkedList<>();
+        String firstCoordinate = null;
+
+        double[] points = new double[CTM_SIZE];
+        for (int i = 0; i < CTM_SIZE; i++) {
+            points[i] = (Double) lgidict.getObjectFromPath(CTM + "/[" + i + "]")
+                    .accept(toDoubleVisitor);
+        }
+        AffineTransform affineTransform = new AffineTransform(points);
+
+        for (int i = 0; i < neatLineArray.size(); i++) {
+            neatline.add((Double) neatLineArray.get(i)
+                    .accept(toDoubleVisitor));
+        }
+
+        for (int i = 0; i < neatline.size(); i += 2) {
+            double x = neatline.get(i);
+            double y = neatline.get(i + 1);
+
+            Point2D p = new Point2D.Double(x, y);
+
+            Point2D pprime = affineTransform.transform(p, null);
+
+            String xySet = point2dToWkt(pprime);
+
+            if (firstCoordinate == null) {
+                firstCoordinate = xySet;
+            }
+            coordinateList.add(xySet);
+        }
+        coordinateList.add(firstCoordinate);
+        String wktString = StringUtils.join(coordinateList, ", ");
+        LOGGER.debug("{}", wktString);
+        return wktString.toString();
+    }
+
+
+
+    /**
+     * This visitor class converts parsable COS Objects into {@link Double}s
+     */
+    private static class ToDoubleVisitor implements ICOSVisitor {
+
+        @Override
+        public Object visitFromArray(COSArray cosArray) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromBoolean(COSBoolean cosBoolean) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromDictionary(COSDictionary cosDictionary) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromDocument(COSDocument cosDocument) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromFloat(COSFloat cosFloat) throws IOException {
+            return cosFloat.doubleValue();
+        }
+
+        @Override
+        public Object visitFromInt(COSInteger cosInteger) throws IOException {
+            return (double) cosInteger.longValue();
+        }
+
+        @Override
+        public Object visitFromName(COSName cosName) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromNull(COSNull cosNull) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromStream(COSStream cosStream) throws IOException {
+            return null;
+        }
+
+        @Override
+        public Object visitFromString(COSString cosString) throws IOException {
+            return Double.valueOf(cosString.getString());
+        }
+    }
+}

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PDDocumentGenerator.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PDDocumentGenerator.java
@@ -13,8 +13,10 @@
  */
 package ddf.catalog.transformer.input.pdf;
 
+import java.io.InputStream;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 
-public interface GeoPdfParser extends CheckedFunction<PDDocument, String> {
+public interface PDDocumentGenerator extends CheckedFunction<InputStream, PDDocument> {
 
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PDDocumentGeneratorImpl.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PDDocumentGeneratorImpl.java
@@ -13,8 +13,14 @@
  */
 package ddf.catalog.transformer.input.pdf;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 
-public interface GeoPdfParser extends CheckedFunction<PDDocument, String> {
-
+public class PDDocumentGeneratorImpl implements PDDocumentGenerator {
+    @Override
+    public PDDocument apply(InputStream inputStream) throws IOException {
+        return PDDocument.load(inputStream);
+    }
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfThumbnailGenerator.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfThumbnailGenerator.java
@@ -13,8 +13,10 @@
  */
 package ddf.catalog.transformer.input.pdf;
 
+import java.util.Optional;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 
-public interface GeoPdfParser extends CheckedFunction<PDDocument, String> {
+public interface PdfThumbnailGenerator extends CheckedFunction<PDDocument, Optional<byte[]>> {
 
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfThumbnailGeneratorImpl.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfThumbnailGeneratorImpl.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+
+public class PdfThumbnailGeneratorImpl implements PdfThumbnailGenerator {
+
+    private static final int RESOLUTION_DPI = 44;
+
+    private static final float IMAGE_QUALITY = 1.0f;
+
+    private static final float IMAGE_HEIGHTWIDTH = 128;
+
+    private static final String FORMAT_NAME = "jpg";
+
+    @Override
+    public Optional<byte[]> apply(PDDocument pdfDocument) throws IOException {
+        PDFRenderer pdfRenderer = new PDFRenderer(pdfDocument);
+
+        if (pdfDocument.getNumberOfPages() < 1) {
+            return Optional.empty();
+        }
+
+        BufferedImage image = pdfRenderer.renderImageWithDPI(0, RESOLUTION_DPI, ImageType.RGB);
+
+        int largestDimension = Math.max(image.getHeight(), image.getWidth());
+        float scalingFactor = IMAGE_HEIGHTWIDTH / largestDimension;
+        int scaledHeight = (int) (image.getHeight() * scalingFactor);
+        int scaledWidth = (int) (image.getWidth() * scalingFactor);
+
+        BufferedImage scaledImage = new BufferedImage(scaledWidth,
+                scaledHeight,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = scaledImage.createGraphics();
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        graphics.drawImage(image, 0, 0, scaledWidth, scaledHeight, null);
+        graphics.dispose();
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ImageIOUtil.writeImage(scaledImage,
+                    FORMAT_NAME,
+                    outputStream,
+                    RESOLUTION_DPI,
+                    IMAGE_QUALITY);
+            return Optional.of(outputStream.toByteArray());
+        }
+    }
+}

--- a/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,9 +12,46 @@
  *
  **/
  -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
 
-    <bean id="pdfTransformer" class="ddf.catalog.transformer.input.pdf.PdfInputTransformer"/>
+    <bean id="pdfMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
+        <argument value="pdf"/>
+        <argument>
+            <list>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
+            </list>
+        </argument>
+    </bean>
+
+    <service ref="pdfMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="pdf"/>
+        </service-properties>
+    </service>
+
+    <bean id="pdfTransformer" class="ddf.catalog.transformer.input.pdf.PdfInputTransformer">
+
+        <cm:managed-properties
+                persistent-id="ddf.catalog.transformer.input.pdf.PdfInputTransformer"
+                update-strategy="container-managed"/>
+
+        <argument ref="pdfMetacardType"/>
+        <argument value="false"/>
+        <argument>
+            <bean class="ddf.catalog.transformer.input.pdf.PDDocumentGeneratorImpl"/>
+        </argument>
+        <argument>
+            <bean class="ddf.catalog.transformer.input.pdf.GeoPdfParserImpl"/>
+        </argument>
+        <argument>
+            <bean class="ddf.catalog.transformer.input.pdf.PdfThumbnailGeneratorImpl"/>
+        </argument>
+    </bean>
 
     <service ref="pdfTransformer" interface="ddf.catalog.transform.InputTransformer">
         <service-properties>
@@ -27,9 +64,11 @@
         </service-properties>
     </service>
 
-    <reference-list id="contentExtractors" interface="ddf.catalog.content.operation.ContentMetadataExtractor"
+    <reference-list id="contentExtractors"
+                    interface="ddf.catalog.content.operation.ContentMetadataExtractor"
                     availability="optional">
-        <reference-listener bind-method="addContentMetadataExtractors" unbind-method="removeContentMetadataExtractor"
+        <reference-listener bind-method="addContentMetadataExtractors"
+                            unbind-method="removeContentMetadataExtractor"
                             ref="pdfTransformer"/>
     </reference-list>
 

--- a/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="PDF Input Transformer"
+         name="PDF Input Transformer"
+         id="ddf.catalog.transformer.input.pdf.PdfInputTransformer">
+
+        <AD description="Use the PDF's metadata to determine the metacard title. If this is not enabled, the metacard title will be the file name."
+            name="Use PDF Title" id="usePdfTitleAsTitle" required="true" type="Boolean"
+            default="false"/>
+
+    </OCD>
+
+    <Designate pid="ddf.catalog.transformer.input.pdf.PdfInputTransformer">
+        <Object ocdref="ddf.catalog.transformer.input.pdf.PdfInputTransformer"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfDocumentGenerator.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfDocumentGenerator.java
@@ -49,7 +49,7 @@ public class GeoPdfDocumentGenerator {
     private static PDPage generateGeoPdfPage(int numberOfFramesPerPage, String projectionType) {
         PDPage pdPage = new PDPage();
         COSDictionary cosDictionary = pdPage.getCOSObject();
-        cosDictionary.setItem(GeoPdfParser.LGIDICT, generateLGIDictArray(numberOfFramesPerPage,
+        cosDictionary.setItem(GeoPdfParserImpl.LGIDICT, generateLGIDictArray(numberOfFramesPerPage,
                 projectionType));
         return pdPage;
     }
@@ -57,7 +57,7 @@ public class GeoPdfDocumentGenerator {
     private static PDPage generateGeoPdfPage(String projectionType, boolean generateNeatLine) {
         PDPage pdPage = new PDPage();
         COSDictionary cosDictionary = pdPage.getCOSObject();
-        cosDictionary.setItem(GeoPdfParser.LGIDICT, generateMapFrameDictionary(projectionType,
+        cosDictionary.setItem(GeoPdfParserImpl.LGIDICT, generateMapFrameDictionary(projectionType,
                 generateNeatLine));
         return pdPage;
     }
@@ -73,12 +73,12 @@ public class GeoPdfDocumentGenerator {
     private static COSDictionary generateMapFrameDictionary(String projectionType) {
         COSDictionary cosDictionary = new COSDictionary();
         if (StringUtils.isNotBlank(projectionType)) {
-            cosDictionary.setItem(GeoPdfParser.PROJECTION, generateProjectionDictionary(
+            cosDictionary.setItem(GeoPdfParserImpl.PROJECTION, generateProjectionDictionary(
                     projectionType));
         }
 
-        cosDictionary.setItem(GeoPdfParser.NEATLINE, generateNeatLineArray());
-        cosDictionary.setItem(GeoPdfParser.CTM, generateCTMArray());
+        cosDictionary.setItem(GeoPdfParserImpl.NEATLINE, generateNeatLineArray());
+        cosDictionary.setItem(GeoPdfParserImpl.CTM, generateCTMArray());
         return cosDictionary;
     }
 
@@ -86,15 +86,15 @@ public class GeoPdfDocumentGenerator {
             boolean generateNeatLine) {
         COSDictionary cosDictionary = new COSDictionary();
         if (StringUtils.isNotBlank(projectionType)) {
-            cosDictionary.setItem(GeoPdfParser.PROJECTION, generateProjectionDictionary(
+            cosDictionary.setItem(GeoPdfParserImpl.PROJECTION, generateProjectionDictionary(
                     projectionType));
         }
 
         if (generateNeatLine) {
-            cosDictionary.setItem(GeoPdfParser.NEATLINE, generateNeatLineArray());
+            cosDictionary.setItem(GeoPdfParserImpl.NEATLINE, generateNeatLineArray());
         }
 
-        cosDictionary.setItem(GeoPdfParser.CTM, generateCTMArray());
+        cosDictionary.setItem(GeoPdfParserImpl.CTM, generateCTMArray());
         return cosDictionary;
     }
 
@@ -126,7 +126,7 @@ public class GeoPdfDocumentGenerator {
 
     private static COSDictionary generateProjectionDictionary(String projectionType) {
         COSDictionary projectionDictionary = new COSDictionary();
-        projectionDictionary.setString(GeoPdfParser.PROJECTION_TYPE, projectionType);
+        projectionDictionary.setString(GeoPdfParserImpl.PROJECTION_TYPE, projectionType);
         return projectionDictionary;
     }
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfParserTest.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/GeoPdfParserTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.junit.Test;
 
-public class TestGeoPdfParser {
+public class GeoPdfParserTest {
 
     public static final String WKT_POLYGON =
             "POLYGON ((-75.15840498869015 43.93500189524018, -75.15840498868951 37.63917521983974, -80.50866091541451 37.639175219841135, -80.50866091541393 43.93500189523885, -75.15840498869015 43.93500189524018, -75.15840498869015 43.93500189524018))";
@@ -31,12 +31,12 @@ public class TestGeoPdfParser {
     public static final String WKT_POLYGON_NO_NEATLINE =
             "POLYGON ((-80.77532309213824 36.77844766314338, -78.57704723006924 36.77844766314343, -78.5770472300693 39.623275249350364, -80.7753230921383 39.623275249350314, -80.77532309213824 36.77844766314338))";
 
-    private static final GeoPdfParser GEO_PDF_PARSER = new GeoPdfParser();
+    private static final GeoPdfParserImpl GEO_PDF_PARSER = new GeoPdfParserImpl();
 
     @Test
     public void testEmptyPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateEmptyPdf();
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, nullValue());
     }
 
@@ -44,8 +44,8 @@ public class TestGeoPdfParser {
     public void testSinglePageMultiFrameGeographicGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
                 2,
-                GeoPdfParser.GEOGRAPHIC);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+                GeoPdfParserImpl.GEOGRAPHIC);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, is(WKT_MULTIPOLYGON));
     }
 
@@ -53,54 +53,54 @@ public class TestGeoPdfParser {
     public void testSinglePageSingleMultiFrameGeographicGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
                 1,
-                GeoPdfParser.GEOGRAPHIC);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+                GeoPdfParserImpl.GEOGRAPHIC);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, is(WKT_POLYGON));
     }
 
     @Test
     public void testSinglePageMultiFrameNonGeographicGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, 2, "UT");
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, nullValue());
     }
 
     @Test
     public void testSinglePageMultiFrameNoProjectionGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, 2, "");
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, nullValue());
     }
 
     @Test
     public void testSinglePageSingleFrameGeographicGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
-                GeoPdfParser.GEOGRAPHIC,
+                GeoPdfParserImpl.GEOGRAPHIC,
                 true);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, is(WKT_POLYGON));
     }
 
     @Test
     public void testSinglePageSingleFrameNonGeographicGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, "UT", true);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, nullValue());
     }
 
     @Test
     public void testSinglePageSingleFrameNoProjectionGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1, "", true);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, nullValue());
     }
 
     @Test
     public void testSinglePageSingleFrameNoNeatLineGeoPdf() throws Exception {
         PDDocument pdfDocument = GeoPdfDocumentGenerator.generateGeoPdf(1,
-                GeoPdfParser.GEOGRAPHIC,
+                GeoPdfParserImpl.GEOGRAPHIC,
                 false);
-        String wktString = GEO_PDF_PARSER.getWktFromPDF(pdfDocument);
+        String wktString = GEO_PDF_PARSER.apply(pdfDocument);
         assertThat(wktString, is(WKT_POLYGON_NO_NEATLINE));
     }
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/PdfInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/test/java/ddf/catalog/transformer/input/pdf/PdfInputTransformerTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.input.pdf;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentInformation;
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.types.Contact;
+import ddf.catalog.data.types.Topic;
+import ddf.catalog.transform.CatalogTransformerException;
+
+public class PdfInputTransformerTest {
+
+    private PdfInputTransformer pdfInputTransformer;
+
+    private PDDocument pdDocument;
+
+    private PDDocumentInformation documentInformation;
+
+    @Before
+    public void setup() {
+        pdfInputTransformer = new PdfInputTransformer(mock(MetacardTypeImpl.class),
+                false,
+                inputStream -> pdDocument,
+                pdDocument1 -> null,
+                pdDocument1 -> Optional.empty());
+
+        pdDocument = mock(PDDocument.class);
+        documentInformation = mock(PDDocumentInformation.class);
+
+        when(pdDocument.getDocumentInformation()).thenReturn(documentInformation);
+
+    }
+
+    @Test
+    public void testUsePdfTitleAsTitleFalse() throws IOException, CatalogTransformerException {
+        pdfInputTransformer.setUsePdfTitleAsTitle(false);
+        when(documentInformation.getTitle()).thenReturn("TheTitle");
+
+        Metacard metacard = pdfInputTransformer.transform(null);
+
+        assertThat(metacard.getTitle(), is(nullValue()));
+    }
+
+    @Test
+    public void testUsePdfTitleAsTitleTrue() throws IOException, CatalogTransformerException {
+        String title = "TheTitle";
+        pdfInputTransformer.setUsePdfTitleAsTitle(true);
+        when(documentInformation.getTitle()).thenReturn(title);
+
+        Metacard metacard = pdfInputTransformer.transform(null);
+
+        assertThat(metacard.getTitle(), is(title));
+    }
+
+    @Test
+    public void testAuthor() throws IOException, CatalogTransformerException {
+        String author = "TheAuthor";
+
+        when(documentInformation.getAuthor()).thenReturn(author);
+
+        Metacard metacard = pdfInputTransformer.transform(mock(InputStream.class));
+
+        assertThat(metacard.getAttribute(Contact.CREATOR_NAME)
+                .getValue(), is(author));
+
+    }
+
+    @Test
+    public void testKeywords() throws IOException, CatalogTransformerException {
+        String keywords = "TheKeywords";
+
+        when(documentInformation.getKeywords()).thenReturn(keywords);
+
+        Metacard metacard = pdfInputTransformer.transform(mock(InputStream.class));
+
+        assertThat(metacard.getAttribute(Topic.KEYWORD)
+                .getValue(), is(keywords));
+
+    }
+
+}


### PR DESCRIPTION
#### What does this PR do?

Update PdfInputTransformer for new taxonomy. This is the second attempt, which includes the content metadata extractors.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brendan-hofmann 
@jrnorth 
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@jlcsmith
#### How should this be tested?
Ingest a PDF and check SOLR for non-new-taxonomy fields.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2341
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
