### PR TITLE
DDF-2513 (Backport) Fix password UI in CSW Registry Store

### DIFF
--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,7 +25,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
 
         <AD description="Enable push (write) to this registry"
             name="Allow Push" id="pushAllowed" required="true"


### PR DESCRIPTION
#### What does this PR do?  Fixes CSW Registry Store's password field to display an empty box instead of dots when the password hasn't been entered (empty).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler
@jrnorth
@azgoalie
@emanns95 
@ahoffer
@NGoss
@spearskw

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris 
@stustison

#### How should this be tested?
Open the Admin app, then the DDF Registry app and click on the Configuration Tab.  Click on the CSW Registry Store and view the "Password" field.  It should be blank (not a series of dots).

Enter in a password and notice the dots display.  Save the entry and then reopen it.  The password should now display dots as the password has a value.

Click on CSW Registry Store again for a new entry and the "Password" field should be blank.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests