### PR TITLE
DDF-2498 Added ability to specify source and target for Migrate Command

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DuplicateCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DuplicateCommands.java
@@ -142,7 +142,7 @@ public abstract class DuplicateCommands extends CatalogCommands {
     String cqlFilter = null;
 
     @Option(name = "--maxMetacards", required = false, aliases = {"-mm",
-            "-max"}, multiValued = false, description = "Option to specify a maximum amount of metacards to ingest.")
+            "-max"}, multiValued = false, description = "Option to specify a maximum amount of metacards to query.")
     int maxMetacards;
 
     protected AtomicInteger ingestedCount = new AtomicInteger(0);
@@ -186,6 +186,7 @@ public abstract class DuplicateCommands extends CatalogCommands {
 
         final long totalHits = originalResponse.getHits();
         if (totalHits <= 0) {
+            LOGGER.debug("Query returned 0 hits.");
             return;
         }
 

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ReplicateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ReplicateCommand.java
@@ -50,7 +50,7 @@ public class ReplicateCommand extends DuplicateCommands {
     @Override
     protected Object executeWithSubject() throws Exception {
         if (batchSize > MAX_BATCH_SIZE || batchSize < 1) {
-            console.println("Batch Size must be between 1 and 1000.");
+            console.println("Batch Size must be between 1 and " + MAX_BATCH_SIZE + ".");
             return null;
         }
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds `--from` and `--to` options to the Migrate Command to specify the providers, and it adds a `--list` option to list the available providers.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @glenhein @peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@kcwire
#### How should this be tested?
Add an external provider, and test that the `catalog:migrate` and the options work as expected when migrating from this new external provider to the `SolrHttpCatalogProvider`.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2498
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

