### PR TITLE
DDF-2444 Added anyTags filter to include results with empty tags

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
@@ -68,7 +68,7 @@ import ddf.catalog.util.impl.DescribableImpl;
 
 /**
  * Support class for resource delegate operations for the {@code CatalogFrameworkImpl}.
- *
+ * <p>
  * This class contains six delegated resource methods and methods to support them. No
  * operations/support methods should be added to this class except in support of CFI
  * resource operations.
@@ -428,8 +428,7 @@ public class ResourceOperations extends DescribableImpl {
             ResourceResponse resourceResponse) {
         if (resourceResponse != null) {
             // must add the request properties into response properties in case the source forgot to
-            Map<String, Serializable> properties =
-                    new HashMap<>(resourceResponse.getProperties());
+            Map<String, Serializable> properties = new HashMap<>(resourceResponse.getProperties());
             resourceRequest.getProperties()
                     .forEach(properties::putIfAbsent);
             resourceResponse = new ResourceResponseImpl(resourceResponse.getRequest(),
@@ -438,7 +437,6 @@ public class ResourceOperations extends DescribableImpl {
         }
         return resourceResponse;
     }
-
 
     private ResourceResponse processPostResourcePlugins(ResourceResponse resourceResponse)
             throws StopProcessingException {
@@ -665,11 +663,24 @@ public class ResourceOperations extends DescribableImpl {
     }
 
     private Query anyTag(Query query) {
+        //Any metacard tag
         Filter anyTag = frameworkProperties.getFilterBuilder()
                 .attribute(Metacard.TAGS)
                 .is()
                 .like()
                 .text(FilterDelegate.WILDCARD_CHAR);
+
+        //no metacard tag
+        Filter nullTag = frameworkProperties.getFilterBuilder()
+                .attribute(Metacard.TAGS)
+                .is()
+                .empty();
+
+        //any or no metacard tag
+        anyTag = frameworkProperties.getFilterBuilder()
+                .anyOf(anyTag, nullTag);
+
+        //any or no metacard tag and the query
         Filter filter = frameworkProperties.getFilterBuilder()
                 .allOf(anyTag, query);
         return new QueryImpl(filter,

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -350,11 +350,15 @@ public class TestFederation extends AbstractIntegrationTest {
 
         getSecurityPolicy().configureRestForGuest();
 
-        // @formatter:off
         expect("List of active downloads is empty").within(30, SECONDS)
                 .until(() -> when().get(RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl())
-                        .then().log().all().extract().body().jsonPath().getList(""), hasSize(0));
-        // @formatter:on
+                        .then()
+                        .log()
+                        .all()
+                        .extract()
+                        .body()
+                        .jsonPath()
+                        .getList(""), hasSize(0));
 
         if (server != null) {
             server.stop();
@@ -1839,7 +1843,8 @@ public class TestFederation extends AbstractIntegrationTest {
 
         expect("Waiting for activities").within(10, SECONDS)
                 .until(() -> {
-                    List<String> activities = cometDClient.getMessagesInAscOrder(ACTIVITIES_CHANNEL);
+                    List<String> activities =
+                            cometDClient.getMessagesInAscOrder(ACTIVITIES_CHANNEL);
                     if (foundExpectedActivity(activities, filename1, ACTIVITES_STARTED_MESSAGE)
                             && foundExpectedActivity(activities,
                             failFilename,


### PR DESCRIPTION
#### What does this PR do?
Fixes itest failures caused by filters on Metacard.TAGS removing metacards without tags from the query.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard 
@mcalcote 
@spearskw 
@rzwiefel 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic

#### How should this be tested?
Full build and tests

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

