### PR TITLE
DDF-2458 Provide finer grain control of registry write operations

### DIFF
--- a/catalog/spatial/registry/registry-policy-plugin/src/main/java/org/codice/ddf/registry/policy/RegistryPolicyPlugin.java
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/java/org/codice/ddf/registry/policy/RegistryPolicyPlugin.java
@@ -44,16 +44,6 @@ public class RegistryPolicyPlugin implements PolicyPlugin {
 
     private Set<String> registryEntryIds = new HashSet<>();
 
-    private List<String> registryBypassPolicyStrings;
-
-    private List<String> createAccessPolicyStrings;
-
-    private List<String> updateAccessPolicyStrings;
-
-    private List<String> deleteAccessPolicyStrings;
-
-    private List<String> readAccessPolicyStrings;
-
     private Map<String, Set<String>> bypassAccessPolicy = new HashMap<>();
 
     private Map<String, Set<String>> createAccessPolicy = new HashMap<>();
@@ -107,44 +97,19 @@ public class RegistryPolicyPlugin implements PolicyPlugin {
         this.registryDisabled = registryDisabled;
     }
 
-    /**
-     * Getter for the permissions string array
-     *
-     * @return The list of bypass permissions
-     */
-    public List<String> getRegistryBypassPolicyStrings() {
-        return this.registryBypassPolicyStrings;
-    }
-
-    public List<String> getCreateAccessPolicyStrings() {
-        return createAccessPolicyStrings;
-    }
-
     public void setCreateAccessPolicyStrings(List<String> accessPolicyStrings) {
-        this.createAccessPolicyStrings = accessPolicyStrings;
         parsePermissionsFromString(accessPolicyStrings, createAccessPolicy);
     }
 
     public void setUpdateAccessPolicyStrings(List<String> accessPolicyStrings) {
-        this.updateAccessPolicyStrings = accessPolicyStrings;
         parsePermissionsFromString(accessPolicyStrings, updateAccessPolicy);
     }
 
-    public List<String> getDeleteAccessPolicyStrings() {
-        return deleteAccessPolicyStrings;
-    }
-
     public void setDeleteAccessPolicyStrings(List<String> accessPolicyStrings) {
-        this.deleteAccessPolicyStrings = accessPolicyStrings;
         parsePermissionsFromString(accessPolicyStrings, deleteAccessPolicy);
     }
 
-    public List<String> getReadAccessPolicyStrings() {
-        return readAccessPolicyStrings;
-    }
-
     public void setReadAccessPolicyStrings(List<String> readAccessPolicyStrings) {
-        this.readAccessPolicyStrings = readAccessPolicyStrings;
         parsePermissionsFromString(readAccessPolicyStrings, readAccessPolicy);
     }
 
@@ -154,7 +119,6 @@ public class RegistryPolicyPlugin implements PolicyPlugin {
      * @param permStrings The list of bypass permissions
      */
     public void setRegistryBypassPolicyStrings(List<String> permStrings) {
-        this.registryBypassPolicyStrings = permStrings;
         parsePermissionsFromString(permStrings, bypassAccessPolicy);
     }
 
@@ -169,7 +133,8 @@ public class RegistryPolicyPlugin implements PolicyPlugin {
         policy.clear();
         if (permStrings != null) {
             for (String perm : permStrings) {
-                String[] parts = perm.split("=");
+                String[] parts = perm.trim()
+                        .split("=");
                 if (parts.length == 2) {
                     String attributeName = parts[0];
                     String attributeValue = parts[1];

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,17 +11,29 @@
  *
  **/
 -->
-<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <bean id="registryPolicyPlugin" class="org.codice.ddf.registry.policy.RegistryPolicyPlugin">
         <cm:managed-properties persistent-id="org.codice.ddf.registry.policy.RegistryPolicyPlugin"
-                               update-strategy="container-managed" />
+                               update-strategy="container-managed"/>
         <property name="registryBypassPolicyStrings">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin</value>
+                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin
+                </value>
             </array>
         </property>
-        <property name="writeAccessPolicyStrings">
+        <property name="createAccessPolicyStrings">
+            <array>
+                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+            </array>
+        </property>
+        <property name="updateAccessPolicyStrings">
+            <array>
+                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+            </array>
+        </property>
+        <property name="deleteAccessPolicyStrings">
             <array>
                 <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
             </array>

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,7 +17,7 @@
          name="Registry Policy Plugin"
          id="org.codice.ddf.registry.policy.RegistryPolicyPlugin">
 
-        <AD description="Roles/attributes required for create operations. Example: {role=role1;type=type1}"
+        <AD description="Roles/attributes required for create operations on registry entries. Example: {role=role1;type=type1}"
             name="Registry Create Attributes" id="createAccessPolicyStrings" required="true"
             type="String" cardinality="100"
             default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,26 +17,41 @@
          name="Registry Policy Plugin"
          id="org.codice.ddf.registry.policy.RegistryPolicyPlugin">
 
-        <AD description="Roles/attributes required for CUD (create/update/delete) operations on registry entries. Example: {role=role1;type=type1}"
-            name="Registry CUD Attributes" id="writeAccessPolicyStrings" required="true" type="String" cardinality="100"
+        <AD description="Roles/attributes required for create operations. Example: {role=role1;type=type1}"
+            name="Registry Create Attributes" id="createAccessPolicyStrings" required="true"
+            type="String" cardinality="100"
+            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+
+        <AD description="Roles/attributes required for update operations on registry entries. Example: {role=role1;type=type1}"
+            name="Registry Update Attributes" id="updateAccessPolicyStrings" required="true"
+            type="String" cardinality="100"
+            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+
+        <AD description="Roles/attributes required for delete operations on registry entries. Example: {role=role1;type=type1}"
+            name="Registry Delete Attributes" id="deleteAccessPolicyStrings" required="true"
+            type="String" cardinality="100"
             default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
 
         <AD description="Roles/attributes required for reading registry entries. Example: {role=role1;type=type1}"
-            name="Registry Read Attributes" id="readAccessPolicyStrings" required="true" type="String" cardinality="100"
+            name="Registry Read Attributes" id="readAccessPolicyStrings" required="true"
+            type="String" cardinality="100"
             default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
 
         <AD description="Roles/attributes required for an admin to bypass all filtering/access controls. Example: {role=role1;type=type1}"
-            name="Registry Admin Attributes" id="registryBypassPolicyStrings" required="true" type="String" cardinality="100"
+            name="Registry Admin Attributes" id="registryBypassPolicyStrings" required="true"
+            type="String" cardinality="100"
             default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin"/>
 
         <AD description="Disables all write access to registry entries in the catalog. Only users with Registry Admin Attributes will be able to write registry entries"
-            name="Disable Registry Write Access" id="registryDisabled" required="false" type="Boolean"/>
+            name="Disable Registry Write Access" id="registryDisabled" required="false"
+            type="Boolean"/>
 
         <AD description="A flag indicating whether or not the Registry Entry Ids represent a 'white list' (allowed - checked) or a 'black list' (blocked - unchecked) ids"
             name="Entries are White List" id="whiteList" required="false" type="Boolean"/>
 
         <AD description="List of registry entry ids to be used in the white/black list."
-            name="Registry Entries Ids" id="registryEntryIds" required="false" type="String" cardinality="1000"/>
+            name="Registry Entries Ids" id="registryEntryIds" required="false" type="String"
+            cardinality="1000"/>
     </OCD>
 
     <Designate pid="org.codice.ddf.registry.policy.RegistryPolicyPlugin">

--- a/catalog/spatial/registry/registry-policy-plugin/src/test/java/org/codice/ddf/registry/policy/RegistryPolicyPluginTest.java
+++ b/catalog/spatial/registry/registry-policy-plugin/src/test/java/org/codice/ddf/registry/policy/RegistryPolicyPluginTest.java
@@ -84,6 +84,8 @@ public class RegistryPolicyPluginTest {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
         rpp.setCreateAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setUpdateAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setDeleteAccessPolicyStrings(Collections.singletonList("role=guest"));
 
         Metacard mcard = new MetacardImpl();
         mcard.setAttribute(new AttributeImpl(Metacard.TAGS, RegistryConstants.REGISTRY_TAG));
@@ -93,9 +95,9 @@ public class RegistryPolicyPluginTest {
         PolicyResponse response = rpp.processPreCreate(mcard, null);
         assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
         response = rpp.processPreUpdate(mcard, null);
-        assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
+        assertThat(response.operationPolicy(), equalTo(rpp.getUpdateAccessPolicy()));
         response = rpp.processPreDelete(Collections.singletonList(mcard), null);
-        assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
+        assertThat(response.operationPolicy(), equalTo(rpp.getDeleteAccessPolicy()));
 
     }
 
@@ -118,7 +120,7 @@ public class RegistryPolicyPluginTest {
     public void testRemoteCudOperations() throws Exception {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
-        rpp.setDeleteAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setCreateAccessPolicyStrings(Collections.singletonList("role=guest"));
 
         Metacard mcard = new MetacardImpl();
         mcard.setAttribute(new AttributeImpl(Metacard.TAGS, RegistryConstants.REGISTRY_TAG));
@@ -208,6 +210,8 @@ public class RegistryPolicyPluginTest {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
         rpp.setCreateAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setUpdateAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setDeleteAccessPolicyStrings(Collections.singletonList("role=guest"));
         rpp.setReadAccessPolicyStrings(Collections.singletonList("role=guest"));
         rpp.setRegistryEntryIds(Collections.singleton("1234567890abcdefg987654321"));
 
@@ -260,6 +264,7 @@ public class RegistryPolicyPluginTest {
                 .operationPolicy()
                 .isEmpty(), is(true));
 
+        assertThat(rpp.isWhiteList(), is(false));
     }
 
     private RegistryPolicyPlugin createRegistryPlugin() {

--- a/catalog/spatial/registry/registry-policy-plugin/src/test/java/org/codice/ddf/registry/policy/RegistryPolicyPluginTest.java
+++ b/catalog/spatial/registry/registry-policy-plugin/src/test/java/org/codice/ddf/registry/policy/RegistryPolicyPluginTest.java
@@ -83,7 +83,7 @@ public class RegistryPolicyPluginTest {
     public void testCudRegistryOperations() throws Exception {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
-        rpp.setWriteAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setCreateAccessPolicyStrings(Collections.singletonList("role=guest"));
 
         Metacard mcard = new MetacardImpl();
         mcard.setAttribute(new AttributeImpl(Metacard.TAGS, RegistryConstants.REGISTRY_TAG));
@@ -91,11 +91,11 @@ public class RegistryPolicyPluginTest {
         mcard.setAttribute(new AttributeImpl(Metacard.ID, "1234567890abcdefg987654321"));
 
         PolicyResponse response = rpp.processPreCreate(mcard, null);
-        assertThat(response.operationPolicy(), equalTo(rpp.getWriteAccessPolicy()));
+        assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
         response = rpp.processPreUpdate(mcard, null);
-        assertThat(response.operationPolicy(), equalTo(rpp.getWriteAccessPolicy()));
+        assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
         response = rpp.processPreDelete(Collections.singletonList(mcard), null);
-        assertThat(response.operationPolicy(), equalTo(rpp.getWriteAccessPolicy()));
+        assertThat(response.operationPolicy(), equalTo(rpp.getCreateAccessPolicy()));
 
     }
 
@@ -118,7 +118,7 @@ public class RegistryPolicyPluginTest {
     public void testRemoteCudOperations() throws Exception {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
-        rpp.setWriteAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setDeleteAccessPolicyStrings(Collections.singletonList("role=guest"));
 
         Metacard mcard = new MetacardImpl();
         mcard.setAttribute(new AttributeImpl(Metacard.TAGS, RegistryConstants.REGISTRY_TAG));
@@ -207,7 +207,7 @@ public class RegistryPolicyPluginTest {
     public void testUnusedMethods() throws Exception {
         RegistryPolicyPlugin rpp = createRegistryPlugin();
         rpp.setRegistryBypassPolicyStrings(Collections.singletonList("role=system-admin"));
-        rpp.setWriteAccessPolicyStrings(Collections.singletonList("role=guest"));
+        rpp.setCreateAccessPolicyStrings(Collections.singletonList("role=guest"));
         rpp.setReadAccessPolicyStrings(Collections.singletonList("role=guest"));
         rpp.setRegistryEntryIds(Collections.singleton("1234567890abcdefg987654321"));
 
@@ -216,7 +216,7 @@ public class RegistryPolicyPluginTest {
                 .get("role")
                 .iterator()
                 .next(), equalTo("system-admin"));
-        assertThat(rpp.getWriteAccessPolicy()
+        assertThat(rpp.getCreateAccessPolicy()
                 .get("role")
                 .iterator()
                 .next(), equalTo("guest"));


### PR DESCRIPTION
#### What does this PR do?
Currently the RegistryPolicyPlugin only has one configuration for all write operations (create/update/delete). This PR provides a way to configure access to each individual type of operation so you can control the create/update/delete operations separately.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @vinamartin @gordocanchola @brianfelix 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold

#### How should this be tested?
Build and confirm Registry Operations perform as expected

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2458 
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
