### PR TITLE
DDF-1560 Updates the ForkJoinPool in XmResponseQueueTransformer to be the global pool.

### DIFF
--- a/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -72,7 +72,7 @@
         <property name="threshold" value="50"/>
     </bean>
 
-    <bean id="fjp" class="java.util.concurrent.ForkJoinPool"/>
+    <bean id="fjp" class="java.util.concurrent.ForkJoinPool" factory-method="commonPool"/>
 
     <service ref="xmlResponseQueueTransformer"
              interface="ddf.catalog.transform.QueryResponseTransformer">


### PR DESCRIPTION
#### What does this PR do?
Uses the global pool instead of creating a new FJP for `XmlResponseQueueTransformer`.

 As of Java 8, there is a common pool that can be used for FJ tasks. It should not be _overused_ in order to prevent pool contention, but this transformer does not have any tasks that run long enough to cause issues for other pool users.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ahoffer @ryeats 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison

#### How should this be tested?
Build/test. Install DDF and ingest a record, then execute an opensearch query with output in xml.
Example: `https://localhost:8993/services/catalog/query?q=*&mr=10&format=xml`

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-1560

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests