### PR TITLE
DDF-2171 Performing a textual search with an empty value will now default to a wildcard search, when in the faceted search view

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/service/SearchService.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/service/SearchService.java
@@ -192,7 +192,9 @@ public class SearchService {
 
         Filter filter = null;
         try {
-            filter = ECQL.toFilter(cql);
+            if (StringUtils.isNotBlank(cql)) {
+                filter = ECQL.toFilter(cql);
+            }
         } catch (CQLException e) {
             LOGGER.debug("Unable to parse CQL filter", e);
             return;


### PR DESCRIPTION
#### What does this PR do?
When a textual query was performed with an empty value, while in the faceted view of the Search UI, an exception occurred as an empty CQL filter is not parseable. This has been changed to now perform a wildcard search if the value is empty.

-Added a conditional statement to prevent an empty CQL filter from being parsed. 
-If the CQL filter is empty (null), it'll be initialized with a wildcard contextual filter, which is what the code already does. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver
@coyotesqrl 
@stustison 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@pklinef 
#### How should this be tested?
1. Ingest a file.
2. Perform a query while in the faceted view of the Search UI using an empty value.
3. Verify a result has returned.
4. Verify no exception has occurred in the logs.

#### What are the relevant tickets?
DDF-2171

- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests