### PR TITLE
DDF-2414: Override maven.repo.local property in owasp-diff-runner tests

### DIFF
--- a/libs/owasp-diff-runner/src/test/java/ddf/lib/TestOwaspDiffRunner.java
+++ b/libs/owasp-diff-runner/src/test/java/ddf/lib/TestOwaspDiffRunner.java
@@ -65,7 +65,7 @@ public class TestOwaspDiffRunner {
         fakeRepo = new TemporaryFolder();
         fakeRepo.create();
         File fakeChangedPom = fakeRepo.newFile("pom.xml");
-
+        System.setProperty("maven.repo.local", fakeChangedPom.getParent());
         //Set command line returns
         when(mavenVersionCommandProcess.getInputStream()).thenReturn(new ByteArrayInputStream((
                 "Maven home: " + fakeRepo.getRoot()
@@ -119,12 +119,8 @@ public class TestOwaspDiffRunner {
         expectedEx.expect(OwaspDiffRunnerException.class);
         expectedEx.expectMessage(OwaspDiffRunnerException.UNABLE_TO_RETRIEVE_LOCAL_MAVEN_REPO);
 
-        try {
-            System.setProperty("maven.repo.local", "not-a-real-repo");
-            owaspDiffRunner.main(null);
-        } finally {
-            System.clearProperty("maven.repo.local");
-        }
+        System.setProperty("maven.repo.local", "not-a-real-repo");
+        owaspDiffRunner.main(null);
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Fixs the tests to ignore a passed maven.repo.local property.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@Lambeaux @adimka 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 
#### How should this be tested?
owasp-diff-runner module builds when the maven.local.repo points to a directory that doesn't exist
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

