### PR TITLE
DDF-2450: Fixes solr exceptions when attributes name clash

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -260,11 +260,21 @@ public class DynamicSchemaResolver {
 
                         attributeValues = byteArrays;
                     }
-                    solrInputDocument.addField(formatIndexName, attributeValues);
-                    if (!(formatIndexName.endsWith(SchemaFields.BINARY_SUFFIX)
-                            || formatIndexName.endsWith(SchemaFields.OBJECT_SUFFIX))) {
-                        solrInputDocument.addField(formatIndexName + SchemaFields.SORT_KEY_SUFFIX,
-                                attributeValues.get(0));
+
+                    // Prevent adding a field already on document
+                    if (solrInputDocument.getFieldValue(formatIndexName) == null) {
+                        solrInputDocument.addField(formatIndexName, attributeValues);
+                        if (!(formatIndexName.endsWith(SchemaFields.BINARY_SUFFIX)
+                                || formatIndexName.endsWith(SchemaFields.OBJECT_SUFFIX))) {
+                            solrInputDocument.addField(
+                                    formatIndexName + SchemaFields.SORT_KEY_SUFFIX,
+                                    attributeValues.get(0));
+                        }
+                    } else {
+                        if (LOGGER.isTraceEnabled()) {
+                            LOGGER.trace("Skipping adding field already found on document ({})",
+                                    formatIndexName);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### What does this PR do?
Fixes exceptions caused by (mostly) duplicate attribute descriptors. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @emanns95 @codice/solr 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison
@pklinef 



#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2450

 - Previously when you would have identically named attributes on a metacard
  solr would throw an exception if you try to store them. This fixes by making
  sure that there is not a field value for a given field name already set on
  the solr document. This will also continue the legacy behavior of the first
  attribute in gets set as the value of a metacard.