### PR TITLE
DDF-2517: Lazy load iframes to improve admin loading.

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/application/IFrameView.js
+++ b/platform/admin/ui/src/main/webapp/js/views/application/IFrameView.js
@@ -12,18 +12,38 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/* global define */
+/* global define,setInterval,clearInterval */
 define([
     'marionette',
     'icanhaz',
-    'text!iframeView'
-    ],function (Marionette, ich, iframeView) {
+    'text!iframeView',
+    'text!waitForVisible'
+    ],function (Marionette, ich, iframeView, waitForVisible) {
 
     ich.addTemplate('iframeView',iframeView);
+    ich.addTemplate('waitForVisible',waitForVisible);
 
     var IFrameView = Marionette.ItemView.extend({
         template: 'iframeView',
         className: 'iframe-view'
     });
-    return IFrameView;
+
+    return Marionette.Layout.extend({
+        template: 'waitForVisible',
+        isVisible: function () {
+            return this.$el.is(':visible');
+        },
+        regions: { iframe: '.wait-for-visible' },
+        initialize: function () {
+            // delay rendering of iframe until the element is actually visible
+            var interval = setInterval(function () {
+                if (this.isVisible()) {
+                    // once this is visible, show iframe and stop polling for visibility
+                    this.iframe.show(new IFrameView({ model: this.model }));
+                    clearInterval(interval);
+                }
+            }.bind(this), 250);
+        }
+    });
+
 });

--- a/platform/admin/ui/src/main/webapp/templateConfig.js
+++ b/platform/admin/ui/src/main/webapp/templateConfig.js
@@ -37,6 +37,7 @@
             pluginTabContentItemView:'templates/application/application-detail/PluginTabContent.item.view.handlebars',
             pluginTabContentCollectionView:'templates/application/application-detail/PluginTabContent.collection.view.handlebars',
             iframeView:'templates/application/iframeView.handlebars',
+            waitForVisible: 'templates/application/waitForVisible.handlebars',
 
             // installer module templates
             applicationWrapperTemplate: 'templates/installer/application.handlebars',

--- a/platform/admin/ui/src/main/webapp/templates/application/waitForVisible.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/application/waitForVisible.handlebars
@@ -1,0 +1,14 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="wait-for-visible"></div>


### PR DESCRIPTION
#### What does this PR do?

Adding documentation to the Admin UI decreases loading performance because all iframe Admin UI modules are loaded by default. This address that issue by only loading an iframe if it is visible.

#### Who is reviewing it?

@tbatie 
@adimka 
@andrewkfiedler 

#### Choose 2 committers to review/merge the PR

@coyotesqrl
@pklinef 

#### How should this be tested?

Ensure all iframe admin modules sill load. This include log-viewer, cert manager, metric, and sources.

#### What are the relevant tickets?

[DDF-2517](https://codice.atlassian.net/browse/DDF-2517)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests