### PR TITLE
DDF-2477: Admin UI no longer requires setting the system port. That is derived from the HTTP or HTTPS port and the selected default protocol.

### DIFF
--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/impl/SystemPropertiesAdmin.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
 
+    public static final String HTTP_PROTOCOL = "http://";
+
     private static final String DEFAULT_LOCALHOST_DN = "localhost.local";
 
     private MBeanServer mbeanServer;
@@ -121,17 +123,9 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
         LOGGER.debug("get system properties");
 
         ArrayList<SystemPropertyDetails> properties = new ArrayList<>();
-        properties.add(getSystemPropertyDetails(SystemBaseUrl.PROTOCOL,
-                PROTOCOL_TITLE,
-                PROTOCOL_DESCRIPTION,
-                PROTOCOL_OPTIONS));
         properties.add(getSystemPropertyDetails(SystemBaseUrl.HOST,
                 HOST_TITLE,
                 HOST_DESCRIPTION,
-                null));
-        properties.add(getSystemPropertyDetails(SystemBaseUrl.PORT,
-                DEFAULT_PORT_TITLE,
-                DEFAULT_PORT_DESCRIPTION,
                 null));
         properties.add(getSystemPropertyDetails(SystemBaseUrl.HTTP_PORT,
                 HTTP_PORT_TITLE,
@@ -182,7 +176,6 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
         try {
             Properties systemDotProperties = new Properties(systemPropertiesFile);
 
-            updateProperty(SystemBaseUrl.PORT, updatedSystemProperties, systemDotProperties);
             updateProperty(SystemBaseUrl.HOST, updatedSystemProperties, systemDotProperties);
             updateProperty(SystemBaseUrl.PROTOCOL, updatedSystemProperties, systemDotProperties);
             updateProperty(SystemBaseUrl.HTTP_PORT, updatedSystemProperties, systemDotProperties);
@@ -191,6 +184,7 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
             updateProperty(SystemInfo.SITE_CONTACT, updatedSystemProperties, systemDotProperties);
             updateProperty(SystemInfo.SITE_NAME, updatedSystemProperties, systemDotProperties);
             updateProperty(SystemInfo.VERSION, updatedSystemProperties, systemDotProperties);
+            updatePortProperty(updatedSystemProperties, systemDotProperties);
 
             systemDotProperties.save();
 
@@ -286,6 +280,19 @@ public class SystemPropertiesAdmin implements SystemPropertiesAdminMBean {
             systemDotProperties.put(key, value);
             System.setProperty(key, value);
         }
+    }
+
+    private void updatePortProperty(Map<String, String> updatedProperties,
+            Properties systemDotProperties) {
+        String protocol = SystemBaseUrl.getProtocol();
+
+        String port = SystemBaseUrl.getHttpsPort();
+        if (protocol != null && protocol.equalsIgnoreCase(HTTP_PROTOCOL)) {
+            port = SystemBaseUrl.getHttpPort();
+        }
+
+        systemDotProperties.put(SystemBaseUrl.PORT, port);
+        System.setProperty(SystemBaseUrl.PORT, port);
     }
 
     private void configureMBean() {

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/SystemPropertiesAdminTest.java
@@ -50,15 +50,12 @@ public class SystemPropertiesAdminTest {
 
     @Before
     public void setUp() throws IOException {
-        System.setProperty(SystemBaseUrl.HOST, "host");
-        expectedSystemPropertiesCount++;
         System.setProperty(SystemBaseUrl.PORT, "1234");
+        System.setProperty(SystemBaseUrl.HOST, "host");
         expectedSystemPropertiesCount++;
         System.setProperty(SystemBaseUrl.HTTP_PORT, "4567");
         expectedSystemPropertiesCount++;
         System.setProperty(SystemBaseUrl.HTTPS_PORT, "8901");
-        expectedSystemPropertiesCount++;
-        System.setProperty(SystemBaseUrl.PROTOCOL, "https://");
         expectedSystemPropertiesCount++;
         System.setProperty(SystemInfo.ORGANIZATION, "org");
         expectedSystemPropertiesCount++;
@@ -84,10 +81,8 @@ public class SystemPropertiesAdminTest {
         SystemPropertiesAdmin spa = new SystemPropertiesAdmin();
         List<SystemPropertyDetails> details = spa.readSystemProperties();
         assertThat(getDetailsValue(details, SystemBaseUrl.HOST), equalTo("host"));
-        assertThat(getDetailsValue(details, SystemBaseUrl.PORT), equalTo("1234"));
         assertThat(getDetailsValue(details, SystemBaseUrl.HTTP_PORT), equalTo("4567"));
         assertThat(getDetailsValue(details, SystemBaseUrl.HTTPS_PORT), equalTo("8901"));
-        assertThat(getDetailsValue(details, SystemBaseUrl.PROTOCOL), equalTo("https://"));
         assertThat(getDetailsValue(details, SystemInfo.ORGANIZATION), equalTo("org"));
         assertThat(getDetailsValue(details, SystemInfo.SITE_CONTACT), equalTo("contact"));
         assertThat(getDetailsValue(details, SystemInfo.SITE_NAME), equalTo("site"));
@@ -134,7 +129,7 @@ public class SystemPropertiesAdminTest {
         spa.writeSystemProperties(map);
         List<SystemPropertyDetails> details = spa.readSystemProperties();
         assertThat(SystemBaseUrl.getHost(), equalTo("newhost"));
-        assertThat(SystemBaseUrl.getPort(), equalTo("1234"));
+        assertThat(SystemBaseUrl.getPort(), equalTo("8901"));
         assertThat(SystemBaseUrl.getHttpPort(), equalTo("4567"));
         assertThat(SystemBaseUrl.getHttpsPort(), equalTo("8901"));
         assertThat(SystemBaseUrl.getProtocol(), equalTo("https://"));
@@ -149,7 +144,7 @@ public class SystemPropertiesAdminTest {
         Properties sysProps = new Properties();
         try (FileReader sysPropsReader = new FileReader(systemPropsFile)) {
             sysProps.load(sysPropsReader);
-            assertThat(sysProps.size(), is(1));
+            assertThat(sysProps.size(), is(2));
             assertThat(sysProps.getProperty(SystemBaseUrl.HOST), equalTo("newhost"));
         }
 


### PR DESCRIPTION
#### What does this PR do?
Updates the Admin UI so that the system.port is derived from the protocol selection and the port number entered for either HTTP or HTTPS port.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested?
Perform a build and install of DDF. Change the port and/or protocol in the Admin UI. Verify <install>/etc/system.properties has the correct value for property: org.codice.ddf.system.port

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2477

#### Screenshots (if appropriate)
![screen shot 2016-09-14 at 9 49 07 am](https://cloud.githubusercontent.com/assets/17255437/18519284/9b2222f8-7a60-11e6-9115-59159fa799b2.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
