### PR TITLE
DDF-2503 Reordered the execution of applyAttributeOverrides to run after injectAttributes

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -79,7 +79,7 @@ import ddf.security.Subject;
 
 /**
  * Support class for create delegate operations for the {@code CatalogFrameworkImpl}.
- *
+ * <p>
  * This class contains two delegated methods and methods to support them. No
  * operations/support methods should be added to this class except in support of CFI
  * create operations.
@@ -148,9 +148,9 @@ public class CreateOperations {
             createRequest = processPrecreateAccessPlugins(createRequest);
 
             createRequest.getProperties()
-                    .put(Constants.OPERATION_TRANSACTION_KEY,
-                            new OperationTransactionImpl(OperationTransaction.OperationType.CREATE,
-                                    Collections.emptyList()));
+                    .put(Constants.OPERATION_TRANSACTION_KEY, new OperationTransactionImpl(
+                            OperationTransaction.OperationType.CREATE,
+                            Collections.emptyList()));
 
             createRequest = processPreIngestPlugins(createRequest);
             createRequest = validateCreateRequest(createRequest);
@@ -230,6 +230,8 @@ public class CreateOperations {
         streamCreateRequest.getProperties()
                 .put(CONTENT_PATHS, tmpContentPaths);
 
+        injectAttributes(metacardMap);
+        setDefaultValues(metacardMap);
         streamCreateRequest = applyAttributeOverrides(streamCreateRequest, metacardMap);
 
         try {
@@ -302,6 +304,19 @@ public class CreateOperations {
         }
 
         return CollectionUtils.containsAny(tags, fanoutBlacklist);
+    }
+
+    private void injectAttributes(Map<String, Metacard> metacardMap) {
+        for(Map.Entry<String, Metacard> entry : metacardMap.entrySet()) {
+            Metacard originalMetacard = entry.getValue();
+            metacardMap.put(entry.getKey(), opsMetacardSupport.applyInjectors(originalMetacard,
+                    frameworkProperties.getAttributeInjectors()));
+        }
+    }
+
+    private void setDefaultValues(Map<String, Metacard> metacardMap) {
+        metacardMap.values()
+                .forEach(opsMetacardSupport::setDefaultValues);
     }
 
     private CreateRequest injectAttributes(CreateRequest request) {
@@ -624,8 +639,8 @@ public class CreateOperations {
                         .setAttribute(new AttributeImpl(Metacard.RESOURCE_URI,
                                 contentItem.getUri()));
                 contentItem.getMetacard()
-                        .setAttribute(new AttributeImpl(Metacard.RESOURCE_SIZE,
-                                String.valueOf(contentItem.getSize())));
+                        .setAttribute(new AttributeImpl(Metacard.RESOURCE_SIZE, String.valueOf(
+                                contentItem.getSize())));
             }
             metacardMap.put(contentItem.getId(), contentItem.getMetacard());
         }


### PR DESCRIPTION
#### What does this PR do?
This PR reorders the execution of applyAttributeOverrides so that they can additionally be applied to injectable attributes through the Content Directory Monitor
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@coyotesqrl 
#### How should this be tested?
Build and Install DDF, configure an injectable attribute, configure the Content Directory Monitor to override the value and observe the expected behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2503
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests