### PR TITLE
DDF-2171 Performing a textual search with an empty value will now default to a wildcard search, when in the faceted search view (2.8.x)

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/service/SearchService.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/service/SearchService.java
@@ -193,7 +193,9 @@ public class SearchService {
 
         Filter filter = null;
         try {
-            filter = ECQL.toFilter(cql);
+            if (StringUtils.isNotBlank(cql)) {
+                filter = ECQL.toFilter(cql);
+             }
         } catch (CQLException e) {
             LOGGER.warn("Unable to parse CQL filter", e);
             return;


### PR DESCRIPTION
Backport to 2.8.x
Original PR: Original PR: #1202