### PR TITLE
DDF-2452: Added javadoc and sources to the release profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,16 +8,24 @@
 *.DS_Store
 node_modules/
 node/
-target/
 bin/
 atlassian-ide-plugin.xml
 *.sonar-ide.properties
 **/webapp/css/styles.css
 platform/solr/**/overlays
-dependency-reduced-pom.xml
 
 # JMeter Related files to ignore
 jmeter.log
 *.jmx.log
 *.jtl
 
+# Maven Ignores (https://raw.githubusercontent.com/github/gitignore/master/Maven.gitignore)
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -159,7 +159,7 @@
             </build>
         </profile>
         <profile>
-            <id>javadoc-unpack</id>
+            <id>release</id>
             <dependencies>
                 <dependency>
                     <groupId>ddf.catalog.core</groupId>

--- a/libs/activities/pom.xml
+++ b/libs/activities/pom.xml
@@ -24,26 +24,6 @@
     <packaging>jar</packaging>
     <name>DDF :: Activities</name>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <!--
-                         Reverted back to Maven Release Plugin 2.4.1 to release activities. Using
-                         2.4.1 requires the use of a git version prior to 1.8.4.
-                         At some point this should be upgraded to 2.5. The issue that occurred
-                         was the maven release plugin was not committing during the release.
-                     -->
-                    <version>2.4.1</version>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>clean verify install</preparationGoals>
-                        <pushChanges>false</pushChanges>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/libs/checksum/pom.xml
+++ b/libs/checksum/pom.xml
@@ -43,16 +43,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <preparationGoals>clean verify install</preparationGoals>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/libs/common-system/pom.xml
+++ b/libs/common-system/pom.xml
@@ -31,16 +31,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <preparationGoals>clean verify install</preparationGoals>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/libs/notifications/pom.xml
+++ b/libs/notifications/pom.xml
@@ -24,26 +24,6 @@
     <packaging>jar</packaging>
     <name>DDF :: Notifications</name>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <!--
-                         Reverted back to Maven Release Plugin 2.4.1 to release activities. Using
-                         2.4.1 requires the use of a git version prior to 1.8.4.
-                         At some point this should be upgraded to 2.5. The issue that occurred
-                         was the maven release plugin was not committing during the release.
-                     -->
-                    <version>2.4.1</version>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>clean verify install</preparationGoals>
-                        <pushChanges>false</pushChanges>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -45,16 +45,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <preparationGoals>clean verify install</preparationGoals>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -336,9 +336,9 @@
                     <version>2.5.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>clean verify install</preparationGoals>
+                        <preparationGoals>clean install</preparationGoals>
                         <pushChanges>false</pushChanges>
-                        <arguments>-Pjavadoc-unpack ${arguments}</arguments>
+                        <arguments>-Prelease ${arguments}</arguments>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -624,12 +624,32 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <distributionManagement>
-                <site>
-                    <id>reports</id>
-                    <url>${reports.repository.url}/${version}</url>
-                </site>
-            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>owasp</id>


### PR DESCRIPTION
#### What does this PR do?

* Adds javadocs to release profile
* Adds sources to the release profile
* Ensures release profile is triggered during release
* Adds additional gitignores for maven
* Removes unnecessary maven-release-plugin configurations from child modules

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@codice/continuous-integration 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@shaundmorris

#### How should this be tested?

* Run `mvn release:prepare -Dmaven.repo.local=/tmp/m2` this should create javadoc and source jars for all artifacts

#### Any background context you want to provide?

Previously javadoc and source jars were not created automatically during a release

#### What are the relevant tickets?

[DDF-2452](https://codice.atlassian.net/browse/DDF-2452)

#### Checklist:
- [ ] Documentation Updated

