### PR TITLE
DDF-2454 Sort order of source regeneration entries in dialog and disallow identity node.

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.collection.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/model/Node.collection.js
@@ -24,7 +24,7 @@ define([
         comparator: function(model){
             var fedNode = model.getObjectOfType('urn:registry:federation:node');
             if (fedNode !== null && fedNode.length > 0) {
-                return fedNode[0].Name;
+                return fedNode[0].Name.toLowerCase();
             }
         }
     });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Registry.view.js
@@ -74,6 +74,9 @@ define([
                 this.identityRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getIdentityNode())}));
                 this.additionalRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getSecondaryNodes()), multiValued: true}));
                 this.remoteNodeRegion.show(new RegistryView.NodeTable({collection: new NodeCollection(this.model.getRemoteNodes()), multiValued:true, readOnly:true}));
+                if(this.model.models.length <= 1){
+                    $('.regenerate-sources').prop("disabled",true);
+                }
             },
             showEditNode: function (node) {
                 wreqr.vent.trigger("showModal",
@@ -327,14 +330,20 @@ define([
                 if (this.model) {
                     data = this.model.toJSON();
                 }
-                var array = [];
+                var nodes = [];
                 _.each(this.options.nodes, function (node) {
-                    array.push({
+                    if(node.get('identityNode')){
+                        return;
+                    }
+                    nodes.push({
                         name: node.getObjectOfType('urn:registry:federation:node')[0].Name,
                         id: node.get('id')
                     });
                 });
-                data.registry = array;
+                nodes = _.sortBy(nodes, function(o){
+                   return o.name.toLowerCase();
+                });
+                data.registry = nodes;
                 return data;
             }
         });

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -200,9 +200,11 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
      */
     private synchronized void updateRegistryConfigurations(Metacard metacard, boolean createEvent)
             throws IOException, InvalidSyntaxException, ParserException {
-        boolean identityNode = RegistryUtility.isIdentityNode(metacard);
+        if(RegistryUtility.isIdentityNode(metacard)){
+            return;
+        }
 
-        boolean autoActivateConfigurations = activateConfigurations && !identityNode && (createEvent
+        boolean autoActivateConfigurations = activateConfigurations && (createEvent
                 || !preserveActiveConfigurations);
 
         List<ServiceBindingType> bindingTypes = registryTypeHelper.getBindingTypes(


### PR DESCRIPTION
#### What does this PR do?
Sorts the order of entries that show up in the regenerate sources dialog and also keep the identity node from showing up in that list.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@vinamartin @gordocanchola @Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison
@figliold 
#### How should this be tested?
Start up an instance and add some secondary nodes. Verify that when you click the 'Regenerate Sources' button that the resulting dialog shows the entries in alphabetical order and that the identity node is not in the list.
#### Any background context you want to provide?
Based on feedback from sprint review and @mcalcote 
#### What are the relevant tickets?
DDF-2354
#### Screenshots (if appropriate)
![screen shot 2016-09-21 at 1 16 17 pm](https://cloud.githubusercontent.com/assets/5248090/18727521/df50c70c-7ffd-11e6-86c6-02f2d244bc92.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

