### PR TITLE
DDF-2266 Backport - Added RegistryStoreCleanupHandler to cleanup registry entries once a remote registry is removed

### DIFF
--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.api.impl;
+
+import java.security.PrivilegedActionException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.registry.api.internal.RegistryStore;
+import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminService;
+import org.codice.ddf.security.common.Security;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * This handler cleans up registry entries in the local catalog when a remote registry connection
+ * is removed.
+ */
+public class RegistryStoreCleanupHandler implements EventHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryStoreCleanupHandler.class);
+
+    private FederationAdminService federationAdminService;
+
+    private ExecutorService executor;
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private boolean cleanupRelatedMetacards = true;
+
+    private Map<Object, RegistryStore> registryStorePidToServiceMap = new ConcurrentHashMap<>();
+
+    public void bindRegistryStore(ServiceReference serviceReference) {
+        BundleContext bundleContext = getBundleContext();
+
+        if (serviceReference != null && bundleContext != null) {
+            RegistryStore registryStore =
+                    (RegistryStore) bundleContext.getService(serviceReference);
+
+            registryStorePidToServiceMap.put(serviceReference.getProperty(Constants.SERVICE_PID),
+                    registryStore);
+        }
+    }
+
+    public void unbindRegistryStore(ServiceReference serviceReference) {
+        if (serviceReference != null) {
+            registryStorePidToServiceMap.remove(serviceReference.getProperty(Constants.SERVICE_PID));
+        }
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        Object eventProperty = event.getProperty(EventConstants.EVENT);
+        if (!cleanupRelatedMetacards || eventProperty == null
+                || !(eventProperty instanceof ServiceEvent)) {
+            return;
+        }
+
+        if (((ServiceEvent) eventProperty).getType() != ServiceEvent.UNREGISTERING) {
+            return;
+        }
+        Object servicePid =
+                ((ServiceEvent) event.getProperty(EventConstants.EVENT)).getServiceReference()
+                        .getProperty(Constants.SERVICE_PID);
+        if (servicePid == null) {
+            return;
+        }
+
+        RegistryStore service = registryStorePidToServiceMap.get(servicePid);
+        if (service == null) {
+            return;
+        }
+        executor.execute(() -> {
+            String registryId = service.getRegistryId();
+            try {
+                List<Metacard> metacards =
+                        Security.runAsAdminWithException(() -> federationAdminService.getInternalRegistryMetacardsByRegistryId(
+                                registryId));
+                List<String> idsToDelete = metacards.stream()
+                        .map(Metacard::getId)
+                        .collect(Collectors.toList());
+                if (!idsToDelete.isEmpty()) {
+                    Security.runAsAdminWithException(() -> {
+                        federationAdminService.deleteRegistryEntriesByMetacardIds(idsToDelete);
+                        return null;
+                    });
+                }
+            } catch (PrivilegedActionException e) {
+                LOGGER.info(
+                        "Unable to clean up registry metacards after registry store {} was deleted",
+                        service.getId(),
+                        e);
+            }
+        });
+
+    }
+
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.debug("Thread pool failed to terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+    }
+
+    BundleContext getBundleContext() {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle != null) {
+            return bundle.getBundleContext();
+        }
+        return null;
+    }
+
+    public void setCleanupRelatedMetacards(boolean cleanupRelatedMetacards) {
+        this.cleanupRelatedMetacards = cleanupRelatedMetacards;
+    }
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+}

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,12 +41,18 @@
 
     <bean id="registryPublisherExecutor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
     <bean id="metacardHandlerExecutor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
+    <bean id="cleanupHandlerExecutor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
 
     <bean id="registryPublisher"
           class="org.codice.ddf.registry.api.impl.RegistryStorePublisher">
         <property name="federationAdminService" ref="federationAdminService"/>
         <property name="registryPublicationService" ref="registryPublicationService"/>
         <property name="executor" ref="registryPublisherExecutor"/>
+    </bean>
+
+    <bean id="storeCleanupHandler" class="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler">
+        <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="executor" ref="cleanupHandlerExecutor"/>
     </bean>
 
     <bean id="registryMetacardHandler" class="org.codice.ddf.registry.api.impl.RegistryMetacardHandler" destroy-method="destroy">
@@ -70,6 +76,8 @@
                     availability="optional">
         <reference-listener ref="registryPublisher" bind-method="bindRegistryStore"
                             unbind-method="unbindRegistryStore"/>
+        <reference-listener ref="storeCleanupHandler" bind-method="bindRegistryStore"
+                            unbind-method="unbindRegistryStore"/>
     </reference-list>
 
     <service ref="registryPublisher" interface="org.osgi.service.event.EventHandler">
@@ -77,6 +85,16 @@
             <entry key="event.topics">
                 <array value-type="java.lang.String">
                     <value>org/osgi/framework/ServiceEvent/MODIFIED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+
+    <service ref="storeCleanupHandler" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>org/osgi/framework/ServiceEvent/UNREGISTERING</value>
                 </array>
             </entry>
         </service-properties>
@@ -115,7 +133,7 @@
 
     <cm:managed-service-factory
 
-            id="ddf.catalog.registry.api.impl.RegistryStoreImpl.id"
+            id="org.codice.ddf.registry.api.impl.RegistryStoreImpl.id"
             factory-pid="Csw_Registry_Store">
         <interfaces>
             <value>org.codice.ddf.registry.api.internal.RegistryStore</value>

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -41,8 +41,20 @@
 
     </OCD>
 
+    <OCD name="Registry Store Cleanup" id="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler" description="Configuration for Registry Store Cleanup Handler">
+
+        <AD description="If selected, when a registry store is deleted, all of the metacards associated with that store will be deleted"
+            name="Cleanup Metacards On Delete" id="cleanupRelatedMetacards" required="true"
+            type="Boolean" default="true"/>
+
+    </OCD>
+
     <Designate pid="Csw_Registry_Store" factoryPid="Csw_Registry_Store">
         <Object ocdref="Csw_Registry_Store"/>
+    </Designate>
+
+    <Designate pid="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler">
+        <Object ocdref="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler"/>
     </Designate>
 
 </metatype:MetaData>

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandlerTest.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandlerTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.api.impl;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.registry.api.internal.RegistryStore;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegistryStoreCleanupHandlerTest {
+    @Mock
+    private ExecutorService executorService;
+
+    @Mock
+    private FederationAdminService federationAdmin;
+
+    @Mock
+    private BundleContext context;
+
+    @Mock
+    private RegistryStore store;
+
+    private MetacardImpl mcard;
+
+    private Event event;
+
+    private Dictionary<String, Object> eventProperties;
+
+    private RegistryStoreCleanupHandler cleanupHandler;
+
+    @Before
+    public void setup() {
+
+        cleanupHandler = new RegistryStoreCleanupHandler() {
+            @Override
+            BundleContext getBundleContext() {
+                return context;
+            }
+        };
+        cleanupHandler.setExecutor(executorService);
+        cleanupHandler.setFederationAdminService(federationAdmin);
+        setupSerialExecutor();
+
+        when(context.getService(any(ServiceReference.class))).thenReturn(store);
+        when(store.getRegistryId()).thenReturn("registryId");
+
+        mcard = new MetacardImpl();
+        mcard.setId("id");
+        mcard.setModifiedDate(new Date());
+        mcard.setAttribute(Metacard.TAGS, RegistryConstants.REGISTRY_TAG_INTERNAL);
+        mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID, "registryId"));
+        eventProperties = new Hashtable<>();
+
+    }
+
+    @Test
+    public void testBindRegistryStoreNullReference() throws Exception {
+        ServiceReference ref = getServiceReference("servicePid");
+        handleEvent(null,
+                ref,
+                ServiceEvent.UNREGISTERING,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnBindRegistryStore() throws Exception {
+        ServiceReference ref = getServiceReference("servicePid");
+        cleanupHandler.bindRegistryStore(ref);
+        cleanupHandler.unbindRegistryStore(ref);
+        handleEvent(null,
+                ref,
+                ServiceEvent.UNREGISTERING,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnregisterEvent() throws Exception {
+        ServiceReference ref = getServiceReference("servicePid");
+        handleEvent(ref,
+                ref,
+                ServiceEvent.UNREGISTERING,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnregisterEventCleanupDisabled() throws Exception {
+        cleanupHandler.setCleanupRelatedMetacards(false);
+        ServiceReference ref = getServiceReference("servicePid");
+        handleEvent(ref,
+                ref,
+                ServiceEvent.UNREGISTERING,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnregisterEventWrongServiceEvent() throws Exception {
+        ServiceReference ref = getServiceReference("servicePid");
+        handleEvent(ref,
+                ref,
+                ServiceEvent.REGISTERED,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnregisterEventUnrelatedService() throws Exception {
+        ServiceReference ref1 = getServiceReference("servicePid");
+        ServiceReference ref2 = getServiceReference("differentServicePid");
+        handleEvent(ref1,
+                ref2,
+                ServiceEvent.UNREGISTERING,
+                "registryId",
+                Collections.singletonList(mcard));
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testUnregisterEventNoRelatedMetacards() throws Exception {
+        ServiceReference ref = getServiceReference("servicePid");
+        handleEvent(ref, ref, ServiceEvent.UNREGISTERING, "registryId", Collections.emptyList());
+        verify(federationAdmin,
+                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        cleanupHandler.destroy();
+        verify(executorService, times(1)).awaitTermination(60L, TimeUnit.SECONDS);
+        verify(executorService, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyTerminateTasks() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        cleanupHandler.destroy();
+        verify(executorService, times(2)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterupt() throws Exception {
+        when(executorService.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException("interrupt"));
+        cleanupHandler.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    private void handleEvent(ServiceReference bindRef, ServiceReference eventRef,
+            int serviceEventType, String searchRegId, List<Metacard> metacards) throws Exception {
+        cleanupHandler.bindRegistryStore(bindRef);
+        ServiceEvent serviceEvent = mock(ServiceEvent.class);
+        when(serviceEvent.getType()).thenReturn(serviceEventType);
+        when(serviceEvent.getServiceReference()).thenReturn(eventRef);
+        eventProperties.put(EventConstants.EVENT, serviceEvent);
+        when(federationAdmin.getInternalRegistryMetacardsByRegistryId(searchRegId)).thenReturn(
+                metacards);
+        event = new Event("myevent", eventProperties);
+        cleanupHandler.handleEvent(event);
+    }
+
+    private ServiceReference getServiceReference(String pid) {
+        ServiceReference reference = mock(ServiceReference.class);
+        when(reference.getProperty(Constants.SERVICE_PID)).thenReturn(pid);
+        return reference;
+    }
+
+    private void setupSerialExecutor() {
+        doAnswer((args) -> {
+            ((Runnable) args.getArguments()[0]).run();
+            return null;
+        }).when(executorService)
+                .execute(any());
+    }
+}

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
@@ -15,6 +15,7 @@ package org.codice.ddf.registry.federationadmin.service.impl;
 
 import java.security.PrivilegedActionException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,8 @@ public class RefreshRegistryEntries {
 
     private FilterBuilder filterBuilder;
 
+    private boolean enableDelete = true;
+
     public RefreshRegistryEntries() {
 
     }
@@ -78,12 +81,35 @@ public class RefreshRegistryEntries {
     public void refreshRegistryEntries() throws FederationAdminException {
 
         RemoteRegistryResults remoteResults = getRemoteRegistryMetacardsMap();
-        Map<String, Metacard> remoteRegistryMetacardsMap = remoteResults
-                .getRemoteRegistryMetacards();
+        Map<String, Metacard> remoteRegistryMetacardsMap =
+                remoteResults.getRemoteRegistryMetacards();
         Map<String, Metacard> registryMetacardsMap = getRegistryMetacardsMap();
 
         List<Metacard> remoteMetacardsToUpdate = new ArrayList<>();
         List<Metacard> remoteMetacardsToCreate = new ArrayList<>();
+        List<Metacard> remoteMetacardsToDelete = new ArrayList<>();
+
+        Map<String, List<Metacard>> remoteRegistryToMetacardMap = getMetacardRegistryIdMap(
+                remoteRegistryMetacardsMap.values());
+        Map<String, List<Metacard>> localRegistryToMetacardMap = getMetacardRegistryIdMap(
+                registryMetacardsMap.values());
+
+        for (String regId : remoteResults.getRegistryStoresQueried()) {
+            if (!localRegistryToMetacardMap.containsKey(regId) || remoteResults.getFailureList()
+                    .contains(regId)) {
+                continue;
+            }
+
+            if (remoteRegistryToMetacardMap.containsKey(regId)) {
+                remoteMetacardsToDelete.addAll(localRegistryToMetacardMap.get(regId)
+                        .stream()
+                        .filter(e -> !hasMatch(e, remoteRegistryToMetacardMap.get(regId)))
+                        .collect(Collectors.toList()));
+            } else {
+
+                remoteMetacardsToDelete.addAll(localRegistryToMetacardMap.get(regId));
+            }
+        }
 
         for (Map.Entry<String, Metacard> remoteEntry : remoteRegistryMetacardsMap.entrySet()) {
             if (registryMetacardsMap.containsKey(remoteEntry.getKey())) {
@@ -98,12 +124,40 @@ public class RefreshRegistryEntries {
                 remoteMetacardsToCreate.add(remoteEntry.getValue());
             }
         }
+
         if (CollectionUtils.isNotEmpty(remoteMetacardsToUpdate)) {
             writeRemoteUpdates(remoteMetacardsToUpdate);
         }
         if (CollectionUtils.isNotEmpty(remoteMetacardsToCreate)) {
             createRemoteEntries(remoteMetacardsToCreate);
         }
+        if (enableDelete && !remoteMetacardsToDelete.isEmpty()) {
+            deleteRemoteEntries(remoteMetacardsToDelete);
+        }
+    }
+
+    private boolean hasMatch(Metacard local, List<Metacard> remoteMetacards) {
+        String id = RegistryUtility.getStringAttribute(local,
+                RegistryObjectMetacardType.REMOTE_METACARD_ID,
+                "");
+        return remoteMetacards.stream()
+                .filter(e -> e.getId()
+                        .equals(id))
+                .findFirst()
+                .isPresent();
+    }
+
+    private Map<String, List<Metacard>> getMetacardRegistryIdMap(Collection<Metacard> metacards) {
+        Map<String, List<Metacard>> map = new HashMap<>();
+        for (Metacard mcard : metacards) {
+            String regId = RegistryUtility.getStringAttribute(mcard,
+                    RegistryObjectMetacardType.REMOTE_REGISTRY_ID,
+                    "");
+            map.computeIfAbsent(regId, k -> new ArrayList<>());
+            map.get(regId)
+                    .add(mcard);
+        }
+        return map;
     }
 
     private Map<String, Metacard> getRegistryMetacardsMap() throws FederationAdminException {
@@ -123,6 +177,7 @@ public class RefreshRegistryEntries {
     private RemoteRegistryResults getRemoteRegistryMetacardsMap() throws FederationAdminException {
         Map<String, Metacard> remoteRegistryMetacards = new HashMap<>();
         List<String> failedQueries = new ArrayList<>();
+        List<String> storesQueried = new ArrayList<>();
         List<String> localMetacardRegIds;
         try {
             List<Metacard> localMetacards =
@@ -138,7 +193,9 @@ public class RefreshRegistryEntries {
             if (!store.isPullAllowed() || !store.isAvailable()) {
                 continue;
             }
+
             try {
+                storesQueried.add(store.getRegistryId());
                 response = store.query(new QueryRequestImpl(getBasicRegistryQuery()));
                 remoteRegistryMetacards.putAll(response.getResults()
                         .stream()
@@ -154,7 +211,7 @@ public class RefreshRegistryEntries {
                 continue;
             }
         }
-        return new RemoteRegistryResults(remoteRegistryMetacards, failedQueries);
+        return new RemoteRegistryResults(remoteRegistryMetacards, failedQueries, storesQueried);
     }
 
     private void writeRemoteUpdates(List<Metacard> remoteMetacardsToUpdate)
@@ -176,18 +233,39 @@ public class RefreshRegistryEntries {
     private void createRemoteEntries(List<Metacard> remoteMetacardsToCreate)
             throws FederationAdminException {
         try {
-            Security.runAsAdminWithException(
-                    () -> federationAdminService.addRegistryEntries(remoteMetacardsToCreate, null));
+            Security.runAsAdminWithException(() -> federationAdminService.addRegistryEntries(
+                    remoteMetacardsToCreate,
+                    null));
         } catch (PrivilegedActionException e) {
-            throw new FederationAdminException(e.getMessage());
+            throw new FederationAdminException("Error creating remote entries", e);
+        }
+    }
+
+    private void deleteRemoteEntries(List<Metacard> remoteMetacardsToDelete)
+            throws FederationAdminException {
+        try {
+            Security.runAsAdminWithException(() -> {
+                federationAdminService.deleteRegistryEntriesByMetacardIds(remoteMetacardsToDelete.stream()
+                        .map(Metacard::getId)
+                        .collect(Collectors.toList()));
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            String message = "Error deleting remote entries.";
+            LOGGER.debug("{} Metacard IDs: {}", message, remoteMetacardsToDelete);
+            throw new FederationAdminException(message, e);
         }
     }
 
     private Query getBasicRegistryQuery() {
         List<Filter> filters = new ArrayList<>();
-        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE).is().equalTo()
+        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE)
+                .is()
+                .equalTo()
                 .text(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
-        filters.add(filterBuilder.attribute(Metacard.TAGS).is().equalTo()
+        filters.add(filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .equalTo()
                 .text(RegistryConstants.REGISTRY_TAG));
 
         PropertyName propertyName = new PropertyNameImpl(Metacard.MODIFIED);
@@ -211,20 +289,31 @@ public class RefreshRegistryEntries {
         this.federationAdminService = federationAdminService;
     }
 
+    public void setEnableDelete(boolean enableDelete) {
+        this.enableDelete = enableDelete;
+    }
+
     private static class RemoteRegistryResults {
 
         Map<String, Metacard> remoteRegistryMetacards;
 
+        List<String> registryStoresQueried;
+
         List<String> failureList;
 
         public RemoteRegistryResults(Map<String, Metacard> remoteRegistryMetacards,
-                List<String> failureList) {
+                List<String> failureList, List<String> storesQueried) {
             this.remoteRegistryMetacards = remoteRegistryMetacards;
             this.failureList = failureList;
+            this.registryStoresQueried = storesQueried;
         }
 
         public Map<String, Metacard> getRemoteRegistryMetacards() {
             return remoteRegistryMetacards;
+        }
+
+        public List<String> getRegistryStoresQueried() {
+            return registryStoresQueried;
         }
 
         public List<String> getFailureList() {

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -14,13 +14,16 @@
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-    <OCD description="Registry Federation Admin Service" name="Registry Federation Admin Service"
-         id="Registry_Federation_Admin_Service">
-        <AD name="Registry Refresh Interval" id="registrySubPollerInterval" required="true"
+    <OCD description="Registry subscription poller" name="Refresh Registry Subscriptions"
+         id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
+        <AD name="Registry Refresh Interval" id="refreshInterval" required="true"
             type="String" default="30"
             description="The refresh interval for the registry subscriptions/updates. In seconds."/>
+        <AD name="Enable Stale Metacard Deletion" id="enableDelete" required="true"
+            type="Boolean" default="true"
+            description="When selected, a registry metacard from a remote registry that is no longer available will be automatically deleted"/>
     </OCD>
-    <Designate pid="Registry_Federation_Admin_Service">
-        <Object ocdref="Registry_Federation_Admin_Service"/>
+    <Designate pid="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
+        <Object ocdref="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"/>
     </Designate>
 </metatype:MetaData>


### PR DESCRIPTION
#### What does this PR do?
Backport for https://github.com/codice/ddf/pull/1150
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
#### How should this be tested?
Verify bamboo passes
#### Any background context you want to provide?
https://github.com/codice/ddf/pull/1150
#### What are the relevant tickets?
DDf-2266
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

 - Includes subscription cleanup logic as well for when remote registries stop providing certain registry entries.
(cherry picked from commit 41f9d4e)