### PR TITLE
DDF-2517: Display documentation in the admin UI

### DIFF
--- a/platform/admin/admin-app/pom.xml
+++ b/platform/admin/admin-app/pom.xml
@@ -167,5 +167,10 @@
             <artifactId>admin-core-configpolicy</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.admin.modules</groupId>
+            <artifactId>admin-docs-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/platform/admin/admin-app/src/main/resources/features.xml
+++ b/platform/admin/admin-app/src/main/resources/features.xml
@@ -42,6 +42,12 @@
         <bundle>mvn:ddf.admin.modules/admin-modules-configuration/${project.version}</bundle>
     </feature>
 
+    <feature name="admin-modules-docs" install="manual" version="${project.version}"
+             description="DDF Documentation Module">
+        <feature prerequisite="true">admin-ui</feature>
+        <bundle>mvn:ddf.admin.modules/admin-docs-ui/${project.version}</bundle>
+    </feature>
+
     <feature name="admin-modules-installer" install="manual" version="${project.version}"
              description="DDF Installer Module">
         <feature prerequisite="true">admin-ui</feature>
@@ -64,6 +70,7 @@
              description="Contains the modules that should be installed after the installer is finished.">
         <feature>admin-modules-configuration</feature>
         <feature>admin-modules-application</feature>
+        <feature>admin-modules-docs</feature>
         <bundle>mvn:ddf.admin.modules/admin-metrics-ui/${project.version}</bundle>
         <bundle>mvn:ddf.admin.modules/admin-security-certificate-ui/${project.version}</bundle>
     </feature>

--- a/platform/admin/modules/admin-modules-docs/pom.xml
+++ b/platform/admin/modules/admin-modules-docs/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>admin-modules</artifactId>
+        <groupId>ddf.admin.modules</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <name>DDF :: Admin :: Modules :: Documentation UI</name>
+    <artifactId>admin-docs-ui</artifactId>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            spark-core
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.eclipse.jetty.websocket.*,
+                            !sun.reflect,
+                            *
+                        </Import-Package>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.08</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.06</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.06</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.07</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsModule.java
+++ b/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsModule.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ui.admin.docs;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.codice.ddf.ui.admin.api.module.AdminModule;
+
+public class DocsModule implements AdminModule {
+
+    @Override
+    public String getName() {
+        return "Documentation";
+    }
+
+    @Override
+    public String getId() {
+        return "docs";
+    }
+
+    @Override
+    public URI getJSLocation() {
+        return null;
+    }
+
+    @Override
+    public URI getCSSLocation() {
+        return null;
+    }
+
+    @Override
+    public URI getIframeLocation() {
+        try {
+            return new URI("./documentation/documentation.html");
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsRequestSupplier.java
+++ b/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsRequestSupplier.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ui.admin.docs;
+
+import java.util.function.BiFunction;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+public class DocsRequestSupplier
+        implements BiFunction<HttpServletRequest, String, HttpServletRequestWrapper> {
+    @Override
+    public HttpServletRequestWrapper apply(HttpServletRequest httpServletRequest,
+            String relativePath) {
+        return new HttpServletRequestWrapper(httpServletRequest) {
+            @Override
+            public String getServletPath() {
+                return "/";
+            }
+
+            @Override
+            public String getPathInfo() {
+                return relativePath;
+            }
+
+            @Override
+            public String getRequestURI() {
+                return relativePath;
+            }
+        };
+    }
+}

--- a/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsSparkApplication.java
+++ b/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/DocsSparkApplication.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ui.admin.docs;
+
+import static spark.Spark.get;
+import static spark.Spark.staticFiles;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+
+import spark.servlet.SparkApplication;
+
+public class DocsSparkApplication implements SparkApplication {
+
+    public static final String DOCS_ROOT_DIR = Paths.get(System.getProperty("karaf.home"),
+            "documentation")
+            .toString();
+    @Override
+    public void init() {
+
+        File docHtml = getDocumentationHtml();
+
+        if (docHtml != null) {
+            staticFiles.externalLocation(docHtml.getParent());
+        }
+
+        get("/*",
+                (req, res) -> getClass().getClassLoader()
+                        .getResourceAsStream("/404.html"));
+    }
+
+    public File getDocumentationHtml() {
+
+        if (!Files.exists(Paths.get(DOCS_ROOT_DIR))) {
+            return null;
+        }
+
+        Collection<File> files = FileUtils.listFiles(new File(DOCS_ROOT_DIR),
+                new NameFileFilter("documentation.html"),
+                TrueFileFilter.INSTANCE);
+
+        if (files.isEmpty()) {
+            return null;
+        }
+
+        return files.iterator()
+                .next()
+                .getAbsoluteFile();
+    }
+}

--- a/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/SparkServlet.java
+++ b/platform/admin/modules/admin-modules-docs/src/main/java/org/codice/ui/admin/docs/SparkServlet.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ui.admin.docs;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import spark.globalstate.ServletFlag;
+import spark.http.matching.MatcherFilter;
+import spark.route.ServletRoutes;
+import spark.servlet.SparkApplication;
+import spark.staticfiles.StaticFilesConfiguration;
+import spark.utils.CollectionUtils;
+
+/**
+ * Servlet that can be configured through a web.xml to serve {@code SparkApplication}s.
+ * Needs to be initialized with the {@code applicationName} init parameter (or through a direct
+ * call to {@link #setSparkApplications(List)}) to the list of application classes defining routes.
+ * An optional {@code wrapperSupplierName} parameter can be provided (or directly set through the
+ * {@link #setRequestSupplier(BiFunction)} method) to provide added path flexibility.
+ */
+public class SparkServlet extends HttpServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SparkServlet.class);
+
+    private static final String SLASH_WILDCARD = "/*";
+
+    private static final String SLASH = "/";
+
+    private static final String APPLICATION_CLASS_PARAM = "applicationName";
+
+    private static final String WRAPPER_SUPPLIER_PARAM_NAME = "wrapperSupplierName";
+
+    private static final String FILTER_MAPPING_PARAM = "filterMappingUrlPattern";
+
+    private static final BiFunction<HttpServletRequest, String, HttpServletRequestWrapper>
+            DEFAULT_REQ_FUNC =
+            new BiFunction<HttpServletRequest, String, HttpServletRequestWrapper>() {
+                @Override
+                public HttpServletRequestWrapper apply(HttpServletRequest req,
+                        String relativePath) {
+                    return new HttpServletRequestWrapper(req) {
+                        @Override
+                        public String getPathInfo() {
+                            return relativePath;
+                        }
+
+                        @Override
+                        public String getRequestURI() {
+                            return relativePath;
+                        }
+                    };
+                }
+            };
+
+    private BiFunction<HttpServletRequest, String, HttpServletRequestWrapper> requestSupplier;
+
+    private final List<SparkApplication> sparkApplications =
+            Collections.synchronizedList(new ArrayList<>());
+
+    private String filterMappingPattern = null;
+
+    private String filterPath;
+
+    private MatcherFilter matcherFilter;
+
+    public void setRequestSupplier(
+            BiFunction<HttpServletRequest, String, HttpServletRequestWrapper> requestSupplier) {
+        this.requestSupplier = requestSupplier;
+    }
+
+    public void setSparkApplications(List<SparkApplication> sparkApplications) {
+        this.sparkApplications.addAll(sparkApplications);
+    }
+
+    public void setFilterMappingPattern(String filterMappingPattern) {
+        this.filterMappingPattern = filterMappingPattern;
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        ServletFlag.runFromServlet();
+
+        populateWrapperSupplier(config);
+        populateSparkApplications(config);
+
+        sparkApplications.stream()
+                .sequential()
+                .forEach(SparkApplication::init);
+
+        filterPath = getConfigPath(filterMappingPattern, config);
+        matcherFilter = new MatcherFilter(ServletRoutes.get(),
+                StaticFilesConfiguration.servletInstance,
+                false,
+                false);
+    }
+
+    @Override
+    public void destroy() {
+        sparkApplications.stream()
+                .filter(Objects::nonNull)
+                .forEach(SparkApplication::destroy);
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        final String relativePath = getRelativePath(req, filterPath);
+
+        HttpServletRequestWrapper requestWrapper = requestSupplier.apply(req, relativePath);
+
+        // handle static resources
+        boolean consumed = StaticFilesConfiguration.servletInstance.consume(req, resp);
+
+        if (consumed) {
+            return;
+        }
+
+        matcherFilter.doFilter(requestWrapper, resp, null);
+    }
+
+    private static String getConfigPath(String filterMappingPattern, ServletConfig config) {
+        String result = Optional.ofNullable(filterMappingPattern)
+                .orElse(config.getInitParameter(FILTER_MAPPING_PARAM));
+        if (result == null || result.equals(SLASH_WILDCARD)) {
+            return "";
+        } else if (!result.startsWith(SLASH) || !result.endsWith(SLASH_WILDCARD)) {
+            throw new RuntimeException(String.format(
+                    "The %s must start with '/' and end with '/*'. Instead it is: %s",
+                    FILTER_MAPPING_PARAM,
+                    result));
+        }
+        return result.substring(1, result.length() - 1);
+    }
+
+    private static String getRelativePath(HttpServletRequest request, String filterPath) {
+        String path = request.getRequestURI()
+                .substring(request.getContextPath()
+                        .length());
+
+        if (path.length() > 0) {
+            path = path.substring(1);
+        }
+
+        if (filterPath.equals(path + SLASH)) {
+            path += SLASH;
+        }
+
+        if (path.startsWith(filterPath)) {
+            path = path.substring(filterPath.length());
+        }
+
+        if (!path.startsWith(SLASH)) {
+            path = SLASH + path;
+        }
+
+        try {
+            path = URLDecoder.decode(path, "UTF-8");
+        } catch (UnsupportedEncodingException ignore) {
+            // this can't really ever happen
+        }
+
+        LOGGER.debug("Relative path = {}", path);
+        return path;
+    }
+
+    private void populateWrapperSupplier(ServletConfig config) {
+        // Do not override an injected supplier through initialization
+        if (requestSupplier != null) {
+            return;
+        }
+
+        String wrapperSupplierName = config.getInitParameter(WRAPPER_SUPPLIER_PARAM_NAME);
+
+        if (StringUtils.isNotBlank(wrapperSupplierName)) {
+            try {
+                Class<?> wrapperClass = Class.forName(wrapperSupplierName);
+                if (BiFunction.class.isAssignableFrom(wrapperClass)) {
+                    requestSupplier =
+                            (BiFunction<HttpServletRequest, String, HttpServletRequestWrapper>) wrapperClass.newInstance();
+                }
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                LOGGER.debug(
+                        "Error converting {} to BiFunction<HttpServletRequest, String, HttpServletRequestWrapper>; "
+                                + "falling back to default",
+                        wrapperSupplierName,
+                        e);
+            }
+
+        }
+
+        if (requestSupplier == null) {
+            requestSupplier = DEFAULT_REQ_FUNC;
+        }
+    }
+
+    private void populateSparkApplications(ServletConfig config) {
+        // Do not override injected spark applications through initialization
+        if (!CollectionUtils.isEmpty(sparkApplications)) {
+            return;
+        }
+
+        String applications = config.getInitParameter(APPLICATION_CLASS_PARAM);
+
+        if (StringUtils.isNotBlank(applications)) {
+            sparkApplications.addAll(Pattern.compile(",")
+                    .splitAsStream(applications)
+                    .map(String::trim)
+                    .map(this::getApplication)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    private SparkApplication getApplication(String applicationClassName) {
+        try {
+            Class<?> appClass = Class.forName(applicationClassName);
+            if (SparkApplication.class.isAssignableFrom(appClass)) {
+                return SparkApplication.class.cast(appClass.newInstance());
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            LOGGER.debug("Error converting {} to SparkApplication", applicationClassName, e);
+        }
+
+        return null;
+    }
+
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        throw new NotSerializableException(getClass().getName());
+    }
+
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        throw new NotSerializableException(getClass().getName());
+    }
+}

--- a/platform/admin/modules/admin-modules-docs/src/main/resources/404.html
+++ b/platform/admin/modules/admin-modules-docs/src/main/resources/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Missing Docs</title>
+        <style>
+            h1 {
+                margin: 0;
+                font-weight: bold;
+                color: #18bc9c;
+                padding: 10px;
+                font-family: sans-serif;
+            }
+            p {
+                margin: 0;
+                padding: 10px;
+                color: #2c3e50;
+                font-size: 1.3em;
+                font-family: sans-serif;
+            }
+        </style>
+    </head>
+<body>
+    <h1>Documentation Not Found</h1>
+</body>
+</html>

--- a/platform/admin/modules/admin-modules-docs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/modules/admin-modules-docs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,37 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="docsModule" class="org.codice.ui.admin.docs.DocsModule"/>
+    <service interface="org.codice.ddf.ui.admin.api.module.AdminModule" ref="docsModule"/>
+
+    <bean id="docsSparkApp" class="org.codice.ui.admin.docs.DocsSparkApplication"/>
+    <bean id="docsReqSupplier" class="org.codice.ui.admin.docs.DocsRequestSupplier"/>
+    <bean id="sparkServlet" class="org.codice.ui.admin.docs.SparkServlet">
+        <property name="sparkApplications">
+            <list>
+                <ref component-id="docsSparkApp"/>
+            </list>
+        </property>
+        <property name="requestSupplier" ref="docsReqSupplier"/>
+        <property name="filterMappingPattern" value="/admin/documentation/*"/>
+    </bean>
+
+    <service ref="sparkServlet" interface="javax.servlet.Servlet">
+        <service-properties>
+            <entry key="urlPatterns" value="/admin/documentation/*"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/admin/modules/admin-modules-docs/src/test/java/org/codice/ui/admin/docs/TestAdminDocsModule.java
+++ b/platform/admin/modules/admin-modules-docs/src/test/java/org/codice/ui/admin/docs/TestAdminDocsModule.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ui.admin.docs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestAdminDocsModule {
+
+    @ClassRule
+    public static TemporaryFolder tempFolder;
+
+    public static File mockDdfHome;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        tempFolder = new TemporaryFolder();
+        tempFolder.create();
+        mockDdfHome = tempFolder.newFolder("ddf");
+        System.setProperty("karaf.home", mockDdfHome.getPath());
+    }
+
+    @Test
+    public void noDocsFolder() {
+        DocsSparkApplication docsSparkApp = new DocsSparkApplication();
+        assertEquals(null, docsSparkApp.getDocumentationHtml());
+    }
+
+    @Test
+    public void docsFolderPresentNoDocHtml() throws IOException {
+        File docFolder = tempFolder.newFolder("ddf", "documentation");
+
+        try {
+            DocsSparkApplication docsSparkApp = new DocsSparkApplication();
+            assertEquals(null, docsSparkApp.getDocumentationHtml());
+        } finally {
+            docFolder.delete();
+        }
+    }
+
+    @Test
+    public void docsFolderAndDocHtmlPresent() throws IOException {
+        File docFolder = tempFolder.newFolder("ddf", "documentation", "html");
+        Path docHtml = Files.createFile(Paths.get(docFolder.getPath(), "documentation.html"));
+
+        try {
+            DocsSparkApplication docsSparkApp = new DocsSparkApplication();
+            assertEquals(docHtml.toString(), docsSparkApp.getDocumentationHtml().getPath());
+        } finally {
+            Files.delete(docHtml);
+            docFolder.delete();
+        }
+    }
+}

--- a/platform/admin/modules/pom.xml
+++ b/platform/admin/modules/pom.xml
@@ -27,6 +27,7 @@
         <module>admin-modules-installer</module>
         <module>admin-modules-configuration</module>
         <module>admin-modules-application</module>
+        <module>admin-modules-docs</module>
         <module>admin-metrics-ui</module>
         <module>admin-security-ui</module>
         <module>admin-security-certificate-ui</module>


### PR DESCRIPTION
#### What does this PR do?
Adds documentation to admin UI
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@djblue @ricklarsen 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
#### How should this be tested?
Build the distribution with documentation, do a full install, make sure docs are displayed in the admin UI. Remove the documentation root folder and make sure "Documentation not found" message is displayed properly.
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
<img width="1438" alt="admin docs" src="https://cloud.githubusercontent.com/assets/9013620/18920282/ca905c44-8555-11e6-886a-21454ba778c5.png">
<img width="1433" alt="admin no docs" src="https://cloud.githubusercontent.com/assets/9013620/18920283/ca9c2cf4-8555-11e6-8d09-53f7a7753edb.png">
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

