### PR TITLE
Ddf 2395 Update Application reference section

### DIFF
--- a/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -16,7 +16,7 @@
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
     <OCD name="Xml Query Transformer"
-         description="Xml Response Queue Transformer"
+         description="XML Response Queue Transformer"
          id="ddf.catalog.transformer.xml.XmlResponseQueueTransformer">
         <AD name="Parallel Marhsalling Threshold" id="threshold" required="true" type="Integer"
             default="50"

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-as-fanout-proxy-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-as-fanout-proxy-contents.adoc
@@ -1,0 +1,14 @@
+
+==== Configuring ${branding} as a Fanout Proxy
+
+This scenario describes how to configure ${branding} as a fanout proxy such that only queries and resource retrieval requests are processed and create/update/delete requests are rejected.
+Additionally, all queries are enterprise queries and no catalog provider needs to be configured.
+
+. Start ${branding} following the Starting and Stopping instructions.
+. Reconfigure ${branding} in fanout proxy mode by going to the Features tab in the ${admin-console}.
+The Standard Catalog Framework (`catalog-core-standardframework` feature) has a property (`fanout`) that needs to be enabled.
+
+${branding} is now operating as a fanout proxy.
+Only queries and resource retrieval requests will be allowed.
+All queries will be federated.
+Create, update, and delete requests will throw an `UnsupportedOperationException`, even if a Catalog Provider was configured prior to the reconfiguration to fanout.

--- a/distribution/docs/src/main/resources/_contents/_draft-admin-contents/managing-admin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_draft-admin-contents/managing-admin-contents.adoc
@@ -1,0 +1,38 @@
+
+The ${ddf-admin} Application contains components that are integral for the installation and configuration ${branding} applications.
+
+It contains various services and interfaces that allow administrators more control over their systems and enhances administrative capabilities when installing and managing ${branding}.
+
+The ${ddf-admin} application contains an application service that handles all operations that are performed on applications.
+This includes adding, removing, starting, stopping, and showing status.
+
+=== ${ddf-admin} Application Prerequisites
+
+None.
+
+=== Installing the ${ddf-admin} Application
+
+The ${ddf-admin} application is installed by default with a standard installation.
+
+=== Configuring the ${ddf-admin} Application
+
+* Navigate to the ${admin-console}.
+* Select the *${ddf-admin}* application.
+* Select the *Configuration* tab.
+
+.${ddf-admin} Configurations
+[cols="3" options="header"]
+|===
+|Name
+|Property
+|Description
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.admin.ui.configuration-table-contents.adoc[]
+
+|===
+
+include::{adoc-include}/_tables/org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc[]
+
+include::{adoc-include}/_tables/org.codice.admin.ui.configuration-table-contents.adoc[]

--- a/distribution/docs/src/main/resources/_contents/_draft-catalog-contents/managing-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_draft-catalog-contents/managing-catalog-contents.adoc
@@ -1,0 +1,47 @@
+
+The ${ddf-catalog} provides a framework for storing, searching, processing, and transforming information.
+
+Clients typically perform create, read, update, and delete (CRUD) operations against the Catalog.
+
+At the core of the Catalog functionality is the Catalog Framework, which routes all requests and responses through the system, invoking additional processing per the system configuration.
+
+=== ${ddf-catalog} Application Prerequisites
+
+To use the ${ddf-catalog} Application, the following applications/features must be installed:
+
+* ${ddf-platform}
+
+=== Installing the ${ddf-catalog} Application
+
+The ${ddf-catalog} is pre-installed with a standard installation.
+
+=== Configuring the ${ddf-catalog} Application
+
+.${ddf-catalog} Available Configurations
+[cols="1,1m,2" options="header"]
+|===
+|Configuration
+|ID
+|Description
+
+include::{adoc-include}/_tables/conf-plugin.backup-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-OpenSearchSource-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.catalog.security.CatalogPolicy-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.catalog.CatalogFrameworkImpl-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.catalog.plugin.expiration.ExpirationDatePlugin-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.services.schematron.SchematronValidationService-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.catalog.security.policy.xml.XmlAttributeSecurityPolicyPlugin-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.catalog.transformer.xml.XmlResponseQueueTransformer-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.catalog.metacard.duplication.DuplicationValidator-table-contents.adoc[]
+
+|===

--- a/distribution/docs/src/main/resources/_contents/_draft-geowebcache-contents/managing-geowebcache-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_draft-geowebcache-contents/managing-geowebcache-contents.adoc
@@ -1,26 +1,31 @@
-${ddf-geowebcache} enables a server providing a tile cache and tile service aggregation.
+
+${ddf-geowebcache} enables a server providing a map tile cache and tile service aggregation.
 See (http://geowebcache.org[GeoWebCache]) for more information.
 This application also provides an administrative plugin for the management of GeoWebCached layers.
-GeoWebCache also provides a user interface for previewing, truncating, or seeding layers at \${secure_url}/geowebcache/.
+GeoWebCache also provides a user interface for previewing, truncating, or seeding layers at ${secure_url}/geowebcache/.
 
-=== Prerequisites for ${ddf-geowebcache}
+=== ${ddf-geowebcache} Application Prerequisites
 
-none.
+None.
 
 === Installing ${ddf-geowebcache}
 
-The ${ddf-geowebcache} application is *not* installed by default. To install:
+The ${ddf-geowebcache} application is *not* installed by default.
+
+To install:
 
 * Navigate to the ${admin-console}.
 * Select *Manage*.
-* Select the ${ddf-geowebcache} application
 * Select the application *Start* button. The application will move to *Active Applications* on startup.
+* Select *Back* in ${admin-console}.
 
 === Configuring ${ddf-geowebcache}
 
 ${ddf-geowebcache} can be configured to cache layers locally, using the following procedures.
 
 ==== Adding GeoWebCache Layers
+
+Add layers to the local cache:
 
 * Navigate to the ${admin-console}.
 * Select the ${ddf-geowebcache} Application.

--- a/distribution/docs/src/main/resources/_contents/_draft-platform-contents/managing-platform-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_draft-platform-contents/managing-platform-contents.adoc
@@ -1,0 +1,44 @@
+
+The ${ddf-platform} application is considered to be a core application of the distribution.
+The Platform application provides the fundamental building blocks that the distribution needs to run.
+These building blocks include subsets of:
+
+* http://karaf.apache.org/[Karaf] 
+* http://cxf.apache.org/CXF[CXF] 
+* http://camel.apache.org/[Camel] 
+
+A Command Scheduler is also included as part of the Platform application.
+The Command Scheduler allows users to schedule Command Line Shell Commands to run at certain specified intervals for the convenience of a "platform independent" method of running certain commands, such as backing up data or logging settings.
+
+==== ${ddf-platform} Application Prerequisites
+
+None.
+
+==== Installing ${ddf-platform}
+
+The ${ddf-platform} application is installed by default with a standard installation.
+
+==== Configuring ${ddf-platform}
+
+.${ddf-platform} Available Configurations
+[cols="1,1,2" options="header"]
+|===
+|Configuration
+|ID
+|Description
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.distribution.landing-page.properties-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.platform.logging.LoggingService-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf_Custom_Mime_Type_Resolver-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-MetricsReporting-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-org.codice.ddf.persistence.internal.PersistentStoreImpl-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.platform.scheduler.Command-table-contents.adoc[]
+
+include::{adoc-include}/_tables/conf-ddf.platform.ui.config-table-contents.adoc[]
+
+|===

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-MetricsReporting-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-MetricsReporting-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<MetricsReporting,Metrics Reporting>>
+|MetricsReporting
+|Metrics Reporting
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-OpenSearchSource-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-OpenSearchSource-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<OpenSearchSource,Catalog OpenSearch Federated Source>>
+|OpenSearchSource
+|DDF OpenSearch Federated Source
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.CatalogFrameworkImpl-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.CatalogFrameworkImpl-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.catalog.CatalogFrameworkImpl,Catalog Standard Framework>>
+|ddf.catalog.CatalogFrameworkImpl
+|DDF Local site
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.metacard.duplication.DuplicationValidator-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.metacard.duplication.DuplicationValidator-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.catalog.metacard.duplication.DuplicationValidator,Catalog Duplicate Validator>>
+|ddf.catalog.metacard.duplication.DuplicationValidator
+|null
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.transformer.xml.XmlResponseQueueTransformer-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.transformer.xml.XmlResponseQueueTransformer-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.catalog.transformer.xml.XmlResponseQueueTransformer,Xml Query Transformer>>
+|ddf.catalog.transformer.xml.XmlResponseQueueTransformer
+|XML Response Queue Transformer
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.platform.scheduler.Command-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.platform.scheduler.Command-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.platform.scheduler.Command,Platform Command Scheduler>>
+|ddf.platform.scheduler.Command
+|
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.platform.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.platform.ui.config-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.platform.ui.config,Platform UI Configuration>>
+|ddf.platform.ui.config
+|Global User Interface configurations used across the applications. Contains configuration for banners and other generic ui components.
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.services.schematron.SchematronValidationService-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.services.schematron.SchematronValidationService-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<ddf.services.schematron.SchematronValidationService,Schematron Validation Services>>
+|ddf.services.schematron.SchematronValidationService
+|Schematron Validators
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf_Custom_Mime_Type_Resolver-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf_Custom_Mime_Type_Resolver-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<DDF_Custom_Mime_Type_Resolver,MIME Custom Types>>
+|DDF_Custom_Mime_Type_Resolver
+|DDF Custom Mime Types
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.admin.ui.configuration-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.admin.ui.configuration-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.admin.ui.configuration,Admin UI Configuration>>
+|org.codice.admin.ui.configuration
+|null
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.admin.config.policy.AdminConfigPolicy,Admin Configuration Policy>>
+|org.codice.ddf.admin.config.policy.AdminConfigPolicy
+|Admin Configuration Policy
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.plugin.expiration.ExpirationDatePlugin-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.plugin.expiration.ExpirationDatePlugin-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.catalog.plugin.expiration.ExpirationDatePlugin,Expiration Date Pre-Ingest Plugin>>
+|org.codice.ddf.catalog.plugin.expiration.ExpirationDatePlugin
+|Catalog pre-ingest plugin to set an expiration date on metacards
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.CatalogPolicy-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.CatalogPolicy-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.catalog.security.CatalogPolicy,Catalog Policy Plugin>>
+|org.codice.ddf.catalog.security.CatalogPolicy
+|Catalog Policy Plugin
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin,Metacard Attribute Security Policy Plugin>>
+|org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin
+|Metacard Attribute Security Policy Plugin
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.policy.xml.XmlAttributeSecurityPolicyPlugin-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.catalog.security.policy.xml.XmlAttributeSecurityPolicyPlugin-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.catalog.security.policy.xml.XmlAttributeSecurityPolicyPlugin,XML Attribute Security Policy Plugin>>
+|org.codice.ddf.catalog.security.policy.xml.XmlAttributeSecurityPolicyPlugin
+|XML Attribute Security Policy Plugin
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.distribution.landing-page.properties-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.distribution.landing-page.properties-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.distribution.landing-page.properties,Landing Page>>
+|org.codice.ddf.distribution.landing-page.properties
+|null
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.persistence.internal.PersistentStoreImpl-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.persistence.internal.PersistentStoreImpl-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.persistence.internal.PersistentStoreImpl,Persistent Store>>
+|org.codice.ddf.persistence.internal.PersistentStoreImpl
+|null
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.platform.logging.LoggingService-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.platform.logging.LoggingService-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.platform.logging.LoggingService,Logging Service>>
+|org.codice.ddf.platform.logging.LoggingService
+|null
+

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<plugin.backup,Backup Post-Ingest Plugin>>
+|plugin.backup
+|Backup Post-Ingest Plugin Configuration
+

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.admin.ui.configuration-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.admin.ui.configuration-table-contents.adoc
@@ -1,0 +1,76 @@
+.[[org.codice.admin.ui.configuration]]Admin UI Configuration
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Enable System Usage message
+|systemUsageEnabled
+|Boolean
+|Turns on a system usage message, which is shown when the Admin Application is opened.
+|false
+|true
+
+|System Usage Message Title
+|systemUsageTitle
+|String
+|A title for the system usage message when the application is opened.
+|
+|true
+
+|System Usage Message
+|systemUsageMessage
+|String
+|A system usage message to be displayed to the user each time the user opens the application.
+|
+|true
+
+|Show System Usage Message once per session
+|systemUsageOncePerSession
+|Boolean
+|With this selected,the system usage message will be shown once for each browser session. Uncheck this to have the usage message appear every time the admin page is opened or refreshed.
+|true
+|true
+
+|Header
+|header
+|String
+|Specifies the header text to be rendered on the Administrator Console.
+|
+|true
+
+|Footer
+|footer
+|String
+|Specifies the footer text to be rendered on the Administrator Console.
+|
+|true
+
+|Style
+|style
+|String
+|Specifies the style of the Header and Footer.
+|green
+|true
+
+|Text Color
+|textColor
+|String
+|Specifies the text color of the Header and Footer.
+|banner-text-white
+|true
+
+|Ignored Installer Applications
+|disabledInstallerApps
+|String
+|Comma delimited list (appName, appName2, ...appNameN) of applications that will be disabled in the installer.
+|admin-app,platform-app
+|null
+
+|===
+

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.admin.config.policy.AdminConfigPolicy-table-contents.adoc
@@ -1,0 +1,29 @@
+.[[org.codice.ddf.admin.config.policy.AdminConfigPolicy]]Admin Configuration Policy
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Feature and App Permissions
+|featurePolicies
+|String
+|When enabled, the desired features or apps will only be modifiable and viewable to users with the set attributes.
+The entry should be the format of: `feature name/app name = "user attribute name=user attribute value"`
+|
+|false
+
+|Configuration Permissions
+|servicePolicies
+|String
+|When enabled, the desired service will only be modifiable and viewable to users with the set attributes.
+The entry should be the format of: `configuration ID = "user attribute name=user attribute value"`
+|null
+|false
+
+|===
+

--- a/distribution/docs/src/main/resources/draft-documentation.adoc
+++ b/distribution/docs/src/main/resources/draft-documentation.adoc
@@ -1,4 +1,4 @@
-= ${branding-expanded} Documentation
+= DRAFT ${branding-expanded} Documentation
 include::${project.build.directory}/doc-contents/_contents/config.adoc[]
 
 = Introduction
@@ -88,6 +88,9 @@ include::{adoc-include}/_configuring/configuring-from-import-contents.adoc[]
 
 === Other Configurations
 
+
+include::{adoc-include}/_configuring/configuring-as-fanout-proxy-contents.adoc[]
+
 include::{adoc-include}/_configuring/configuring-catalog-provider-contents.adoc[]
 
 include::{adoc-include}/_configuring/managing-features-contents.adoc[]
@@ -131,5 +134,37 @@ include::{adoc-include}/_running/monitoring-contents.adoc[]
 === Troubleshooting ${branding}
 
 include::{adoc-include}/_running/troubleshooting-contents.adoc[]
+
+= Application Reference
+
+====
+Installation and configuration details by application.
+====
+
+== ${ddf-admin} Reference
+[small]#Version: ${project.version}#
+
+include::{adoc-include}/_draft-admin-contents/managing-admin-contents.adoc[]
+
+<<<
+
+== ${ddf-catalog} Reference
+[small]#Version: ${project.version}#
+
+include::{adoc-include}/_draft-catalog-contents/managing-catalog-contents.adoc[]
+
+<<<
+
+== ${ddf-geowebcache} Reference
+[small]#Version: ${project.version}#
+
+include::{adoc-include}/_draft-geowebcache-contents/managing-geowebcache-contents.adoc[]
+
+<<<
+
+== ${ddf-platform} Reference
+[small]#Version: ${project.version}#
+
+include::{adoc-include}/_draft-platform-contents/managing-platform-contents.adoc[]
 
 <<<

--- a/platform/admin/ui/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/admin/ui/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,30 +23,30 @@
                 default="false"
         />
         <AD
-                description="A title for the system usage message when the application is opened"
+                description="A title for the system usage message when the application is opened."
                 name="System Usage Message Title" id="systemUsageTitle" required="true"
                 type="String"
                 default=""
         />
         <AD
-                description="A system usage message to be displayed to the user each time the user opens the application"
+                description="A system usage message to be displayed to the user each time the user opens the application."
                 name="System Usage Message" id="systemUsageMessage" required="true" type="String"
                 default=""
         />
         <AD
-                description="With this selected, the system usage message will be shown once for each browser session.  Uncheck this to have the usage message appear every time the admin page is opened or refreshed."
-                name="Show System Usage Message once per session" id="systemUsageOncePerSession"
+                description="With this selected, the system usage message will be shown once for each browser session. Uncheck this to have the usage message appear every time the admin page is opened or refreshed."
+                name="Show System Usage Message once per session" id="systemUsageOncePerSession."
                 required="true" type="Boolean"
                 default="true"
         />
 
         <AD
-                description="Specifies the header text to be rendered on the Administrator Console"
+                description="Specifies the header text to be rendered on the Administrator Console."
                 name="Header" id="header" required="true" type="String"
                 default=""
                 />
         <AD
-                description="Specifies the footer text to be rendered on the Administrator Console"
+                description="Specifies the footer text to be rendered on the Administrator Console."
                 name="Footer" id="footer" required="true" type="String"
                 default=""
                 />
@@ -83,7 +83,7 @@
 
 
         <AD id="disabledInstallerApps" type="String" name="Ignored Installer Applications"
-            description="Comma delimited list (appName,appName2,...appNameN) of applications that will be disabled in the installer"
+            description="Comma delimited list (appName,appName2,...appNameN) of applications that will be disabled in the installer."
             default="admin-app,platform-app">
         </AD>
 


### PR DESCRIPTION
#### What does this PR do?

Revises the current `Managing <application>` sections for the Admin, Catalog, GeoWebCache, and Platform Applications.

- Non-app-specific content has been moved to more general sections.
- Renamed sections from `Managing <app>` to `<App> Reference`
- Formatting standardized.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@spearskw @emanns95 @mweser 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@pklinef

#### How should this be tested?
Review doc contents
#### Any background context you want to provide?

Sub-task of DDF-2309; See PR https://github.com/codice/ddf/pull/1036

The changes here will not yet be visible in the published documentation. To view new version, open draft-documentation in either html or pdf in the docs target directory. [pdf version attached to this PR] Once all changes are integrated, the draft-documentation will supersede the current version.

#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2395

#### Screenshots (if appropriate)

[draft-documentation.pdf](https://github.com/codice/ddf/files/438252/draft-documentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
