### PR TITLE
DDF-2382 - 2.9.X - Update Registry Metacard Attributes to reflect common metacard taxonomy changes

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.js
@@ -234,12 +234,12 @@ define([
         getSecondaryNodes: function() {
             return this.models.filter(function(model){
                 var transValues = model.get('TransientValues');
-                return transValues && !transValues['registry-identity-node'] && transValues['registry-local-node'];
+                return transValues && !transValues['registry.local.registry-identity-node'] && transValues['registry.local.registry-local-node'];
             });
         },
         getIdentityNode: function(){
             var array = this.models.filter(function(model){
-                return model.get('TransientValues') && model.get('TransientValues')['registry-identity-node'];
+                return model.get('TransientValues') && model.get('TransientValues')['registry.local.registry-identity-node'];
             });
             if(array.length === 1){
                 array[0].set('identityNode',true);
@@ -250,7 +250,7 @@ define([
         getRemoteNodes: function(){
             return this.models.filter(function(model){
                 var transValues = model.get('TransientValues');
-                return !transValues || !transValues['registry-local-node'];
+                return !transValues || !transValues['registry.local.registry-local-node'];
             });
         },
         deleteNodes: function (nodes) {

--- a/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
+++ b/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
@@ -51,35 +51,35 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
 
     public static final String DATA_END_DATE = "data-end-date";
 
-    public static final String LINKS = "links";
+    public static final String LINKS = "registry.links";
 
-    public static final String REGION = "region";
+    public static final String REGION = "registry.region";
 
-    public static final String DATA_SOURCES = "input-data-sources";
+    public static final String DATA_SOURCES = "registry.input-data-sources";
 
     public static final String DATA_TYPES = "data-types";
 
     //list of all the service binding ids
-    public static final String SERVICE_BINDINGS = "service-bindings";
+    public static final String SERVICE_BINDINGS = "registry.service-bindings";
 
     //list of bindingType fields from all the service bindings
-    public static final String SERVICE_BINDING_TYPES = "service-binding-types";
+    public static final String SERVICE_BINDING_TYPES = "registry.service-binding-types";
 
-    public static final String REGISTRY_ID = "registry-id";
+    public static final String REGISTRY_ID = "registry.registry-id";
 
-    public static final String REGISTRY_IDENTITY_NODE = "registry-identity-node";
+    public static final String REGISTRY_IDENTITY_NODE = "registry.local.registry-identity-node";
 
-    public static final String PUBLISHED_LOCATIONS = "published-locations";
+    public static final String PUBLISHED_LOCATIONS = "registry.local.published-locations";
 
-    public static final String LAST_PUBLISHED = "last-published";
+    public static final String LAST_PUBLISHED = "registry.local.last-published";
 
-    public static final String REGISTRY_BASE_URL = "registry-base-url";
+    public static final String REGISTRY_BASE_URL = "registry.registry-base-url";
 
-    public static final String REGISTRY_LOCAL_NODE = "registry-local-node";
+    public static final String REGISTRY_LOCAL_NODE = "registry.local.registry-local-node";
 
-    public static final String REMOTE_REGISTRY_ID = "remote-registry-id";
+    public static final String REMOTE_REGISTRY_ID = "registry.local.remote-registry-id";
 
-    public static final String REMOTE_METACARD_ID = "remote-metacard-id";
+    public static final String REMOTE_METACARD_ID = "registry.local.remote-metacard-id";
 
     public static final Set<String> TRANSIENT_ATTRIBUTES;
 

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/converter/RegistryPackageConverter.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/java/org/codice/ddf/registry/converter/RegistryPackageConverter.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -379,19 +378,6 @@ public class RegistryPackageConverter {
             metacard.setAttribute(RegistryObjectMetacardType.REGISTRY_ID, registryObject.getId());
         }
 
-        if (registryObject.isSetObjectType()) {
-            String objectType = registryObject.getObjectType();
-            Matcher matcher = URN_PATTERN.matcher(objectType);
-            if (matcher.find()) {
-                objectType = matcher.group(1)
-                        .replaceAll(":", ".");
-                if (!objectType.startsWith(RegistryConstants.REGISTRY_TAG)) {
-                    objectType = String.format("%s.%s", RegistryConstants.REGISTRY_TAG, objectType);
-                }
-            }
-            metacard.setContentTypeName(objectType);
-        }
-
         if (registryObject.isSetName()) {
             setMetacardStringAttribute(INTERNATIONAL_STRING_TYPE_HELPER.getString(registryObject.getName()),
                     Metacard.TITLE,
@@ -416,11 +402,13 @@ public class RegistryPackageConverter {
                 if (extId.getId()
                         .equals(RegistryConstants.REGISTRY_MCARD_ID_LOCAL)) {
                     metacard.setId(extId.getValue());
-                } else if (extId.getId().equals(RegistryConstants.REGISTRY_ID_ORIGIN)) {
+                } else if (extId.getId()
+                        .equals(RegistryConstants.REGISTRY_ID_ORIGIN)) {
                     if (!System.getProperty(RegistryConstants.REGISTRY_ID_PROPERTY)
                             .equals(extId.getValue())) {
                         setMetacardStringAttribute(extId.getValue(),
-                                RegistryObjectMetacardType.REMOTE_REGISTRY_ID, metacard);
+                                RegistryObjectMetacardType.REMOTE_REGISTRY_ID,
+                                metacard);
                     }
                 }
             }

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/test/java/org/codice/ddf/registry/transformer/RegistryTransformerTest.java
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/test/java/org/codice/ddf/registry/transformer/RegistryTransformerTest.java
@@ -14,10 +14,10 @@
 package org.codice.ddf.registry.transformer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -57,8 +57,7 @@ public class RegistryTransformerTest {
     private Parser parser;
 
     private void assertRegistryMetacard(Metacard meta) {
-        assertThat(meta.getContentTypeName(),
-                startsWith(RegistryObjectMetacardType.REGISTRY_METACARD_TYPE_NAME));
+        assertThat(meta.getTags(), contains(RegistryConstants.REGISTRY_TAG));
     }
 
     @Before

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -616,10 +616,6 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
     private List<Filter> getBasicFilter(String tag) {
         List<Filter> filters = new ArrayList<>();
-        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE)
-                .is()
-                .equalTo()
-                .text(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
         filters.add(filterBuilder.attribute(Metacard.TAGS)
                 .is()
                 .equalTo()

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
@@ -322,10 +322,6 @@ public class RefreshRegistryEntries {
 
     private Query getBasicRegistryQuery() {
         List<Filter> filters = new ArrayList<>();
-        filters.add(filterBuilder.attribute(Metacard.CONTENT_TYPE)
-                .is()
-                .equalTo()
-                .text(RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
         filters.add(filterBuilder.attribute(Metacard.TAGS)
                 .is()
                 .equalTo()

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -319,7 +319,7 @@ public class TestRegistry extends AbstractIntegrationTest {
         federationAdminServiceImpl.addRegistryEntry(Library.getRegistryNode(id, regId, remoteRegId),
                 destinations);
 
-        ValidatableResponse validatableResponse = getCswRegistryResponse("registry-id", regId);
+        ValidatableResponse validatableResponse = getCswRegistryResponse("registry.registry-id", regId);
 
         final String xPathRegistryID =
                 "string(//GetRecordsResponse/SearchResults/RegistryPackage/ExternalIdentifier/@registryObject)";

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/common/Library.java
@@ -225,7 +225,7 @@ public final class Library {
                 + "  <csw:Delete typeName=\"rim:RegistryPackage\" handle=\"something\">\n"
                 + "    <csw:Constraint version=\"2.0.0\">\n" + "      <ogc:Filter>\n"
                 + "        <ogc:PropertyIsEqualTo>\n"
-                + "            <ogc:PropertyName>remote-metacard-id</ogc:PropertyName>\n"
+                + "            <ogc:PropertyName>registry.local.remote-metacard-id</ogc:PropertyName>\n"
                 + "            <ogc:Literal>" + id + "</ogc:Literal>\n"
                 + "        </ogc:PropertyIsEqualTo>\n" + "      </ogc:Filter>\n"
                 + "    </csw:Constraint>\n" + "  </csw:Delete>\n" + "</csw:Transaction>";


### PR DESCRIPTION
#### What does this PR do?
The registry apps RegistryObjectMetacardType was updated to match the changes to the new metacard attribute taxonomy that were made in the master branch, but are not fully ported to 2.9.x.
This means the constants were changed such that the branches' registry functionality will still be compatible between builds.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @gordocanchola @vinamartin @brianfelix @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@jlcsmith 
@shaundmorris  

#### How should this be tested?
Install DDF, Start the Registry App and confirm the identity node is present in the local nodes tab. Confirm edits to the nodes are retained and that connections can still be made using the remote nodes tab.

#### Any background context you want to provide?
This PR does not match the changes made in the ticket on the master branch, but does update the registry metacard fields to match the master changes for future compatibility.

#### What are the relevant tickets?
DDF-2382 

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

