### PR TITLE
DDF-2423: Updating new attribute descriptors

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/AssociationsAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/AssociationsAttributes.java
@@ -36,13 +36,13 @@ public class AssociationsAttributes implements Associations, MetacardType {
         descriptors.add(new AttributeDescriptorImpl(DERIVED,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(RELATED,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 true /* multivalued */,
                 BasicTypes.STRING_TYPE));
         DESCRIPTORS = Collections.unmodifiableSet(descriptors);

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
@@ -36,13 +36,13 @@ public class CoreAttributes implements Core, MetacardType {
         descriptors.add(new AttributeDescriptorImpl(CHECKSUM,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(CHECKSUM_ALGORITHM,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(CREATED,
@@ -55,7 +55,7 @@ public class CoreAttributes implements Core, MetacardType {
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
-                true /* multivalued */,
+                false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(EXPIRATION,
                 true /* indexed */,
@@ -66,7 +66,7 @@ public class CoreAttributes implements Core, MetacardType {
         descriptors.add(new AttributeDescriptorImpl(ID,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(LANGUAGE,
@@ -107,14 +107,14 @@ public class CoreAttributes implements Core, MetacardType {
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(RESOURCE_DOWNLOAD_URL,
                 true /* indexed */,
-                false /* stored */,
+                true /* stored */,
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(RESOURCE_SIZE,
                 true /* indexed */,
                 true /* stored */,
-                true /* tokenized */,
+                false /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(RESOURCE_URI,
@@ -130,7 +130,7 @@ public class CoreAttributes implements Core, MetacardType {
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
         descriptors.add(new AttributeDescriptorImpl(THUMBNAIL,
-                true /* indexed */,
+                false /* indexed */,
                 true /* stored */,
                 false /* tokenized */,
                 false /* multivalued */,


### PR DESCRIPTION
#### What does this PR do?
Updating attribute descriptors that were not what we wanted them to be.  There will be a separate PR to update `DynamicSchemaResolver` and the `MetacardType` to attempt to prevent against duplicates coming in externally. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
@pklinef
