### PR TITLE
DDF-2474 Fixes issue with ingesting a large zip file with more metacards than space in blocking queue.

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -33,12 +35,13 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
@@ -113,13 +116,11 @@ public class IngestCommand extends CatalogCommands {
             .appendSuffix(" second", " seconds")
             .toFormatter();
 
+    private final Phaser phaser = new Phaser();
+
     private final AtomicInteger ingestCount = new AtomicInteger();
 
     private final AtomicInteger ignoreCount = new AtomicInteger();
-
-    private final AtomicBoolean doneBuildingQueue = new AtomicBoolean();
-
-    private final AtomicInteger processingThreads = new AtomicInteger();
 
     private final AtomicInteger fileCount = new AtomicInteger(Integer.MAX_VALUE);
 
@@ -128,8 +129,6 @@ public class IngestCommand extends CatalogCommands {
     private File failedIngestDirectory = null;
 
     private InputTransformer transformer = null;
-
-    private InputCollectionTransformer zipDecompression;
 
     @Argument(name = "File path or Directory path", description =
             "File path to a record or a directory of files to be ingested. Paths are absolute and must be in quotes."
@@ -168,71 +167,17 @@ public class IngestCommand extends CatalogCommands {
     @Option(name = "--include-content", required = false, aliases = {}, multiValued = false, description = "Ingest a zip file that contains metacards and content using the default transformer.  The specified zip must be signed externally using DDF certificates.")
     boolean includeContent = false;
 
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
     @Override
     protected Object executeWithSubject() throws Exception {
-
-        final CatalogFacade catalog = getCatalog();
-
-        final File inputFile = new File(filePath);
-
-        SecurityLogger.audit("Called catalog:ingest command with path : {}", filePath);
-
-        if (!inputFile.exists()) {
-            printErrorMessage("File or directory [" + filePath + "] must exist.");
-            console.println("If the file does indeed exist, try putting the path in quotes.");
+        final File inputFile = getInputFile();
+        if (inputFile == null) {
             return null;
         }
 
-        if (includeContent && !FilenameUtils.isExtension(filePath, "zip")) {
-            console.print("File " + filePath + " must be a zip file.");
-            return null;
-        }
-
-        if (deprecatedBatchSize != DEFAULT_BATCH_SIZE) {
-            // user specified the old style batch size, so use that
-            printErrorMessage(
-                    "Batch size positional argument is DEPRECATED, please use --batchsize option instead.");
-            batchSize = deprecatedBatchSize;
-        }
-
-        if (batchSize <= 0) {
-            printErrorMessage("A batch size of [" + batchSize
-                    + "] was supplied. Batch size must be greater than 0.");
-            return null;
-        }
-
-        if (!StringUtils.isEmpty(failedDir)) {
-            failedIngestDirectory = new File(failedDir);
-            if (!verifyFailedIngestDirectory()) {
-                return null;
-            }
-
-            /**
-             * Batch size is always set to 1, when using an Ingest Failure Directory.  If a batch size is specified by the user, issue
-             * a warning stating that a batch size of 1 will be used.
-             */
-            if (batchSize != DEFAULT_BATCH_SIZE) {
-                console.println(
-                        "WARNING: An ingest failure directory was supplied in addition to a batch size of "
-                                + batchSize
-                                + ". When using an ingest failure directory, the batch size must be 1. Setting batch size to 1.");
-            }
-
-            batchSize = 1;
-        }
-
-        if (!SERIALIZED_OBJECT_ID.matches(transformerId)) {
-            transformer = getTransformer();
-            if (transformer == null) {
-                console.println(transformerId + " is an invalid input transformer.");
-                return null;
-            }
-        }
-
-        Stream<Path> ingestStream = Files.walk(inputFile.toPath(), FileVisitOption.FOLLOW_LINKS);
-
-        int totalFiles = (inputFile.isDirectory()) ? inputFile.list().length : 1;
-        fileCount.getAndSet(totalFiles);
+        int totalFiles = totalFileCount(inputFile);
+        fileCount.set(totalFiles);
 
         final ArrayBlockingQueue<Metacard> metacardQueue = new ArrayBlockingQueue<>(
                 batchSize * multithreaded);
@@ -243,7 +188,13 @@ public class IngestCommand extends CatalogCommands {
 
         printProgressAndFlush(start, fileCount.get(), 0);
 
-        queueExecutor.submit(() -> buildQueue(ingestStream, metacardQueue, start));
+        // Registering for the main thread and on behalf of the buildQueue thread;
+        // the buildQueue thread will unregister itself when the files have all
+        // been added to the blocking queue and the final registration will
+        // be held for the await.
+        phaser.register();
+        phaser.register();
+        queueExecutor.submit(() -> buildQueue(inputFile, metacardQueue, start));
 
         final ScheduledExecutorService batchScheduler =
                 Executors.newSingleThreadScheduledExecutor();
@@ -258,15 +209,11 @@ public class IngestCommand extends CatalogCommands {
                 blockingQueue,
                 rejectedExecutionHandler);
 
+        final CatalogFacade catalog = getCatalog();
         submitToCatalog(batchScheduler, executorService, metacardQueue, catalog, start);
 
-        while (!doneBuildingQueue.get() || processingThreads.get() != 0) {
-            try {
-                TimeUnit.SECONDS.sleep(2);
-            } catch (InterruptedException e) {
-                LOGGER.info("Ingest 'Waiting for processing to finish' thread interrupted: {}", e);
-            }
-        }
+        // await on catalog processing threads to complete emptying queue
+        phaser.awaitAdvance(phaser.arrive());
 
         try {
             queueExecutor.shutdown();
@@ -314,17 +261,89 @@ public class IngestCommand extends CatalogCommands {
         return null;
     }
 
+    private File getInputFile() {
+        final File inputFile = new File(filePath);
+
+        SecurityLogger.audit("Called catalog:ingest command with path : {}", filePath);
+
+        if (!inputFile.exists()) {
+            printErrorMessage(String.format("File or directory [%s] must exist.", filePath));
+            console.println("If the file does indeed exist, try putting the path in quotes.");
+            return null;
+        }
+
+        if (includeContent && !FilenameUtils.isExtension(filePath, "zip")) {
+            console.printf("File %s must be a zip file.", filePath);
+            return null;
+        }
+
+        if (deprecatedBatchSize != DEFAULT_BATCH_SIZE) {
+            // user specified the old style batch size, so use that
+            printErrorMessage(
+                    "Batch size positional argument is DEPRECATED, please use --batchsize option instead.");
+            batchSize = deprecatedBatchSize;
+        }
+
+        if (batchSize <= 0) {
+            printErrorMessage(String.format(
+                    "A batch size of [%d] was supplied. Batch size must be greater than 0.",
+                    batchSize));
+            return null;
+        }
+
+        if (StringUtils.isNotEmpty(failedDir)) {
+            failedIngestDirectory = new File(failedDir);
+            if (!verifyFailedIngestDirectory()) {
+                return null;
+            }
+
+            // Batch size is always set to one when using an Ingest Failure Directory. If a batch
+            // size is specified by the user, issue a warning stating that a batch size of one will
+            // be used.
+            if (batchSize != DEFAULT_BATCH_SIZE) {
+                console.printf(
+                        "WARNING: An ingest failure directory was supplied in addition to a batch "
+                                + "size of %d. When using an ingest failure directory, the batch "
+                                + "size must be 1. Setting batch size to 1.%n",
+                        batchSize);
+            }
+
+            batchSize = 1;
+        }
+
+        if (!SERIALIZED_OBJECT_ID.matches(transformerId)) {
+            transformer = getTransformer();
+            if (transformer == null) {
+                console.println(transformerId + " is an invalid input transformer.");
+                return null;
+            }
+        }
+        return inputFile;
+    }
+
+    private int totalFileCount(File inputFile) throws IOException {
+        if (inputFile.isDirectory()) {
+            int cnt = 0;
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(inputFile.toPath())) {
+                for (Path entry : stream) {
+                    cnt++;
+                }
+                return cnt;
+            }
+        }
+
+        return 1;
+    }
+
     /**
      * Helper method to build ingest log strings
      */
     private String buildIngestLog(ArrayList<Metacard> metacards) {
         StringBuilder strBuilder = new StringBuilder();
 
-        final String newLine = System.getProperty("line.separator");
-
         for (int i = 0; i < metacards.size(); i++) {
             Metacard card = metacards.get(i);
-            strBuilder.append(newLine)
+            strBuilder.append(NEW_LINE)
                     .append("Batch #: ")
                     .append(i + 1)
                     .append(" | ");
@@ -434,8 +453,8 @@ public class IngestCommand extends CatalogCommands {
 
     private void makeFailedIngestDirectory() {
         if (!failedIngestDirectory.mkdirs()) {
-            printErrorMessage("Unable to create directory [" + failedIngestDirectory.getAbsolutePath()
-                            + "].");
+            printErrorMessage(String.format("Unable to create directory [%s].",
+                    failedIngestDirectory.getAbsolutePath()));
         }
     }
 
@@ -447,15 +466,22 @@ public class IngestCommand extends CatalogCommands {
             createResponse = createMetacards(catalog, metacards);
         } catch (IngestException e) {
             printErrorMessage("Error executing command: " + e.getMessage());
-            INGEST_LOGGER.warn("Error ingesting metacard batch {}", buildIngestLog(metacards), e);
+            if (INGEST_LOGGER.isWarnEnabled()) {
+                INGEST_LOGGER.warn("Error ingesting metacard batch {}",
+                        buildIngestLog(metacards),
+                        e);
+            }
         } catch (SourceUnavailableException e) {
-            INGEST_LOGGER.warn("Error on process batch, local provider not available. {}"
-                    + " metacards failed to ingest. {}",
-                    metacards.size(),
-                    buildIngestLog(metacards),
-                    e);
+            if (INGEST_LOGGER.isWarnEnabled()) {
+                INGEST_LOGGER.warn("Error on process batch, local provider not available. {}"
+                                + " metacards failed to ingest. {}",
+                        metacards.size(),
+                        buildIngestLog(metacards),
+                        e);
+            }
         } finally {
-            processingThreads.decrementAndGet();
+            IntStream.range(0, metacards.size())
+                    .forEach(i -> phaser.arriveAndDeregister());
         }
 
         if (createResponse != null) {
@@ -465,7 +491,8 @@ public class IngestCommand extends CatalogCommands {
     }
 
     private void moveToFailedIngestDirectory(File source) {
-        File destination = new File(failedIngestDirectory.getAbsolutePath() + File.separator + source.getName());
+        File destination = new File(
+                failedIngestDirectory.getAbsolutePath() + File.separator + source.getName());
 
         if (!source.renameTo(destination)) {
             printErrorMessage("Unable to move source file [" + source.getAbsolutePath() + "] to ["
@@ -473,88 +500,99 @@ public class IngestCommand extends CatalogCommands {
         }
     }
 
-    private void buildQueue(Stream<Path> ingestStream, ArrayBlockingQueue<Metacard> metacardQueue,
+    private void buildQueue(File inputFile, ArrayBlockingQueue<Metacard> metacardQueue,
             long start) {
-
-        if (includeContent) {
-            File inputFile = new File(filePath);
-            Map<String, Serializable> arguments = new HashMap<>();
-            arguments.put(DumpCommand.FILE_PATH, inputFile.getParent() + File.separator);
-            arguments.put(FILE_NAME, inputFile.getName());
-
-            ByteSource byteSource = com.google.common.io.Files.asByteSource(inputFile);
-
-            zipDecompression = getZipDecompression();
-            if (zipDecompression != null) {
-
-                try (InputStream inputStream = byteSource.openBufferedStream()) {
-                    List<Metacard> metacardList = zipDecompression.transform(inputStream,
-                            arguments);
-                    if (metacardList.size() != 0) {
-                        metacardFileMapping = generateFileMap(new File(inputFile.getParent(), CONTENT_PATH));
-                        fileCount.set(metacardList.size());
-                        metacardQueue.addAll(metacardList);
-                    }
-                } catch (IOException | CatalogTransformerException e) {
-                    LOGGER.info("Unable to transform zip file into metacard list.", e);
-                    INGEST_LOGGER.warn("Unable to transform zip file into metacard list.", e);
-                }
+        try {
+            if (includeContent) {
+                processIncludeContent(metacardQueue);
             } else {
-                LOGGER.info(
-                        "No Zip Transformer found.  Unable to transform zip file into metacard list.");
-                INGEST_LOGGER.warn(
-                        "No Zip Transformer found.  Unable to transform zip file into metacard list.");
+                try {
+                    Stream<Path> ingestStream = Files.walk(inputFile.toPath(),
+                            FileVisitOption.FOLLOW_LINKS);
+                    ingestStream.map(Path::toFile)
+                            .filter(file -> !file.isDirectory())
+                            .forEach(file -> addFileToQueue(metacardQueue, start, file));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
-
-        } else {
-
-            ingestStream.map(Path::toFile)
-                    .filter(file -> !file.isDirectory())
-                    .forEach(file -> {
-
-                        if (file.isHidden()) {
-                            ignoreCount.incrementAndGet();
-                        } else {
-                            String extension = "." + FilenameUtils.getExtension(file.getName());
-
-                            if (ignoreList != null && (ignoreList.contains(extension)
-                                    || ignoreList.contains(file.getName()))) {
-                                ignoreCount.incrementAndGet();
-                                printProgressAndFlush(start,
-                                        fileCount.get(),
-                                        ingestCount.get() + ignoreCount.get());
-                            } else {
-                                Metacard result;
-                                try {
-                                    result = readMetacard(file);
-                                } catch (IngestException e) {
-                                    result = null;
-                                    logIngestException(e, file);
-                                    if (failedIngestDirectory != null) {
-                                        moveToFailedIngestDirectory(file);
-                                    }
-                                    printErrorMessage(
-                                            "Failed to ingest file [" + file.getAbsolutePath()
-                                                    + "].");
-                                    INGEST_LOGGER.warn("Failed to ingest file [{}].",
-                                            file.getAbsolutePath());
-                                }
-
-                                if (result != null) {
-                                    try {
-                                        metacardQueue.put(result);
-                                    } catch (InterruptedException e) {
-                                        INGEST_LOGGER.error(
-                                                "Thread interrupted while waiting to 'put' metacard: {}",
-                                                result.getId(),
-                                                e);
-                                    }
-                                }
-                            }
-                        }
-                    });
+        } finally {
+            phaser.arriveAndDeregister();
         }
-        doneBuildingQueue.set(true);
+    }
+
+    private void addFileToQueue(ArrayBlockingQueue<Metacard> metacardQueue, long start, File file) {
+        if (file.isHidden()) {
+            ignoreCount.incrementAndGet();
+            return;
+        }
+
+        String extension = "." + FilenameUtils.getExtension(file.getName());
+        if (ignoreList != null && (ignoreList.contains(extension)
+                || ignoreList.contains(file.getName()))) {
+            ignoreCount.incrementAndGet();
+            printProgressAndFlush(start, fileCount.get(), ingestCount.get() + ignoreCount.get());
+            return;
+        }
+
+        Metacard result = null;
+        try {
+            result = readMetacard(file);
+        } catch (IngestException e) {
+            logIngestException(e, file);
+            if (failedIngestDirectory != null) {
+                moveToFailedIngestDirectory(file);
+            }
+            printErrorMessage(String.format("Failed to ingest file [%s].", file.getAbsolutePath()));
+            INGEST_LOGGER.warn("Failed to ingest file [{}].", file.getAbsolutePath());
+        }
+
+        if (result != null) {
+            try {
+                metacardQueue.put(result);
+                phaser.register();
+            } catch (InterruptedException e) {
+                INGEST_LOGGER.error("Thread interrupted while waiting to 'put' metacard: {}",
+                        result.getId(),
+                        e);
+            }
+        }
+    }
+
+    private void processIncludeContent(ArrayBlockingQueue<Metacard> metacardQueue) {
+        File inputFile = new File(filePath);
+        Map<String, Serializable> arguments = new HashMap<>();
+        arguments.put(DumpCommand.FILE_PATH, inputFile.getParent() + File.separator);
+        arguments.put(FILE_NAME, inputFile.getName());
+
+        ByteSource byteSource = com.google.common.io.Files.asByteSource(inputFile);
+
+        InputCollectionTransformer zipDecompression = getZipDecompression();
+        if (zipDecompression != null) {
+
+            try (InputStream inputStream = byteSource.openBufferedStream()) {
+                List<Metacard> metacardList = zipDecompression.transform(inputStream, arguments);
+                if (metacardList.size() != 0) {
+                    metacardFileMapping = generateFileMap(new File(inputFile.getParent(),
+                            CONTENT_PATH));
+                    fileCount.set(metacardList.size());
+                    for (Metacard metacard : metacardList) {
+                        metacardQueue.put(metacard);
+                    }
+                    phaser.bulkRegister(metacardList.size());
+                }
+            } catch (IOException | CatalogTransformerException | InterruptedException e) {
+                // Clear the queue, to make this an all-or-nothing transaction
+                metacardQueue.clear();
+                LOGGER.info("Unable to transform zip file into metacard list.", e);
+                INGEST_LOGGER.warn("Unable to transform zip file into metacard list.", e);
+            }
+        } else {
+            LOGGER.info(
+                    "No Zip Transformer found.  Unable to transform zip file into metacard list.");
+            INGEST_LOGGER.warn(
+                    "No Zip Transformer found.  Unable to transform zip file into metacard list.");
+        }
     }
 
     private void submitToStorageProvider(List<Metacard> metacardList) {
@@ -620,15 +658,15 @@ public class IngestCommand extends CatalogCommands {
         batchScheduler.scheduleWithFixedDelay(() -> {
             int queueSize = metacardQueue.size();
             if (queueSize > 0) {
-
                 ArrayList<Metacard> metacardBatch = new ArrayList<>(batchSize);
 
-                if (queueSize > batchSize || doneBuildingQueue.get()) {
+                // When the producer has finished populating the queue, it will countdown
+                // the phaser. The remaining count in the phaser will be metacardCount + main thread
+                if (queueSize > batchSize || queueSize == phaser.getRegisteredParties() - 1) {
                     metacardQueue.drainTo(metacardBatch, batchSize);
-                    processingThreads.incrementAndGet();
                 }
 
-                if (metacardBatch.size() > 0) {
+                if (!metacardBatch.isEmpty()) {
                     executorService.submit(() -> {
                         try {
                             processBatch(catalog, metacardBatch);

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -691,7 +691,7 @@ public class IngestCommand extends CatalogCommands {
 
                 // When the producer has finished populating the queue, it will countdown
                 // the phaser. The remaining count in the phaser will be metacardCount + main thread
-                if (queueSize > batchSize || queueSize == phaser.getRegisteredParties() - 1) {
+                if (queueSize >= batchSize || queueSize == phaser.getRegisteredParties() - 1) {
                     metacardQueue.drainTo(metacardBatch, batchSize);
                 }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where some records might not be ingested with no error logged if the zip file to be ingested contained more than `--batchsize` * `--multithreaded` metacards.

This also cleans up the threading logic, relying on a Phaser used as a CountUp/DownLatch instead of flags and Thread.sleeps().

This needs to be backported to 2.9.x but might require a slightly more complex cherrypick as some other changes have been introduced to master and not backported.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @rzwiefel @tbatie 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested?
- Full build/test run.
- Threading tests
    - Get some metacards to be ingested by any transformer and put them into a directory. I would recommend at least 100.
    - Ingest through the karaf command line (include the `-p` flag to speed the tests, passing various values for the `-b` (`--batchsize`) and `-m` (`--multithreaded`) flags to test different possible edge cases. e.g.
        - `-b 1 -m 1` 
        - `-b 1 -m 20` 
        - `-b [number of metacards in test]`
        - `-b [number of metacards in test] -m 1`
        - `-b [number of metacards in test] -m 3`
        - `-b [factor of metacard count]` (For 100, using 10 or 20 would be good for this)
        - `-b [factor of metacard count - 1]`
        - `-b [factor of metacard count + 1]`
        - `-b [metacard count/2]`
        - `-b [metacard count/2 - 1]`
        - `-b [metacard count/2 + 1]`
        - `-b [metacard count - 1]`
        - `-b [metacard count + 1]`
        - `-b [prime number less than metacard count]`
    - Run each of the above tests several times to ensure there are no timing issues. There is no need to remove the records from the catalog between tests. If the threading is going to fail, it's going to do so whether the records are already present of not.
- Zip ingest test
    - Create zip file of metacards to ingest, either manually or through `catalog:dump`
    - Sign the zip file. This can be accomplished by running `jarsigner -keystore $DDF_HOME/etc/keystores/serverKeystore.jks [zipfile] localhost`, assuming your DDF instance is named `localhost`.
    - Ingest the zip file, first with default batch and thread size, then by adjusting those parameters so their product is smaller than the number of metacards in the zip file. e.g.
        - `ingest --include-content [zipfile]`
        - `ingest --include-content -b 2 -m 2 [zipfile]` (If you have more than four metacards in your zip, these values would trigger the error prior to this fix.)

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2474

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests