### PR TITLE
DDF-2461 Syncs registry name with site name

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
@@ -82,9 +82,13 @@ define([
                     data = this.model.toJSON();
                     data.validationError = this.model.get('error');
                     data.errorIndices = this.model.errorIndices;
+                    if (this.model.get('identityNode') && this.model.get('key') === 'Name'){
+                        data.editable = false;
+                    }
                     if (this.readOnly) {
                         data.editable = false;
                     }
+
                 }
                 return data;
             },

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/NodeModal.view.js
@@ -34,10 +34,7 @@ define([
         NodeModal.View = Marionette.Layout.extend({
             template: 'modalNode',
             className: 'modal',
-            /**
-             * Button events, right now there's a submit button
-             * I do not know where to go with the cancel button.
-             */
+
             events: {
                 "click .submit-button": "submitData",
                 "click .cancel-button": "cancel",
@@ -65,6 +62,10 @@ define([
                 this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.contactInfo.get('segmentId'), this.updateContactTabError);
                 this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.serviceInfo.get('segmentId'), this.updateServiceTabError);
                 this.listenTo(wreqr.vent, 'fieldErrorChange:' + this.model.contentInfo.get('segmentId'), this.updateContentTabError);
+
+                this.model.generalInfo.get('segments').forEach(function (segment){
+                    segment.set('identityNode', this.model.get('identityNode'));
+                }.bind(this));
 
                 this.generalInfoView = new Segment.SegmentCollectionView({
                     model: this.model.generalInfo,

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Segment.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Segment.view.js
@@ -62,7 +62,8 @@ define([
 
                 var standardFields = [];
                 var advancedFields = [];
-                this.model.get('fields').forEach( function (field) {
+                this.model.get('fields').forEach(function (field) {
+                    field.set('identityNode', this.model.get('identityNode'));
                     if (!field.get('custom') && !field.get('advanced')) {
                         standardFields.push(field);
                     }
@@ -70,7 +71,7 @@ define([
                         advancedFields.push(field);
                         this.addvancedFields = true;
                     }
-                });
+                }.bind(this));
                 this.formFieldsView = new Field.FieldCollectionView({collection: new Backbone.Collection(standardFields), readOnly: this.readOnly});
                 this.formSegmentsView = new Segment.SegmentCollectionView({
                     model: this.model,

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
@@ -131,6 +131,9 @@ table.align-middle{
   }
   .node-field {
     margin-top: 10px;
+    input[readonly] {
+        background-color: #eee;
+    }
   }
   .coords {
     padding-left: 10px;

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
@@ -14,29 +14,38 @@
 
 package org.codice.ddf.registry.federationadmin.service.impl;
 
+import static org.codice.ddf.registry.schemabindings.EbrimConstants.RIM_FACTORY;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.parser.ParserException;
 import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminException;
+import org.codice.ddf.registry.schemabindings.helper.InternationalStringTypeHelper;
 import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.registry.schemabindings.helper.SlotTypeHelper;
 import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,12 +59,15 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.security.Subject;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IdentityNodeInitializationTest {
 
     private static final String TEST_SITE_NAME = "Slate Rock and Gravel Company";
+
+    private static final String CHANGED_TEST_SITE_NAME = "Gravel and Slate Rock Company";
 
     private static final String TEST_VERSION = "FF 2.0";
 
@@ -92,6 +104,7 @@ public class IdentityNodeInitializationTest {
         System.setProperty(SystemInfo.SITE_NAME, TEST_SITE_NAME);
         System.setProperty(SystemInfo.VERSION, TEST_VERSION);
         testMetacard = getTestMetacard();
+        testMetacard.setAttribute(new AttributeImpl(Metacard.METADATA, ""));
     }
 
     @Test
@@ -113,9 +126,35 @@ public class IdentityNodeInitializationTest {
     public void initWithPreviousPrimaryEntry() throws Exception {
         testMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
                 "registryId"));
+        testMetacard.setAttribute(new AttributeImpl(Metacard.TITLE, TEST_SITE_NAME));
         when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.of(
                 testMetacard));
         identityNodeInitialization.init();
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test
+    public void initWithPreviousEntryWithNameChange() throws Exception {
+        System.setProperty(SystemInfo.SITE_NAME, CHANGED_TEST_SITE_NAME);
+        RegistryPackageType registryPackageType = buildRegistryPackageType();
+
+        testMetacard.setAttribute(new AttributeImpl(Metacard.METADATA,
+                metacardMarshaller.getRegistryPackageAsXml(registryPackageType)));
+        testMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                "registryId"));
+        testMetacard.setAttribute(new AttributeImpl(Metacard.TITLE, TEST_SITE_NAME));
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.of(
+                testMetacard));
+
+        ArgumentCaptor<Metacard> updatedMetacard = ArgumentCaptor.forClass(Metacard.class);
+        doNothing().when(federationAdminService)
+                .updateRegistryEntry(updatedMetacard.capture());
+
+        identityNodeInitialization.init();
+
+        assertThat(updatedMetacard.getValue()
+                .getTitle(), is(CHANGED_TEST_SITE_NAME));
+        verify(federationAdminService, times(1)).updateRegistryEntry(any(Metacard.class));
         verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
     }
 
@@ -129,18 +168,16 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithIngestException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
-        when(federationAdminService.addRegistryEntry(any(Metacard.class)))
-                .thenThrow(FederationAdminException.class);
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenThrow(
+                FederationAdminException.class);
         identityNodeInitialization.init();
         verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
 
     @Test
     public void initWithRegistryTransformerException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
         doThrow(CatalogTransformerException.class).when(registryTransformer)
                 .transform(any(InputStream.class));
         identityNodeInitialization.init();
@@ -149,8 +186,7 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithParserException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
         doThrow(ParserException.class).when(metacardMarshaller)
                 .getRegistryPackageAsInputStream(any(RegistryPackageType.class));
         identityNodeInitialization.init();
@@ -159,9 +195,9 @@ public class IdentityNodeInitializationTest {
 
     @Test
     public void initWithIOException() throws Exception {
-        when(federationAdminService.getLocalRegistryIdentityMetacard())
-                .thenReturn(Optional.empty());
-        doThrow(IOException.class).when(registryTransformer).transform(any(InputStream.class));
+        when(federationAdminService.getLocalRegistryIdentityMetacard()).thenReturn(Optional.empty());
+        doThrow(IOException.class).when(registryTransformer)
+                .transform(any(InputStream.class));
         identityNodeInitialization.init();
         verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
@@ -170,4 +206,34 @@ public class IdentityNodeInitializationTest {
         return new MetacardImpl(new RegistryObjectMetacardType());
     }
 
+    private RegistryPackageType buildRegistryPackageType() {
+        SlotTypeHelper slotTypeHelper = new SlotTypeHelper();
+        InternationalStringTypeHelper internationalStringTypeHelper =
+                new InternationalStringTypeHelper();
+        String registryPackageId = RegistryConstants.GUID_PREFIX + UUID.randomUUID()
+                .toString()
+                .replaceAll("-", "");
+        RegistryPackageType registryPackage = RIM_FACTORY.createRegistryPackageType();
+        registryPackage.setId(registryPackageId);
+        registryPackage.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+
+        ExtrinsicObjectType extrinsicObject = RIM_FACTORY.createExtrinsicObjectType();
+        extrinsicObject.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+
+        String extrinsicObjectId = RegistryConstants.GUID_PREFIX + UUID.randomUUID()
+                .toString()
+                .replaceAll("-", "");
+        extrinsicObject.setId(extrinsicObjectId);
+        extrinsicObject.setName(internationalStringTypeHelper.create(TEST_SITE_NAME));
+
+        String home = SystemBaseUrl.getBaseUrl();
+        extrinsicObject.setHome(home);
+
+        registryPackage.setRegistryObjectList(RIM_FACTORY.createRegistryObjectListType());
+        registryPackage.getRegistryObjectList()
+                .getIdentifiable()
+                .add(RIM_FACTORY.createIdentifiable(extrinsicObject));
+
+        return registryPackage;
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
Previously, the default registry name would be `ddf.distribution` before being set by a user if the registry was selected at install. 
The name is now bound to the site name system property. 
The editable field is now disabled and I've grayed it out for clarity.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@djblue @clockard @brianfelix 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@pklinef

#### How should this be tested?
Install a ddf and select the registry app to be installed during the installer process.
Change the site name to any other name using the installer. 
Verify that after restart, the name is the name chosen during the installer. Add additional local nodes and verify they can be renamed (the name is not grayed out). 

#### What are the relevant tickets?
DDF-2461

#### Screenshots (if appropriate)
![screen shot 2016-09-12 at 12 08 26 pm](https://cloud.githubusercontent.com/assets/9013407/18450844/8a766284-78e9-11e6-9b1e-c11a77775964.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
