### PR TITLE
DDF-2455 SchematronValidationService incorrectly appears as a source type

### DIFF
--- a/catalog/admin/admin-poller-service/pom.xml
+++ b/catalog/admin/admin-poller-service/pom.xml
@@ -59,6 +59,11 @@
             <groupId>ddf.action.core</groupId>
             <artifactId>action-core-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -104,22 +109,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>.55</minimum>
+                                            <minimum>.60</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>.62</minimum>
+                                            <minimum>.70</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>.45</minimum>
+                                            <minimum>.60</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>.53</minimum>
+                                            <minimum>.60</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,6 +12,7 @@
  **/
 -->
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xsi:schemaLocation="
   http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
@@ -29,7 +30,22 @@
           init-method="init"
           destroy-method="destroy">
         <argument ref="configurationAdmin"/>
+        <cm:managed-properties persistent-id="org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean"
+                               update-strategy="container-managed"/>
         <property name="reportActionProviders" ref="reportActionProviders"/>
         <property name="operationActionProviders" ref="operationActionProviders"/>
+        <property name="includeAsSource">
+            <list>
+                <value>*source*</value>
+                <value>*Source*</value>
+                <value>*service*</value>
+                <value>*Service*</value>
+            </list>
+        </property>
+        <property name="excludeAsSource">
+            <list>
+                <value>ddf.services.schematron.SchematronValidationService</value>
+            </list>
+        </property>
     </bean>
 </blueprint>

--- a/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="Admin Poller Service"
+         name="Admin Poller Service"
+         id="org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean">
+
+        <AD name="Included FactoryPids:" id="includeAsSource"
+            description="LDAP patterns that will select the ManagedServiceFactory pids being used to
+            create a list of configurable source types. Adding a pattern to this list allows it to
+            be listed as a configurable source type in the Sources tab of the Admin UI. Excluded
+             patterns will take precedence over included patterns. The pattern can be an exact,
+             case-sensitive match, or '*' can be used as a wildcard.
+            Ex: '*source' will match anything ending in 'source'."
+            required="true" type="String" default="*source*,*Source*,*service*,*Service*" cardinality="100"/>
+
+        <AD name="Excluded FactoryPids:" id="excludeAsSource"
+            description="LDAP patterns that will filter out ManagedServiceFactory pids being used to
+            create a list of configurable source types. Adding a factoryPid to this list will ensure that it
+            will not be listed as a configurable source type in the Sources tab of the Admin UI. The pattern
+            can be an exact, case-sensitive match, or '*' can be used as a wildcard.
+            Ex: '*source*' will match anything containing 'source'."
+            required="true" type="String" default="ddf.services.schematron.SchematronValidationService" cardinality="100"/>
+
+    </OCD>
+
+    <Designate
+            pid="org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean">
+        <Object ocdref="org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/admin/admin-poller-service/src/test/groovy/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanTest.groovy
+++ b/catalog/admin/admin-poller-service/src/test/groovy/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanTest.groovy
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.admin.poller
+
+import spock.lang.Specification
+
+class AdminPollerServiceBeanTest extends Specification {
+
+    def "test LDAP filter generation"() {
+        setup:
+        def apsb = new AdminPollerServiceBean(null)
+        apsb.setIncludeAsSource(includes)
+        apsb.setExcludeAsSource(excludes)
+
+        expect:
+        apsb.getFilterProperties() == filter
+
+        where:
+        includes                | excludes          | filter
+        null                    | null              | "(|(service.factoryPid=*))"
+        []                      | []                | "(|(service.factoryPid=*))"
+        ["foo", "bar"]          | []                | "(|(service.factoryPid=foo)(service.factoryPid=bar))"
+        []                      | ["foo"]           | "(&(|(service.factoryPid=*))(&(!(service.factoryPid=foo))))"
+        ["fus", "roh", "dah"]   | ["foo", "bar"]    | "(&(|(service.factoryPid=fus)(service.factoryPid=roh)(service.factoryPid=dah))(&(!(service.factoryPid=foo))(!(service.factoryPid=bar))))"
+    }
+}

--- a/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
+++ b/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
@@ -183,11 +183,11 @@ public class AdminPollerTest {
                 // Mock out the metatypes
                 Map<String, Object> metatype = new HashMap<>();
                 metatype.put("id", "OpenSearchSource");
-                metatype.put("metatype", new ArrayList<Map<String, Object>>());
+                metatype.put("OSGI-INF/blueprint/metatype", new ArrayList<Map<String, Object>>());
 
                 Map<String, Object> noConfigMetaType = new HashMap<>();
                 noConfigMetaType.put("id", "No Configurations");
-                noConfigMetaType.put("metatype", new ArrayList<Map<String, Object>>());
+                noConfigMetaType.put("OSGI-INF/blueprint/metatype", new ArrayList<Map<String, Object>>());
 
                 when(helper.getMetatypes()).thenReturn(CollectionUtils.asList(metatype,
                         noConfigMetaType));

--- a/distribution/docs/src/main/resources/_contents/configuring-from-the-admin-console-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/configuring-from-the-admin-console-contents.adoc
@@ -80,6 +80,13 @@ Configuration via this page could result in an unstable system.
 Proceed with caution!
 ====
 
+====== Configuring Admin Poller Source Types
+Configurable source types can be adjusted by including or excluding the FactoryPid of the ManagedServiceFactory
+producing the source. By default all FactoryPids including the words *source* or *service* are included.
+If this produces undesirable results, patterns can be added via the Admin Poller Service to include
+or exclude specific FactoryPids. The system must be restarted for changes to take effect. Patterns
+are case senstive and can be exact matches or use * as a wildcard.
+
 ===== Managing Features Using the ${admin-console}
 
 . Select the appropriate application.


### PR DESCRIPTION
#### What does this PR do?
Allows the filter being used to generate the list of source types to be configured from the admin UI. The default settings no longer list Schematron and any other offending pids can be easily excluded through the UI.
Updates documentation about this process.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@tbatie @ryeats 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@shaundmorris 

#### How should this be tested?
1. Make sure Schematron Validation Services doesn't appear as an source configuration option in the Catalog UI upon first starting the system.
2. Confirm the Admin Poller Service modal works on the System tab of the Admin UI
3. Confirm Schematron's the default settings appear in the modal (see screenshot).
4. Add a few patterns (\*csw\*, \*Csw\*, \*Federated\*, \*federated\*) and restart ddf to confirm that adding to the filter list removes sources.
5. Since the modal has been acting up, re-install ddf and confirm the modal appears on the first click without having to refresh the page.

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2455

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/10200041/18367852/df3fee90-75d1-11e6-982b-4fcee7f864af.png)


![image](https://cloud.githubusercontent.com/assets/10200041/18367873/f544ca94-75d1-11e6-809e-cb31e49f0e3f.png)


#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

