### PR TITLE
DDF-2349 Fixed NaN on ingest modal

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
@@ -125,7 +125,7 @@ define([
                     state: 'start',
                     error: data.errorThrown,
                     cancellable: true,
-                    progress: parseInt(data.loaded / data.total * 100, 10)
+                    progress: parseInt(data.loaded / data.total * 100, 10) || 0
                 });
             },
             checkIfDialogComplete: function () {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug where the Ingest Modal in the Standard Search UI initially showed `NaN%` instead of 0.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build and Install DDF, ingest through the Standard Search UI and observe no `NaN%` when starting the uploads.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2349
#### Screenshots (if appropriate)
https://codice.atlassian.net/browse/DDF-2349
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

