### PR TITLE
DDF-2345 -> 2.9.X Further enforced registry node date formatting

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Segment.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Segment.js
@@ -42,7 +42,7 @@ define([
                 properties['value' + i] = values[i];
             }
         } else if (values && field.get('type') === 'date') {
-            var dateTime = moment(values).utc();
+            var dateTime = moment.parseZone(values).utc();
 
             if (!dateTime.isValid()) {
                 dateTime = moment().utc();

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
@@ -18,6 +18,7 @@ define([
         'backbone',
         'marionette',
         'underscore',
+        'moment',
         'jquery',
         'q',
         'wreqr',
@@ -29,7 +30,7 @@ define([
         'text!templates/nodeRow.handlebars',
         'text!templates/deleteNodeModal.handlebars'
     ],
-    function (ich,Backbone,Marionette,_,$,Q,wreqr,Node, NodeCollection, NodeModal,registryPage, nodeList, nodeRow, deleteNodeModal) {
+    function (ich,Backbone,Marionette,_,moment,$,Q,wreqr,Node, NodeCollection, NodeModal,registryPage, nodeList, nodeRow, deleteNodeModal) {
 
         var RegistryView = {};
 
@@ -188,6 +189,16 @@ define([
                 if(extrinsicData.length === 1) {
                     data.name = extrinsicData[0].Name;
                     data.slots = extrinsicData[0].Slot;
+                    data.slots.forEach(function (slotValue) {
+                        if (slotValue.slotType === "xs:dateTime") {
+                            var date = moment.parseZone(slotValue.value[0]).utc().format('MMM DD, YYYY HH:mm') + 'Z';
+                            if (slotValue.name === "lastUpdated") {
+                                data.lastUpdated = date;
+                            } else if (slotValue.name === "liveDate") {
+                                data.liveDate = date;
+                            }
+                        }
+                    });
                 }
                 return data;
             }

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/nodeRow.handlebars
@@ -26,18 +26,10 @@
     </div>
 </td>
 <td>
-    {{#each slots}}
-        {{#is name "liveDate"}}
-            <label class="label">{{value}}</label>
-        {{/is}}
-    {{/each}}
+    <label class="label">{{liveDate}}</label>
 </td>
 <td>
-    {{#each slots}}
-        {{#is name "lastUpdated"}}
-            <label class="label">{{value}}</label>
-        {{/is}}
-    {{/each}}
+    <label class="label">{{lastUpdated}}</label>
 </td>
 <td/>
 <td>


### PR DESCRIPTION
#### What does this PR do?
Normalizes the dates which previously may have been formatted differently than CSW nodes, this change ensures they will appear consistently when viewing the various nodes from the Local Node UI. This also improves the dates' user readability in the ui across all supported browsers.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @vinamartin @gordocanchola @brianfelix @andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison 
@shaundmorris 

#### How should this be tested?
Start Registry App and use the remote node ui to connect to a node with non-normalized dates, then navigate to the local node ui and observe the live dates formatting. **Please see me** for specific steps to verify the original issue has been addressed.

**Hero testing should confirm the changes in Firefox, IE and Chrome**

#### Any background context you want to provide?
The previous work under DDF-2345 was bug fixes and implementing the moment.js library so I chose to use the same ticket number for this issue as well.

#### What are the relevant tickets?
DDF-2345 Update Registry Node Info screen to handle invalid dates

**MERGED https://github.com/codice/ddf/pull/1214**

#### Screenshots (if appropriate)
![ddf2345](https://cloud.githubusercontent.com/assets/11355332/18140546/df043b7e-6f6a-11e6-99a6-9a035ab1ce41.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

