### PR TITLE
DDF-2459: Content directory monitors now keep working after system restart (backport)

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -66,7 +66,6 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcestatusplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-tagsfilterplugin/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.security/catalog-security-logging/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-attribute/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-defaultvalues/${project.version}</bundle>

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponentResolver.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponentResolver.java
@@ -31,14 +31,11 @@ public class ContentComponentResolver implements ComponentResolver {
      * @param component the Camel component associated with this component resolver
      */
     public ContentComponentResolver(Component component) {
-        LOGGER.trace("INSIDE: constructor");
         this.component = component;
     }
 
     @Override
     public Component resolveComponent(String name, CamelContext context) throws Exception {
-        LOGGER.trace("INSIDE: resolveComponent");
-
         if (ContentComponent.NAME.equals(name)) {
             return component;
         }

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>0.9.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
         </dependency>
@@ -110,7 +115,8 @@
                             catalog-core-api-impl,
                             ddf-security-common,
                             platform-util,
-                            platform-util-unavailableurls
+                            platform-util-unavailableurls,
+                            failsafe
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -133,22 +139,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.4</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.46</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
@@ -14,7 +14,9 @@
 package org.codice.ddf.catalog.content.monitor;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.File;
@@ -22,322 +24,203 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
-import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockComponent;
 import org.apache.camel.model.FromDefinition;
-import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.Constants;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 
+@RunWith(JUnit4.class)
 public class ContentDirectoryMonitorTest extends CamelTestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(ContentDirectoryMonitorTest.class);
 
-    private static final String INPUT_FILENAME = "input.txt";
+    private static final String PROTOCOL = "file://";
 
-    private static final String INPUT_FILEPATH = "target/" + INPUT_FILENAME;
-
-    private static final String MONITORED_DIRECTORY = "target/inbox";
-
-    private ModelCamelContext camelContext;
-
-    private ContentDirectoryMonitor contentDirectoryMonitor;
-
-    private Processor noOpProcessor = exchange -> {
-    };
+    private static final String DUMMY_DATA = "Dummy data in a text file. ";
 
     private static final List<String> ATTRIBUTE_OVERRIDES = Arrays.asList("test1=someParameter1",
             "test2=someParameter2");
 
-    @After
-    public void tearDown() throws Exception {
-        LOGGER.debug("INSIDE tearDown");
+    private static final int MAX_SECONDS_FOR_FILE_COPY = 5;
 
-        // This will also stop all routes/components/endpoints, etc. 
-        // and clear internal state/cache
+    private static final int MAX_CHECKS_FOR_FILE_COPY = 10;
+
+    private String monitoredDirectoryPath;
+
+    private File monitoredDirectory;
+
+    private CamelContext camelContext;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws Exception {
+        monitoredDirectory = temporaryFolder.newFolder("inbox");
+        monitoredDirectoryPath = monitoredDirectory.getAbsolutePath();
+
+        camelContext = super.createCamelContext();
+        camelContext.start();
+
+        MockComponent contentComponent = new MockComponent();
+        camelContext.addComponent("content", contentComponent);
+    }
+
+    @After
+    public void destroy() throws Exception {
         camelContext.stop();
-        camelContext = null;
+    }
+
+    @Test
+    public void testRouteCreationWithoutContentComponent() throws Exception {
+        camelContext.removeComponent("content");
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
+        submitConfigOptions(monitor, monitoredDirectoryPath, false);
+        assertThat("The content directory monitor should not have any route definitions",
+                monitor.getRouteDefinitions(),
+                empty());
+        assertThat("The camel context should not have any route definitions",
+                camelContext.getRouteDefinitions(),
+                empty());
     }
 
     @Test
     public void testRouteCreationWithCopyIngestedFiles() throws Exception {
-        boolean copyIngestedFiles = true;
-
-        RouteDefinition routeDefinition = createRoute(MONITORED_DIRECTORY, copyIngestedFiles);
-
-        verifyRoute(routeDefinition, MONITORED_DIRECTORY, copyIngestedFiles);
+        testRouteCreationWithGivenCopyStatus(true);
     }
 
     @Test
     public void testRouteCreationWithoutCopyIngestedFiles() throws Exception {
-        boolean copyIngestedFiles = false;
+        testRouteCreationWithGivenCopyStatus(false);
+    }
 
-        RouteDefinition routeDefinition = createRoute(MONITORED_DIRECTORY, copyIngestedFiles);
-
-        verifyRoute(routeDefinition, MONITORED_DIRECTORY, copyIngestedFiles);
+    private void testRouteCreationWithGivenCopyStatus(boolean copyIngestedFiles) throws Exception {
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
+        submitConfigOptions(monitor, monitoredDirectoryPath, copyIngestedFiles);
+        assertThat("The content directory monitor should only have one route definition",
+                monitor.getRouteDefinitions(),
+                hasSize(1));
+        RouteDefinition routeDefinition = monitor.getRouteDefinitions()
+                .get(0);
+        verifyRoute(routeDefinition, monitoredDirectoryPath, copyIngestedFiles);
     }
 
     @Test
-    public void testRouteCreationMissingMonitoredDirectory() throws Exception {
-        String monitoredDirectory = "";
-        boolean copyIngestedFiles = true;
-
-        camelContext = (ModelCamelContext) super.createCamelContext();
-        camelContext.start();
-
-        // Map the "content" scheme to a mock component so that we do not have to
-        // mock the entire custom ContentComponent and include its implementation
-        // in pom with scope=test
-        camelContext.addComponent("content", new MockComponent());
-
-        contentDirectoryMonitor = new ContentDirectoryMonitor(camelContext);
-        contentDirectoryMonitor.systemSubjectBinder = noOpProcessor;
-        contentDirectoryMonitor.setMonitoredDirectoryPath(monitoredDirectory);
-        contentDirectoryMonitor.setCopyIngestedFiles(copyIngestedFiles);
-
-        // Simulates what container would do once all setters have been invoked
-        contentDirectoryMonitor.init();
-
-        assertThat(camelContext.getRouteDefinitions()
-                .size(), is(0));
+    public void testMoveFile() throws Exception {
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
+        submitConfigOptions(monitor, monitoredDirectoryPath, true);
+        doAndVerifyFileMove(monitoredDirectory, monitoredDirectory, "input1.txt");
     }
 
     @Test
-    public void testMoveFolder() throws Exception {
-        boolean copyIngestedFiles = true;
+    public void testUpdateExistingContentDirectoryMonitor() throws Exception {
+        File monitoredDirectory1 = temporaryFolder.newFolder("inbox1");
+        File monitoredDirectory2 = temporaryFolder.newFolder("inbox2");
 
-        createRoute(MONITORED_DIRECTORY, copyIngestedFiles);
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
 
-        // Put file in monitored directory
-        String fileContents = "Dummy data in a text file";
-        FileUtils.writeStringToFile(new File(INPUT_FILEPATH), fileContents);
+        submitConfigOptions(monitor, monitoredDirectory1.getAbsolutePath(), true);
+        doAndVerifyFileMove(monitoredDirectory1, monitoredDirectory1, "input1.txt");
 
-        template.sendBodyAndHeader("file://" + MONITORED_DIRECTORY,
-                fileContents,
-                Exchange.FILE_NAME,
-                INPUT_FILENAME);
+        submitConfigOptions(monitor, monitoredDirectory2.getAbsolutePath(), true);
+        doAndVerifyFileMove(monitoredDirectory2, monitoredDirectory2, "input2.txt");
 
-        Thread.sleep(3000);
-
-        // Verify the file moved to the .ingested directory
-        File target = new File(MONITORED_DIRECTORY + "/.ingested/" + INPUT_FILENAME);
-        assertTrue("File not moved to .ingested folder", target.exists());
-
-        // Cleanup
-        FileUtils.deleteDirectory(new File(MONITORED_DIRECTORY));
-    }
-
-    /**
-     * Verify if route has a failure then the file being processed is moved to the .errors
-     * directory.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testUpdateExistingDirectoryMonitor() throws Exception {
-        boolean copyIngestedFiles = true;
-
-        createRoute(MONITORED_DIRECTORY, copyIngestedFiles);
-
-        // Put file in monitored directory
-        String fileContents = "Dummy data in a text file";
-        FileUtils.writeStringToFile(new File(INPUT_FILEPATH), fileContents);
-        template.sendBodyAndHeader("file://" + MONITORED_DIRECTORY,
-                fileContents,
-                Exchange.FILE_NAME,
-                INPUT_FILENAME);
-
-        Thread.sleep(3000);
-
-        // Verify the file moved to the .ingested directory
-        File target = new File(MONITORED_DIRECTORY + "/.ingested/" + INPUT_FILENAME);
-        assertTrue("File 1 not moved to .ingested folder", target.exists());
-
-        // Update the existing directory monitor to point to different directory
-        String newMonitoredDirectory = "target/inbox_2";
-        Map<String, Object> properties = new HashMap<String, Object>();
-        properties.put("monitoredDirectoryPath", newMonitoredDirectory);
-        properties.put("copyIngestedFiles", true);
-        contentDirectoryMonitor.updateCallback(properties);
-
-        // Put file in new monitored directory
-        fileContents = "Dummy data in second text file";
-        FileUtils.writeStringToFile(new File("target/input_2.txt"), fileContents);
-        template.sendBodyAndHeader("file://" + newMonitoredDirectory,
-                fileContents,
-                Exchange.FILE_NAME,
-                "input_2.txt");
-
-        Thread.sleep(3000);
-
-        // Verify the file moved to the .ingested directory
-        target = new File(newMonitoredDirectory + "/.ingested/input_2.txt");
-        assertTrue("File 2 not moved to .ingested folder", target.exists());
-
-        // Put file in original monitored directory
-        fileContents = "Dummy data in third text file";
-        FileUtils.writeStringToFile(new File("target/input_3.txt"), fileContents);
-        template.sendBodyAndHeader("file://" + MONITORED_DIRECTORY,
-                fileContents,
-                Exchange.FILE_NAME,
-                "input_3.txt");
-
-        Thread.sleep(3000);
-
-        // Verify the file is not moved to the .ingested directory since it is
-        // no longer monitored
-        target = new File(MONITORED_DIRECTORY + "/.ingested/input_3.txt");
-        assertFalse("File 3 moved to .ingested folder", target.exists());
-        target = new File(MONITORED_DIRECTORY + "/input_3.txt");
-        assertTrue("File 3 not in old monitored folder", target.exists());
-
-        // Cleanup
-        FileUtils.deleteDirectory(new File(MONITORED_DIRECTORY));
-        FileUtils.deleteDirectory(new File(newMonitoredDirectory));
+        doAndVerifyFileDidNotMove(monitoredDirectory1, monitoredDirectory2, "input3.txt");
     }
 
     @Test
-    public void testMultipleDirectoryMonitors() throws Exception {
-        String firstMonitoredDirectory = "target/inbox_1";
-        boolean copyIngestedFiles = true;
+    public void testMultipleContentDirectoryMonitors() throws Exception {
+        File monitoredDirectory1 = temporaryFolder.newFolder("inbox1");
+        File monitoredDirectory2 = temporaryFolder.newFolder("inbox2");
 
-        createRoute(firstMonitoredDirectory, copyIngestedFiles);
+        ContentDirectoryMonitor monitor1 = createContentDirectoryMonitor();
+        ContentDirectoryMonitor monitor2 = createContentDirectoryMonitor();
 
-        String secondMonitoredDirectory = "target/inbox_2";
-        copyIngestedFiles = true;
+        submitConfigOptions(monitor1, monitoredDirectory1.getAbsolutePath(), true);
+        submitConfigOptions(monitor2, monitoredDirectory2.getAbsolutePath(), true);
 
-        createRoute(secondMonitoredDirectory, copyIngestedFiles);
-
-        // Put file in first monitored directory
-        String fileContents = "text file 1";
-        FileUtils.writeStringToFile(new File(INPUT_FILEPATH), fileContents);
-        template.sendBodyAndHeader("file://" + firstMonitoredDirectory,
-                fileContents,
-                Exchange.FILE_NAME,
-                INPUT_FILENAME);
-
-        fileContents = "text file 2";
-        FileUtils.writeStringToFile(new File("target/input_2.txt"), fileContents);
-        template.sendBodyAndHeader("file://" + secondMonitoredDirectory,
-                fileContents,
-                Exchange.FILE_NAME,
-                "input_2.txt");
-
-        Thread.sleep(3000);
-
-        // Verify the files were moved to the correct .ingested directories
-        File target = new File(firstMonitoredDirectory + "/.ingested/" + INPUT_FILENAME);
-        assertTrue("File 1 not moved to .ingested folder", target.exists());
-
-        target = new File(secondMonitoredDirectory + "/.ingested/input_2.txt");
-        assertTrue("File 2 not moved to .ingested folder", target.exists());
-
-        // Cleanup
-        FileUtils.deleteDirectory(new File(firstMonitoredDirectory));
-        FileUtils.deleteDirectory(new File(secondMonitoredDirectory));
+        doAndVerifyFileMove(monitoredDirectory1, monitoredDirectory1, "input1.txt");
+        doAndVerifyFileMove(monitoredDirectory2, monitoredDirectory2, "input2.txt");
     }
 
     @Test
     public void testDirectoryMonitorWithParameters() throws Exception {
-        boolean copyIngestedFiles = true;
-
-        camelContext = (ModelCamelContext) super.createCamelContext();
-        camelContext.start();
-        camelContext.addComponent("content", new MockComponent());
-
-        contentDirectoryMonitor = new ContentDirectoryMonitor(camelContext);
-        contentDirectoryMonitor.systemSubjectBinder = noOpProcessor;
-        contentDirectoryMonitor.setMonitoredDirectoryPath(MONITORED_DIRECTORY);
-        contentDirectoryMonitor.setCopyIngestedFiles(copyIngestedFiles);
-        contentDirectoryMonitor.setAttributeOverrides(ATTRIBUTE_OVERRIDES);
-        contentDirectoryMonitor.init();
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
+        submitConfigOptions(monitor, monitoredDirectoryPath, true, ATTRIBUTE_OVERRIDES);
         RouteDefinition routeDefinition = camelContext.getRouteDefinitions()
                 .get(0);
-        assertThat(routeDefinition.toString(), containsString(
-                "SetHeader[" + Constants.ATTRIBUTE_OVERRIDES_KEY + ", simple{Simple: test1=someParameter1,test2=someParameter2}"));
+        assertThat(routeDefinition.toString(),
+                containsString("SetHeader[" + Constants.ATTRIBUTE_OVERRIDES_KEY
+                        + ", simple{Simple: test1=someParameter1,test2=someParameter2}"));
     }
 
-    /**
-     * ********************************************************************************
-     */
-
-    private RouteDefinition createRouteWithAdvice(String monitoredDirectory,
-            boolean copyIngestedFiles) throws Exception {
-        camelContext = (ModelCamelContext) super.createCamelContext();
-        camelContext.start();
-
-        contentDirectoryMonitor = new ContentDirectoryMonitor(camelContext);
-        contentDirectoryMonitor.systemSubjectBinder = noOpProcessor;
-        contentDirectoryMonitor.setMonitoredDirectoryPath(monitoredDirectory);
-        contentDirectoryMonitor.setCopyIngestedFiles(copyIngestedFiles);
-
-        // Simulates what container would do once all setters have been invoked
-        contentDirectoryMonitor.init();
-
-        // Did not work because it expects the route to be "adviced" already exists. So the above
-        // init()
-        // call created the initial route with the "content:framework" node in it, and then this
-        // AdviceWithRouteBuilder replaced the content:framework with mock:result, but created a
-        // second
-        // route that had this change in it. (So still get NPE because first route fires and cannot
-        // resolve the "content" scheme)
-        camelContext.getRouteDefinitions()
-                .get(0)
-                .adviceWith(camelContext, new AdviceWithRouteBuilder() {
-                    @Override
-                    public void configure() throws Exception {
-                        // weave the node in the route which has id = content://framework
-                        // and replace it with the following route path
-                        weaveByToString(".*content:framework.*").replace()
-                                .to("mock:result");
-                    }
-                });
-
-        // Initial Camel route should now be created
-        List<RouteDefinition> routeDefinitions = contentDirectoryMonitor.getRouteDefinitions();
-        assertThat(routeDefinitions.size(), is(1));
-        LOGGER.debug("routeDefinition = {}", routeDefinitions.get(0));
-
-        return routeDefinitions.get(0);
+    @Test
+    public void testRouteCreationMissingMonitoredDirectory() throws Exception {
+        ContentDirectoryMonitor monitor = createContentDirectoryMonitor();
+        submitConfigOptions(monitor, "", true);
+        assertThat("Camel context should not have any route definitions",
+                camelContext.getRouteDefinitions(),
+                empty());
+        assertThat("Content directory monitor should not have any route definitions",
+                monitor.getRouteDefinitions(),
+                empty());
     }
 
-    private RouteDefinition createRoute(String monitoredDirectory, boolean copyIngestedFiles)
+    private void doAndVerifyFileMove(File destinationFolder, File monitoredFolder,
+            String inputFileName) throws Exception {
+        doFileMove(destinationFolder, inputFileName);
+        Failsafe.with(new RetryPolicy().retryWhen(false)
+                .withMaxRetries(MAX_CHECKS_FOR_FILE_COPY)
+                .withDelay(1, TimeUnit.SECONDS))
+            .withFallback(() -> {
+                throw new RuntimeException("File did not get moved in time");
+            })
+            .get(() -> verifyFileMovedToIngestedDirectory(monitoredFolder, inputFileName));
+
+        assertThat("File SHOULD have been moved to the /.ingested directory",
+                verifyFileMovedToIngestedDirectory(monitoredFolder, inputFileName),
+                is(true));
+    }
+
+    private void doAndVerifyFileDidNotMove(File destinationFolder, File monitoredFolder,
+            String inputFileName) throws Exception {
+        doFileMove(destinationFolder, inputFileName);
+        TimeUnit.SECONDS.sleep(MAX_SECONDS_FOR_FILE_COPY);
+        assertThat("File SHOULD NOT have been moved to the /.ingested directory",
+                verifyFileMovedToIngestedDirectory(monitoredFolder, inputFileName),
+                is(false));
+    }
+
+    private void doFileMove(File destinationFolder, String inputFileName) throws Exception {
+        FileUtils.writeStringToFile(new File(destinationFolder, inputFileName), DUMMY_DATA);
+        template.sendBodyAndHeader(PROTOCOL + destinationFolder.getAbsolutePath(),
+                DUMMY_DATA,
+                Exchange.FILE_NAME,
+                inputFileName);
+    }
+
+    private boolean verifyFileMovedToIngestedDirectory(File monitoredFolder, String fileName)
             throws Exception {
-
-        // Simulates what container would do for <camel:camelContext id="camelContext">
-        // declaration in beans.xml file
-        camelContext = (ModelCamelContext) super.createCamelContext();
-        camelContext.start();
-
-        // Map the "content" scheme to a mock component so that we do not have to
-        // mock the entire custom ContentComponent and include its implementation
-        // in pom with scope=test
-        camelContext.addComponent("content", new MockComponent());
-
-        contentDirectoryMonitor = new ContentDirectoryMonitor(camelContext);
-        contentDirectoryMonitor.systemSubjectBinder = noOpProcessor;
-        contentDirectoryMonitor.setMonitoredDirectoryPath(monitoredDirectory);
-        contentDirectoryMonitor.setCopyIngestedFiles(copyIngestedFiles);
-
-        // Simulates what container would do once all setters have been invoked
-        contentDirectoryMonitor.init();
-
-        // Initial Camel route should now be created
-        List<RouteDefinition> routeDefinitions = contentDirectoryMonitor.getRouteDefinitions();
-        assertThat(routeDefinitions.size(), is(1));
-        LOGGER.debug("routeDefinition = {}", routeDefinitions.get(0));
-
-        return routeDefinitions.get(0);
+        File target = new File(monitoredFolder.getAbsolutePath() + "/.ingested/" + fileName);
+        return target.exists();
     }
 
     private void verifyRoute(RouteDefinition routeDefinition, String monitoredDirectory,
@@ -346,17 +229,45 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
         assertThat(fromDefinitions.size(), is(1));
         String uri = fromDefinitions.get(0)
                 .getUri();
+
         LOGGER.debug("uri = {}", uri);
+
         String expectedUri = "file:" + monitoredDirectory + "?moveFailed=.errors";
         if (copyIngestedFiles) {
             expectedUri += "&move=.ingested";
         } else {
             expectedUri += "&delete=true";
         }
+
         assertThat(uri, equalTo(expectedUri));
         List<ProcessorDefinition<?>> processorDefinitions = routeDefinition.getOutputs();
-
         assertThat(processorDefinitions.size(), is(2));
     }
 
+    private void submitConfigOptions(ContentDirectoryMonitor monitor, String monitoredDirectory,
+            boolean copyIngestedFiles) throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("monitoredDirectoryPath", monitoredDirectory);
+        properties.put("copyIngestedFiles", copyIngestedFiles);
+        monitor.updateCallback(properties);
+    }
+
+    private void submitConfigOptions(ContentDirectoryMonitor monitor, String monitoredDirectory,
+            boolean copyIngestedFiles, List<String> attributeOverrides) throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("monitoredDirectoryPath", monitoredDirectory);
+        properties.put("copyIngestedFiles", copyIngestedFiles);
+        properties.put("attributeOverrides", attributeOverrides.toArray());
+        monitor.updateCallback(properties);
+    }
+
+    private ContentDirectoryMonitor createContentDirectoryMonitor() {
+        ContentDirectoryMonitor monitor = new ContentDirectoryMonitor(camelContext,
+                1,
+                1,
+                Runnable::run);
+        monitor.systemSubjectBinder = exchange -> {
+        };
+        return monitor;
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
Backports DDF-2459 for `2.9.x`

#### Who is reviewing it?
@shaundmorris

#### Choose 2 committers to review/merge the PR.
@lessarderic
@pklinef

#### How should this be tested?
Ensure content directory monitors keep ingesting files dropped into their directories after a system reboot. 

##### Implementation details

CDMs now wait for the "content" CamelComponent before adding routes.
Have the CDM retry adding routes for a given period of time.
Wait for the content CamelComponent instead of recursively retrying on exceptions.
Rework unit tests.