### PR TITLE
DDF-2466 Updated CswQueryResponseTransformer to handle a CatalogTrans…

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
@@ -99,9 +99,9 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
 
     private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
 
-    private static final String NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE = "numberOfRecordsMatched";
+    public static final String NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE = "numberOfRecordsMatched";
 
-    private static final String NEXT_RECORD_ATTRIBUTE = "nextRecord";
+    public static final String NEXT_RECORD_ATTRIBUTE = "nextRecord";
 
     private static final String RECORD_SCHEMA_ATTRIBUTE = "recordSchema";
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
@@ -25,6 +25,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -297,7 +298,7 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
                 try {
                     contents[index] = completedFuture.get()
                             .getInputStream();
-                } catch (ExecutionException e) {
+                } catch (ExecutionException | CancellationException | InterruptedException e) {
                     LOGGER.debug("Error transforming Metacard", e);
                     numResults.decrementAndGet();
                 } finally {

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/CswQueryResponseTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -34,6 +34,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.activation.MimeType;
 import javax.xml.XMLConstants;
@@ -66,6 +67,7 @@ import ddf.catalog.transform.MetacardTransformer;
 import ddf.catalog.transform.QueryResponseTransformer;
 import ddf.catalog.transformer.api.PrintWriter;
 import ddf.catalog.transformer.api.PrintWriterProvider;
+
 import net.opengis.cat.csw.v_2_0_2.AcknowledgementType;
 import net.opengis.cat.csw.v_2_0_2.EchoedRequestType;
 import net.opengis.cat.csw.v_2_0_2.ElementSetType;
@@ -189,6 +191,17 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
             nextRecord = 0;
         }
 
+        String metacardsString = null;
+        AtomicLong numReturned = new AtomicLong(cswRecordCollection.getNumberOfRecordsReturned());
+
+        if (!ResultType.HITS.equals(cswRecordCollection.getResultType())) {
+            arguments.put(CswConstants.OMIT_XML_DECLARATION, Boolean.TRUE);
+            metacardsString = multiThreadedMarshal(results,
+                    numReturned,
+                    cswRecordCollection.getOutputSchema(),
+                    arguments);
+        }
+
         if (!cswRecordCollection.isById()) {
             writer.addAttribute(VERSION_ATTRIBUTE, CswConstants.VERSION_2_0_2);
 
@@ -208,14 +221,13 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
             writer.endNode();
 
             writer.startNode(SEARCH_RESULTS_QNAME);
-            writer.addAttribute(NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE,
-                    Long.toString(cswRecordCollection.getNumberOfRecordsMatched()));
+            writer.addAttribute(NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE, Long.toString(
+                    cswRecordCollection.getNumberOfRecordsMatched()));
 
             if (ResultType.HITS.equals(cswRecordCollection.getResultType())) {
                 writer.addAttribute(NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE, Long.toString(0));
             } else {
-                writer.addAttribute(NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE,
-                        Long.toString(cswRecordCollection.getNumberOfRecordsReturned()));
+                writer.addAttribute(NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE, numReturned.toString());
                 writer.addAttribute(NEXT_RECORD_ATTRIBUTE, Long.toString(nextRecord));
             }
 
@@ -231,11 +243,6 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
         }
 
         if (!ResultType.HITS.equals(cswRecordCollection.getResultType())) {
-            arguments.put(CswConstants.OMIT_XML_DECLARATION, Boolean.TRUE);
-
-            String metacardsString = multiThreadedMarshal(results,
-                    cswRecordCollection.getOutputSchema(),
-                    arguments);
             writer.setRawValue(metacardsString);
         }
 
@@ -255,54 +262,65 @@ public class CswQueryResponseTransformer implements QueryResponseTransformer {
           fixed work-queue.
      */
     //private void multiThreadedMarshal(PrintWriter writer, List<Result> results,
-    private String multiThreadedMarshal(List<Result> results, String recordSchema,
-            final Map<String, Serializable> arguments) throws CatalogTransformerException {
+    private String multiThreadedMarshal(List<Result> results, AtomicLong numResults,
+            String recordSchema, final Map<String, Serializable> arguments)
+            throws CatalogTransformerException {
 
         CompletionService<BinaryContent> completionService = new ExecutorCompletionService<>(
                 queryExecutor);
 
-        try {
-            final MetacardTransformer transformer =
-                    metacardTransformerManager.getTransformerBySchema(recordSchema);
-            if (transformer == null) {
-                throw new CatalogTransformerException(
-                        "Cannot find transformer for schema: " + recordSchema);
-            }
-
-            Map<Future<BinaryContent>, Result> futures = new HashMap<>(results.size());
-            for (Result result : results) {
-                final Metacard mc = result.getMetacard();
-
-                // the "current" thread will run submitted task when queueSize exceeded; effectively
-                // blocking enqueue of more tasks.
-                futures.put(completionService.submit(() -> {
-                    BinaryContent content = transformer.transform(mc, arguments);
-                    return content;
-                }), result);
-            }
-
-            // TODO - really? I can't use a list of some sort?
-            InputStream[] contents = new InputStream[results.size()];
-
-            while (!futures.isEmpty()) {
-                Future<BinaryContent> completedFuture = completionService.take();
-                int index = results.indexOf(futures.get(completedFuture));
-                contents[index] = completedFuture.get()
-                        .getInputStream();
-                futures.remove(completedFuture);
-            }
-
-            CharArrayWriter accum = new CharArrayWriter(ACCUM_INITIAL_SIZE);
-            for (InputStream is : contents) {
-                IOUtils.copy(is, accum);
-            }
-
-            return accum.toString();
-
-        } catch (IOException | InterruptedException | ExecutionException xe) {
-            throw new CatalogTransformerException(xe);
+        final MetacardTransformer transformer = metacardTransformerManager.getTransformerBySchema(
+                recordSchema);
+        if (transformer == null) {
+            throw new CatalogTransformerException(
+                    "Cannot find transformer for schema: " + recordSchema);
         }
 
+        Map<Future<BinaryContent>, Result> futures = new HashMap<>(results.size());
+        for (Result result : results) {
+            final Metacard mc = result.getMetacard();
+
+            // the "current" thread will run submitted task when queueSize exceeded; effectively
+            // blocking enqueue of more tasks.
+            futures.put(completionService.submit(() -> {
+                BinaryContent content = transformer.transform(mc, arguments);
+                return content;
+            }), result);
+        }
+
+        InputStream[] contents = new InputStream[results.size()];
+
+        while (!futures.isEmpty()) {
+            try {
+                Future<BinaryContent> completedFuture = completionService.take();
+                int index = results.indexOf(futures.get(completedFuture));
+                try {
+                    contents[index] = completedFuture.get()
+                            .getInputStream();
+                } catch (ExecutionException e) {
+                    LOGGER.debug("Error transforming Metacard", e);
+                    numResults.decrementAndGet();
+                } finally {
+                    futures.remove(completedFuture);
+                }
+            } catch (InterruptedException e) {
+                LOGGER.debug("Metacard transform interrupted", e);
+            }
+
+        }
+
+        CharArrayWriter accum = new CharArrayWriter(ACCUM_INITIAL_SIZE);
+        for (InputStream is : contents) {
+            try {
+                if (is != null) {
+                    IOUtils.copy(is, accum);
+                }
+            } catch (IOException e) {
+                LOGGER.debug("Error copying Metacard Binary content", e);
+            }
+        }
+
+        return accum.toString();
     } // end multiThreadedMarshal()
 
     private boolean isByIdQuery(Map<String, Serializable> arguments) {

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
@@ -382,11 +382,11 @@ public class TestCswQueryResponseTransformer {
         MetacardTransformer mockMetacardTransformer = mock(MetacardTransformer.class);
 
         final AtomicLong atomicLong = new AtomicLong(0);
-        when(mockMetacardTransformer.transform(any(Metacard.class),
-                anyMap())).then(invocationOnMock -> {
+        when(mockMetacardTransformer.transform(any(Metacard.class), anyMap())).then(invocationOnMock -> {
             if (atomicLong.incrementAndGet() == 2) {
                 throw new CatalogTransformerException("");
             }
+            
             Metacard metacard = (Metacard) invocationOnMock.getArguments()[0];
             BinaryContentImpl bci = new BinaryContentImpl(IOUtils.toInputStream(
                     metacard.getId() + ","), new MimeType("application/xml"));

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
@@ -364,7 +364,7 @@ public class TestCswQueryResponseTransformer {
     }
 
     @Test
-    public void testMarshalAcknowledgement2()
+    public void testMarshalAcknowledgementWithFailedTransforms()
             throws WebApplicationException, IOException, JAXBException,
             CatalogTransformerException {
 
@@ -379,17 +379,14 @@ public class TestCswQueryResponseTransformer {
         args.put(CswConstants.GET_RECORDS, query);
 
         PrintWriter printWriter = getSimplePrintWriter();
-
         MetacardTransformer mockMetacardTransformer = mock(MetacardTransformer.class);
 
-        AtomicLong atomicLong = new AtomicLong(0);
+        final AtomicLong atomicLong = new AtomicLong(0);
         when(mockMetacardTransformer.transform(any(Metacard.class),
                 anyMap())).then(invocationOnMock -> {
             if (atomicLong.incrementAndGet() == 2) {
-
                 throw new CatalogTransformerException("");
             }
-
             Metacard metacard = (Metacard) invocationOnMock.getArguments()[0];
             BinaryContentImpl bci = new BinaryContentImpl(IOUtils.toInputStream(
                     metacard.getId() + ","), new MimeType("application/xml"));

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/TestCswQueryResponseTransformer.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -13,10 +13,12 @@
  **/
 package org.codice.ddf.spatial.ogc.csw.catalog.transformer;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
@@ -35,6 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.activation.MimeType;
 import javax.ws.rs.WebApplicationException;
@@ -57,6 +60,8 @@ import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -73,6 +78,7 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import ddf.catalog.transformer.api.PrintWriter;
 import ddf.catalog.transformer.api.PrintWriterProvider;
+
 import net.opengis.cat.csw.v_2_0_2.AcknowledgementType;
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 import net.opengis.cat.csw.v_2_0_2.ResultType;
@@ -217,9 +223,8 @@ public class TestCswQueryResponseTransformer {
         verify(mockPrintWriter, times(1)).startNode(strArgCaptor.capture());
 
         List<String> values = strArgCaptor.getAllValues();
-        assertThat("Missing root GetRecordByIdResponse node.",
-                values.get(0),
-                is(CswQueryResponseTransformer.RECORD_BY_ID_RESPONSE_QNAME));
+        assertThat("Missing root GetRecordByIdResponse node.", values.get(0), is(
+                CswQueryResponseTransformer.RECORD_BY_ID_RESPONSE_QNAME));
 
     }
 
@@ -359,6 +364,58 @@ public class TestCswQueryResponseTransformer {
     }
 
     @Test
+    public void testMarshalAcknowledgement2()
+            throws WebApplicationException, IOException, JAXBException,
+            CatalogTransformerException {
+
+        GetRecordsType query = new GetRecordsType();
+        query.setResultType(ResultType.RESULTS);
+        query.setMaxRecords(BigInteger.valueOf(6));
+        query.setStartPosition(BigInteger.valueOf(0));
+        SourceResponse sourceResponse = createSourceResponse(query, 6);
+
+        Map<String, Serializable> args = new HashMap<>();
+        args.put(CswConstants.RESULT_TYPE_PARAMETER, ResultType.RESULTS);
+        args.put(CswConstants.GET_RECORDS, query);
+
+        PrintWriter printWriter = getSimplePrintWriter();
+
+        MetacardTransformer mockMetacardTransformer = mock(MetacardTransformer.class);
+
+        AtomicLong atomicLong = new AtomicLong(0);
+        when(mockMetacardTransformer.transform(any(Metacard.class),
+                anyMap())).then(invocationOnMock -> {
+            if (atomicLong.incrementAndGet() == 2) {
+
+                throw new CatalogTransformerException("");
+            }
+
+            Metacard metacard = (Metacard) invocationOnMock.getArguments()[0];
+            BinaryContentImpl bci = new BinaryContentImpl(IOUtils.toInputStream(
+                    metacard.getId() + ","), new MimeType("application/xml"));
+            return bci;
+        });
+
+        when(mockPrintWriterProvider.build((Class<Metacard>) notNull())).thenReturn(printWriter);
+        when(mockTransformerManager.getTransformerBySchema(anyString())).thenReturn(
+                mockMetacardTransformer);
+
+        CswQueryResponseTransformer cswQueryResponseTransformer = new CswQueryResponseTransformer(
+                mockTransformerManager,
+                mockPrintWriterProvider);
+        cswQueryResponseTransformer.init();
+        BinaryContent content = cswQueryResponseTransformer.transform(sourceResponse, args);
+        cswQueryResponseTransformer.destroy();
+
+        String xml = new String(content.getByteArray());
+        assertThat(xml, containsString(
+                CswQueryResponseTransformer.NUMBER_OF_RECORDS_MATCHED_ATTRIBUTE + " 6"));
+        assertThat(xml, containsString(
+                CswQueryResponseTransformer.NUMBER_OF_RECORDS_RETURNED_ATTRIBUTE + " 5"));
+        assertThat(xml, containsString(CswQueryResponseTransformer.NEXT_RECORD_ATTRIBUTE + " 0"));
+    }
+
+    @Test
     public void verifyResultOrderIsMaintained() throws CatalogTransformerException, IOException {
         // when
         when(mockPrintWriterProvider.build((Class<Metacard>) notNull())).thenReturn(mockPrintWriter);
@@ -455,5 +512,63 @@ public class TestCswQueryResponseTransformer {
                 CswJAXBElementProvider.class.getClassLoader());
 
         return context;
+    }
+
+    private PrintWriter getSimplePrintWriter() {
+        return new PrintWriter() {
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            @Override
+            public void setRawValue(String s) {
+                stringBuilder.append(s);
+            }
+
+            @Override
+            public String makeString() {
+                return stringBuilder.toString();
+            }
+
+            @Override
+            public void startNode(String s, Class aClass) {
+                stringBuilder.append(s);
+            }
+
+            @Override
+            public void startNode(String s) {
+                stringBuilder.append(s);
+            }
+
+            @Override
+            public void addAttribute(String s, String s1) {
+                stringBuilder.append(s);
+                stringBuilder.append(" ");
+                stringBuilder.append(s1);
+            }
+
+            @Override
+            public void setValue(String s) {
+                stringBuilder.append(s);
+            }
+
+            @Override
+            public void endNode() {
+            }
+
+            @Override
+            public void flush() {
+
+            }
+
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public HierarchicalStreamWriter underlyingWriter() {
+                return null;
+            }
+        };
     }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR updates the CswQueryResponseTransformer to recover from a CatalogTransformerException during marshaling.  This prevents CSW queries from failing completely in the event that one or more metacards fail to be transformed.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jrnorth @glenhein @lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build DDF, ingest some data, and use PostMan to query the CSW Endpoint.  Observe correct behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2466
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…formerException as a single transform failure rather than failing the entire query response