### PR TITLE
DDF-2297 Federated queries sometimes fail to return results

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/controller/SearchControllerTest.java
@@ -154,9 +154,14 @@ public class SearchControllerTest {
         when(mockSearchRequest.getSourceIds()).thenReturn(new HashSet<>(Arrays.asList(SOURCE_ID_LIST)));
         when(mockSearchRequest.getQuery()).thenReturn(mockQuery);
         when(mockQuery.getSortBy()).thenReturn(SortBy.NATURAL_ORDER);
-
         when(mockBayeuxServer.getChannel(anyString())).thenReturn(mockServerChannel);
-        when(mockExecutor.submit(any(Runnable.class))).thenReturn(mockFuture);
+        when(mockExecutor.submit(any(Runnable.class))).thenAnswer(
+                (args) -> {
+                    Runnable runnable = (Runnable) args.getArguments()[0];
+                    runnable.run();
+                    return mockFuture;
+                }
+        );
     }
 
     @Test
@@ -530,7 +535,7 @@ public class SearchControllerTest {
                 ServerMessage.Mutable.class);
         when(mockFuture.get(anyLong(), any(TimeUnit.class))).thenThrow(exception);
         searchController.executeQuery(mockSearchRequest, mockServerSession, null);
-        verify(mockServerChannel, times(1)).publish(any(ServerSession.class),
+        verify(mockServerChannel, times(3)).publish(any(ServerSession.class),
                 serverMessageCaptor.capture());
         validateReasonMessageInJson(serverMessageCaptor.getValue(), expectedReasonMessage);
     }

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Progress.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Progress.view.js
@@ -108,6 +108,7 @@ define([
                         this.$el.find('#progress-text').show();
                     }
                 } else {
+                    this.merge();
                     this.$el.find('#progress-text').hide();
                     this.$el.find('#searching-text').show();
                 }


### PR DESCRIPTION
#### What does this PR do?
This change fixes 2 bugs in the processing of federated search results.
First, it fixes a threading bug in SearchController that was blocking results
from being returned to the UI. Code had been added to handle exceptions, but
that code wasn't running in its own thread. As a result, the error-checking
prevented the method from returning.

Second, it fixes a minor bug in the case when the local solr results are
empty and those results weren't being merged into the set of cached
results. This was preventing the progress bar from being updated correctly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@roelens8 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@stustison

#### How should this be tested?

1) install the bundle provided by the bug submitter (available here: https://groups.google.com/forum/#!topic/ddf-users/F_kKYMsiEzg)
2) Perform some queries with various numbers in the search box (10, 20, 30, etc)
   - Verify that the progress bar doesn't hang up
   - Verify that you get back the expected number of results, especially with inputs above 30.

#### Any background context you want to provide?
There is some confusion about the purpose of the timeout setting that the bug reporter mentions. There is no connection between that parameter and the described behavior.

#### What are the relevant tickets?
DDF-2297

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests