### PR TITLE
DDF-2275 Reverted DERIVED_RESOURCE_URI to the original metacard attribute name

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Core.java
@@ -85,7 +85,7 @@ public interface Core {
     /**
      * {@link ddf.catalog.data.Attribute} that provides URIs for derived formats of the {@literal ddf.catalog.data.Metacard.RESOURCE_URI}
      */
-    String DERIVED_RESOURCE_URI = "resource-derived-uri";
+    String DERIVED_RESOURCE_URI = Metacard.DERIVED_RESOURCE_URI; 
 
     /**
      * {@link ddf.catalog.data.Attribute} name for accessing the resource download URL for the product this


### PR DESCRIPTION
#### What does this PR do?
Reverts Core Attribute DERIVED RESOURCE URI to the original metacard attribute name for backwards compatibility.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@dcruver 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Verify CAL-119 PR https://github.com/codice/alliance/pull/130. Ensure `resource.derived-uri` attribute is set on metacard for ingested NITF images.

#### Any background context you want to provide?
The image chipping PR (https://github.com/codice/alliance/pull/130) in Alliance is dependent on this change.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2275

Relates To: https://codice.atlassian.net/browse/CAL-119

#### Screenshots (if appropriate)
N/A 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests