### PR TITLE
DDF-2457: Improve the Sources Tab with appropriate and current status…

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/index.html
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/index.html
@@ -33,6 +33,9 @@
     <![endif]-->
 </head>
 <body>
+<div id="page-loading">
+    <p>Please wait while loading page <span class="fa fa-refresh fa-spin"></span></p>
+</div>
 <main class="container" role="main"></main>
 <script data-main="main" src="lib/requirejs/require.js"></script>
 <script data-main="main" src="lib/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
@@ -7,6 +7,20 @@ table.align-middle {
   }
 }
 
+#page-loading {
+  p {
+    padding-top: 5em;
+    text-align: center;
+  }
+}
+
+#sources-loading {
+  p {
+    padding-top: 5em;
+    text-align: center;
+  }
+}
+
 #sourcesRegion {
   a {
     text-decoration: none;

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/main.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/main.js
@@ -140,7 +140,7 @@
         app.start();
 
         require(['js/module'], function () {
-
+            $("#page-loading").addClass('hide');
         });
 
     });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
@@ -11,6 +11,7 @@
  *
  **/
  --}}
+<div id="sources-loading"><p>Please wait while loading sources <span class="fa fa-refresh fa-spin"></span></p></div>
 <table class='table table-striped align-middle'>
     <thead>
         <th class="name">Name</th>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
@@ -43,10 +43,14 @@
 </td>
 <td colspan="4">
     {{#if currentConfiguration}}
-        {{#if available}}
-            <span class='label label-success'>Available</span>
+        {{#if loading}}
+            <span class='label label-info'>Loading</span>
         {{else}}
-            <span class='label label-warning'>Unavailable</span>
+            {{#if available}}
+                <span class='label label-success'>Available</span>
+            {{else}}
+                <span class='label label-warning'>Unavailable</span>
+            {{/if}}
         {{/if}}
     {{/if}}
 </td>


### PR DESCRIPTION
#### What does this PR do?
Previously when retrieving sources statuses, users were presented with misleading information.  For example, when the sources tab was being loaded, users received a message stating "There are no sources configured".  When a source's status had not yet been retrieved from the server, its status would show up as "Unavailable".  This PR addresses the initial loading issue by displaying a message to the user that the sources are being loaded.  It addresses the misleading source status indicators by displaying a "Loading" indicator next to any source whose status has not yet been retrieved from the server.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@garrettfreibott 
@andrewkfiedler 
@vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef 
#### How should this be tested?
Hero Build

Manual Test:
1) Using the Chrome Developer Tools, simulate a slow network (high latency) connection.
2) Navigate to the Sources tab in the Admin Console (DDF Catalog -> Sources)
3) Verify a loading message is displayed.
4) Added a few sources.
5) Refresh the sources tab.
6) Verify that Loading indicators are displayed for sources as their statuses are retrieved from the server
7) Delete all of the sources
8) Verify that the page displays a "no sources configured message". 
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2457
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

![screen shot 2016-09-14 at 3 45 59 pm](https://cloud.githubusercontent.com/assets/4838043/18533520/4e52fe38-7a98-11e6-8df2-fdf3f0f82b84.png)
![screen shot 2016-09-14 at 3 48 04 pm](https://cloud.githubusercontent.com/assets/4838043/18533526/53327e10-7a98-11e6-9bd1-b3ab0defac9e.png)
![screen shot 2016-09-14 at 4 03 02 pm](https://cloud.githubusercontent.com/assets/4838043/18533529/56508be6-7a98-11e6-91a1-a4c69f0dcb5a.png)
