### PR TITLE
DDF-2462: Start and stop feature utility methods used for integration tests do not wait when requested

### DIFF
--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManager.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManager.java
@@ -28,16 +28,69 @@ public interface ServiceManager {
 
     BundleContext getBundleContext();
 
+    /**
+     * Creates a Managed Service that is created from a Managed Service Factory. Waits for the
+     * asynchronous call that the properties have been updated and the service can be used.
+     * <p>
+     * For Managed Services not created from a Managed Service Factory, use
+     * {@link #startManagedService(String, Map)} instead.
+     *
+     * @param factoryPid the factory pid of the Managed Service Factory
+     * @param properties the service properties for the Managed Service
+     * @throws IOException if access to persistent storage fails
+     */
     void createManagedService(String factoryPid, Map<String, Object> properties) throws IOException;
 
+    /**
+     * Starts a Managed Service. Waits for the asynchronous call that the properties have been
+     * updated and the service can be used.
+     * <p>
+     * For Managed Services created from a Managed Service Factory, use
+     * {@link #createManagedService(String, Map)} instead.
+     *
+     * @param servicePid persistent identifier of the Managed Service to start
+     * @param properties service configuration properties
+     * @throws IOException thrown if if access to persistent storage fails
+     */
     void startManagedService(String servicePid, Map<String, Object> properties) throws IOException;
 
+    /**
+     * Stops a managed service.
+     *
+     * @param servicePid persistent identifier of the Managed Service to stop
+     * @throws IOException thrown if if access to persistent storage fails
+     */
     void stopManagedService(String servicePid) throws IOException;
 
+    /**
+     * Installs and starts one or more features.
+     *
+     * @param wait         if {@code true}, this method will wait until the state of all the
+     *                     features is {@code Started} and all bundles are {@code Active} before
+     *                     returning
+     * @param featureNames names of the features to install and start
+     * @throws Exception thrown if one of the features fails to be installed or started
+     */
     void startFeature(boolean wait, String... featureNames) throws Exception;
 
+    /**
+     * Stops and uninstalls one or more features.
+     *
+     * @param wait         if {@code true}, this method will wait until the state of all the
+     *                     features is {@code Uninstalled} and all bundles are {@code Active} before
+     *                     returning
+     * @param featureNames names of the features to install and start
+     * @throws Exception thrown if one of the features fails to be installed or started
+     */
     void stopFeature(boolean wait, String... featureNames) throws Exception;
 
+    /**
+     * Restarts one or more bundles. The bundles will be stopped in the order provided and started
+     * in the reverse order.
+     *
+     * @param bundleSymbolicNames list of bundle symbolic names to restart
+     * @throws BundleException if one of the bundles fails to stop or start
+     */
     void restartBundles(String... bundleSymbolicNames) throws BundleException;
 
     void stopBundle(String bundleSymbolicName) throws BundleException;
@@ -49,6 +102,13 @@ public interface ServiceManager {
     void waitForAllBundles() throws InterruptedException;
 
     void waitForRequiredBundles(String symbolicNamePrefix) throws InterruptedException;
+
+    /**
+     * Waits for one or more bundle to be uninstalled.
+     *
+     * @param bundleSymbolicNames symbolic names of the bundles to wait for
+     */
+    void waitForBundleUninstall(String... bundleSymbolicNames);
 
     void waitForFeature(String featureName, Predicate<FeatureState> predicate) throws Exception;
 

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManagerImpl.java
@@ -78,7 +78,7 @@ public class ServiceManagerImpl implements ServiceManager {
 
     public static final long MANAGED_SERVICE_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
 
-    public static final long REQUIRED_BUNDLES_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
+    public static final long FEATURES_AND_BUNDLES_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
 
     public static final long HTTP_ENDPOINT_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
 
@@ -222,7 +222,7 @@ public class ServiceManagerImpl implements ServiceManager {
     private FeaturesService getFeaturesService() throws InterruptedException {
         FeaturesService featuresService = null;
         boolean ready = false;
-        long timeoutLimit = System.currentTimeMillis() + REQUIRED_BUNDLES_TIMEOUT;
+        long timeoutLimit = System.currentTimeMillis() + FEATURES_AND_BUNDLES_TIMEOUT;
         while (!ready) {
             ServiceReference<FeaturesService> featuresServiceRef =
                     FrameworkUtil.getBundle(this.getClass())
@@ -242,7 +242,7 @@ public class ServiceManagerImpl implements ServiceManager {
             if (!ready) {
                 if (System.currentTimeMillis() > timeoutLimit) {
                     fail(String.format("Feature service could not be resolved within %d minutes.",
-                            TimeUnit.MILLISECONDS.toMinutes(REQUIRED_BUNDLES_TIMEOUT)));
+                            TimeUnit.MILLISECONDS.toMinutes(FEATURES_AND_BUNDLES_TIMEOUT)));
                 }
                 Thread.sleep(1000);
             }
@@ -330,7 +330,7 @@ public class ServiceManagerImpl implements ServiceManager {
             bundleService = getService(BundleService.class);
         }
 
-        long timeoutLimit = System.currentTimeMillis() + REQUIRED_BUNDLES_TIMEOUT;
+        long timeoutLimit = System.currentTimeMillis() + FEATURES_AND_BUNDLES_TIMEOUT;
         while (!ready) {
             List<Bundle> bundles = Arrays.asList(getBundleContext().getBundles());
 
@@ -364,7 +364,7 @@ public class ServiceManagerImpl implements ServiceManager {
                 if (System.currentTimeMillis() > timeoutLimit) {
                     printInactiveBundles();
                     fail(String.format("Bundles and blueprint did not start within %d minutes.",
-                            TimeUnit.MILLISECONDS.toMinutes(REQUIRED_BUNDLES_TIMEOUT)));
+                            TimeUnit.MILLISECONDS.toMinutes(FEATURES_AND_BUNDLES_TIMEOUT)));
                 }
                 LOGGER.info("Bundles not up, sleeping...");
                 Thread.sleep(1000);
@@ -382,7 +382,7 @@ public class ServiceManagerImpl implements ServiceManager {
                 .collect(Collectors.toList());
 
         WaitCondition.expect(String.format("Bundles %s uninstalled", symbolicNamesSet))
-                .within(2, TimeUnit.MINUTES)
+                .within(FEATURES_AND_BUNDLES_TIMEOUT, TimeUnit.MILLISECONDS)
                 .until(() -> bundleIds.stream()
                         .filter(id -> getBundleContext().getBundle(id) != null)
                         .collect(Collectors.toList())
@@ -395,7 +395,7 @@ public class ServiceManagerImpl implements ServiceManager {
             throws Exception {
         boolean ready = false;
 
-        long timeoutLimit = System.currentTimeMillis() + REQUIRED_BUNDLES_TIMEOUT;
+        long timeoutLimit = System.currentTimeMillis() + FEATURES_AND_BUNDLES_TIMEOUT;
         FeaturesService featuresService = getFeaturesService();
 
         while (!ready) {
@@ -418,7 +418,7 @@ public class ServiceManagerImpl implements ServiceManager {
                     printInactiveBundles();
                     fail(String.format("Feature did not change to State [" + predicate.toString()
                                     + "] within %d minutes.",
-                            TimeUnit.MILLISECONDS.toMinutes(REQUIRED_BUNDLES_TIMEOUT)));
+                            TimeUnit.MILLISECONDS.toMinutes(FEATURES_AND_BUNDLES_TIMEOUT)));
                 }
                 LOGGER.info("Still waiting on feature [{}], current state [{}]...",
                         featureName,

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ServiceManagerImpl.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.bundle.core.BundleInfo;
@@ -67,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.osgi.util.OsgiStringUtils;
 
+import com.google.common.collect.Sets;
 import com.jayway.restassured.response.Response;
 
 public class ServiceManagerImpl implements ServiceManager {
@@ -96,17 +98,6 @@ public class ServiceManagerImpl implements ServiceManager {
                 .getBundleContext();
     }
 
-    /**
-     * Creates a Managed Service that is created from a Managed Service Factory. Waits for the
-     * asynchronous call that the properties have been updated and the service can be used.
-     * <p>
-     * For Managed Services not created from a Managed Service Factory, use
-     * {@link #startManagedService(String, Map)} instead.
-     *
-     * @param factoryPid the factory pid of the Managed Service Factory
-     * @param properties the service properties for the Managed Service
-     * @throws IOException if access to persistent storage fails
-     */
     public void createManagedService(String factoryPid, Map<String, Object> properties)
             throws IOException {
 
@@ -115,17 +106,6 @@ public class ServiceManagerImpl implements ServiceManager {
         startManagedService(sourceConfig, properties);
     }
 
-    /**
-     * Starts a Managed Service. Waits for the asynchronous call that the properties have been
-     * updated and the service can be used.
-     * <p>
-     * For Managed Services created from a Managed Service Factory, use
-     * {@link #createManagedService(String, Map)} instead.
-     *
-     * @param servicePid persistent identifier of the Managed Service to start
-     * @param properties service configuration properties
-     * @throws IOException thrown if if access to persistent storage fails
-     */
     public void startManagedService(String servicePid, Map<String, Object> properties)
             throws IOException {
         Configuration sourceConfig = adminConfig.getConfiguration(servicePid, null);
@@ -133,12 +113,6 @@ public class ServiceManagerImpl implements ServiceManager {
         startManagedService(sourceConfig, properties);
     }
 
-    /**
-     * Stops a managed service.
-     *
-     * @param servicePid
-     * @throws IOException
-     */
     public void stopManagedService(String servicePid) throws IOException {
         Configuration sourceConfig = adminConfig.getConfiguration(servicePid, null);
         ServiceConfigurationListener listener =
@@ -215,11 +189,17 @@ public class ServiceManagerImpl implements ServiceManager {
     public void startFeature(boolean wait, String... featureNames) throws Exception {
         for (String featureName : featureNames) {
             FeatureState state = getFeaturesService().getState(featureName);
+
             if (FeatureState.Installed != state) {
                 getFeaturesService().installFeature(featureName, EnumSet.of(NoAutoRefreshBundles));
             }
         }
+
         if (wait) {
+            for (String featureName : featureNames) {
+                waitForFeature(featureName, state -> state == FeatureState.Started);
+            }
+
             waitForAllBundles();
         }
     }
@@ -228,7 +208,12 @@ public class ServiceManagerImpl implements ServiceManager {
         for (String featureName : featureNames) {
             getFeaturesService().uninstallFeature(featureName, EnumSet.of(NoAutoRefreshBundles));
         }
+
         if (wait) {
+            for (String featureName : featureNames) {
+                waitForFeature(featureName, state -> state == FeatureState.Uninstalled);
+            }
+
             waitForAllBundles();
         }
     }
@@ -273,13 +258,6 @@ public class ServiceManagerImpl implements ServiceManager {
         return getBundleContext().getService(applicationServiceRef);
     }
 
-    /**
-     * Restarts one or more bundles. The bundles will be stopped in the order provided and started
-     * in the reverse order.
-     *
-     * @param bundleSymbolicNames list of bundle symbolic names to restart
-     * @throws BundleException if one of the bundles fails to stop or start
-     */
     public void restartBundles(String... bundleSymbolicNames) throws BundleException {
         LOGGER.debug("Restarting bundles {}", bundleSymbolicNames);
 
@@ -394,17 +372,39 @@ public class ServiceManagerImpl implements ServiceManager {
         }
     }
 
+    public void waitForBundleUninstall(String... bundleSymbolicNames) {
+        Set<String> symbolicNamesSet = Sets.newHashSet(bundleSymbolicNames);
+        LOGGER.info("Waiting for bundles {} to be uninstalled...", symbolicNamesSet);
+
+        final List<Long> bundleIds = Arrays.stream(getBundleContext().getBundles())
+                .filter(b -> symbolicNamesSet.contains(b.getSymbolicName()))
+                .map(Bundle::getBundleId)
+                .collect(Collectors.toList());
+
+        WaitCondition.expect(String.format("Bundles %s uninstalled", symbolicNamesSet))
+                .within(2, TimeUnit.MINUTES)
+                .until(() -> bundleIds.stream()
+                        .filter(id -> getBundleContext().getBundle(id) != null)
+                        .collect(Collectors.toList())
+                        .isEmpty());
+
+        LOGGER.info("Bundles {} uninstalled", symbolicNamesSet);
+    }
+
     public void waitForFeature(String featureName, Predicate<FeatureState> predicate)
             throws Exception {
         boolean ready = false;
 
         long timeoutLimit = System.currentTimeMillis() + REQUIRED_BUNDLES_TIMEOUT;
         FeaturesService featuresService = getFeaturesService();
+
         while (!ready) {
+            FeatureState state = null;
+
             if (featuresService != null) {
                 Feature feature = featuresService.getFeature(featureName);
-                FeatureState state = featuresService.getState(
-                        feature.getName() + "/" + feature.getVersion());
+                state = featuresService.getState(feature.getName() + "/" + feature.getVersion());
+
                 if (state == null) {
                     LOGGER.warn("No Feature found for featureName: {}", featureName);
                     return;
@@ -420,9 +420,9 @@ public class ServiceManagerImpl implements ServiceManager {
                                     + "] within %d minutes.",
                             TimeUnit.MILLISECONDS.toMinutes(REQUIRED_BUNDLES_TIMEOUT)));
                 }
-                LOGGER.info("Feature [{}] not [{}], sleeping...",
+                LOGGER.info("Still waiting on feature [{}], current state [{}]...",
                         featureName,
-                        predicate.toString());
+                        state);
                 Thread.sleep(1000);
             }
         }


### PR DESCRIPTION
#### What does this PR do?
Changed start and stop feature methods used by the integration code to wait for the feature state to change before returning.
Also added a new method to wait for a list of bundles to be uninstalled.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@shaundmorris

#### How should this be tested?
Bamboo build successful.

#### Any background context you want to provide?
This is a back-port of https://github.com/codice/ddf/pull/1246.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2462

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
