### PR TITLE
DDF-2393:fixed branding usage in docs intro

### DIFF
--- a/distribution/docs/src/main/resources/_contents/introduction-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/introduction-contents.adoc
@@ -1,4 +1,4 @@
-${ddf-branding-expanded} (${branding}) is a free and open-source common data layer that abstracts services and business logic from the underlying data structures to enable rapid integration of new data sources.
+${ddf-branding-expanded} (${ddf-branding}) is a free and open-source common data layer that abstracts services and business logic from the underlying data structures to enable rapid integration of new data sources.
 
 Licensed under http://www.gnu.org/licenses/gpl.html[LGPL], ${ddf-branding} is an interoperability platform that provides secure and scalable discovery and retrieval from a wide array of disparate sources.
 
@@ -13,27 +13,27 @@ ${ddf-branding} is:
 ${branding} is comprised of several modular applications, to be installed or uninstalled as needed.
 
 ${ddf-branding} Administrative Application::
-The administrative application enhances administrative capabilities when installing and managing ${branding}. It contains various services and interfaces that allow administrators more control over their systems.
+_${ddf-branding} version ${ddf.version}_ Enhances administrative capabilities when installing and managing ${branding}. It contains various services and interfaces that allow administrators more control over their systems.
 
 ${ddf-branding} Catalog Application::
-The ${branding} Catalog provides a framework for storing, searching, processing, and transforming information.
-Clients typically perform local and/or federated query, create, read, update, and delete (QCRUD) operations against the Catalog.
+_${ddf-branding} version ${ddf.version}_ Provides a framework for storing, searching, processing, and transforming information.
+Clients typically perform local and/or federated create, read, update, and delete (CRUD) operations against the Catalog.
 At the core of the Catalog functionality is the *Catalog Framework*, which routes all requests and responses through the system, invoking additional processing per the system configuration.
 
 ${ddf-branding} Platform Application::
-The Platform application is considered to be a core application of the distribution.
+_${ddf-branding} version ${ddf.version}_ Core application of the distribution.
 The Platform application has fundamental building blocks that the distribution needs to run.
 
 ${ddf-branding} Security Application::
-The Security application provides authentication, authorization, and auditing services for the ${branding}.
+_${ddf-branding} version ${ddf.version}_ Provides authentication, authorization, and auditing services for the ${branding}.
 It is both a framework that developers and integrators can extend and a reference implementation that meets security requirements.
 
 ${ddf-branding} Solr Catalog Application::
-The Solr Catalog Provider (SCP) is an implementation of the `CatalogProvider` interface using http://lucene.apache.org/solr/[Apache Solr] as a data store.
+_${ddf-branding} version ${ddf.version}_ Include the Solr Catalog Provider (SCP), an implementation of the `CatalogProvider` interface using http://lucene.apache.org/solr/[Apache Solr] as a data store.
 
 ${ddf-branding} Spatial Application::
-The ${ddf-branding} Spatial Application provides KML transformer and a KML network link endpoint that allows a user to generate a View-based KML Query Results Network Link.
+_${ddf-branding} version ${ddf.version}_ Provides KML transformer and a KML network link endpoint that allows a user to generate a View-based KML Query Results Network Link.
 
 ${ddf-branding} Standard Search UI::
-The ${ddf-branding} Standard Search UI application allows a user to search for records in the local Catalog (provider) and federated sources.
+_${ddf-branding} version ${ddf.version}_ Allows a user to search for records in the local Catalog (provider) and federated sources.
 Results of the search are returned and displayed on a globe or map, providing a visual representation of where the records were found.


### PR DESCRIPTION
#### What does this PR do?

Updates use of ${branding} in Introductory section of documentation that should be ${ddf-branding}.

#### Who is reviewing it? 

@mcalcote @vinamartin
#### Choose 2 committers to review/merge the PR.

@coyotesqrl
@shaundmorris

#### How should this be tested?

docs render correctly. 

#### Any background context you want to provide?


#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2393

#### Screenshots (if appropriate)
n/a
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

