### PR TITLE
DDF-2282  Backport - Updated RefreshRegistryEntries remote registry queries to be multi-threaded

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
@@ -19,6 +19,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -45,7 +51,6 @@ import ddf.catalog.operation.Query;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.source.UnsupportedQueryException;
 
 /**
  * Though refreshRegistrySubscriptions in this class is a public method, it should never be called by any
@@ -53,11 +58,12 @@ import ddf.catalog.source.UnsupportedQueryException;
  * route and should avoid elevating privileges for any other service or being exposed to any
  * other endpoint.
  */
-@SuppressWarnings("PackageAccessibility")
 public class RefreshRegistryEntries {
     private static final Logger LOGGER = LoggerFactory.getLogger(RefreshRegistryEntries.class);
 
     private static final int PAGE_SIZE = 1000;
+
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
 
     private List<RegistryStore> registryStores;
 
@@ -67,8 +73,26 @@ public class RefreshRegistryEntries {
 
     private boolean enableDelete = true;
 
+    private ScheduledExecutorService executor;
+
+    private int taskWaitTimeSeconds = 30;
+
+    private int refreshIntervalSeconds = 30;
+
+    private Future scheduledTask;
+
     public RefreshRegistryEntries() {
 
+    }
+
+    public void init() {
+        scheduledTask = executor.scheduleWithFixedDelay(() -> {
+            try {
+                refreshRegistryEntries();
+            } catch (FederationAdminException e) {
+                LOGGER.error("Problem refreshing registry entries.", e);
+            }
+        }, 10, refreshIntervalSeconds, TimeUnit.SECONDS);
     }
 
     /**
@@ -79,6 +103,10 @@ public class RefreshRegistryEntries {
      * @throws FederationAdminException
      */
     public void refreshRegistryEntries() throws FederationAdminException {
+
+        if (!registriesAvailable()) {
+            return;
+        }
 
         RemoteRegistryResults remoteResults = getRemoteRegistryMetacardsMap();
         Map<String, Metacard> remoteRegistryMetacardsMap =
@@ -147,6 +175,13 @@ public class RefreshRegistryEntries {
                 .isPresent();
     }
 
+    private boolean registriesAvailable() {
+        return registryStores.stream()
+                .filter(RegistryStore::isAvailable)
+                .findFirst()
+                .isPresent();
+    }
+
     private Map<String, List<Metacard>> getMetacardRegistryIdMap(Collection<Metacard> metacards) {
         Map<String, List<Metacard>> map = new HashMap<>();
         for (Metacard mcard : metacards) {
@@ -178,40 +213,68 @@ public class RefreshRegistryEntries {
         Map<String, Metacard> remoteRegistryMetacards = new HashMap<>();
         List<String> failedQueries = new ArrayList<>();
         List<String> storesQueried = new ArrayList<>();
-        List<String> localMetacardRegIds;
+        List<String> localMetacardRegIds = getLocalRegistryIds();
+
+        //Create the remote query task to be run.
+        List<Callable<RemoteResult>> tasks = new ArrayList<>();
+        for (RegistryStore store : registryStores) {
+            if (!store.isPullAllowed() || !store.isAvailable()) {
+                continue;
+            }
+            storesQueried.add(store.getRegistryId());
+            tasks.add(() -> {
+                SourceResponse response =
+                        store.query(new QueryRequestImpl(getBasicRegistryQuery()));
+                Map<String, Metacard> results = response.getResults()
+                        .stream()
+                        .map(e -> e.getMetacard())
+                        .filter(e -> !localMetacardRegIds.contains(RegistryUtility.getRegistryId(e)))
+                        .collect(Collectors.toMap(Metacard::getId, Function.identity()));
+                return new RemoteResult(store.getRegistryId(), results);
+
+            });
+        }
+
+        failedQueries.addAll(storesQueried);
+        List<RemoteResult> results = executeTasks(tasks);
+        results.stream()
+                .forEach(result -> {
+                    failedQueries.remove(result.getRegistryId());
+                    remoteRegistryMetacards.putAll(result.getRemoteRegistryMetacards());
+                });
+
+        return new RemoteRegistryResults(remoteRegistryMetacards, failedQueries, storesQueried);
+    }
+
+    private List<RemoteResult> executeTasks(List<Callable<RemoteResult>> tasks) {
+        List<RemoteResult> results = new ArrayList<>();
+        try {
+            List<Future<RemoteResult>> futures = executor.invokeAll(tasks);
+            for (Future<RemoteResult> future : futures) {
+                try {
+                    results.add(future.get(taskWaitTimeSeconds, TimeUnit.SECONDS));
+                } catch (ExecutionException e) {
+                    LOGGER.debug("Error executing query on a remote registry.", e);
+                } catch (TimeoutException e) {
+                    LOGGER.debug("Timeout occurred when querying a remote registry");
+                }
+            }
+        } catch (InterruptedException e) {
+            LOGGER.debug("Remote registry queries interrupted", e);
+        }
+        return results;
+    }
+
+    private List<String> getLocalRegistryIds() throws FederationAdminException {
         try {
             List<Metacard> localMetacards =
                     Security.runAsAdminWithException(() -> federationAdminService.getLocalRegistryMetacards());
-            localMetacardRegIds = localMetacards.stream()
+            return localMetacards.stream()
                     .map(e -> RegistryUtility.getRegistryId(e))
                     .collect(Collectors.toList());
         } catch (Exception e) {
             throw new FederationAdminException("Error querying for local metacards ", e);
         }
-        SourceResponse response;
-        for (RegistryStore store : registryStores) {
-            if (!store.isPullAllowed() || !store.isAvailable()) {
-                continue;
-            }
-
-            try {
-                storesQueried.add(store.getRegistryId());
-                response = store.query(new QueryRequestImpl(getBasicRegistryQuery()));
-                remoteRegistryMetacards.putAll(response.getResults()
-                        .stream()
-                        .map(e -> e.getMetacard())
-                        .filter(e -> !localMetacardRegIds.contains(RegistryUtility.getRegistryId(e)))
-                        .collect(Collectors.toMap(Metacard::getId, Function.identity())));
-            } catch (UnsupportedQueryException e) {
-                LOGGER.warn("Unable to contact {} for registry subscription query", store.getId());
-                LOGGER.debug("Unable to contact {} for registry subscription query",
-                        store.getId(),
-                        e);
-                failedQueries.add(store.getRegistryId());
-                continue;
-            }
-        }
-        return new RemoteRegistryResults(remoteRegistryMetacards, failedQueries, storesQueried);
     }
 
     private void writeRemoteUpdates(List<Metacard> remoteMetacardsToUpdate)
@@ -293,13 +356,67 @@ public class RefreshRegistryEntries {
         this.enableDelete = enableDelete;
     }
 
+    public void setExecutor(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public void setRefreshIntervalSeconds(int refreshIntervalSeconds) {
+        if (this.refreshIntervalSeconds == refreshIntervalSeconds) {
+            return;
+        }
+        this.refreshIntervalSeconds = refreshIntervalSeconds;
+        if (scheduledTask != null) {
+            this.scheduledTask.cancel(false);
+            this.init();
+        }
+    }
+
+    public void setTaskWaitTimeSeconds(Integer taskWaitTimeSeconds) {
+        this.taskWaitTimeSeconds = taskWaitTimeSeconds;
+    }
+
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    LOGGER.error("Thread pool didn't terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+    }
+
+    static class RemoteResult {
+
+        private String registryId;
+
+        private Map<String, Metacard> remoteRegistryMetacards;
+
+        public RemoteResult(String registryId, Map<String, Metacard> remoteRegistryMetacards) {
+            this.registryId = registryId;
+            this.remoteRegistryMetacards = remoteRegistryMetacards;
+        }
+
+        public String getRegistryId() {
+            return registryId;
+        }
+
+        public Map<String, Metacard> getRemoteRegistryMetacards() {
+            return remoteRegistryMetacards;
+        }
+
+    }
+
     private static class RemoteRegistryResults {
 
-        Map<String, Metacard> remoteRegistryMetacards;
+        private Map<String, Metacard> remoteRegistryMetacards;
 
-        List<String> registryStoresQueried;
+        private List<String> registryStoresQueried;
 
-        List<String> failureList;
+        private List<String> failureList;
 
         public RemoteRegistryResults(Map<String, Metacard> remoteRegistryMetacards,
                 List<String> failureList, List<String> storesQueried) {
@@ -309,15 +426,15 @@ public class RefreshRegistryEntries {
         }
 
         public Map<String, Metacard> getRemoteRegistryMetacards() {
-            return remoteRegistryMetacards;
+            return new HashMap<>(remoteRegistryMetacards);
         }
 
         public List<String> getRegistryStoresQueried() {
-            return registryStoresQueried;
+            return new ArrayList<>(registryStoresQueried);
         }
 
         public List<String> getFailureList() {
-            return failureList;
+            return new ArrayList<>(failureList);
         }
     }
 }

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,10 @@
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <ext:property-placeholder/>
 
     <bean id="federationAdminService"
           class="org.codice.ddf.registry.federationadmin.service.impl.FederationAdminServiceImpl">
@@ -25,16 +28,23 @@
     </bean>
 
     <bean id="refreshRegistryEntries"
-          class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
-        <cm:managed-properties persistent-id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
-                               update-strategy="container-managed" />
+          class="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
+          destroy-method="destroy" init-method="init">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries"
+                update-strategy="container-managed"/>
         <property name="federationAdminService" ref="federationAdminService"/>
         <property name="filterBuilder" ref="filterBuilder"/>
         <property name="registryStores" ref="registryStore"/>
+        <property name="executor" ref="registryPollerThreadPool"/>
     </bean>
 
-    <bean id="executor" class="java.util.concurrent.Executors" factory-method="newSingleThreadScheduledExecutor"/>
-
+    <bean id="identityNodeInitializerExecutor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor"/>
+    <bean id="registryPollerThreadPool" class="java.util.concurrent.Executors"
+          factory-method="newScheduledThreadPool">
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
+    </bean>
 
     <bean id="identityNodeInitialization"
           class="org.codice.ddf.registry.federationadmin.service.impl.IdentityNodeInitialization"
@@ -42,7 +52,7 @@
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryTransformer" ref="inputTransformer"/>
         <property name="federationAdminService" ref="federationAdminService"/>
-        <property name="executorService" ref="executor"/>
+        <property name="executorService" ref="identityNodeInitializerExecutor"/>
     </bean>
 
     <bean id="metacardMarshaller"
@@ -51,15 +61,8 @@
     </bean>
 
 
-    <cm:property-placeholder persistent-id="Registry_Federation_Admin_Service"
-                             update-strategy="reload">
-        <cm:default-properties>
-            <cm:property name="registrySubPollerInterval" value="30"/>
-        </cm:default-properties>
-    </cm:property-placeholder>
-
-
-    <reference-list id="registryStore" interface="org.codice.ddf.registry.api.internal.RegistryStore"
+    <reference-list id="registryStore"
+                    interface="org.codice.ddf.registry.api.internal.RegistryStore"
                     availability="optional"/>
 
 
@@ -90,12 +93,5 @@
                filter="(id=rim:RegistryPackage)"/>
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
-
-    <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="ctxRegistrySubPoller">
-        <route>
-            <from uri="timer://registrySubTimer?fixedRate=true&amp;period={{registrySubPollerInterval}}s"/>
-            <to uri="bean:refreshRegistryEntries?method=refreshRegistryEntries"/>
-        </route>
-    </camelContext>
 
 </blueprint>

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -16,9 +16,12 @@
 
     <OCD description="Registry subscription poller" name="Refresh Registry Subscriptions"
          id="org.codice.ddf.registry.federationadmin.service.impl.RefreshRegistryEntries">
-        <AD name="Registry Refresh Interval" id="refreshInterval" required="true"
-            type="String" default="30"
-            description="The refresh interval for the registry subscriptions/updates. In seconds."/>
+        <AD name="Registry Refresh Interval" id="refreshIntervalSeconds" required="true"
+            type="Integer" default="30"
+            description="The refresh interval for the registry subscriptions/updates in seconds."/>
+        <AD name="Registry Query Timeout" id="taskWaitTimeSeconds" required="true"
+            type="Integer" default="30"
+            description="The time to wait for a registry query request to complete in seconds."/>
         <AD name="Enable Stale Metacard Deletion" id="enableDelete" required="true"
             type="Boolean" default="true"
             description="When selected, a registry metacard from a remote registry that is no longer available will be automatically deleted"/>


### PR DESCRIPTION
#### What does this PR do?
Backport for https://github.com/codice/ddf/pull/1183
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@lessarderic

#### How should this be tested?
Verify bamboo build passes
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2282
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

 - Also switched to an internal scheduler for polling instead of a camel route
(cherry picked from commit b6ecb4e)