### PR TITLE
DDF-2438 Fixed registry entry duplication issue in IdentificationPlugin

### DIFF
--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/TagsFilterDelegate.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/TagsFilterDelegate.java
@@ -69,8 +69,9 @@ public class TagsFilterDelegate extends SimpleFilterDelegate<Boolean> {
 
     @Override
     public Boolean not(Boolean operand) {
-        return operand;
+        return tags == null ? operand : !operand;
     }
+
 
     @Override
     public Boolean propertyIsEqualTo(String propertyName, String pattern, boolean isCaseSensitive) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.opengis.filter.Filter;
-import org.opengis.filter.sort.SortBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -406,7 +405,7 @@ public class DeleteOperations {
                 new QueryImpl(queryOperations.getFilterWithAdditionalFilters(idFilters),
                         1,  /* start index */
                         0,  /* page size */
-                        SortBy.NATURAL_ORDER,
+                        null,
                         false, /* total result count */
                         0   /* timeout */);
         return new QueryRequestImpl(queryImpl, deleteRequest.getStoreIds());

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.opengis.filter.Filter;
-import org.opengis.filter.sort.SortBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -573,7 +572,7 @@ public class UpdateOperations {
                 new QueryImpl(queryOperations.getFilterWithAdditionalFilters(idFilters),
                         1,  /* start index */
                         0,  /* page size */
-                        SortBy.NATURAL_ORDER,
+                        null,
                         false, /* total result count */
                         0   /* timeout */);
         return new QueryRequestImpl(queryImpl, updateRequest.getStoreIds());

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
@@ -49,15 +49,12 @@ import ddf.catalog.data.Result;
 import ddf.catalog.filter.delegate.TagsFilterDelegate;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
-import ddf.catalog.operation.DeleteRequest;
-import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.UpdateResponse;
-import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
@@ -174,23 +171,6 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
         }
 
         return super.update(request);
-    }
-
-    @Override
-    public DeleteResponse delete(DeleteRequest request) throws IngestException {
-        //delete's for registry are normally done by registry-id but the '-' in the
-        //registry-id attribute name is not understood by the csw endpoint so we
-        //replace the request with one based on the metacard id's from the remote
-        //system which have been stored in the operation transaction
-        List<String> ids =
-                ((OperationTransaction) request.getPropertyValue(Constants.OPERATION_TRANSACTION_KEY)).getPreviousStateMetacards()
-                        .stream()
-                        .map(Metacard::getId)
-                        .collect(Collectors.toList());
-        DeleteRequest newRequest = new DeleteRequestImpl(ids.toArray(new String[ids.size()]),
-                request.getProperties());
-
-        return super.delete(newRequest);
     }
 
     @Override

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.registry.api.internal.RegistryStore;
@@ -49,12 +50,17 @@ import ddf.catalog.data.Result;
 import ddf.catalog.filter.delegate.TagsFilterDelegate;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.CreateResponseImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
@@ -136,6 +142,46 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
                 .anyMatch(Objects::isNull)) {
             throw new IngestException("One or more of the metacards is not a registry metacard");
         }
+
+        List<Filter> regIdFilters = request.getMetacards()
+                .stream()
+                .map(e -> filterBuilder.attribute(RegistryObjectMetacardType.REMOTE_METACARD_ID)
+                        .is()
+                        .equalTo()
+                        .text(e.getId()))
+                .collect(Collectors.toList());
+        Filter tagFilter = filterBuilder.attribute(Metacard.TAGS)
+                .is()
+                .equalTo()
+                .text(RegistryConstants.REGISTRY_TAG_INTERNAL);
+        QueryImpl query = new QueryImpl(filterBuilder.allOf(tagFilter,
+                filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
+                        .empty(),
+                filterBuilder.anyOf(regIdFilters)));
+        QueryRequest queryRequest = new QueryRequestImpl(query);
+        try {
+            SourceResponse queryResponse = super.query(queryRequest);
+
+            Map<String, Metacard> responseMap = queryResponse.getResults()
+                    .stream()
+                    .collect(Collectors.toMap(e -> RegistryUtility.getRegistryId(e.getMetacard()),
+                            Result::getMetacard));
+            List<Metacard> metacardsToCreate = request.getMetacards()
+                    .stream()
+                    .filter(e -> !responseMap.containsKey(RegistryUtility.getRegistryId(e)))
+                    .collect(Collectors.toList());
+            List<Metacard> allMetacards = new ArrayList<>(responseMap.values());
+            if (CollectionUtils.isNotEmpty(metacardsToCreate)) {
+                CreateResponse createResponse =
+                        super.create(new CreateRequestImpl(metacardsToCreate));
+                allMetacards.addAll(createResponse.getCreatedMetacards());
+            }
+            return new CreateResponseImpl(request, request.getProperties(), allMetacards);
+        } catch (UnsupportedQueryException e) {
+            LOGGER.warn(
+                    "Unable to perform pre-create remote query. Proceeding with original query. Error was {}",
+                    e.getMessage());
+        }
         return super.create(request);
     }
 
@@ -171,6 +217,19 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
         }
 
         return super.update(request);
+    }
+
+    @Override
+    public DeleteResponse delete(DeleteRequest request) throws IngestException {
+        List<String> ids =
+                ((OperationTransaction) request.getPropertyValue(Constants.OPERATION_TRANSACTION_KEY)).getPreviousStateMetacards()
+                        .stream()
+                        .map(Metacard::getId)
+                        .collect(Collectors.toList());
+        DeleteRequest newRequest = new DeleteRequestImpl(ids.toArray(new String[ids.size()]),
+                request.getProperties());
+
+        return super.delete(newRequest);
     }
 
     @Override

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
@@ -28,7 +28,6 @@ import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,14 +41,10 @@ import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.Csw;
-import org.codice.ddf.spatial.ogc.csw.catalog.common.CswAxisOrder;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
-import org.codice.ddf.spatial.ogc.csw.catalog.common.source.CswFilterFactory;
-import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.CswTransactionRequest;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.opengis.filter.Filter;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
@@ -64,7 +59,6 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.filter.FilterDelegate;
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.CreateRequest;
@@ -73,7 +67,6 @@ import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.CreateRequestImpl;
-import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
@@ -89,7 +82,6 @@ import net.opengis.cat.csw.v_2_0_2.InsertResultType;
 import net.opengis.cat.csw.v_2_0_2.TransactionResponseType;
 import net.opengis.cat.csw.v_2_0_2.TransactionSummaryType;
 import net.opengis.cat.csw.v_2_0_2.dc.elements.SimpleLiteral;
-import net.opengis.filter.v_1_1_0.FilterType;
 
 public class TestRegistryStore {
 
@@ -173,7 +165,6 @@ public class TestRegistryStore {
         CreateRequest request = new CreateRequestImpl(mcard);
         registryStore.create(request);
     }
-
 
     @Test
     public void testCreateNoExistingMetacard() throws Exception {
@@ -318,39 +309,6 @@ public class TestRegistryStore {
 
         verify(registryStore, times(0)).getConfigurationPid();
 
-    }
-
-    @Test
-    public void testDelete() throws Exception {
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        Csw csw = mock(Csw.class);
-        TransactionResponseType transResponse = mock(TransactionResponseType.class);
-        TransactionSummaryType transSummary = mock(TransactionSummaryType.class);
-        when(transResponse.getTransactionSummary()).thenReturn(transSummary);
-        when(transSummary.getTotalDeleted()).thenReturn(new BigInteger("1"));
-        when(csw.transaction(any(CswTransactionRequest.class))).thenReturn(transResponse);
-        when(factory.getClientForSubject(any())).thenReturn(csw);
-        when(transformer.getTransformerIdForSchema(any())).thenReturn(null);
-        FilterAdapter mockAdaptor = mock(FilterAdapter.class);
-        CswFilterFactory filterFactory = new CswFilterFactory(CswAxisOrder.LAT_LON, false);
-        FilterType filterType = filterFactory.buildPropertyIsLikeFilter(Metacard.ID,
-                "testId",
-                false);
-        when(mockAdaptor.adapt(any(Filter.class),
-                any(FilterDelegate.class))).thenReturn(filterType);
-        registryStore.setFilterAdapter(mockAdaptor);
-        DeleteRequestImpl request = new DeleteRequestImpl(Collections.singletonList(
-                RegistryObjectMetacardType.REGISTRY_ID), "registryId", new HashMap<>());
-
-        OperationTransactionImpl opTrans =
-                new OperationTransactionImpl(OperationTransaction.OperationType.DELETE,
-                        Collections.singletonList(getDefaultMetacard()));
-        request.getProperties()
-                .put(Constants.OPERATION_TRANSACTION_KEY, opTrans);
-        registryStore.delete(request);
-
-        verify(filterBuilder).attribute(captor.capture());
-        assertThat(captor.getValue(), is("id"));
     }
 
     @Test

--- a/catalog/spatial/registry/registry-identification-plugin/pom.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/pom.xml
@@ -63,6 +63,11 @@
             <groupId>ddf.security</groupId>
             <artifactId>ddf-security-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPlugin.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.identification;
+
+import java.security.PrivilegedActionException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.common.metacard.RegistryUtility;
+import org.codice.ddf.security.common.Security;
+import org.opengis.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PostIngestPlugin;
+import ddf.catalog.util.impl.Requests;
+
+/**
+ * The RegistryIdPostIngestPlugin collects a set of registry-ids that are currently in the system
+ * and makes them available to the IdentificationPlugin for duplication checking.
+ * <p>
+ * Initially the catalog is queried to initialize the set of registry-ids. After that the list is
+ * maintained by the process methods for create and delete responses.
+ */
+public class RegistryIdPostIngestPlugin implements PostIngestPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryIdPostIngestPlugin.class);
+
+    private static final int RETRY_INTERVAL = 30;
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private static final int PAGE_SIZE = 1000;
+
+    private ScheduledExecutorService executorService;
+
+    private CatalogFramework catalogFramework;
+
+    private FilterBuilder filterBuilder;
+
+    private Set<String> registryIds = ConcurrentHashMap.newKeySet();
+
+    private Set<String> localRegistryIds = ConcurrentHashMap.newKeySet();
+
+    private Set<String> remoteMetacardIds = ConcurrentHashMap.newKeySet();
+
+    private Security security;
+
+    public RegistryIdPostIngestPlugin() {
+        security = Security.getInstance();
+    }
+
+    public RegistryIdPostIngestPlugin(Security security){
+        this.security = security;
+    }
+
+    public Set<String> getRegistryIds() {
+        return Collections.unmodifiableSet(registryIds);
+    }
+
+    public Set<String> getRemoteMetacardIds() {
+        return remoteMetacardIds;
+    }
+
+    public Set<String> getLocalRegistryIds() {
+        return localRegistryIds;
+    }
+
+    @Override
+    public CreateResponse process(CreateResponse input) throws PluginExecutionException {
+        if (input != null && input.getCreatedMetacards() != null
+                && Requests.isLocal(input.getRequest())) {
+            addIdsFromMetacards(input.getCreatedMetacards());
+        }
+        return input;
+    }
+
+    @Override
+    public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
+        return input;
+    }
+
+    @Override
+    public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
+        if (input != null && input.getDeletedMetacards() != null
+                && Requests.isLocal(input.getRequest())) {
+            removeIdsForMetacards(input.getDeletedMetacards());
+        }
+        return input;
+    }
+
+    /**
+     * Init method initializes the id sets from the catalog. If the catalog is not available it
+     * will retry later.
+     */
+    public void init() {
+        try {
+            List<Metacard> registryMetacards;
+            Filter registryFilter = filterBuilder.anyOf(filterBuilder.attribute(Metacard.TAGS)
+                            .is()
+                            .equalTo()
+                            .text(RegistryConstants.REGISTRY_TAG),
+                    filterBuilder.attribute(Metacard.TAGS)
+                            .is()
+                            .equalTo()
+                            .text(RegistryConstants.REGISTRY_TAG_INTERNAL));
+            QueryImpl query = new QueryImpl(registryFilter);
+            query.setPageSize(PAGE_SIZE);
+            QueryRequest request = new QueryRequestImpl(query);
+
+            QueryResponse response = Security.runAsAdminWithException(() -> security
+                    .runWithSubjectOrElevate(() -> catalogFramework.query(request)));
+
+            if (response == null) {
+                throw new PluginExecutionException(
+                        "Failed to initialize RegistryIdPostIngestPlugin. Query for registry metacards came back null");
+            }
+
+            registryMetacards = response.getResults()
+                    .stream()
+                    .map(Result::getMetacard)
+                    .collect(Collectors.toList());
+            addIdsFromMetacards(registryMetacards);
+        } catch (PrivilegedActionException | PluginExecutionException e) {
+            LOGGER.debug("Error getting registry metacards. Will try again later");
+            executorService.schedule(this::init, RETRY_INTERVAL, TimeUnit.SECONDS);
+        }
+    }
+
+    public void destroy() {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+                if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.debug("Thread pool didn't terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+        }
+    }
+
+    public void setFilterBuilder(FilterBuilder filterBuilder) {
+        this.filterBuilder = filterBuilder;
+    }
+
+    public void setCatalogFramework(CatalogFramework framework) {
+        this.catalogFramework = framework;
+    }
+
+    public void setExecutorService(ScheduledExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    private void addIdsFromMetacards(List<Metacard> metacards) {
+        for (Metacard mcard : metacards) {
+            if (RegistryUtility.isRegistryMetacard(mcard)) {
+                registryIds.add(RegistryUtility.getRegistryId(mcard));
+                if (RegistryUtility.isLocalNode(mcard)) {
+                    localRegistryIds.add(RegistryUtility.getRegistryId(mcard));
+                }
+            } else if (RegistryUtility.isInternalRegistryMetacard(mcard)) {
+                remoteMetacardIds.add(RegistryUtility.getStringAttribute(mcard,
+                        RegistryObjectMetacardType.REMOTE_METACARD_ID,
+                        ""));
+            }
+        }
+    }
+
+    private void removeIdsForMetacards(List<Metacard> metacards) {
+        for (Metacard mcard : metacards) {
+            if (RegistryUtility.isRegistryMetacard(mcard)) {
+                registryIds.remove(RegistryUtility.getRegistryId(mcard));
+                if (RegistryUtility.isLocalNode(mcard)) {
+                    localRegistryIds.remove(RegistryUtility.getRegistryId(mcard));
+                }
+            } else if (RegistryUtility.isInternalRegistryMetacard(mcard)) {
+                remoteMetacardIds.remove(RegistryUtility.getStringAttribute(mcard,
+                        RegistryObjectMetacardType.REMOTE_METACARD_ID,
+                        ""));
+            }
+        }
+    }
+}

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,15 +17,31 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
-    <bean id="metacardMarshaller" class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
+    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+
+    <bean id="metacardMarshaller"
+          class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
         <argument ref="xmlParser"/>
+    </bean>
+
+    <bean id="executor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor"/>
+
+    <bean id="registryPostIngestPlugin"
+          class="org.codice.ddf.registry.identification.RegistryIdPostIngestPlugin"
+          init-method="init" destroy-method="destroy">
+        <property name="catalogFramework" ref="catalogFramework"/>
+        <property name="filterBuilder" ref="filterBuilder"/>
+        <property name="executorService" ref="executor"/>
     </bean>
 
     <bean id="identificationPlugin"
           class="org.codice.ddf.registry.identification.IdentificationPlugin">
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
+        <property name="registryIdPostIngestPlugin" ref="registryPostIngestPlugin"/>
     </bean>
 
     <service ref="identificationPlugin" auto-export="interfaces" ranking="-1000"/>
-
+    <service ref="registryPostIngestPlugin" auto-export="interfaces" ranking="1000"/>
 </blueprint>

--- a/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
@@ -77,6 +77,7 @@ public class IdentificationPluginTest {
         parser = new XmlParser();
         identificationPlugin = new IdentificationPlugin();
         identificationPlugin.setMetacardMarshaller(new MetacardMarshaller(parser));
+        identificationPlugin.setRegistryIdPostIngestPlugin(new RegistryIdPostIngestPlugin());
         setParser(parser);
         sampleData = new MetacardImpl();
         sampleData.setId("testNewMetacardId");

--- a/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPluginTest.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPluginTest.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.identification;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.security.common.Security;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.CreateResponseImpl;
+import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+import ddf.catalog.source.UnsupportedQueryException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegistryIdPostIngestPluginTest {
+
+    private RegistryIdPostIngestPlugin registryIdPostIngestPlugin;
+
+    private FilterBuilder builder = new GeotoolsFilterBuilder();
+
+    @Mock
+    private CatalogFramework framework;
+
+    @Mock
+    private ScheduledExecutorService executorService;
+
+    @Mock
+    private Security security;
+
+    @Before
+    public void setup() throws Exception {
+        registryIdPostIngestPlugin = new RegistryIdPostIngestPlugin(security);
+        registryIdPostIngestPlugin.setCatalogFramework(framework);
+        registryIdPostIngestPlugin.setExecutorService(executorService);
+        registryIdPostIngestPlugin.setFilterBuilder(builder);
+        when(security.runWithSubjectOrElevate(any(Callable.class))).thenAnswer(invocation -> ((Callable) invocation.getArguments()[0]).call());
+    }
+
+    @Test
+    public void testProcessCreate() throws Exception {
+        CreateResponse response = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultMetacard()));
+        registryIdPostIngestPlugin.process(response);
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(1));
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .iterator()
+                .next(), equalTo("regId"));
+    }
+
+    @Test
+    public void testProcessCreateLocal() throws Exception {
+        MetacardImpl metacard = getDefaultMetacard();
+        metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE, true);
+        CreateResponse response = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(metacard));
+        registryIdPostIngestPlugin.process(response);
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(1));
+        assertThat(registryIdPostIngestPlugin.getLocalRegistryIds()
+                .size(), equalTo(1));
+        assertThat(registryIdPostIngestPlugin.getLocalRegistryIds()
+                .iterator()
+                .next(), equalTo("regId"));
+    }
+
+    @Test
+    public void testProcessCreateInternal() throws Exception {
+        CreateResponse response = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultInternalMetacard()));
+        registryIdPostIngestPlugin.process(response);
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(0));
+        assertThat(registryIdPostIngestPlugin.getRemoteMetacardIds()
+                .size(), equalTo(1));
+        assertThat(registryIdPostIngestPlugin.getRemoteMetacardIds()
+                .iterator()
+                .next(), equalTo("remoteMcardId"));
+    }
+
+    @Test
+    public void testProcessCreateNullResponse() throws Exception {
+        registryIdPostIngestPlugin.process((CreateResponse) null);
+    }
+
+    @Test
+    public void testProcessDelete() throws Exception {
+        CreateResponse createResponse = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultMetacard()));
+        registryIdPostIngestPlugin.process(createResponse);
+        DeleteResponse deleteResponse = new DeleteResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultMetacard()));
+        registryIdPostIngestPlugin.process(deleteResponse);
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(0));
+    }
+
+    @Test
+    public void testProcessDeleteLocal() throws Exception {
+        MetacardImpl metacard = getDefaultMetacard();
+        metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE, true);
+        CreateResponse createResponse = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(metacard));
+        registryIdPostIngestPlugin.process(createResponse);
+        assertThat(registryIdPostIngestPlugin.getLocalRegistryIds()
+                .size(), equalTo(1));
+        DeleteResponse deleteResponse = new DeleteResponseImpl(null,
+                null,
+                Collections.singletonList(metacard));
+        registryIdPostIngestPlugin.process(deleteResponse);
+        assertThat(registryIdPostIngestPlugin.getLocalRegistryIds()
+                .size(), equalTo(0));
+    }
+
+    @Test
+    public void testProcessDeleteInternal() throws Exception {
+        CreateResponse createResponse = new CreateResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultInternalMetacard()));
+        registryIdPostIngestPlugin.process(createResponse);
+        DeleteResponse deleteResponse = new DeleteResponseImpl(null,
+                null,
+                Collections.singletonList(getDefaultInternalMetacard()));
+        registryIdPostIngestPlugin.process(deleteResponse);
+        assertThat(registryIdPostIngestPlugin.getRemoteMetacardIds()
+                .size(), equalTo(0));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        Metacard metacard = getDefaultMetacard();
+        QueryResponseImpl response = new QueryResponseImpl(null,
+                Collections.singletonList(new ResultImpl(metacard)),
+                1L);
+        when(framework.query(any(QueryRequest.class))).thenReturn(response);
+        registryIdPostIngestPlugin.init();
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(1));
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .iterator()
+                .next(), equalTo("regId"));
+    }
+
+    @Test
+    public void testInitCatalogNotAvailable() throws Exception {
+        when(framework.query(any(QueryRequest.class))).thenThrow(new UnsupportedQueryException(
+                "exception"));
+        registryIdPostIngestPlugin.init();
+        assertThat(registryIdPostIngestPlugin.getRegistryIds()
+                .size(), equalTo(0));
+        verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        registryIdPostIngestPlugin.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyTerminateTasks() throws Exception {
+        when(executorService.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        registryIdPostIngestPlugin.destroy();
+        verify(executorService, times(2)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void testDestroyInterupt() throws Exception {
+        when(executorService.awaitTermination(anyLong(),
+                any(TimeUnit.class))).thenThrow(new InterruptedException("interrupt"));
+        registryIdPostIngestPlugin.destroy();
+        verify(executorService, times(1)).awaitTermination(anyLong(), any(TimeUnit.class));
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    private MetacardImpl getDefaultMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId("id");
+        metacard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG));
+        metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, "regId");
+        return metacard;
+    }
+
+    private Metacard getDefaultInternalMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId("id");
+        metacard.setTags(Collections.singleton(RegistryConstants.REGISTRY_TAG_INTERNAL));
+        metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, "regId");
+        metacard.setAttribute(RegistryObjectMetacardType.REMOTE_REGISTRY_ID, "remoteRegId");
+        metacard.setAttribute(RegistryObjectMetacardType.REMOTE_METACARD_ID, "remoteMcardId");
+        return metacard;
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Fixes a duplication issue where loopback registry configurations cause local nodes to be duplicated.
There had been duplication logic in the IdentificationPlugin before but was removed when we
added the internal registry entries. Added the logic back in a separate class and only apply it to registry entries that aren't internal.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison 
@figliold
#### How should this be tested?
Install ddf and ddf-registry. Create a loopback remote registry. After a minute or so go to solr and verify there is only one registry metacard entry (metacard-tags=registry)
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2438
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

