### PR TITLE
DDF-2382 Fix registry-id key used in configurations.

### DIFF
--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreImpl.java
@@ -114,7 +114,8 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
         map.put(REMOTE_NAME, value -> setRemoteName((String) value));
         map.put(PUSH_ALLOWED_PROPERTY, value -> setPushAllowed((Boolean) value));
         map.put(PULL_ALLOWED_PROPERTY, value -> setPullAllowed((Boolean) value));
-        map.put(RegistryObjectMetacardType.REGISTRY_ID, value -> setRegistryId((String) value));
+        map.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
+                value -> setRegistryId((String) value));
         return map;
     }
 
@@ -349,7 +350,7 @@ public class RegistryStoreImpl extends AbstractCswStore implements RegistryStore
             Configuration currentConfig = configAdmin.getConfiguration(currentPid);
             Dictionary<String, Object> currentProperties = currentConfig.getProperties();
             currentProperties.put(REMOTE_NAME, remoteName);
-            currentProperties.put(RegistryObjectMetacardType.REGISTRY_ID, registryId);
+            currentProperties.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, registryId);
             currentConfig.update(currentProperties);
         } catch (IOException e) {
             LOGGER.debug("Unable to update registry configurations, ", e);

--- a/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/RegistryConstants.java
+++ b/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/RegistryConstants.java
@@ -28,6 +28,8 @@ public class RegistryConstants {
 
     public static final String REGISTRY_ID_PROPERTY = "org.codice.ddf.registry.identity-id";
 
+    public static final String CONFIGURATION_REGISTRY_ID_PROPERTY = "registry-id";
+
     //ebrim constants
     //Object types
     public static final String REGISTRY_NODE_OBJECT_TYPE = "urn:registry:federation:node";

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProvider.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.registry.api.internal.RegistryStore;
-import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
 import org.codice.ddf.registry.publication.manager.RegistryPublicationManager;
 import org.osgi.framework.InvalidSyntaxException;
@@ -150,7 +150,7 @@ public class RegistryPublicationActionProvider implements MultiActionProvider {
                         ((Source) subject).getId()));
                 return (String) Arrays.stream(configurations)
                         .map(Configuration::getProperties)
-                        .map(p -> p.get(RegistryObjectMetacardType.REGISTRY_ID))
+                        .map(p -> p.get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY))
                         .filter(Objects::nonNull)
                         .findFirst()
                         .orElse(null);
@@ -160,7 +160,7 @@ public class RegistryPublicationActionProvider implements MultiActionProvider {
             }
         } else if (subject instanceof Configuration) {
             return (String) ((Configuration) subject).getProperties()
-                    .get(RegistryObjectMetacardType.REGISTRY_ID);
+                    .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY);
         }
         return null;
     }

--- a/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/test/java/org/codice/ddf/registry/publication/action/provider/RegistryPublicationActionProviderTest.java
@@ -117,7 +117,7 @@ public class RegistryPublicationActionProviderTest {
     public void testCanHandleRegistrySource() throws Exception {
         when(source.getId()).thenReturn("regId1");
         Dictionary<String, Object> properties = new Hashtable<>();
-        properties.put(RegistryObjectMetacardType.REGISTRY_ID, "regId1");
+        properties.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, "regId1");
         when(configuration.getProperties()).thenReturn(properties);
         assertThat(publicationActionProvider.canHandle(source), is(true));
     }
@@ -132,7 +132,7 @@ public class RegistryPublicationActionProviderTest {
     @Test
     public void testCanHandleRegistryConfig() throws Exception {
         Dictionary<String, Object> properties = new Hashtable<>();
-        properties.put(RegistryObjectMetacardType.REGISTRY_ID, "regId1");
+        properties.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, "regId1");
         when(configuration.getProperties()).thenReturn(properties);
         assertThat(publicationActionProvider.canHandle(configuration), is(true));
     }
@@ -179,7 +179,8 @@ public class RegistryPublicationActionProviderTest {
         assertThat(actions.get(0)
                         .getUrl()
                         .toString(),
-                equalTo(SystemBaseUrl.constructUrl("internal/registries/regId1/publication/regId2", true)));
+                equalTo(SystemBaseUrl.constructUrl("internal/registries/regId1/publication/regId2",
+                        true)));
     }
 
     @Test
@@ -199,7 +200,8 @@ public class RegistryPublicationActionProviderTest {
         assertThat(actions.get(0)
                         .getUrl()
                         .toString(),
-                equalTo(SystemBaseUrl.constructUrl("internal/registries/regId1/publication/regId2", true)));
+                equalTo(SystemBaseUrl.constructUrl("internal/registries/regId1/publication/regId2",
+                        true)));
     }
 
     private Metacard getRegistryMetacard(String regId) {

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryReportActionProvider.java
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/java/org/codice/ddf/registry/report/action/provider/RegistryReportActionProvider.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
-import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
@@ -118,7 +118,8 @@ public class RegistryReportActionProvider implements MultiActionProvider {
                 if (configurations.length > 0) {
                     for (Configuration configuration : configurations) {
                         if (configuration.getProperties()
-                                .get(RegistryObjectMetacardType.REGISTRY_ID) != null) {
+                                .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY)
+                                != null) {
                             return processSubject(configuration);
                         }
                     }
@@ -132,10 +133,10 @@ public class RegistryReportActionProvider implements MultiActionProvider {
 
     private List<Action> processSubject(Configuration configuration) {
         if (configuration.getProperties()
-                .get(RegistryObjectMetacardType.REGISTRY_ID) != null) {
+                .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY) != null) {
             try {
                 String registryId = URLEncoder.encode(configuration.getProperties()
-                        .get(RegistryObjectMetacardType.REGISTRY_ID)
+                        .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY)
                         .toString(), (StandardCharsets.UTF_8).toString());
                 Action action = getAction(registryId, "");
 
@@ -190,7 +191,7 @@ public class RegistryReportActionProvider implements MultiActionProvider {
                 && RegistryUtility.isRegistryMetacard((Metacard) subject))
                 || subject instanceof Source || (subject instanceof Configuration &&
                 ((Configuration) subject).getProperties()
-                        .get(RegistryObjectMetacardType.REGISTRY_ID) != null);
+                        .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY) != null);
 
     }
 

--- a/catalog/spatial/registry/registry-report-action-provider/src/test/java/org/codice/ddf/registry/report/action/provider/TestRegistryReportActionProvider.java
+++ b/catalog/spatial/registry/registry-report-action-provider/src/test/java/org/codice/ddf/registry/report/action/provider/TestRegistryReportActionProvider.java
@@ -367,7 +367,7 @@ public class TestRegistryReportActionProvider {
         configureActionProvider();
         Dictionary<String, Object> testDictionary = new Hashtable<>();
 
-        testDictionary.put(RegistryObjectMetacardType.REGISTRY_ID, SAMPLE_REGISTRY_ID);
+        testDictionary.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, SAMPLE_REGISTRY_ID);
 
         when(configuration.getProperties()).thenReturn(testDictionary);
 
@@ -389,7 +389,7 @@ public class TestRegistryReportActionProvider {
         configureActionProvider(SAMPLE_PROTOCOL, "23^&*#", SAMPLE_PORT, SAMPLE_SERVICES_ROOT);
         Dictionary<String, Object> testDictionary = new Hashtable<>();
 
-        testDictionary.put(RegistryObjectMetacardType.REGISTRY_ID, SAMPLE_REGISTRY_ID);
+        testDictionary.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, SAMPLE_REGISTRY_ID);
 
         when(configuration.getProperties()).thenReturn(testDictionary);
 

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.parser.ParserException;
-import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
 import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminException;
 import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminService;
@@ -254,7 +254,8 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
             serviceConfigurationProperties.putAll(slotMap);
             serviceConfigurationProperties.put(ID, configId);
             serviceConfigurationProperties.put(SHORTNAME, configId);
-            serviceConfigurationProperties.put(RegistryObjectMetacardType.REGISTRY_ID, registryId);
+            serviceConfigurationProperties.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
+                    registryId);
 
             curConfig.update(serviceConfigurationProperties);
             fpidToConfigurationMap.remove(curConfig.getFactoryPid()
@@ -370,7 +371,7 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
 
         Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
                 CONFIGURATION_FILTER,
-                RegistryObjectMetacardType.REGISTRY_ID,
+                RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 registryId));
         if (configurations != null && configurations.length > 0) {
             String sourceName = (String) configurations[0].getProperties()
@@ -444,7 +445,7 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
         Map<String, Configuration> configurationMap = new HashMap<>();
         Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
                 CONFIGURATION_FILTER,
-                RegistryObjectMetacardType.REGISTRY_ID,
+                RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 registryId));
 
         if (configurations == null) {
@@ -499,7 +500,7 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
         String configRegistryId = null;
         for (Configuration config : configurations) {
             configRegistryId = (String) config.getProperties()
-                    .get(RegistryObjectMetacardType.REGISTRY_ID);
+                    .get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY);
             if (configRegistryId != null) {
                 break;
             }

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/test/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandlerTest.java
@@ -318,7 +318,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -345,7 +345,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -371,7 +371,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "SomeOtherBindingType");
         Configuration newDisabledConfig = mock(Configuration.class);
@@ -421,7 +421,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "SomeOtherBindingType");
         when(config.getProperties()).thenReturn(props);
@@ -453,7 +453,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "SomeOtherBindingType");
         Configuration newDisabledConfig = mock(Configuration.class);
@@ -492,7 +492,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "SomeOtherBindingType");
         when(config.getProperties()).thenReturn(props);
@@ -532,7 +532,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "Some_Other_Binding_Type");
         Configuration newDisabledConfig = mock(Configuration.class);
@@ -582,7 +582,7 @@ public class SourceConfigurationHandlerTest {
         when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -605,7 +605,7 @@ public class SourceConfigurationHandlerTest {
         when(configAdmin.listConfigurations(anyString())).thenReturn(new Configuration[] {config});
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW2_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -655,7 +655,7 @@ public class SourceConfigurationHandlerTest {
                 null);
         verify(newConfig).update(captor.capture());
         Dictionary passedValues = captor.getValue();
-        assertThat(passedValues.get(RegistryObjectMetacardType.REGISTRY_ID),
+        assertThat(passedValues.get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY),
                 equalTo("urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
         assertThat(passedValues.get("attId"), equalTo("attValue"));
         assertThat(passedValues.get("urlBindingName"), equalTo("cswUrl"));
@@ -840,7 +840,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -871,7 +871,7 @@ public class SourceConfigurationHandlerTest {
         Hashtable<String, Object> props = new Hashtable<>();
         props.put("id", "TestRegNode");
         props.put("origConfig", "origConfigValue");
-        props.put(RegistryObjectMetacardType.REGISTRY_ID,
+        props.put(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY,
                 "urn:uuid:2014ca7f59ac46f495e32b4a67a51276");
         props.put("bindingType", "CSW_2.0.2");
         when(config.getProperties()).thenReturn(props);
@@ -980,7 +980,7 @@ public class SourceConfigurationHandlerTest {
     }
 
     private void assertCswProperties(Dictionary passedValues) {
-        assertThat(passedValues.get(RegistryObjectMetacardType.REGISTRY_ID),
+        assertThat(passedValues.get(RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY),
                 equalTo("urn:uuid:2014ca7f59ac46f495e32b4a67a51276"));
         assertThat(passedValues.get("urlBindingName"), equalTo("cswUrl"));
         assertThat(passedValues.get("id"), equalTo("TestRegNode"));


### PR DESCRIPTION
#### What does this PR do?
Changes the key used to store registry id information in configuration files from the metacard metatype of registry.registry-id to just a constant of registry-id. The `.` in the name causes the property to be lost when passed to backbone UIs on the front end.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@mcalcote @gordocanchola 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@shaundmorris

#### How should this be tested?
Install ddf with registry. 
Create a secondary local node with a service binding
Go to the sources tab and make a change to the source that was generated for the secondary local node
Update something on the secondary node (like description) and save it. 
Reload the sources tab and verify that there is still only the one entry without an id in the name
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2382
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

