### PR TITLE
DDF-2446 Fix view/model sync in query multiselects

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -43,7 +43,8 @@ define([
                 'click .resetButton': 'reset',
                 'click .time': 'clearTime',
                 'click .location': 'clearLocation',
-                'click .type': 'clearType',
+                'click #noType': 'clearType',
+                'click #type': 'setType',
                 'click #locationPoint' : 'drawCircle',
                 'click #locationPolygon' : 'drawPolygon',
                 'click #locationBbox' : 'drawBbox',
@@ -158,6 +159,7 @@ define([
                 }
                 this.model.set('federation','selected');
                 this.updateScrollbar();
+                this.refreshSources();
             },
 
             clearTime: function () {
@@ -195,6 +197,11 @@ define([
                 this.model.set({
                     type: undefined
                 }, {unset: true});
+                this.updateScrollbar();
+            },
+
+            setType: function () {
+                this.refreshTypes();
                 this.updateScrollbar();
             },
 
@@ -264,6 +271,14 @@ define([
                     allTypes = this.types.toJSON();
                 }
                 return _.extend(this.model.toJSON(), {types: allTypes, sources: allSources, isWorkspace: this.isWorkspace, is3D: maptype.is3d(), is2D: maptype.is2d()});
+            },
+
+            refreshSources: function () {
+                $('.select-sources').selectpicker('refresh');
+            },
+
+            refreshTypes: function () {
+                $('.select-types').selectpicker('refresh');
             },
 
             onRender: function () {
@@ -359,11 +374,11 @@ define([
                 // changes when sources are added/removed or
                 // modified (e.g., become available/unavailable)
                 this.sources.bind('add change remove', function() {
-                    $('.select-sources').selectpicker('refresh');
+                    this.refreshSources();
                 });
 
                 this.types.bind('add change remove', function() {
-                    $('.select-types').selectpicker('refresh');
+                    this.refreshTypes();
                 });
 
                 this.initDateTimePicker('#absoluteStartTime');

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/search/searchForm.handlebars
@@ -273,13 +273,13 @@
         </li>
         <li>
             <div class="btn-group btn-group-xs margin-bottom-large" data-toggle="buttons">
-                <label class="btn btn-default type {{#ifNotOr type}}active{{/ifNotOr}}" data-target="#noTypeTab" data-toggle="tab">
+                <label id="noType" class="btn btn-default type {{#ifNotOr type}}active{{/ifNotOr}}" data-target="#noTypeTab" data-toggle="tab">
                     <input type="radio" name="noTypeButton">
                     <i class="fa fa-circle"></i>
                     <i class="fa fa-circle-o"></i>
                     Any
                 </label>
-                <label class="btn btn-default type {{#if type}}active{{/if}}" data-target="#typeTab" data-toggle="tab">
+                <label id="type" class="btn btn-default type {{#if type}}active{{/if}}" data-target="#typeTab" data-toggle="tab">
                     <input type="radio" name="typeButton">
                     <i class="fa fa-circle"></i>
                     <i class="fa fa-circle-o"></i>


### PR DESCRIPTION
#### What does this PR do?
Add refresh calls when Specific Sources or Specific Types are selected.
This keeps them up to the date with the model changes caused by the
other options.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@andrewkfiedler @emanns95
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef
@shaundmorris
@stustison
#### How should this be tested?
Follow the instructions in the ticket and verify it no longer misbehaves. Test both Types and Sources.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2446
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests