### PR TITLE
DDF-2309: fix for adoc bug causing ToC to appear in table cells

### DIFF
--- a/distribution/docs/src/main/resources/_contents/config.adoc
+++ b/distribution/docs/src/main/resources/_contents/config.adoc
@@ -17,3 +17,6 @@ ifdef::backend-pdf[]
 == License
 This work is licensed under a http://creativecommons.org/licenses/by/4.0[Creative Commons Attribution 4.0 International License].
 endif::[]
+
+//workaround for asciidoctor bug adding ToC to tables
+:toc!:


### PR DESCRIPTION
#### What does this PR do?

Fix for adoc bug that causes ToC headers to appear in table cells. 

#### Who is reviewing it?

@lcrosenbu @Lambeaux @jrnorth 
#### Choose 2 committers to review/merge the PR.

@coyotesqrl
@pklinef

#### How should this be tested?

verify tables no longer appear in html documentation output. `ctrl+f` for "Table of Contents" should have one result. (The _real_ ToC).

#### Any background context you want to provide?

Newer version of asciidoctor introduced a regression causing "Table of Contents" headers to appear in table cells. This is the approved workaround per https://github.com/asciidoctor/asciidoctor/issues/1582

#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2309

#### Screenshots (if appropriate)

before (bad): 
![screen shot 2016-08-25 at 11 26 56 am](https://cloud.githubusercontent.com/assets/10619999/17981581/23272d0e-6ab9-11e6-8f90-5e3f3f4cc60a.png)

after (good):
![screen shot 2016-08-25 at 11 31 31 am](https://cloud.githubusercontent.com/assets/10619999/17981612/3ddddd5a-6ab9-11e6-8b66-c6236afef3a8.png)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

