### PR TITLE
DDF-1979: added Resource Management to default install profile

### DIFF
--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -22,6 +22,7 @@
         <feature>search-ui-app</feature>
         <feature>solr-app</feature>
         <feature>spatial-app</feature>
+        <feature>resourcemanagement-app</feature>
     </feature>
 
     <feature name="profile-development" install="manual" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
Adds Resource Management Application to default install profile
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
#### How should this be tested?
Verify resource management app is installed by default
#### Any background context you want to provide?
2 important bugs were fixed making this app a candidate app for the default install profile:
https://codice.atlassian.net/browse/DDF-2368
https://codice.atlassian.net/browse/DDF-2386

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

