### PR TITLE
DDF-2506 Use LatLonType for geometry sort keys

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -237,7 +237,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.70</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClient.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClient.java
@@ -65,6 +65,13 @@ public class SolrMetacardClient {
 
     protected static final String RELEVANCE_SORT_FIELD = "score";
 
+    private static final String DISTANCE_SORT_FUNCTION = "geodist()";
+
+    private static final String DISTANCE_SORT_FIELD = "_distance_";
+
+    private static final String GEOMETRY_SORT_FIELD =
+            Metacard.GEOGRAPHY + SchemaFields.GEO_SUFFIX + SchemaFields.SORT_KEY_SUFFIX;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SolrMetacardClient.class);
 
     private static final String QUOTE = "\"";
@@ -92,7 +99,6 @@ public class SolrMetacardClient {
         }
 
         SolrQuery query = getSolrQuery(request, filterDelegateFactory.newInstance(resolver));
-        String sortProperty = getSortProperty(request, query);
 
         long totalHits;
         List<Result> results = new ArrayList<>();
@@ -109,7 +115,7 @@ public class SolrMetacardClient {
                 }
                 ResultImpl tmpResult;
                 try {
-                    tmpResult = createResult(doc, sortProperty);
+                    tmpResult = createResult(doc);
                     // TODO: register metacard type???
                 } catch (MetacardCreationException e) {
                     throw new UnsupportedQueryException("Could not create metacard(s).", e);
@@ -281,20 +287,23 @@ public class SolrMetacardClient {
         query.setStart(request.getQuery()
                 .getStartIndex() - 1);
 
-        checkSpatialFunction(filterDelegate, query);
+        setSortProperty(request, query, filterDelegate);
 
         return query;
     }
 
-    private void checkSpatialFunction(SolrFilterDelegate solrFilterDelegate, SolrQuery query) {
-        if (solrFilterDelegate.isSortedByDistance()) {
-            String queryPhrase = query.getQuery()
-                    .trim();
-            query.setQuery(SolrFilterDelegate.SCORE_DISTANCE + queryPhrase);
+    private void addDistanceSort(SolrQuery query, String sortField, SolrQuery.ORDER order,
+            SolrFilterDelegate delegate) {
+        if (delegate.isSortedByDistance()) {
+            query.addSort(DISTANCE_SORT_FUNCTION, order);
+            query.setFields("*", RELEVANCE_SORT_FIELD, DISTANCE_SORT_FIELD + ":" + DISTANCE_SORT_FUNCTION);
+            query.add("sfield", sortField);
+            query.add("pt", delegate.getSortedDistancePoint());
         }
     }
 
-    protected String getSortProperty(QueryRequest request, SolrQuery query) {
+    protected String setSortProperty(QueryRequest request, SolrQuery query,
+            SolrFilterDelegate solrFilterDelegate) {
         SortBy sortBy = request.getQuery()
                 .getSortBy();
         String sortProperty = "";
@@ -308,9 +317,12 @@ public class SolrMetacardClient {
                 order = SolrQuery.ORDER.asc;
             }
 
-            if (Result.RELEVANCE.equals(sortProperty) || Result.DISTANCE.equals(sortProperty)) {
-                query.setFields("*", RELEVANCE_SORT_FIELD);
+            query.setFields("*", RELEVANCE_SORT_FIELD);
+
+            if (Result.RELEVANCE.equals(sortProperty)) {
                 query.addSort(RELEVANCE_SORT_FIELD, order);
+            } else if (Result.DISTANCE.equals(sortProperty)) {
+                addDistanceSort(query, GEOMETRY_SORT_FIELD, order, solrFilterDelegate);
             } else if (sortProperty.equals(Result.TEMPORAL)) {
                 query.addSort(resolver.getSortKey(resolver.getField(Metacard.EFFECTIVE,
                         AttributeType.AttributeFormat.DATE,
@@ -320,13 +332,16 @@ public class SolrMetacardClient {
 
                 if (!resolvedProperties.isEmpty()) {
                     for (String sortField : resolvedProperties) {
-                        if (!(sortField.endsWith(SchemaFields.BINARY_SUFFIX) || sortField.endsWith(
+                        if (sortField.endsWith(SchemaFields.GEO_SUFFIX)) {
+                            addDistanceSort(query,
+                                    resolver.getSortKey(sortField),
+                                    order,
+                                    solrFilterDelegate);
+                        } else if (!(sortField.endsWith(SchemaFields.BINARY_SUFFIX) || sortField.endsWith(
                                 SchemaFields.OBJECT_SUFFIX))) {
                             query.addSort(resolver.getSortKey(sortField), order);
                         }
                     }
-
-                    query.add("fl", "*," + RELEVANCE_SORT_FIELD);
                 } else {
                     LOGGER.debug(
                             "No schema field was found for sort property [{}]. No sort field was added to the query.",
@@ -339,23 +354,23 @@ public class SolrMetacardClient {
         return resolver.getSortKey(sortProperty);
     }
 
-    private ResultImpl createResult(SolrDocument doc, String sortProperty)
+    private ResultImpl createResult(SolrDocument doc)
             throws MetacardCreationException {
         ResultImpl result = new ResultImpl(createMetacard(doc));
 
         if (doc.get(RELEVANCE_SORT_FIELD) != null) {
-            if (Result.RELEVANCE.equals(sortProperty)) {
-                result.setRelevanceScore(((Float) (doc.get(RELEVANCE_SORT_FIELD))).doubleValue());
-            } else if (Result.DISTANCE.equals(sortProperty)) {
-                Object distance = doc.getFieldValue(RELEVANCE_SORT_FIELD);
+            result.setRelevanceScore(((Float) (doc.get(RELEVANCE_SORT_FIELD))).doubleValue());
+        }
 
-                if (distance != null) {
-                    LOGGER.debug("Distance returned from Solr [{}]", distance);
-                    double convertedDistance = degreesToMeters(Double.valueOf(distance.toString()));
+        if (doc.get(DISTANCE_SORT_FIELD) != null) {
+            Object distance = doc.getFieldValue(DISTANCE_SORT_FIELD);
 
-                    LOGGER.debug("Converted distance into meters [{}]", convertedDistance);
-                    result.setDistanceInMeters(convertedDistance);
-                }
+            if (distance != null) {
+                LOGGER.debug("Distance returned from Solr [{}]", distance);
+                double convertedDistance = new Distance(Double.valueOf(distance.toString()),
+                        Distance.LinearUnit.KILOMETER).getAs(Distance.LinearUnit.METER);
+
+                result.setDistanceInMeters(convertedDistance);
             }
         }
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/MockMetacard.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/MockMetacard.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 
 public class MockMetacard extends MetacardImpl {
@@ -35,7 +37,8 @@ public class MockMetacard extends MetacardImpl {
 
     private static final long serialVersionUID = -189776439741244547L;
 
-    public MockMetacard(String metadata) {
+    public MockMetacard(String metadata, MetacardType type) {
+        super(type);
         // make a simple metacard
         this.setCreatedDate(Calendar.getInstance()
                 .getTime());
@@ -54,6 +57,10 @@ public class MockMetacard extends MetacardImpl {
         // this.setSourceId(DEFAULT_SOURCE_ID) ;
         this.setTitle(DEFAULT_TITLE);
         this.setSecurity(new HashMap<String, List<String>>());
+    }
+
+    public MockMetacard(String metadata) {
+        this(metadata, BasicTypes.BASIC_METACARD);
     }
 
     public static List<String> toStringList(List<Metacard> cards) {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
@@ -14,6 +14,7 @@
 package ddf.catalog.source.solr;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.stub;
@@ -69,6 +70,20 @@ public class TestSolrFilterDelegate {
         // then return a valid Solr query using the given WKT
         assertThat(query.getQuery(),
                 is("testProperty_geohash_index:\"Intersects(invalid JTS wkt)\""));
+    }
+
+    @Test
+    public void intersectsWithValidJtsWkt() {
+        // given a geospatial property
+        stub(mockResolver.getField("testProperty", AttributeFormat.GEOMETRY, false)).toReturn(
+                "testProperty_geohash_index");
+
+        // when the delegate intersects on WKT not handled by JTS
+        SolrQuery query = toTest.intersects("testProperty", "POINT(1 0)");
+
+        // then return a valid Solr query using the given WKT
+        assertThat(query.getQuery(),
+                startsWith("testProperty_geohash_index:\"Intersects(BUFFER(POINT(1.0 0.0), "));
     }
 
     @Test

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
@@ -67,6 +67,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.internal.util.collections.Sets;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.sort.SortBy;
@@ -4866,24 +4867,50 @@ public class TestSolrProvider extends SolrProviderTestCase {
     }
 
     @Test
-    public void testSpatialDistanceCalculationBetweenTwoPoints() throws Exception {
+    public void testSpatialDistanceCalculationBetweenTwoPointsUsingDistanceSortBy() throws Exception {
+        spatialDistanceCalculationBetweenTwoPoints(Metacard.GEOGRAPHY, Result.DISTANCE);
+
+    }
+
+    @Test
+    public void testSpatialDistanceCalculationBetweenTwoPointsUsingAttributeSortBy() throws Exception {
+        spatialDistanceCalculationBetweenTwoPoints("geoattribute", "geoattribute");
+
+    }
+
+    private void spatialDistanceCalculationBetweenTwoPoints(String attribute, String sortBy) throws Exception {
         deleteAllIn(provider);
 
         // given
         double radiusInKilometers = 500;
         double radiusInMeters = radiusInKilometers * METERS_PER_KM;
-        Filter positiveFilter = filterBuilder.attribute(Metacard.GEOGRAPHY)
+        Filter positiveFilter = filterBuilder.attribute(attribute)
                 .withinBuffer()
                 .wkt(PHOENIX_POINT_WKT, radiusInMeters);
 
-        MetacardImpl metacard = new MockMetacard(Library.getFlagstaffRecord());
-        metacard.setLocation(LAS_VEGAS_POINT_WKT);
+        MetacardImpl metacard;
+        if (attribute.equals(Metacard.GEOGRAPHY)) {
+            metacard = new MockMetacard(Library.getFlagstaffRecord());
+        } else {
+            metacard = new MockMetacard(Library.getFlagstaffRecord(),
+                    new MetacardTypeImpl("distanceTest",
+                            BasicTypes.BASIC_METACARD,
+                            Sets.newSet(new AttributeDescriptorImpl(attribute,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    BasicTypes.GEO_TYPE))));
+
+        }
+
+        metacard.setAttribute(attribute, LAS_VEGAS_POINT_WKT);
         List<Metacard> list = Arrays.asList((Metacard) metacard);
 
         create(list);
 
         QueryImpl query = new QueryImpl(positiveFilter);
-        query.setSortBy(new ddf.catalog.filter.impl.SortByImpl(Result.DISTANCE,
+        query.setSortBy(new ddf.catalog.filter.impl.SortByImpl(sortBy,
                 SortOrder.ASCENDING));
 
         // when

--- a/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
@@ -162,8 +162,8 @@
     <!--<dynamicField name="*_d"  type="double" indexed="true"  stored="true"/>-->
     <!--<dynamicField name="*_ds" type="double" indexed="true"  stored="true"  multiValued="true"/>-->
 
-    <!--&lt;!&ndash; Type used to index the lat and lon components for the "location" FieldType &ndash;&gt;-->
-    <!--<dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" />-->
+    <!-- Type used to index the lat and lon components for the "location" FieldType -->
+    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" />
 
     <!--<dynamicField name="*_dt"  type="date"    indexed="true"  stored="true"/>-->
     <!--<dynamicField name="*_dts" type="date"    indexed="true"  stored="true" multiValued="true"/>-->
@@ -212,7 +212,7 @@
     <dynamicField name="*_dbl_sk" type="tdouble" indexed="true" stored="false"/>
     <dynamicField name="*_tdt_sk" type="tdate" indexed="true" stored="false"/>
     <dynamicField name="*_bln_sk" type="boolean" indexed="true" stored="false"/>
-    <dynamicField name="*_geo_sk" type="text_general" indexed="true" stored="false"/>
+    <dynamicField name="*_geo_sk" type="location" indexed="true" stored="false"/>
     <dynamicField name="*_txt_sk" type="text_general" indexed="true" stored="false"/>
     <dynamicField name="*_xml_sk" type="text_general" indexed="true" stored="false"/>
 


### PR DESCRIPTION
#### What does this PR do?
* LatLonType is optimized for distance sorting unlike the
 SpatialRecursivePrefixTreeFieldType.  Switched to LatLonType for
 sorting of geometry attributes.  
* Can now sort by distance on any geometry field.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann @jrnorth @codice/solr 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@pklinef

#### How should this be tested?
Ingest quarter of a million or more metacards with locations.  Index a new metacard with a location to clear any spatial cache.  Do a spatial query and sort by distance.  Results should return in less than a second compared to before which could take minutes.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2506

#### Screenshots (if appropriate)

#### Checklist:
- [ n/a ] Documentation Updated
- [X] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests

