### PR TITLE
DDF-2475 Added optional SRS Name parameter to WFS 2.0 GetFeature requ…

### DIFF
--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -165,6 +165,8 @@ public class WfsSource extends MaskableImpl
 
     private static final String RECEIVE_TIMEOUT_PROPERTY = "receiveTimeout";
 
+    private static final String SRS_NAME_PROPERTY = "srsName";
+
     private static final String WFS_ERROR_MESSAGE = "Error received from Wfs Server.";
 
     private static final String UNKNOWN = "unknown";
@@ -244,6 +246,8 @@ public class WfsSource extends MaskableImpl
 
     private String forcedFeatureType;
 
+    private String srsName;
+
     public WfsSource(FilterAdapter filterAdapter, BundleContext context, AvailabilityTask task,
             SecureCxfClientFactory factory, EncryptionService encryptionService)
             throws SecurityServiceException {
@@ -303,6 +307,7 @@ public class WfsSource extends MaskableImpl
 
         setConnectionTimeout((Integer) configuration.get(CONNECTION_TIMEOUT_PROPERTY));
         setReceiveTimeout((Integer) configuration.get(RECEIVE_TIMEOUT_PROPERTY));
+        setSrsName((String) configuration.get(SRS_NAME_PROPERTY));
 
         String[] nonQueryableProperties =
                 (String[]) configuration.get(NON_QUERYABLE_PROPS_PROPERTY);
@@ -801,6 +806,10 @@ public class WfsSource extends MaskableImpl
                             .getLocalPart();
                 }
 
+                if(StringUtils.isNotBlank(srsName)) {
+                    wfsQuery.setSrsName(srsName);
+                }
+
                 wfsQuery.setTypeNames(Arrays.asList(typeName));
                 wfsQuery.setHandle(filterDelegateEntry.getKey()
                         .getLocalPart());
@@ -1180,6 +1189,14 @@ public class WfsSource extends MaskableImpl
 
     public Integer getReceiveTimeout() {
         return this.receiveTimeout;
+    }
+
+    public void setSrsName(String srsName) {
+        this.srsName = srsName;
+    }
+
+    public String getSrsName() {
+        return this.srsName;
     }
 
     public void setFilterAdapter(FilterAdapter filterAdapter) {

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -60,6 +60,8 @@
             <property name="disableSorting" value="false"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <property name="srsName" value=""/>
+
             <argument ref="encryptionService"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -78,6 +78,10 @@
             name="Receive Timeout" id="receiveTimeout"
             required="true" type="Integer" default="60000"/>
 
+        <AD description="SRS Name to use in outbound GetFeature requests.  The SRS Name parameter is used to assert the specific CRS transformation to be applied to the geometries of the features returned in a response document."
+            name="SRS Name" id="srsName"
+            required="false" type="String" default="EPSG:4326"/>
+
     </OCD>
 
     <Designate pid="Wfs_v2_0_0_Federated_Source" factoryPid="Wfs_v2_0_0_Federated_Source">

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +43,7 @@ import org.apache.ws.commons.schema.XmlSchema;
 import org.apache.ws.commons.schema.XmlSchemaCollection;
 import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityTask;
+import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsConstants;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsException;
 import org.codice.ddf.spatial.ogc.wfs.catalog.mapper.MetacardMapper;
 import org.codice.ddf.spatial.ogc.wfs.catalog.source.WfsUriResolver;
@@ -1075,7 +1077,6 @@ public class TestWfsSource {
     @Test
     public void testSearchByMultipleTypes() throws Exception {
         //Setup
-        int startIndex = 0;
         int pageSize = 10;
         WfsSource source = getWfsSource(ONE_TEXT_PROPERTY_SCHEMA,
                 MockWfsServer.getFilterCapabilities(),
@@ -1107,6 +1108,60 @@ public class TestWfsSource {
 
         //Validate
         assertEquals(2, numTypes);
+    }
+
+    @Test
+    public void testSrsNameProvided() throws Exception {
+
+        int pageSize = 10;
+        WfsSource source = getWfsSource(ONE_TEXT_PROPERTY_SCHEMA,
+                MockWfsServer.getFilterCapabilities(),
+                Wfs20Constants.EPSG_4326_URN,
+                10,
+                false);
+        source.setSrsName(WfsConstants.EPSG_4326);
+
+        Filter filter = builder.attribute(Metacard.CONTENT_TYPE)
+                .is()
+                .equalTo()
+                .text(SAMPLE_FEATURE_NAME + "0");
+        QueryImpl query = new QueryImpl(filter);
+        query.setPageSize(pageSize);
+
+        //Execute
+        GetFeatureType featureType = source.buildGetFeatureRequest(query);
+        QueryType queryType = (QueryType) featureType.getAbstractQueryExpression()
+                .get(0)
+                .getValue();
+
+        assertThat(queryType.getSrsName(), is(WfsConstants.EPSG_4326));
+    }
+
+
+    @Test
+    public void testSrsNameNotProvided() throws Exception {
+
+        int pageSize = 10;
+        WfsSource source = getWfsSource(ONE_TEXT_PROPERTY_SCHEMA,
+                MockWfsServer.getFilterCapabilities(),
+                Wfs20Constants.EPSG_4326_URN,
+                10,
+                false);
+
+        Filter filter = builder.attribute(Metacard.CONTENT_TYPE)
+                .is()
+                .equalTo()
+                .text(SAMPLE_FEATURE_NAME + "0");
+        QueryImpl query = new QueryImpl(filter);
+        query.setPageSize(pageSize);
+
+        //Execute
+        GetFeatureType featureType = source.buildGetFeatureRequest(query);
+        QueryType queryType = (QueryType) featureType.getAbstractQueryExpression()
+                .get(0)
+                .getValue();
+
+        assertThat(queryType.getSrsName(), nullValue());
     }
 
 }

--- a/distribution/docs/src/main/resources/_contents/_spatial-contents/integrating-spatial-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_spatial-contents/integrating-spatial-contents.adoc
@@ -3932,6 +3932,13 @@ This should only be used if the remote source is unable to handle sorting even w
 |Amount of time to wait for a response before timing out, in milliseconds.
 |60000
 |Yes
+
+|SRS Name
+|`srsName`
+|String
+|SRS Name to use in outbound GetFeature requests.  The SRS Name parameter is used to assert the specific CRS transformation to be applied to the geometries of the features returned in a response document.
+|EPSG:4326
+|No
 |===
 
 ==== WFS URL


### PR DESCRIPTION
#### What does this PR do?
Adds an optional srsName parameter to the WFS 2.0 Federated Source GetFeature requests.  This parameter requests the remote server to transform geospatial features to the requested SRS (typically EPSG:4326).
  
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@rzwiefel @bdeining @lcrosenbu @kcwire 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@millerw8 

#### How should this be tested?
Pre-req: GeoServer having FeatureTypes defined with a DefaultCrs that is not EPSG:4326.  GeoServer comes with several as defined in the GetCapabilities doc:
```
<FeatureType xmlns:sf="http://www.openplans.org/spearfish">
<Name>sf:archsites</Name>
<Title>Spearfish archeological sites</Title>
<!-- ... -->
<DefaultCRS>urn:ogc:def:crs:EPSG::26713</DefaultCRS>
<ows:WGS84BoundingBox>
<ows:LowerCorner>-103.8725637911543 44.37740330855979</ows:LowerCorner>
<ows:UpperCorner>-103.63794182141925 44.48804280772808</ows:UpperCorner>
</ows:WGS84BoundingBox>
</FeatureType>
```
 
1) Configure a WFS 2.0 federated source using the default srsName=EPSG:4326
2) Query for the feature type (archsites for example)
3) Verify the metacards returned are mapped correctly

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2475

#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

