### PR TITLE
DDF-1789 Hide workspace back button in the "Add/Edit Search" view to prevent empty queries from generating in the workspace

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -75,6 +75,7 @@ define([
             initialize: function (options) {
                 _.bindAll(this);
                 this.modelBinder = new Backbone.ModelBinder();
+                $('.back.nav-link').hide();
 
                 // Assign each source id as both the HTML <option>'s
                 // "value" attribute and the <option>'s text. Convert the
@@ -267,6 +268,7 @@ define([
             },
 
             onRender: function () {
+                $('.back.nav-link').hide();
                 var view = this;
 
                 var radiusConverter = function (direction, value) {


### PR DESCRIPTION
#### What does this PR do?
There was a bug where an empty query would be created in a Search UI Workspace if the "< Workspace" back button is clicked on instead of the cancel button. To fix this bug, the "< Workspace" back button has been to hidden to prevent a user from clicking on it in the first place.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@djblue 
@stustison 
@andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@pklinef

#### How should this be tested?
1. Create a Workspace
2. Click on the Workspace
3. Click on the "+" to edit a Worksapce
4. Notice that the "< Workspace" button has disappeared, click "Cancel" to cancel editing a query in a Workspace, and that no empty query was generated in the workspace.

#### What are the relevant tickets?
DDF-1789