### PR TITLE
DDF-2449: Registry nodes are now sorted alphabetically.

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.collection.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.collection.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+/*jshint -W024*/
+define([
+    'backbone',
+    './Node'
+], function (Backbone, Node) {
+
+    return Backbone.Collection.extend({
+        model: Node.Model,
+        comparator: function(model){
+            var fedNode = model.getObjectOfType('urn:registry:federation:node');
+            if (fedNode !== null && fedNode.length > 0) {
+                return fedNode[0].Name;
+            }
+        }
+    });
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
@@ -22,13 +22,14 @@ define([
         'q',
         'wreqr',
         'js/model/Node.js',
+        'js/model/Node.collection.js',
         'js/view/NodeModal.view.js',
         'text!templates/registryPage.handlebars',
         'text!templates/nodeList.handlebars',
         'text!templates/nodeRow.handlebars',
         'text!templates/deleteNodeModal.handlebars'
     ],
-    function (ich,Backbone,Marionette,_,$,Q,wreqr,Node,NodeModal,registryPage, nodeList, nodeRow, deleteNodeModal) {
+    function (ich,Backbone,Marionette,_,$,Q,wreqr,Node, NodeCollection, NodeModal,registryPage, nodeList, nodeRow, deleteNodeModal) {
 
         var RegistryView = {};
 
@@ -66,9 +67,9 @@ define([
                 modalRegion: '#registry-modal'
             },
             onRender: function() {
-                this.identityRegion.show(new RegistryView.NodeTable({collection: new Backbone.Collection(this.model.getIdentityNode())}));
-                this.additionalRegion.show(new RegistryView.NodeTable({collection: new Backbone.Collection(this.model.getSecondaryNodes()), multiValued: true}));
-                this.remoteNodeRegion.show(new RegistryView.NodeTable({collection: new Backbone.Collection(this.model.getRemoteNodes()), multiValued:true, readOnly:true}));
+                this.identityRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getIdentityNode())}));
+                this.additionalRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getSecondaryNodes()), multiValued: true}));
+                this.remoteNodeRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getRemoteNodes()), multiValued:true, readOnly:true}));
             },
             showEditNode: function(node) {
                 wreqr.vent.trigger("showModal",


### PR DESCRIPTION
#### What does this PR do?
Sorts registry nodes in the UI alphabetically. 

#### Who is reviewing it?
@garrettfreibott 
@andrewkfiedler 
@clockard 
@vinamartin 

#### Choose 2 committers to review/merge the PR:
@figliold
@shaundmorris

#### How should this be tested?
Ensure DDF passes a full build. Then do the following: 
* Install the registry (if it is not installed already)
* Go to the _DDF Registry_ in the _Admin UI_
* On the first tab (default) called _Node Information_, add some local nodes in a non-alphabetical order with respect to their names. Ensure that the list of nodes remains alphabetically sorted. 
* Delete a node. Ensure the list of nodes remains alphabetically sorted. 
* See Lombardi for a sample CSW xml message that will provide local nodes. _POST_ that message to `/services/csw` and ensure the remote nodes are alphabetically sorted. 

#### Any background context you want to provide?
This is an improvement directly related to community feedback. 

#### Screenshots
![screen shot 2016-09-01 at 1 11 39 pm](https://cloud.githubusercontent.com/assets/7215534/18182682/d2aefae0-7045-11e6-9086-c23c238ecd61.png)

#### Checklist:
- [ ] Documentation Updated