### PR TITLE
(2.9.x) DDF-2499 Turned Resource Derived Download URLs into anchors in Standard Search

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/metacard.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/metacard.handlebars
@@ -105,7 +105,6 @@
                         </ul>
                     </div>
 
-
                     {{#if properties.thumbnail}}
                         <div class="col-sm-12 holder-row">
                             <a href="/services/catalog/sources/{{encodeString properties.source-id}}/{{encodeString properties.id}}?transform=thumbnail" target="_blank"><img class='thumbnail' alt='{{properties.title}}' src='data:image/jpeg;charset=utf-8;base64, {{properties.thumbnail}}' /> </a>
@@ -144,13 +143,23 @@
                                 {{#is @key 'resource-size'}}
                                     <td>{{fileSize this}}</td>
                                 {{else}}
-                                    {{#isUrl this}}
-                                    <td>
-                                        <a target='_blank' title="{{propertyTitle @key}}" href='{{safeString this}}'>{{safeString this}}</a>
-                                    </td>
+                                    {{#is @key 'resource.derived-download-url'}}
+                                        <td>
+                                            {{#each this}}
+                                                {{#isUrl this}}
+                                                    <a target='_blank' href='{{safeString this}}'>{{safeString this}}</a>
+                                                {{/isUrl}}
+                                            {{/each}}
+                                        </td>
                                     {{else}}
-                                    <td>{{safeString this}}</td>
-                                    {{/isUrl}}
+                                        {{#isUrl this}}
+                                            <td>
+                                                <a target='_blank' title="{{propertyTitle @key}}" href='{{safeString this}}'>{{safeString this}}</a>
+                                            </td>
+                                        {{else}}
+                                            <td>{{safeString this}}</td>
+                                        {{/isUrl}}
+                                     {{/is}}
                                 {{/is}}
                             {{/is}}
                         </tr>
@@ -202,4 +211,3 @@
     </div>
 
 </div>
-


### PR DESCRIPTION
#### What does this PR do?
This PR turns Resource Derived Download URLS into anchors for a better user experience
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein @peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@stustison 
#### How should this be tested?
Build and Install DDF, ingest an image and observe anchors in Resource Derived Download URLs
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2499
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests