### PR TITLE
DDF-2480 Fixed upload dialog to reopen if closed during an upload

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/Modal.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/Modal.js
@@ -30,10 +30,11 @@ define([
             initialize: function () {
                 // destroy view after animation completes.
                 // extending views must call: Modal.prototype.initialize.apply(this, arguments);
-                var view = this;
                 this.$el.one('hidden.bs.modal', function () {
-                    view.destroy();
-                });
+                    if (this.shouldDestroy()) {
+                        this.destroy();
+                    }
+                }.bind(this));
             },
             show: function () {
                 this.$el.modal({
@@ -43,6 +44,9 @@ define([
             },
             hide: function () {
                 this.$el.modal('hide');
+            },
+            shouldDestroy: function () {
+                return true;
             }
         });
         return BaseModal;

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestMenu.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestMenu.js
@@ -44,10 +44,13 @@ define([
                 this.listenTo(wreqr.vent, 'upload:finish', this.onUploadFinish);
             },
             showModal: function() {
-                var keepCurrentModal = this.modal && this.modal.isUnfinished();
-                if (!keepCurrentModal) {
+                if (this.modal === undefined) {
+                    this.modal = new IngestModal();
+                } else if (this.modal.isFinished()) {
+                    this.modal.destroy();
                     this.modal = new IngestModal();
                 }
+
                 wreqr.vent.trigger('showModal', this.modal);
             },
             onUploadStart: function() {

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
@@ -47,6 +47,15 @@ define([
                 this.listenTo(this.collection, "add", this.checkIfDialogComplete);
                 this.listenTo(this.collection, "remove", this.checkIfDialogComplete);
             },
+            shouldDestroy: function() {
+                if (this.model === undefined) {
+                    return false;
+                }
+                else {
+                    return !(this.model.get('state') === 'uploading' ||
+                            this.model.get('state') === 'uploaded');
+                }
+            },
             regions: {
                 fileUploadListRegion: '.file-upload-region'
             },
@@ -199,9 +208,9 @@ define([
                     this.$('.upload-info').toggleClass('hidden', true);
                 }
             },
-            isUnfinished: function () {
-                return this.model.get('state') === 'uploading' ||
-                    this.model.get('state') === 'uploaded';
+            isFinished: function () {
+                return !(this.model.get('state') === 'uploading' ||
+                    this.model.get('state') === 'uploaded');
             }
         });
         return IngestModal;


### PR DESCRIPTION
#### What does this PR do?
Fixes the Search UI file upload dialog so it can be reopened if its closed while resources are being uploaded.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler
@jrnorth
@azgoalie
@emanns95 
@ahoffer
@NGoss
@spearskw
@timothytierney

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris 
@stustison

#### How should this be tested?
Open the file upload dialog and select two large files to upload. While the uploads are in progress, close the dialog using the x. Once the dialog has been closed, it cannot be re-opened.

#### Any background context you want to provide?
This PR relates to: https://github.com/codice/ddf/pull/1268

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

