### PR TITLE
DDF-2282  Updated RefreshRegistryEntries remote registry queries to be multi-threaded

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,10 @@
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <ext:property-placeholder/>
 
     <bean id="federationAdminService"
           class="org.codice.ddf.registry.federationadmin.service.impl.FederationAdminServiceImpl">
@@ -25,16 +28,23 @@
     </bean>
 
     <bean id="refreshRegistryEntries"
-          class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
-        <cm:managed-properties persistent-id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
-                               update-strategy="container-managed" />
+          class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
+          destroy-method="destroy" init-method="init">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
+                update-strategy="container-managed"/>
         <property name="federationAdminService" ref="federationAdminService"/>
         <property name="filterBuilder" ref="filterBuilder"/>
         <property name="registryStores" ref="registryStore"/>
+        <property name="executor" ref="registryPollerThreadPool"/>
     </bean>
 
-    <bean id="executor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
-
+    <bean id="identityNodeInitializerExecutor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor"/>
+    <bean id="registryPollerThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newScheduledThreadPool">
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
+    </bean>
 
     <bean id="identityNodeInitialization"
           class="org.codice.ddf.registry.federationadmin.service.impl.IdentityNodeInitialization"
@@ -42,7 +52,7 @@
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryTransformer" ref="inputTransformer"/>
         <property name="federationAdminService" ref="federationAdminService"/>
-        <property name="executorService" ref="executor"/>
+        <property name="executorService" ref="identityNodeInitializerExecutor"/>
     </bean>
 
     <bean id="metacardMarshaller"
@@ -51,15 +61,8 @@
     </bean>
 
 
-    <cm:property-placeholder persistent-id="Registry_Federation_Admin_Service"
-                             update-strategy="reload">
-        <cm:default-properties>
-            <cm:property name="registrySubPollerInterval" value="30"/>
-        </cm:default-properties>
-    </cm:property-placeholder>
-
-
-    <reference-list id="registryStore" interface="org.codice.ddf.registry.api.internal.RegistryStore"
+    <reference-list id="registryStore"
+                    interface="org.codice.ddf.registry.api.internal.RegistryStore"
                     availability="optional"/>
 
 
@@ -90,12 +93,5 @@
                filter="(id=rim:RegistryPackage)"/>
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
-
-    <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="ctxRegistrySubPoller">
-        <route>
-            <from uri="timer://registrySubTimer?fixedRate=true&amp;period={{registrySubPollerInterval}}s"/>
-            <to uri="bean:refreshRegistryEntries?method=refreshRegistryEntries"/>
-        </route>
-    </camelContext>
 
 </blueprint>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -16,9 +16,12 @@
 
     <OCD description="Registry subscription poller" name="Refresh Registry Subscriptions"
          id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
-        <AD name="Registry Refresh Interval" id="refreshInterval" required="true"
-            type="String" default="30"
-            description="The refresh interval for the registry subscriptions/updates. In seconds."/>
+        <AD name="Registry Refresh Interval" id="refreshIntervalSeconds" required="true"
+            type="Integer" default="30"
+            description="The refresh interval for the registry subscriptions/updates in seconds."/>
+        <AD name="Registry Query Timeout" id="taskWaitTimeSeconds" required="true"
+            type="Integer" default="30"
+            description="The time to wait for a registry query request to complete in seconds."/>
         <AD name="Enable Stale Metacard Deletion" id="enableDelete" required="true"
             type="Boolean" default="true"
             description="When selected, a registry metacard from a remote registry that is no longer available will be automatically deleted"/>


### PR DESCRIPTION
#### What does this PR do?
Multithreads the registry subscription polling.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie  @mcalcote 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic
#### How should this be tested?
Setup a couple of ddfs and make sure the subscription between them still works
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2282
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

 - Also switched to an internal scheduler for polling instead of a camel route