### PR TITLE
DDF-2516 Updated Tika, Video, and Pptx InputTransformers to use new taxonomy

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -516,5 +516,10 @@
             <artifactId>catalog-plugin-clientinfo</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-metacardtype</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -72,6 +72,7 @@
         <bundle>mvn:ddf.catalog.security/catalog-security-logging/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-attribute/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-defaultvalues/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-metacardtype/${project.version}</bundle>
 
         <configfile finalname="/data/solr/metacard_cache/conf/solrconfig.xml">
             mvn:ddf.platform.solr/platform-solr-server-standalone/${project.version}/xml/solrconfig

--- a/catalog/core/catalog-core-metacardtype/pom.xml
+++ b/catalog/core/catalog-core-metacardtype/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.catalog.core</groupId>
+        <artifactId>core</artifactId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>catalog-core-metacardtype</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Catalog :: Core :: MetacardType</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                        <Private-Package>
+                            ddf.catalog.data.impl.*
+                        </Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-metacardtype/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-metacardtype/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="commonMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
+        <argument value="common"/>
+        <argument>
+            <list>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
+            </list>
+        </argument>
+    </bean>
+
+    <service ref="commonMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="common"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -121,5 +121,6 @@
         <module>catalog-core-resourcestatusplugin</module>
         <module>catalog-core-tagsfilterplugin</module>
         <module>catalog-core-downloadaction</module>
+        <module>catalog-core-metacardtype</module>
     </modules>
 </project>

--- a/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
+++ b/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
@@ -14,7 +14,6 @@
 package ddf.catalog.transformer.common.tika;
 
 import java.util.Date;
-import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.metadata.Metadata;
@@ -22,13 +21,10 @@ import org.apache.tika.metadata.TikaCoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.impl.MetacardTypeImpl;
 
 /**
  * Creates {@link Metacard}s from Tika {@link Metadata} objects.
@@ -37,42 +33,16 @@ public class MetacardCreator {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetacardCreator.class);
 
     /**
-     * A convenience method for creating a new {@link Metacard} of type
-     * {@link BasicTypes#BASIC_METACARD} from a {@link Metadata} object.
-     *
-     * @param metadata    the {@code Metadata} object containing the metadata relevant to the
-     *                    metacard, must not be null
-     * @param id          the value for the {@link Metacard#ID} attribute that should be set in the
-     *                    generated {@code Metacard}, may be null
-     * @param metadataXml the XML for the {@link Metacard#METADATA} attribute that should be set in
-     *                    the generated {@code Metacard}, may be null
+     * @param metadata     the {@code Metadata} object containing the metadata relevant to the
+     *                     metacard, must not be null
+     * @param id           the value for the {@link Metacard#ID} attribute that should be set in the
+     *                     generated {@code Metacard}, may be null
+     * @param metadataXml  the XML for the {@link Metacard#METADATA} attribute that should be set in
+     *                     the generated {@code Metacard}, may be null
+     * @param metacardType The {@link MetacardType} for the created metacard
      * @return a new {@code Metacard}
      */
-    public static Metacard createBasicMetacard(final Metadata metadata, final String id,
-            final String metadataXml) {
-        return createMetacard(metadata, id, metadataXml, BasicTypes.BASIC_METACARD);
-    }
-
-    /**
-     * @param metadata           the {@code Metadata} object containing the metadata relevant to the
-     *                           metacard, must not be null
-     * @param id                 the value for the {@link Metacard#ID} attribute that should be set in the
-     *                           generated {@code Metacard}, may be null
-     * @param metadataXml        the XML for the {@link Metacard#METADATA} attribute that should be set in
-     *                           the generated {@code Metacard}, may be null
-     * @param extendedAttributes the extra attributes (on top of those already present in
-     *                           {@link BasicTypes#BASIC_METACARD}) that will be available in the metacard
-     * @return a new {@code Metacard}
-     */
-    public static Metacard createEnhancedMetacard(final Metadata metadata, final String id,
-            final String metadataXml, final Set<AttributeDescriptor> extendedAttributes) {
-        MetacardTypeImpl metacardType = new MetacardTypeImpl(BasicTypes.BASIC_METACARD.getName(),
-                BasicTypes.BASIC_METACARD,
-                extendedAttributes);
-        return createMetacard(metadata, id, metadataXml, metacardType);
-    }
-
-    private static Metacard createMetacard(final Metadata metadata, final String id,
+    public static Metacard createMetacard(final Metadata metadata, final String id,
             final String metadataXml, MetacardType metacardType) {
         final Metacard metacard = new MetacardImpl(metacardType);
 

--- a/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
+++ b/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
@@ -35,13 +35,17 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 
 public class MetacardCreatorTest {
     @Test
     public void testNoMetadata() {
         final Metadata metadata = new Metadata();
 
-        final Metacard metacard = MetacardCreator.createBasicMetacard(metadata, null, null);
+        final Metacard metacard = MetacardCreator.createMetacard(metadata,
+                null,
+                null,
+                BasicTypes.BASIC_METACARD);
 
         assertThat(metacard, notNullValue());
         assertThat(metacard.getTitle(), nullValue());
@@ -107,12 +111,19 @@ public class MetacardCreatorTest {
 
         final Metacard metacard;
         if (CollectionUtils.isEmpty(extraAttributes)) {
-            metacard = MetacardCreator.createBasicMetacard(metadata, id, metadataXml);
-        } else {
-            metacard = MetacardCreator.createEnhancedMetacard(metadata,
+            metacard = MetacardCreator.createMetacard(metadata,
                     id,
                     metadataXml,
-                    extraAttributes);
+                    BasicTypes.BASIC_METACARD);
+        } else {
+            MetacardTypeImpl extendedMetacardType =
+                    new MetacardTypeImpl(BasicTypes.BASIC_METACARD.getName(),
+                            BasicTypes.BASIC_METACARD,
+                            extraAttributes);
+            metacard = MetacardCreator.createMetacard(metadata,
+                    id,
+                    metadataXml,
+                    extendedMetacardType);
         }
 
         assertThat(metacard, notNullValue());

--- a/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
@@ -32,13 +32,15 @@ import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.junit.Test;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.transformer.input.tika.TikaInputTransformer;
 
 public class PptxInputTransformerTest {
 
-    private final InputTransformer inputTransformer = new TikaInputTransformer(null);
+    private final InputTransformer inputTransformer = new TikaInputTransformer(null,
+            mock(MetacardType.class));
 
     private InputStream getResource(String resourceName) {
         return PptxInputTransformerTest.class.getResourceAsStream(resourceName);

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,14 +13,21 @@
  **/
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-        <!-- The tika input transformer programmatically registers itself as a service -->
+    <!-- The tika input transformer programmatically registers itself as a service -->
     <bean id="tikaTransformer" class="ddf.catalog.transformer.input.tika.TikaInputTransformer">
-		    <argument ref="blueprintBundleContext"/>
-		</bean>
+        <argument ref="blueprintBundleContext"/>
+        <argument ref="commonMetacardType"/>
+    </bean>
 
-    <reference-list id="contentExtractors" interface="ddf.catalog.content.operation.ContentMetadataExtractor"
+    <reference id="commonMetacardType" interface="ddf.catalog.data.MetacardType"
+               filter="(name=common)"
+               availability="mandatory"/>
+
+    <reference-list id="contentExtractors"
+                    interface="ddf.catalog.content.operation.ContentMetadataExtractor"
                     availability="optional">
-        <reference-listener bind-method="addContentMetadataExtractors" unbind-method="removeContentMetadataExtractor"
+        <reference-listener bind-method="addContentMetadataExtractors"
+                            unbind-method="removeContentMetadataExtractor"
                             ref="tikaTransformer"/>
     </reference-list>
 </blueprint>

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -26,6 +26,7 @@ import static junit.framework.Assert.assertNotNull;
 import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.TimeZone;
@@ -42,18 +43,28 @@ import com.google.common.collect.ImmutableSet;
 import ddf.catalog.content.operation.ContentMetadataExtractor;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 
 public class TikaInputTransformerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TikaInputTransformerTest.class);
 
+    private static final String COMMON_METACARDTYPE = "common";
+
     @Test
     public void testRegisterService() {
         BundleContext mockBundleContext = mock(BundleContext.class);
-        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(mockBundleContext);
+        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(mockBundleContext,
+                getCommonMetacardType());
         verify(mockBundleContext).registerService(eq(InputTransformer.class),
                 eq(tikaInputTransformer),
                 any(Hashtable.class));
@@ -87,7 +98,8 @@ public class TikaInputTransformerTest {
                                 BasicTypes.OBJECT_TYPE));
         when(cme.getMetacardAttributes()).thenReturn(attributeDescriptors);
 
-        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx) {
+        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx,
+                getCommonMetacardType()) {
             @Override
             Bundle getBundle() {
                 return bundleMock;
@@ -97,7 +109,7 @@ public class TikaInputTransformerTest {
         Metacard metacard = tikaInputTransformer.transform(stream);
 
         assertThat(metacard.getMetacardType()
-                .getName(), is(BasicTypes.BASIC_METACARD.getName()));
+                .getName(), is(COMMON_METACARDTYPE));
         int matchedAttrs = (int) metacard.getMetacardType()
                 .getAttributeDescriptors()
                 .stream()
@@ -135,7 +147,8 @@ public class TikaInputTransformerTest {
                                 BasicTypes.OBJECT_TYPE));
         when(cme.getMetacardAttributes()).thenReturn(attributeDescriptors);
 
-        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx) {
+        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(bundleCtx,
+                getCommonMetacardType()) {
             @Override
             Bundle getBundle() {
                 return bundleMock;
@@ -146,7 +159,7 @@ public class TikaInputTransformerTest {
         Metacard metacard = tikaInputTransformer.transform(stream);
 
         assertThat(metacard.getMetacardType()
-                .getName(), is(BasicTypes.BASIC_METACARD.getName()));
+                .getName(), is(COMMON_METACARDTYPE));
         int matchedAttrs = (int) metacard.getMetacardType()
                 .getAttributeDescriptors()
                 .stream()
@@ -544,8 +557,19 @@ public class TikaInputTransformerTest {
     }
 
     private Metacard transform(InputStream stream) throws Exception {
-        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(null);
+        TikaInputTransformer tikaInputTransformer = new TikaInputTransformer(null,
+                getCommonMetacardType());
         Metacard metacard = tikaInputTransformer.transform(stream);
         return metacard;
     }
+
+    private static MetacardType getCommonMetacardType() {
+        return new MetacardTypeImpl(COMMON_METACARDTYPE,
+                Arrays.asList(new ValidationAttributes(),
+                        new ContactAttributes(),
+                        new LocationAttributes(),
+                        new MediaAttributes(),
+                        new AssociationsAttributes()));
+    }
+
 }

--- a/catalog/transformer/catalog-transformer-video-input/src/main/java/ddf/catalog/transformer/input/video/VideoInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-video-input/src/main/java/ddf/catalog/transformer/input/video/VideoInputTransformer.java
@@ -42,6 +42,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
 import org.xml.sax.helpers.XMLReaderFactory;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.transformer.common.tika.MetacardCreator;
@@ -53,11 +54,17 @@ public class VideoInputTransformer implements InputTransformer {
 
     private Templates templates = null;
 
-    public VideoInputTransformer() {
+    private MetacardType metacardType = null;
+
+    public VideoInputTransformer(MetacardType metacardType) {
+
+        this.metacardType = metacardType;
+
         ClassLoader tccl = Thread.currentThread()
                 .getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            Thread.currentThread()
+                    .setContextClassLoader(getClass().getClassLoader());
             templates = TransformerFactory.newInstance(TransformerFactoryImpl.class.getName(),
                     this.getClass()
                             .getClassLoader())
@@ -66,7 +73,8 @@ public class VideoInputTransformer implements InputTransformer {
         } catch (TransformerConfigurationException e) {
             LOGGER.debug("Couldn't create XML transformer", e);
         } finally {
-            Thread.currentThread().setContextClassLoader(tccl);
+            Thread.currentThread()
+                    .setContextClassLoader(tccl);
         }
     }
 
@@ -89,7 +97,7 @@ public class VideoInputTransformer implements InputTransformer {
             metadataText = transformToXml(metadataText);
         }
 
-        return MetacardCreator.createBasicMetacard(metadata, id, metadataText);
+        return MetacardCreator.createMetacard(metadata, id, metadataText, metacardType);
     }
 
     private String transformToXml(String xhtml) {

--- a/catalog/transformer/catalog-transformer-video-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-video-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,7 +13,13 @@
  **/
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-    <bean id="transformer" class="ddf.catalog.transformer.input.video.VideoInputTransformer"/>
+    <bean id="transformer" class="ddf.catalog.transformer.input.video.VideoInputTransformer">
+        <argument ref="commonMetacardType"/>
+    </bean>
+
+    <reference id="commonMetacardType" interface="ddf.catalog.data.MetacardType"
+               filter="(name=common)"
+               availability="mandatory"/>
 
     <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
         <service-properties>

--- a/catalog/transformer/catalog-transformer-video-input/src/test/java/ddf/catalog/transformer/input/video/VideoInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-video-input/src/test/java/ddf/catalog/transformer/input/video/VideoInputTransformerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.io.InputStream;
 import java.text.DateFormat;
@@ -27,6 +28,7 @@ import java.util.TimeZone;
 import org.junit.Test;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 
 public class VideoInputTransformerTest {
     @Test
@@ -47,7 +49,8 @@ public class VideoInputTransformerTest {
     }
 
     private Metacard transform(InputStream stream) throws Exception {
-        VideoInputTransformer videoInputTransformer = new VideoInputTransformer();
+        VideoInputTransformer videoInputTransformer =
+                new VideoInputTransformer(mock(MetacardType.class));
         return videoInputTransformer.transform(stream);
     }
 


### PR DESCRIPTION
#### What does this PR do?
DDF-2516 Updated Tika, Video, and Pptx InputTransformers to use new taxonomy
- Replaced usages of Basic MetacardType in tika related transformers
- Replaced uage of Basic MetacardType in MetacardCreator
- Made MetacardType an argument in MetacardCreator

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@lcrosenbu @rzwiefel @bdeining @coyotesqrl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@kcwire 

#### How should this be tested?
1) Ingest video, pptx, and jpeg (or other formats supported by the tika transformer)
2) Verify attributes from the new taxonomy (like metacard.created/modified) are present in ingested metacards

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

