### PR TITLE
DDF-2361 - (2.9.x) Enable fanout and ddf registry to be used at the same time in the same ddf instance

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -446,17 +446,17 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.46</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.42</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,7 +25,7 @@
         <bean id="mapConverter" class="ddf.catalog.util.impl.MapConverter"/>
     </type-converters>
 
-    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]"/>
 
     <reference id="transformerMapper" interface="ddf.mime.MimeTypeToTransformerMapper"/>
 
@@ -318,8 +318,9 @@
     <bean id="reliableResourceDownloadManager"
           class="ddf.catalog.resource.download.ReliableResourceDownloadManager"
           init-method="init" destroy-method="cleanUp">
-        <cm:managed-properties persistent-id="ddf.catalog.resource.download.ReliableResourceDownloadManager"
-                               update-strategy="container-managed"/>
+        <cm:managed-properties
+                persistent-id="ddf.catalog.resource.download.ReliableResourceDownloadManager"
+                update-strategy="container-managed"/>
         <argument>
             <bean xml:id="downloaderConfig"
                   class="ddf.catalog.resource.download.ReliableResourceDownloaderConfig">
@@ -404,6 +405,13 @@
         <property name="historian" ref="historian"/>
         <property name="masker" ref="sourceListener"/>
         <property name="notificationEnabled" value="true"/>
+        <property name="filterAdapter" ref="filterAdapter"/>
+        <property name="fanoutProxyTagBlacklist">
+            <list value-type="java.lang.String">
+                <value>registry</value>
+                <value>registry-remote</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="sourcePoller" class="ddf.catalog.util.impl.SourcePoller">
@@ -461,10 +469,10 @@
 
     <jaxrs:server id="resourceDownloadEnpoint" address="/catalog/downloads">
         <jaxrs:serviceBeans>
-            <ref component-id="resourceDownloadBean" />
+            <ref component-id="resourceDownloadBean"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
-            <bean class="ddf.catalog.resource.download.DownloadToCacheOnlyExceptionMapper" />
+            <bean class="ddf.catalog.resource.download.DownloadToCacheOnlyExceptionMapper"/>
         </jaxrs:providers>
     </jaxrs:server>
 

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,13 @@
         <AD name="Enable Notifications" id="notificationEnabled" required="false" type="Boolean"
             default="true"
             description="Check to enable notifications."/>
+        <AD name="Fanout tag blacklist" id="fanoutTagBlacklist" required="true" type="String"
+            cardinality="100"
+            description="Ingest operations with tags in this list will be rejected."/>
+        <AD name="Fanout proxy tag blacklist" id="fanoutProxyTagBlacklist" required="true"
+            type="String" cardinality="100"
+            default="registry,registry-remote"
+            description="Query operations with tags in this list will not be passed through."/>
 
     </OCD>
 
@@ -40,7 +47,7 @@
     </Designate>
 
     <Designate pid="ddf.catalog.history.Historian">
-        <Object ocdref="ddf.catalog.history.Historian" />
+        <Object ocdref="ddf.catalog.history.Historian"/>
     </Designate>
 
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
@@ -17,38 +17,70 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.activation.MimeType;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteSource;
 
+import ddf.catalog.cache.solr.impl.ValidationQueryFactory;
+import ddf.catalog.content.StorageProvider;
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.content.data.impl.ContentItemImpl;
+import ddf.catalog.content.impl.MockMemoryStorageProvider;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.UpdateStorageRequest;
+import ddf.catalog.content.operation.impl.CreateStorageRequestImpl;
+import ddf.catalog.content.operation.impl.UpdateStorageRequestImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.federation.FederationStrategy;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.SourceInfoRequest;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.QueryResponseImpl;
 import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.plugin.PostIngestPlugin;
+import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.ConnectedSource;
 import ddf.catalog.source.FederatedSource;
+import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.util.impl.SourcePoller;
 import ddf.catalog.util.impl.SourcePollerRunner;
+import ddf.mime.MimeTypeMapper;
+import ddf.mime.MimeTypeToTransformerMapper;
 
 public class FanoutCatalogFrameworkTest {
     private static final String OLD_SOURCE_ID = "oldSourceId";
@@ -275,6 +307,140 @@ public class FanoutCatalogFrameworkTest {
         // Assert not null simply to prove that we returned an object.
         assertNotNull(framework.getSourceInfo(request));
 
+    }
+
+    @Test(expected = IngestException.class)
+    public void testBlacklistedTagCreateRequestFails() throws Exception {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
+        CreateRequest request = new CreateRequestImpl(metacard);
+        framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
+        framework.create(request);
+    }
+
+    @Test(expected = IngestException.class)
+    public void testBlacklistedTagUpdateRequestFails() throws Exception {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, "metacardId"));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
+
+        UpdateRequest request = new UpdateRequestImpl(metacard.getId(), metacard);
+        framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
+        framework.update(request);
+    }
+
+    @Test(expected = IngestException.class)
+    public void testBlacklistedTagDeleteRequestFails() throws Exception {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, "metacardId"));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
+
+        CatalogProvider catalogProvider = mock(CatalogProvider.class);
+        doReturn(true).when(catalogProvider)
+                .isAvailable();
+        StorageProvider storageProvider = new MockMemoryStorageProvider();
+
+        FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+        FilterAdapter filterAdapter = mock(FilterAdapter.class);
+
+        ValidationQueryFactory validationQueryFactory = new ValidationQueryFactory(filterAdapter,
+                filterBuilder);
+
+        QueryRequestImpl queryRequest = new QueryRequestImpl(mock(Query.class));
+        ResultImpl result = new ResultImpl(metacard);
+        List<Result> results = new ArrayList<>();
+        results.add(result);
+
+        QueryResponseImpl queryResponse = new QueryResponseImpl(queryRequest, results, 1);
+        FederationStrategy strategy = mock(FederationStrategy.class);
+        when(strategy.federate(anyList(), any())).thenReturn(queryResponse);
+
+        QueryResponsePostProcessor queryResponsePostProcessor =
+                mock(QueryResponsePostProcessor.class);
+        doNothing().when(queryResponsePostProcessor)
+                .processResponse(any());
+
+        frameworkProperties.setCatalogProviders(Collections.singletonList(catalogProvider));
+        frameworkProperties.setStorageProviders(Collections.singletonList(storageProvider));
+        frameworkProperties.setFilterBuilder(filterBuilder);
+        frameworkProperties.setValidationQueryFactory(validationQueryFactory);
+        frameworkProperties.setFederationStrategy(strategy);
+        frameworkProperties.setQueryResponsePostProcessor(queryResponsePostProcessor);
+
+        CatalogFrameworkImpl framework = new CatalogFrameworkImpl(frameworkProperties);
+        framework.bind(catalogProvider);
+        framework.bind(storageProvider);
+
+        framework.setId(NEW_SOURCE_ID);
+        framework.setFanoutEnabled(true);
+        framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
+
+        DeleteRequest request = new DeleteRequestImpl(metacard.getId());
+        framework.delete(request);
+    }
+
+    @Test(expected = IngestException.class)
+    public void testBlacklistedTagCreateStorageRequestFails() throws Exception {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
+
+        CatalogProvider catalogProvider = mock(CatalogProvider.class);
+        doReturn(true).when(catalogProvider)
+                .isAvailable();
+        StorageProvider storageProvider = new MockMemoryStorageProvider();
+        MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
+        doReturn("extension").when(mimeTypeMapper)
+                .getFileExtensionForMimeType(anyString());
+        InputTransformer transformer = mock(InputTransformer.class);
+        doReturn(metacard).when(transformer)
+                .transform(any(InputStream.class));
+
+        MimeTypeToTransformerMapper mimeTypeToTransformerMapper =
+                mock(MimeTypeToTransformerMapper.class);
+        doReturn(Collections.singletonList(transformer)).when(mimeTypeToTransformerMapper)
+                .findMatches(any(Class.class), any(MimeType.class));
+
+        frameworkProperties.setCatalogProviders(Collections.singletonList(catalogProvider));
+        frameworkProperties.setStorageProviders(Collections.singletonList(storageProvider));
+        frameworkProperties.setMimeTypeMapper(mimeTypeMapper);
+        frameworkProperties.setMimeTypeToTransformerMapper(mimeTypeToTransformerMapper);
+
+        // Need to set these for InputValidation to work
+        System.setProperty("bad.files", "none");
+        System.setProperty("bad.file.extensions", "none");
+        System.setProperty("bad.mime.types", "none");
+
+        CatalogFrameworkImpl framework = new CatalogFrameworkImpl(frameworkProperties);
+        framework.bind(catalogProvider);
+        framework.bind(storageProvider);
+        framework.setId(NEW_SOURCE_ID);
+        framework.setFanoutEnabled(true);
+        framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
+
+        ContentItem item = new ContentItemImpl(ByteSource.empty(),
+                "text/xml",
+                "filename.xml",
+                metacard);
+        CreateStorageRequest request = new CreateStorageRequestImpl(Collections.singletonList(item),
+                new HashMap<>());
+
+        framework.create(request);
+    }
+
+    @Test(expected = IngestException.class)
+    public void testBlacklistedTagUpdateStorageRequestFails() throws Exception {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, "metacardId"));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
+
+        ContentItem item = new ContentItemImpl(ByteSource.empty(),
+                "text/xml",
+                "filename.xml",
+                metacard);
+        UpdateStorageRequest request = new UpdateStorageRequestImpl(Collections.singletonList(item),
+                new HashMap<>());
+        framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
+        framework.update(request);
     }
 
 }

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/catalog/CatalogIngest.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/catalog/CatalogIngest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.common.test.catalog;
+
+import static com.jayway.restassured.RestAssured.delete;
+import static com.jayway.restassured.RestAssured.given;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import com.jayway.restassured.filter.log.LogDetail;
+
+public class CatalogIngest {
+
+    public static void deleteMetacard(String id, String url, int expectedStatusCode) {
+        delete(url + id).then()
+                .assertThat()
+                .statusCode(expectedStatusCode)
+                .log()
+                .ifValidationFails(LogDetail.ALL);
+    }
+
+    public static void deleteMetacard(String id, String url) {
+        delete(url + id);
+    }
+
+    public static String ingestGeoJson(String json, String url) {
+        return ingest(json, "application/json", url);
+    }
+
+    public static String ingest(String data, String mimeType, String url, int expectedStatusCode) {
+        return given().body(data)
+                .header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .expect()
+                .statusCode(expectedStatusCode)
+                .log()
+                .ifValidationFails(LogDetail.ALL)
+                .post(url)
+                .getHeader("id");
+    }
+
+    public static String ingest(String data, String mimeType, String url) {
+        return given().body(data)
+                .header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .post(url)
+                .getHeader("id");
+    }
+
+    public static void update(String data, String mimeType, String url, int expectedStatusCode) {
+        given().header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .body(data)
+                .expect()
+                .log()
+                .ifValidationFails(LogDetail.ALL)
+                .statusCode(expectedStatusCode)
+                .put(url);
+    }
+
+    public static void update(String data, String mimeType, String url) {
+        given().header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .body(data)
+                .put(url);
+    }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/CatalogBundle.java
@@ -16,8 +16,8 @@ package ddf.test.itests;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +42,8 @@ public class CatalogBundle {
 
     public static final String CATALOG_FRAMEWORK_PID = "ddf.catalog.CatalogFrameworkImpl";
 
-    public static final String RESOURCE_DOWNLOAD_MANAGER_PID = "ddf.catalog.resource.download.ReliableResourceDownloadManager";
+    public static final String RESOURCE_DOWNLOAD_MANAGER_PID =
+            "ddf.catalog.resource.download.ReliableResourceDownloadManager";
 
     private final ServiceManager serviceManager;
 
@@ -159,6 +160,21 @@ public class CatalogBundle {
         serviceManager.startManagedService(CATALOG_FRAMEWORK_PID, properties);
     }
 
+    public void setFanoutTagBlacklist(List<String> blacklist) throws IOException {
+        Map<String, Object> properties = adminConfig.getDdfConfigAdmin()
+                .getProperties(CATALOG_FRAMEWORK_PID);
+
+        if (blacklist != null) {
+            if (properties == null) {
+                properties = new Hashtable<>();
+            }
+
+            properties.put("fanoutTagBlacklist", String.join(",", blacklist));
+
+            serviceManager.startManagedService(CATALOG_FRAMEWORK_PID, properties);
+        }
+    }
+
     public void setupCaching(boolean cachingEnabled) throws IOException {
         Map<String, Object> existingProperties = adminConfig.getDdfConfigAdmin()
                 .getProperties(RESOURCE_DOWNLOAD_MANAGER_PID);
@@ -173,7 +189,8 @@ public class CatalogBundle {
             updatedProperties.put("cacheEnabled", "False");
         }
 
-        Configuration configuration = adminConfig.getConfiguration(RESOURCE_DOWNLOAD_MANAGER_PID, null);
+        Configuration configuration = adminConfig.getConfiguration(RESOURCE_DOWNLOAD_MANAGER_PID,
+                null);
         configuration.update(updatedProperties);
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -14,14 +14,21 @@
 package ddf.test.itests.catalog;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.get;
 import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.when;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpStatus;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -31,6 +38,7 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import com.jayway.restassured.path.json.JsonPath;
 
 import ddf.common.test.BeforeExam;
+import ddf.common.test.catalog.CatalogIngest;
 import ddf.test.itests.AbstractIntegrationTest;
 
 @RunWith(PaxExam.class)
@@ -38,6 +46,9 @@ import ddf.test.itests.AbstractIntegrationTest;
 public class TestFanout extends AbstractIntegrationTest {
 
     private static final String LOCAL_SOURCE_ID = "ddf.distribution";
+
+    // Using default resource tag as the one to blacklist
+    private static final List<String> TAG_BLACKLIST = Collections.singletonList("resource");
 
     @BeforeExam
     public void beforeExam() throws Exception {
@@ -56,6 +67,14 @@ public class TestFanout extends AbstractIntegrationTest {
             LOGGER.error("Failed in @BeforeExam: ", e);
             fail("Failed in @BeforeExam: " + e.getMessage());
         }
+    }
+
+    @Before
+    public void setup() throws IOException {
+        // Start with empty blacklist
+        getCatalogBundle().setFanoutTagBlacklist(Collections.emptyList());
+        // Start with fanout enabled
+        getCatalogBundle().setFanout(true);
     }
 
     private void startCswSource() throws Exception {
@@ -109,26 +128,72 @@ public class TestFanout extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testFanoutQueryWithUnknownSource() throws Exception {
-        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&src=does.not.exist";
-
-        when().get(queryUrl)
-                .then()
-                .log()
-                .all()
-                .assertThat()
-                .body(containsString("Unsupported query"));
+    public void testCswIngestWithFanoutEnabledAndEmptyBlacklist() throws Exception {
+        String id = CatalogIngest.ingest("Some data to ingest",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl(),
+                HttpStatus.SC_CREATED);
+        CatalogIngest.deleteMetacard(id, REST_PATH.getUrl(), HttpStatus.SC_OK);
     }
 
     @Test
-    public void testFanoutQueryWithoutFederatedSources() throws Exception {
-        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&src=local";
+    public void testCswIngestFailsWithFanoutEnabledAndBlacklistSet() throws Exception {
+        getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
+        CatalogIngest.ingest("Some data to ingest. This should fail.",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl(),
+                HttpStatus.SC_BAD_REQUEST);
+    }
 
-        when().get(queryUrl)
-                .then()
-                .log()
-                .all()
-                .assertThat()
-                .body(containsString("Error executing query"));
+    @Test
+    public void testCswUpdateWorksWithFanoutEnabledAndEmptyBlacklist() throws IOException {
+        getCatalogBundle().setFanoutTagBlacklist(Collections.emptyList());
+        String id = CatalogIngest.ingest("Some data to ingest",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl(),
+                HttpStatus.SC_CREATED);
+        CatalogIngest.update("Some data to update",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl() + id,
+                HttpStatus.SC_OK);
+        CatalogIngest.deleteMetacard(id, REST_PATH.getUrl(), HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testCswUpdateFailsWithFanoutEnabledAndBlacklistSet() throws IOException {
+        getCatalogBundle().setFanoutTagBlacklist(Collections.emptyList());
+        String id = CatalogIngest.ingest("Some data to ingest",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl(),
+                HttpStatus.SC_CREATED);
+
+        // Set blacklist so update will fail
+        getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
+        CatalogIngest.update("Some data to update",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl() + id,
+                HttpStatus.SC_BAD_REQUEST);
+
+        // Set blacklist to empty list so the delete will succeed
+        getCatalogBundle().setFanoutTagBlacklist(new ArrayList<>());
+        CatalogIngest.deleteMetacard(id, REST_PATH.getUrl(), HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testCswDeleteFailsWithFanoutEnabledAndBlacklistSet() throws IOException {
+        // The case where delete works with fanout on and empty blacklist is tested as clean up in the other tests.
+        getCatalogBundle().setFanoutTagBlacklist(Collections.emptyList());
+        String id = CatalogIngest.ingest("Some data to ingest",
+                MediaType.TEXT_PLAIN,
+                REST_PATH.getUrl(),
+                HttpStatus.SC_CREATED);
+
+        // Set blacklist so update will fail
+        getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
+        CatalogIngest.deleteMetacard(id, REST_PATH.getUrl(), HttpStatus.SC_BAD_REQUEST);
+
+        // Set blacklist to empty list so the delete will succeed
+        getCatalogBundle().setFanoutTagBlacklist(new ArrayList<>());
+        CatalogIngest.deleteMetacard(id, REST_PATH.getUrl(), HttpStatus.SC_OK);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
This ticket adds the ability for fanout to write to its local store. A blacklist is added to give the admin control over what metacard tags should be rejected while in fanout mode.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)? @clockard @vinamartin @mcalcote @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@pklinef 
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2361
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

…nout is enabled

Fanout is changing to allow access to the local store. The fanout requests will be rejected if fanout is enabled and the request contains a metacard with a tag on the blacklist.

CatalogFrameWorkImpl.java
  Adding a fanoutTagBlacklist that will be used to determine which catalog requests should be blocked.
  Changing the tests for fanout flag to now check the blacklist

blueprint.xml
  Updating catalogFrameworkImpl with metatype info and default values for fanoutProxyTagBlacklist and filterAdapter

metatype.xml
  Adding fanoutTagBlackList
  Adding fanoutProxyTagBlacklist