### PR TITLE
DDF-2345 -> 2.9.x Update Registry Node Info screen to handle invalid dates

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -119,11 +119,13 @@ define([
                 return data;
             },
             getNodeName: function() {
-                var node = this.model.get("RegistryObjectList").ExtrinsicObject.find(function(extObj) {
-                    return extObj.objectType === "urn:registry:federation:node";
+                var extName;
+                this.model.get("RegistryObjectList").ExtrinsicObject.forEach( function (extObj) {
+                    if (extObj.objectType === "urn:registry:federation:node") {
+                        extName = extObj.Name;
+                    }
                 });
-
-                return node.Name;
+                return extName;
             },
             onRender: function () {
                 this.$el.attr('role', "dialog");

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/main.js
@@ -48,7 +48,9 @@
             css: 'lib/require-css/css',
 
             // default admin ui
-            app: 'js/application'
+            app: 'js/application',
+
+            moment: 'lib/moment/min/moment.min'
         },
 
 
@@ -81,6 +83,10 @@
             icanhaz: {
                 deps: ['handlebars', 'jquery'],
                 exports: 'ich'
+            },
+
+            moment: {
+                exports: 'moment'
             },
 
             perfectscrollbar: ['jquery'],

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeList.handlebars
@@ -14,7 +14,7 @@
 <table class='table table-striped align-middle'>
     <thead>
     <th class="name">Name</th>
-    <th class="created">Created On</th>
+    <th class="created">Live Date</th>
     <th class="modified">Last Modified</th>
     <th/>
     <th>


### PR DESCRIPTION
#### What does this PR do?
The Registry Node Information screen will not display information if an invalid date is in any node's information. This would result in node modals not being accessible and not being displayed in the UI.

This PR fixes the issue by replacing any invalid dates/times with a valid date/time representing now. Additionally, the user's input is also validated and an error warning appears if needed. These new valid values are not saved to the node unless the user chooses to do so.

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
@stustison
#### How should this be tested?
Confirm Local Node modal still functions as expected.
#### Any background context you want to provide?
Merged into master -> https://github.com/codice/ddf/pull/1114
#### What are the relevant tickets?
DDF-2345

