### PR TITLE
DDF-2382 Update the registry to use metacard attribute taxonomy

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
@@ -234,12 +234,12 @@ define([
         getSecondaryNodes: function() {
             return this.models.filter(function(model){
                 var transValues = model.get('TransientValues');
-                return transValues && !transValues['registry-identity-node'] && transValues['registry-local-node'];
+                return transValues && !transValues['registry.local.registry-identity-node'] && transValues['registry.local.registry-local-node'];
             });
         },
         getIdentityNode: function(){
             var array = this.models.filter(function(model){
-                return model.get('TransientValues') && model.get('TransientValues')['registry-identity-node'];
+                return model.get('TransientValues') && model.get('TransientValues')['registry.local.registry-identity-node'];
             });
             if(array.length === 1){
                 array[0].set('identityNode',true);
@@ -250,7 +250,7 @@ define([
         getRemoteNodes: function(){
             return this.models.filter(function(model){
                 var transValues = model.get('TransientValues');
-                return !transValues || !transValues['registry-local-node'];
+                return !transValues || !transValues['registry.local.registry-local-node'];
             });
         },
         deleteNodes: function (nodes) {

--- a/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
+++ b/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardTypeImpl;
@@ -28,57 +29,37 @@ import ddf.catalog.data.impl.MetacardTypeImpl;
  */
 public class RegistryObjectMetacardType extends MetacardTypeImpl {
 
+    public static final String DATA_SOURCES = "registry.input-data-sources";
+
+    public static final String LAST_PUBLISHED = "registry.local.last-published";
+
+    public static final String LINKS = "registry.links";
+
+    public static final String PUBLISHED_LOCATIONS = "registry.local.published-locations";
+
+    public static final String REGION = "registry.region";
+
+    public static final String REGISTRY_BASE_URL = "registry.registry-base-url";
+
+    public static final String REGISTRY_ID = "registry.registry-id";
+
+    public static final String REGISTRY_IDENTITY_NODE = "registry.local.registry-identity-node";
+
+    public static final String REGISTRY_LOCAL_NODE = "registry.local.registry-local-node";
+
     public static final String REGISTRY_METACARD_TYPE_NAME = "registry";
 
-    public static final String METACARD_TYPE = "metacard-type";
+    public static final String REMOTE_METACARD_ID = "registry.local.remote-metacard-id";
 
-    public static final String ORGANIZATION_NAME = "organization-name";
+    public static final String REMOTE_REGISTRY_ID = "registry.local.remote-registry-id";
 
-    public static final String ORGANIZATION_ADDRESS = "organization-address";
-
-    public static final String ORGANIZATION_PHONE_NUMBER = "organization-phone-number";
-
-    public static final String ORGANIZATION_EMAIL = "organization-email";
-
-    public static final String ENTRY_TYPE = "entry-type";
-
-    public static final String SECURITY_LEVEL = "security-level";
-
-    public static final String LIVE_DATE = "live-date";
-
-    public static final String DATA_START_DATE = "data-start-date";
-
-    public static final String DATA_END_DATE = "data-end-date";
-
-    public static final String LINKS = "links";
-
-    public static final String REGION = "region";
-
-    public static final String DATA_SOURCES = "input-data-sources";
-
-    public static final String DATA_TYPES = "data-types";
-
-    //list of all the service binding ids
-    public static final String SERVICE_BINDINGS = "service-bindings";
+    public static final String SECURITY_LEVEL = "registry.security-level";
 
     //list of bindingType fields from all the service bindings
-    public static final String SERVICE_BINDING_TYPES = "service-binding-types";
+    public static final String SERVICE_BINDING_TYPES = "registry.service-binding-types";
 
-    public static final String REGISTRY_ID = "registry-id";
-
-    public static final String REGISTRY_IDENTITY_NODE = "registry-identity-node";
-
-    public static final String PUBLISHED_LOCATIONS = "published-locations";
-
-    public static final String LAST_PUBLISHED = "last-published";
-
-    public static final String REGISTRY_BASE_URL = "registry-base-url";
-
-    public static final String REGISTRY_LOCAL_NODE = "registry-local-node";
-
-    public static final String REMOTE_REGISTRY_ID = "remote-registry-id";
-
-    public static final String REMOTE_METACARD_ID = "remote-metacard-id";
+    //list of all the service binding ids
+    public static final String SERVICE_BINDINGS = "registry.service-bindings";
 
     public static final Set<String> TRANSIENT_ATTRIBUTES;
 
@@ -103,29 +84,19 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
     }
 
     private void addRegistryAttributes() {
-        descriptors.addAll(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+        descriptors.add(BasicTypes.BASIC_METACARD.getAttributeDescriptor(Metacard.POINT_OF_CONTACT));
         addQueryableBoolean(REGISTRY_IDENTITY_NODE, false);
         addQueryableBoolean(REGISTRY_LOCAL_NODE, false);
-        addQueryableDate(DATA_END_DATE);
-        addQueryableDate(DATA_START_DATE);
         addQueryableDate(LAST_PUBLISHED);
-        addQueryableDate(LIVE_DATE);
         addQueryableString(DATA_SOURCES, true);
-        addQueryableString(DATA_TYPES, true);
-        addQueryableString(ENTRY_TYPE, false);  //objectType
         addQueryableString(LINKS, true);
-        addQueryableString(METACARD_TYPE, false);
-        addQueryableString(ORGANIZATION_ADDRESS, false);
-        addQueryableString(ORGANIZATION_EMAIL, true);
-        addQueryableString(ORGANIZATION_NAME, false);
-        addQueryableString(ORGANIZATION_PHONE_NUMBER, true);
         addQueryableString(PUBLISHED_LOCATIONS, true);
         addQueryableString(REGION, false);
         addQueryableString(REGISTRY_BASE_URL, false);
         addQueryableString(REGISTRY_ID, false);
         addQueryableString(REMOTE_METACARD_ID, false);
         addQueryableString(REMOTE_REGISTRY_ID, false);
-        addQueryableString(SECURITY_LEVEL, true); //securityLevel
+        addQueryableString(SECURITY_LEVEL, true);
         addQueryableString(SERVICE_BINDING_TYPES, true);
         addQueryableString(SERVICE_BINDINGS, true);
     }

--- a/catalog/spatial/registry/registry-common/src/test/java/org/codice/ddf/registry/common/metacard/TestRegistryObjectMetacardType.java
+++ b/catalog/spatial/registry/registry-common/src/test/java/org/codice/ddf/registry/common/metacard/TestRegistryObjectMetacardType.java
@@ -25,30 +25,20 @@ import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.Metacard;
 
 public class TestRegistryObjectMetacardType {
 
     private static final String[] ATTRIBUTE_DESCRIPTORS =
-            {Metacard.TAGS, Metacard.ID, Metacard.CONTENT_TYPE, Metacard.METADATA, Metacard.CREATED,
-                    Metacard.MODIFIED, Metacard.TITLE, Metacard.DESCRIPTION,
-                    RegistryObjectMetacardType.SECURITY_LEVEL,
-                    RegistryObjectMetacardType.METACARD_TYPE, RegistryObjectMetacardType.ENTRY_TYPE,
-                    Metacard.CONTENT_TYPE_VERSION, RegistryObjectMetacardType.ORGANIZATION_NAME,
-                    RegistryObjectMetacardType.ORGANIZATION_ADDRESS,
-                    RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER,
-                    RegistryObjectMetacardType.ORGANIZATION_EMAIL, Metacard.POINT_OF_CONTACT,
-                    RegistryObjectMetacardType.LIVE_DATE,
-                    RegistryObjectMetacardType.DATA_START_DATE,
-                    RegistryObjectMetacardType.DATA_END_DATE, RegistryObjectMetacardType.LINKS,
-                    Metacard.GEOGRAPHY, RegistryObjectMetacardType.REGION,
-                    RegistryObjectMetacardType.DATA_SOURCES, RegistryObjectMetacardType.DATA_TYPES,
+            {RegistryObjectMetacardType.SECURITY_LEVEL, RegistryObjectMetacardType.LINKS,
+                    RegistryObjectMetacardType.REGION, RegistryObjectMetacardType.DATA_SOURCES,
                     RegistryObjectMetacardType.SERVICE_BINDINGS,
                     RegistryObjectMetacardType.SERVICE_BINDING_TYPES,
                     RegistryObjectMetacardType.REGISTRY_ID,
                     RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
                     RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
                     RegistryObjectMetacardType.REGISTRY_BASE_URL,
+                    RegistryObjectMetacardType.REMOTE_METACARD_ID,
+                    RegistryObjectMetacardType.REMOTE_REGISTRY_ID,
                     RegistryObjectMetacardType.PUBLISHED_LOCATIONS,
                     RegistryObjectMetacardType.LAST_PUBLISHED};
 
@@ -61,7 +51,7 @@ public class TestRegistryObjectMetacardType {
         assertThat(descriptors, not(nullValue()));
         assertThat(CollectionUtils.isEmpty(descriptors), is(false));
 
-        assertThat(registryObjectMetacardType.getAttributeDescriptor(Metacard.ID)
+        assertThat(registryObjectMetacardType.getAttributeDescriptor(RegistryObjectMetacardType.REGISTRY_ID)
                 .isMultiValued(), is(false));
     }
 
@@ -72,5 +62,23 @@ public class TestRegistryObjectMetacardType {
             assertThat(registryObjectMetacardType.getAttributeDescriptor(attrDesc)
                     .isStored(), is(true));
         }
+    }
+
+    @Test
+    public void testAddAttributeMethods() {
+        RegistryObjectMetacardType registryObjectMetacardType = new RegistryObjectMetacardType();
+
+        registryObjectMetacardType.addXml("title1", false);
+        registryObjectMetacardType.addQueryableGeo("title2", true);
+
+        assertThat(registryObjectMetacardType.getAttributeDescriptor("title1")
+                .isStored(), is(true));
+        assertThat(registryObjectMetacardType.getAttributeDescriptor("title1")
+                .isMultiValued(), is(false));
+
+        assertThat(registryObjectMetacardType.getAttributeDescriptor("title2")
+                .isStored(), is(true));
+        assertThat(registryObjectMetacardType.getAttributeDescriptor("title2")
+                .isMultiValued(), is(true));
     }
 }

--- a/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/pom.xml
@@ -78,6 +78,12 @@
             <artifactId>registry-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>1.22.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/transformer/RegistryTransformer.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/transformer/RegistryTransformer.java
@@ -39,6 +39,7 @@ import com.google.common.io.CharStreams;
 
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
@@ -51,6 +52,8 @@ public class RegistryTransformer implements InputTransformer, MetacardTransforme
     private Parser parser;
 
     private ParserConfigurator configurator;
+
+    private MetacardType registryMetacardType;
 
     @Override
     public Metacard transform(InputStream inputStream)
@@ -142,7 +145,7 @@ public class RegistryTransformer implements InputTransformer, MetacardTransforme
             if (registryObjectType != null) {
 
                 metacard = (MetacardImpl) RegistryPackageConverter.getRegistryObjectMetacard(
-                        registryObjectType);
+                        registryObjectType, registryMetacardType);
 
             }
         }
@@ -167,4 +170,7 @@ public class RegistryTransformer implements InputTransformer, MetacardTransforme
         this.parser = parser;
     }
 
+    public void setRegistryMetacardType(MetacardType registryMetacardType) {
+        this.registryMetacardType = registryMetacardType;
+    }
 }

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,6 +17,26 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
+    <bean id="registryObjectMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
+        <argument value="registry"/>
+        <argument>
+            <list>
+                <bean class="org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType"/>
+                <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+            </list>
+        </argument>
+    </bean>
+
+    <service ref="registryObjectMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="registry"/>
+        </service-properties>
+    </service>
+
     <!-- Register the Transformers -->
     <service auto-export="interfaces">
         <service-properties>
@@ -26,6 +46,7 @@
         </service-properties>
         <bean class="org.codice.ddf.registry.transformer.RegistryTransformer">
             <property name="parser" ref="xmlParser"/>
+            <property name="registryMetacardType" ref="registryObjectMetacardType"/>
         </bean>
     </service>
 

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -614,10 +614,6 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
     private List<Filter> getBasicFilter(String tag) {
         List<Filter> filters = new ArrayList<>();
-        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE)
-                .is()
-                .equalTo()
-                .text(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
         filters.add(filterBuilder.attribute(Metacard.TAGS)
                 .is()
                 .equalTo()

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
@@ -323,10 +323,6 @@ public class RefreshRegistryEntries {
 
     private Query getBasicRegistryQuery() {
         List<Filter> filters = new ArrayList<>();
-        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE)
-                .is()
-                .equalTo()
-                .text(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
         filters.add(filterBuilder.attribute(Metacard.TAGS)
                 .is()
                 .equalTo()

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -77,6 +77,7 @@ import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.AttributeBuilder;
 import ddf.catalog.filter.ExpressionBuilder;
@@ -620,8 +621,7 @@ public class FederationAdminServiceImplTest {
         String destination = TEST_DESTINATION;
         Set<String> destinations = new HashSet<>();
         destinations.add(destination);
-        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
-                testMetacard);
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(), testMetacard);
         when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
         federationAdminServiceImpl.deleteRegistryEntriesByRegistryIds(ids, destinations);
         verify(catalogFramework).delete(any(DeleteRequest.class));
@@ -1108,7 +1108,7 @@ public class FederationAdminServiceImplTest {
 
     private QueryRequest getTestQueryRequest() {
         Filter filter = getTestFilter();
-        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
+        SortBy sortBy = FILTER_FACTORY.sort(Core.CREATED, SortOrder.ASCENDING);
         Query query = new QueryImpl(filter);
         ((QueryImpl) query).setSortBy(sortBy);
         QueryRequest request = new QueryRequestImpl(query);
@@ -1149,7 +1149,8 @@ public class FederationAdminServiceImplTest {
 
     private Metacard getPopulatedRemoteTestRegistryMetacard() {
         Metacard mcard = getPopulatedTestRegistryMetacard();
-        mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REMOTE_REGISTRY_ID, "RemoteRegId"));
+        mcard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REMOTE_REGISTRY_ID,
+                "RemoteRegId"));
         return mcard;
     }
 }

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
@@ -48,6 +48,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.security.Subject;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
@@ -85,6 +86,7 @@ public class IdentityNodeInitializationTest {
         registryTransformer = spy(new RegistryTransformer());
         metacardMarshaller = spy(new MetacardMarshaller(parser));
         registryTransformer.setParser(parser);
+        registryTransformer.setRegistryMetacardType(new RegistryObjectMetacardType());
         identityNodeInitialization.setRegistryTransformer(registryTransformer);
         identityNodeInitialization.setMetacardMarshaller(metacardMarshaller);
         identityNodeInitialization.setFederationAdminService(federationAdminService);
@@ -101,8 +103,8 @@ public class IdentityNodeInitializationTest {
         identityNodeInitialization.init();
         verify(federationAdminService).addRegistryEntry(captor.capture());
         Metacard metacard = captor.getValue();
-        assertThat(metacard.getAttribute(Metacard.MODIFIED), notNullValue());
-        assertThat(metacard.getAttribute(Metacard.CREATED), notNullValue());
+        assertThat(metacard.getAttribute(Core.MODIFIED), notNullValue());
+        assertThat(metacard.getAttribute(Core.CREATED), notNullValue());
         assertThat(metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
                 .getValue(), equalTo(true));
         assertThat(metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
@@ -129,18 +131,16 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithIngestException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
-        when(federationAdminService.addRegistryEntry(any(Metacard.class)))
-                .thenThrow(FederationAdminException.class);
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenThrow(
+                FederationAdminException.class);
         identityNodeInitialization.init();
         verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
 
     @Test
     public void initWithRegistryTransformerException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
         doThrow(CatalogTransformerException.class).when(registryTransformer)
                 .transform(any(InputStream.class));
         identityNodeInitialization.init();
@@ -149,8 +149,7 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithParserException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
         doThrow(ParserException.class).when(metacardMarshaller)
                 .getRegistryPackageAsInputStream(any(RegistryPackageType.class));
         identityNodeInitialization.init();
@@ -159,9 +158,9 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithIOException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
-        doThrow(IOException.class).when(registryTransformer).transform(any(InputStream.class));
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        doThrow(IOException.class).when(registryTransformer)
+                .transform(any(InputStream.class));
         identityNodeInitialization.init();
         verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }

--- a/catalog/spatial/registry/registry-rest-endpoint/src/main/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilder.java
+++ b/catalog/spatial/registry/registry-rest-endpoint/src/main/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilder.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
 import org.codice.ddf.registry.rest.endpoint.HandlebarsHelper;
 import org.codice.ddf.registry.schemabindings.converter.web.OrganizationWebConverter;
@@ -37,6 +36,7 @@ import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.google.common.collect.ImmutableMap;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Contact;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 
 /**
@@ -106,17 +106,16 @@ public class RegistryReportBuilder {
     private Map<String, Object> getSummaryMap(Metacard metacard) {
         Map<String, Object> summaryMap = new HashMap<>();
 
-        Map<String, String> summaryAttributes =
-                ImmutableMap.of(RegistryObjectMetacardType.ORGANIZATION_NAME,
-                        "Organization Name",
-                        Metacard.POINT_OF_CONTACT,
-                        "Point of Contact",
-                        RegistryObjectMetacardType.ORGANIZATION_ADDRESS,
-                        "Address",
-                        RegistryObjectMetacardType.ORGANIZATION_EMAIL,
-                        "Email Addresses",
-                        RegistryObjectMetacardType.ORGANIZATION_PHONE_NUMBER,
-                        "Phone Numbers");
+        Map<String, String> summaryAttributes = ImmutableMap.of(Contact.POINT_OF_CONTACT_NAME,
+                "Organization Name",
+                Metacard.POINT_OF_CONTACT,
+                "Point of Contact",
+                Contact.POINT_OF_CONTACT_ADDRESS,
+                "Address",
+                Contact.POINT_OF_CONTACT_EMAIL,
+                "Email Addresses",
+                Contact.POINT_OF_CONTACT_PHONE,
+                "Phone Numbers");
 
         summaryAttributes.keySet()
                 .stream()

--- a/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilderTest.java
+++ b/catalog/spatial/registry/registry-rest-endpoint/src/test/java/org/codice/ddf/registry/rest/endpoint/report/RegistryReportBuilderTest.java
@@ -26,6 +26,7 @@ import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.EbrimConstants;
 import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.jsoup.Jsoup;
@@ -51,6 +52,7 @@ public class RegistryReportBuilderTest {
         parser = new XmlParser();
         registryTransformer = spy(new RegistryTransformer());
         registryTransformer.setParser(parser);
+        registryTransformer.setRegistryMetacardType(new RegistryObjectMetacardType());
         configurator = parser.configureParser(Arrays.asList(RegistryObjectType.class.getPackage()
                         .getName(),
                 EbrimConstants.OGC_FACTORY.getClass()

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -319,7 +319,7 @@ public class TestRegistry extends AbstractIntegrationTest {
         federationAdminServiceImpl.addRegistryEntry(Library.getRegistryNode(id, regId, remoteRegId),
                 destinations);
 
-        ValidatableResponse validatableResponse = getCswRegistryResponse("registry-id", regId);
+        ValidatableResponse validatableResponse = getCswRegistryResponse("registry.registry-id", regId);
 
         final String xPathRegistryID =
                 "string(//GetRecordsResponse/SearchResults/RegistryPackage/ExternalIdentifier/@registryObject)";

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -225,7 +225,7 @@ public final class Library {
                 + "  <csw:Delete typeName=\"rim:RegistryPackage\" handle=\"something\">\n"
                 + "    <csw:Constraint version=\"2.0.0\">\n" + "      <ogc:Filter>\n"
                 + "        <ogc:PropertyIsEqualTo>\n"
-                + "            <ogc:PropertyName>remote-metacard-id</ogc:PropertyName>\n"
+                + "            <ogc:PropertyName>registry.local.remote-metacard-id</ogc:PropertyName>\n"
                 + "            <ogc:Literal>" + id + "</ogc:Literal>\n"
                 + "        </ogc:PropertyIsEqualTo>\n" + "      </ogc:Filter>\n"
                 + "    </csw:Constraint>\n" + "  </csw:Delete>\n" + "</csw:Transaction>";


### PR DESCRIPTION
#### What does this PR do?
The registry apps RegistryObjectMetacardType was updated to conform to the new metacard attribute taxonomy.
This means 
1) RegistryObjectMetacardType now only has registry specific attributes. For 'common' attributes we now use the names from the new attribute classes.
2) All registry specific attributes have been renamed to be `registry.<current-attribute-name>`
Exception to this is the transient attributes which is `registry.local.<current-attribute-name>`
3) The registry-api blueprint was built-up and now exposes the registry metatype as a service. 
4) The registry transformer/package converter no longer parses out the content type from the metacard and the content type is no longer used as a filter for evaluating registry metacards 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @gordocanchola @vinamartin @brianfelix @jlcsmith @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold
@jlcsmith 

#### How should this be tested?
Install DDF, Start the Registry App and confirm the identity node is present in the local nodes tab. Confirm edits to the nodes are retained and that connections can still be made using the remote nodes tab.

#### Any background context you want to provide?
This ticket will need to be backported to the 2.9.x branch.

#### What are the relevant tickets?
DDF-2382 

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

