### PR TITLE
DDF-2361 - Enable fanout and ddf registry to be used at the same time in the same ddf instance

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -467,22 +467,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.61</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -529,8 +529,7 @@ public class UpdateOperations {
         QueryResponse query;
         try {
             query = queryOperations.doQuery(queryRequest,
-                    frameworkProperties.getFederationStrategy(),
-                    false);
+                    frameworkProperties.getFederationStrategy());
         } catch (FederationException e) {
             LOGGER.debug("Unable to complete query for updated metacards.", e);
             throw new IngestException("Exception during runtime while performing update");

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -45,10 +45,19 @@
     </bean>
 
     <bean id="cfQueryOps" class="ddf.catalog.impl.operations.QueryOperations">
+        <cm:managed-properties persistent-id="ddf.catalog.impl.operations.QueryOperations"
+                               update-strategy="container-managed"/>
         <argument ref="frameworkProperties"/>
         <argument ref="cfSourceOps"/>
         <argument ref="cfOpsSecurity"/>
         <argument ref="cfOpsMetacard"/>
+        <property name="filterAdapter" ref="filterAdapter"/>
+        <property name="fanoutProxyTagBlacklist">
+            <list value-type="java.lang.String">
+                <value>registry</value>
+                <value>registry-remote</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="cfResourceOps" class="ddf.catalog.impl.operations.ResourceOperations">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,18 @@
         <AD name="Enable Notifications" id="notificationEnabled" required="false" type="Boolean"
             default="true"
             description="Check to enable notifications."/>
+        <AD name="Fanout tag blacklist" id="fanoutTagBlacklist" required="true" type="String"
+            cardinality="100"
+            description="Ingest operations with tags in this list will be rejected."/>
+
+    </OCD>
+
+    <OCD name="Query Operations"
+         id="ddf.catalog.impl.operations.QueryOperations">
+        <AD name="Fanout proxy tag blacklist" id="fanoutProxyTagBlacklist" required="true"
+            type="String" cardinality="100"
+            default="registry,registry-remote"
+            description="Query operations with tags in this list will not be passed through."/>
 
     </OCD>
 
@@ -34,7 +46,7 @@
     </OCD>
 
     <OCD name="Source Poller" id="ddf.catalog.util.impl.SourcePoller">
-         <AD name="Interval" id="interval" required="true" type="Integer"
+        <AD name="Interval" id="interval" required="true" type="Integer"
             default="1"
             description="The interval (in minutes) at which to execute successive source polling. Must be a positive, nonzero integer."/>
     </OCD>
@@ -46,11 +58,15 @@
     </Designate>
 
     <Designate pid="ddf.catalog.history.Historian">
-        <Object ocdref="ddf.catalog.history.Historian" />
+        <Object ocdref="ddf.catalog.history.Historian"/>
     </Designate>
 
     <Designate pid="ddf.catalog.util.impl.SourcePoller">
-        <Object ocdref="ddf.catalog.util.impl.SourcePoller" />
+        <Object ocdref="ddf.catalog.util.impl.SourcePoller"/>
+    </Designate>
+
+    <Designate pid="ddf.catalog.impl.operations.QueryOperations">
+        <Object ocdref="ddf.catalog.impl.operations.QueryOperations"></Object>
     </Designate>
 
 

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/CatalogBundle.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -156,6 +157,21 @@ public class CatalogBundle {
         }
 
         serviceManager.startManagedService(CATALOG_FRAMEWORK_PID, properties);
+    }
+
+    public void setFanoutTagBlacklist(List<String> blacklist) throws IOException {
+        Map<String, Object> properties = adminConfig.getDdfConfigAdmin()
+                .getProperties(CATALOG_FRAMEWORK_PID);
+
+        if (blacklist != null) {
+            if (properties == null) {
+                properties = new Hashtable<>();
+            }
+
+            properties.put("fanoutTagBlacklist", String.join(",", blacklist));
+
+            serviceManager.startManagedService(CATALOG_FRAMEWORK_PID, properties);
+        }
     }
 
     public void setupCaching(boolean cachingEnabled) throws IOException {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/catalog/CatalogTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/catalog/CatalogTestCommons.java
@@ -30,6 +30,8 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.http.HttpStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
+
+import com.jayway.restassured.filter.log.LogDetail;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 
@@ -84,6 +86,24 @@ public class CatalogTestCommons {
                     .post(REST_PATH.getUrl())
                     .getHeader("id");
         }
+    }
+
+    /**
+     *
+     * @param data - body of the message containing metacard to be ingested
+     * @param mimeType - content type header value
+     * @param expectedStatusCode - expected status code to check for
+     * @return id of ingested metacard
+     */
+    public static String ingest(String data, String mimeType, int expectedStatusCode) {
+        return given().body(data)
+                .header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .expect()
+                .statusCode(expectedStatusCode)
+                .log()
+                .ifValidationFails(LogDetail.ALL)
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
     }
 
     public static String ingestGeoJson(String json) {
@@ -156,6 +176,23 @@ public class CatalogTestCommons {
     }
 
     /**
+     *
+     * @param id - id of metacard to update
+     * @param data - body of request to update with
+     * @param mimeType - content type header value
+     * @param expectedStatusCode - expected status code to check for
+     */
+    public static void update(String id, String data, String mimeType, int expectedStatusCode) {
+        given().header(HttpHeaders.CONTENT_TYPE, mimeType)
+                .body(data)
+                .expect()
+                .log()
+                .ifValidationFails(LogDetail.ALL)
+                .statusCode(expectedStatusCode)
+                .put(new AbstractIntegrationTest.DynamicUrl(REST_PATH, id).getUrl());
+    }
+
+    /**
      * Performs a delete request on the given metacard id
      * @param id - id of metacard to delete
      */
@@ -172,7 +209,7 @@ public class CatalogTestCommons {
         if (checkResponse) {
             delete(REST_PATH.getUrl() + id).then()
                     .assertThat()
-                    .statusCode(200)
+                    .statusCode(HttpStatus.SC_OK)
                     .log()
                     .all();
         } else {
@@ -180,6 +217,14 @@ public class CatalogTestCommons {
                     .log()
                     .all();
         }
+    }
+
+    public static void deleteMetacard(String id, int expectedStatusCode) {
+        delete(REST_PATH.getUrl() + id).then()
+                .assertThat()
+                .statusCode(expectedStatusCode)
+                .log()
+                .ifValidationFails(LogDetail.ALL);
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This ticket adds the ability for fanout to write to its local store. A blacklist is added to give the admin control over what metacard tags should be rejected while in fanout mode.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)? @clockard @vinamartin @mcalcote @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold  
@pklinef 
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2361
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

Fanout is changing to allow access to the local store. The fanout requests will be rejected if fanout is enabled and the request contains a metacard with a tag on the blacklist.

CatalogFrameWorkImpl.java
  Adding a fanoutTagBlackList that will be used to determine which catalog requests should be blocked.
  Changing the tests for fanout flag to now check the blacklist

delegate-operators.xml (blueprint)
  Updating cfQueryOps with metatype info and default values for fanoutProxyTagBlacklist

metatype.xml
  Adding fanoutTagBlackList to Catalog Standard Framework
  Adding fanoutProxyTagBlacklist to Query Operations