### PR TITLE
DDF-2440: Fixes the async conditional wait for SourcePoller tests.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/SourceOperationsTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/SourceOperationsTest.groovy
@@ -36,6 +36,7 @@ class SourceOperationsTest extends Specification {
     private SourcePoller sourcePoller
     private SourcePollerRunner pollerRunner
     private SourceOperations sourceOperations
+    private double pollerWaitTime
 
     def setup() {
         frameworkProperties = new FrameworkProperties()
@@ -44,6 +45,7 @@ class SourceOperationsTest extends Specification {
         fedSources = ['fed1', 'fed2'].collectEntries { [(it): mockFedSource(it)] }
         pollerRunner = new SourcePollerRunner()
         sourcePoller = new SourcePoller(pollerRunner)
+        pollerWaitTime = (sourcePoller.getInterval() * 60) + 5
 
         frameworkProperties.with {
             catalogProviders = this.catalogProviders
@@ -415,7 +417,7 @@ class SourceOperationsTest extends Specification {
         def available = sourceOperations.isSourceAvailable(source)
 
         then:
-        conds.await()
+        conds.await(pollerWaitTime)
 
         then:
         !available
@@ -437,7 +439,7 @@ class SourceOperationsTest extends Specification {
         def available = sourceOperations.isSourceAvailable(source)
 
         then:
-        conds.await()
+        conds.await(pollerWaitTime)
 
         then:
         available


### PR DESCRIPTION
#### What does this PR do?
DDF-2440: Fixes the async conditional wait condition from the default of 1 second to five more seconds than the sourcepoller's interval.

This will allow the SourcePoller time to run its operation in the background.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic

#### How should this be tested?
Full build/test run.

#### Any background context you want to provide?
The async operations usage in here was believed to be sufficient to wait until the underlying code had been run but clearly that is not the case. We should resolve these tests; however, keeping the live at this time is causing intermittent build failures.

#### What are the relevant tickets?
DDF-2440

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
