### PR TITLE
DDF-2266 Fix registry store cleanup bugs

### DIFF
--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
@@ -67,12 +67,6 @@ public class RegistryStoreCleanupHandler implements EventHandler {
         }
     }
 
-    public void unbindRegistryStore(ServiceReference serviceReference) {
-        if (serviceReference != null) {
-            registryStorePidToServiceMap.remove(serviceReference.getProperty(Constants.SERVICE_PID));
-        }
-    }
-
     @Override
     public void handleEvent(Event event) {
         Object eventProperty = event.getProperty(EventConstants.EVENT);
@@ -95,6 +89,8 @@ public class RegistryStoreCleanupHandler implements EventHandler {
         if (service == null) {
             return;
         }
+        registryStorePidToServiceMap.remove(servicePid);
+
         executor.execute(() -> {
             String registryId = service.getRegistryId();
             try {

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -51,6 +51,7 @@
     </bean>
 
     <bean id="storeCleanupHandler" class="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler">
+        <cm:managed-properties persistent-id="org.codice.ddf.registry.api.impl.RegistryStoreCleanupHandler" update-strategy="container-managed"/>
         <property name="federationAdminService" ref="federationAdminService"/>
         <property name="executor" ref="cleanupHandlerExecutor"/>
     </bean>
@@ -76,8 +77,7 @@
                     availability="optional">
         <reference-listener ref="registryPublisher" bind-method="bindRegistryStore"
                             unbind-method="unbindRegistryStore"/>
-        <reference-listener ref="storeCleanupHandler" bind-method="bindRegistryStore"
-                            unbind-method="unbindRegistryStore"/>
+        <reference-listener ref="storeCleanupHandler" bind-method="bindRegistryStore"/>
     </reference-list>
 
     <service ref="registryPublisher" interface="org.osgi.service.event.EventHandler">

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandlerTest.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandlerTest.java
@@ -110,20 +110,6 @@ public class RegistryStoreCleanupHandlerTest {
     }
 
     @Test
-    public void testUnBindRegistryStore() throws Exception {
-        ServiceReference ref = getServiceReference("servicePid");
-        cleanupHandler.bindRegistryStore(ref);
-        cleanupHandler.unbindRegistryStore(ref);
-        handleEvent(null,
-                ref,
-                ServiceEvent.UNREGISTERING,
-                "registryId",
-                Collections.singletonList(mcard));
-        verify(federationAdmin,
-                never()).deleteRegistryEntriesByMetacardIds(Collections.singletonList(mcard.getId()));
-    }
-
-    @Test
     public void testUnregisterEvent() throws Exception {
         ServiceReference ref = getServiceReference("servicePid");
         handleEvent(ref,

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/RegistryPublicationServiceImplTest.java
@@ -300,7 +300,7 @@ public class RegistryPublicationServiceImplTest {
         assertThat(lastPublishedDate.after(before), is(equalTo(true)));
     }
 
-    @Test(expected = FederationAdminException.class)
+    @Test
     public void testUpdateException() throws Exception {
         doThrow(new FederationAdminException("Test Error")).when(federationAdminService)
                 .updateRegistryEntry(any(Metacard.class), any(Set.class));
@@ -309,7 +309,8 @@ public class RegistryPublicationServiceImplTest {
                 REGISTRY_STORE_REGISTRY_ID);
 
         registryPublicationService.update(mcard);
-        verify(federationAdminService, never()).updateRegistryEntry(mcard);
+        verify(federationAdminService).addRegistryEntry(mcard,
+                Collections.singleton(REGISTRY_STORE_ID));
     }
 
     @Test(expected = FederationAdminException.class)


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug with the registry store cleanup handler where the store reference can be removed before the cleanup logic can be run. 
Also adds a simple retry to publication updates
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @vinamartin @tbatie 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 
#### How should this be tested?
Bring up two instances of ddf with the registry running. Have one of the registries subscribe to the other. Verify that you get the other nodes information. Now remove the remote registry you just created. Verify that the node you received from the other registry has been removed.
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2266
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
