### PR TITLE
DDF-2445: Trash icon for deleting remote registry nodes should verify…

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/deleteNodeModal.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/deleteNodeModal.handlebars
@@ -1,0 +1,32 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h4 class="modal-title">
+                Delete Registry Node: {{name}}
+            </h4>
+        </div>
+        <div class="modal-body">
+            <p>Are you sure you want to delete registry node {{name}}?</p>
+        </div>
+        <div class="modal-footer">
+            <div class="btn-group">
+                <button type="button" class="btn btn-primary submit-button">Delete</button>
+                <button type="button" class="btn btn-default cancel-button" data-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#### What does this PR do?
 This PR displays a modal to confirm deletion of a registry node when the trash icon is clicked.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
 @vinamartin 
 @clockard 
@andrewkfiedler 
@garrettfreibott 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris 
#### How should this be tested?
 Hero Build

Manual Test:
1) Setup two DDFs on your local machine 
   a) You will have to change ports on DDF2 (etc/system.properties and etc/ org.apache.karaf.management.cfg) 
2) Install the Registry App on both DDFs (Manage -> Inactive Applications -> DDF Registry)
3)On DDF2, Add Additional Local Nodes (DDF Registry App -> Node Information -> Additional Local Nodes
4) On DDF1, Configure the CSW Registry Store (DDF Registry App -> Configuration -> CSW Registry Store with using the CSW endpoint address of DDF2 
    a) Registry ID: registry
    b) Registry Service URL: https://localhost:<httpsPortOfDDF2>/services/csw
5) On DDF1, Refresh Remote Nodes until you see the Additional Local Nodes that you created on DDF2 appear under Remote Nodes on DDF1
6) On DDF1, attempt to delete local and remote nodes and observe that a modal appears for conformation.
#### Any background context you want to provide?
#### What are the relevant tickets?
 DDF-2445
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

![screen shot 2016-09-02 at 1 03 05 pm](https://cloud.githubusercontent.com/assets/4838043/18217099/cc2d64e8-710f-11e6-8ae2-98ccd8bac278.png)

