### PR TITLE
DDF-2434 Fixed opensearch CatalogEndpoint urlBindingName

### DIFF
--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -45,7 +45,7 @@
           class="ddf.catalog.endpoint.impl.CatalogEndpointImpl">
         <property name="url"
                   value="${org.codice.ddf.system.protocol}${org.codice.ddf.system.hostname}:${org.codice.ddf.system.port}${org.codice.ddf.system.rootContext}/catalog/query"/>
-        <property name="urlBindingName" value="openSearchUrl"/>
+        <property name="urlBindingName" value="endpointUrl"/>
         <property name="id" value="registry.federation.method.openSearch"/>
         <property name="name" value="Open Search Endpoint"/>
         <property name="version" value="1.0.0"/>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -954,7 +954,7 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testCatalogEndpointExposure() throws InvalidSyntaxException {
         // Check the service references
         ArrayList<String> expectedEndpoints = new ArrayList<>();
-        expectedEndpoints.add("openSearchUrl");
+        expectedEndpoints.add("endpointUrl");
         expectedEndpoints.add("cswUrl");
 
         CatalogEndpoint endpoint = getServiceManager().getService(CatalogEndpoint.class);


### PR DESCRIPTION
#### What does this PR do?
Fixed opensearch CatalogEndpoint urlBindingName
The urlBindingName for opensearch was wrong so the wrong property was set in the config causing the opensearch source to use its default values making it a loopback source instead of connecting to the correct endpoint
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris
 
#### How should this be tested?
Since this won't affect any unit or itests just quick build ddf and bring up an instance with registry installed. Add a service with a opensearch binding. Verify the source created in the sources tab has a correctly populated url and not one containing default variables. 
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2434
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

