### PR TITLE
DDF-2507 CSW matchcase will now be ignored for non-string queries

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
@@ -63,7 +63,6 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.permission.Permissions;
-
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 import net.opengis.cat.csw.v_2_0_2.QueryConstraintType;
 import net.opengis.cat.csw.v_2_0_2.QueryType;
@@ -91,11 +90,14 @@ public class CswQueryFactory {
 
     private Map<String, Set<String>> schemaToTagsMapping = new HashMap<>();
 
+    private List<MetacardType> metacardTypes;
+
     public CswQueryFactory(FilterBuilder filterBuilder, FilterAdapter adapter,
-            MetacardType metacardType) {
+            MetacardType metacardType, List<MetacardType> metacardTypes) {
         this.builder = filterBuilder;
         this.adapter = adapter;
         this.metacardType = metacardType;
+        this.metacardTypes = metacardTypes;
     }
 
     public QueryRequest getQueryById(List<String> ids) {
@@ -155,7 +157,7 @@ public class CswQueryFactory {
 
     private CswRecordMapperFilterVisitor buildFilter(QueryConstraintType constraint)
             throws CswException {
-        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType);
+        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType, metacardTypes);
         Filter filter = null;
         if (constraint != null) {
             if (constraint.isSetCqlText()) {

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/CswRecordMapperFilterVisitor.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/CswRecordMapperFilterVisitor.java
@@ -27,6 +27,7 @@ import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.GmdConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.converter.DefaultCswRecordMap;
 import org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter;
+import org.geotools.filter.LiteralExpressionImpl;
 import org.geotools.filter.visitor.DuplicatingFilterVisitor;
 import org.geotools.styling.UomOgcMapping;
 import org.geotools.temporal.object.DefaultInstant;
@@ -190,17 +191,27 @@ public class CswRecordMapperFilterVisitor extends DuplicatingFilterVisitor {
         }
         AttributeType type =
                 attributeTypes.get(((PropertyName) filter.getExpression1()).getPropertyName());
+
+        LiteralExpressionImpl typedExpression = (LiteralExpressionImpl) filter.getExpression2();
         if (type != null) {
-            type.getBinding()
-                    .cast(((Literal) filter.getExpression2()).getValue());
+            if (type.getBinding() == Short.class) {
+                typedExpression.setValue(Short.valueOf((String) typedExpression.getValue()));
+            } else if (type.getBinding() == Integer.class) {
+                typedExpression.setValue(Integer.valueOf((String) typedExpression.getValue()));
+            } else if (type.getBinding() == Long.class) {
+                typedExpression.setValue(Long.valueOf((String) typedExpression.getValue()));
+            } else if (type.getBinding() == Float.class) {
+                typedExpression.setValue(Float.valueOf((String) typedExpression.getValue()));
+            } else if (type.getBinding() == Double.class) {
+                typedExpression.setValue(Double.valueOf((String) typedExpression.getValue()));
+            } else if (type.getBinding() == Boolean.class) {
+                typedExpression.setValue(Boolean.valueOf((String) typedExpression.getValue()));
+            }
         }
 
         Expression expr1 = visit(filter.getExpression1(), extraData);
-        Expression expr2 = visit(filter.getExpression2(), expr1);
-        boolean matchCase = filter.isMatchingCase();
-        return ((Literal) (filter.getExpression2())).getValue() instanceof String ? getFactory(
-                extraData).equal(expr1, expr2, matchCase) : getFactory(extraData).equal(expr1,
-                expr2);
+        Expression expr2 = visit((Expression) typedExpression, expr1);
+        return getFactory(extraData).equal(expr1, expr2, filter.isMatchingCase());
     }
 
     @Override

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/CswRecordMapperFilterVisitor.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/CswRecordMapperFilterVisitor.java
@@ -189,7 +189,9 @@ public class CswRecordMapperFilterVisitor extends DuplicatingFilterVisitor {
                 (LiteralExpressionImpl) filter.getUpperBoundary();
         setExpressionType(type, typedUpperExpression);
 
-        return getFactory(extraData).between(expr, typedLowerExpression, typedLowerExpression);
+        Expression lower = visit((Expression) typedLowerExpression, expr);
+        Expression upper = visit((Expression) typedUpperExpression, expr);
+        return getFactory(extraData).between(expr, lower, upper);
     }
 
     @Override
@@ -220,7 +222,7 @@ public class CswRecordMapperFilterVisitor extends DuplicatingFilterVisitor {
 
         Expression expr1 = visit(filter.getExpression1(), extraData);
         Expression expr2 = visit((Expression) typedExpression, expr1);
-        return getFactory(extraData).equal(expr1, expr2, filter.isMatchingCase());
+        return getFactory(extraData).notEqual(expr1, expr2, filter.isMatchingCase());
     }
 
     @Override

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -158,11 +158,19 @@
 
     <reference id="cswMetacardType" interface="ddf.catalog.data.MetacardType" filter="(name=csw:Record)"/>
 
+    <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
+    <reference-list id="metacardTypeList"
+                    interface="ddf.catalog.data.MetacardType">
+        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin"
+                            ref="metacardTypes"/>
+    </reference-list>
+
     <bean id="cswFilterFactory"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswQueryFactory">
         <argument ref="filterBuilder"/>
         <argument ref="filterAdapter"/>
         <argument ref="cswMetacardType"/>
+        <argument ref="metacardTypes"/>
         <property name="schemaToTagsMapping">
             <array value-type="java.lang.String">
                 <value type="java.lang.String">urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0=registry,registry-remote</value>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -203,13 +203,19 @@ public class CswQueryFactoryTest {
 
     private static QName cswQnameOutPutSchema = new QName(CswConstants.CSW_OUTPUT_SCHEMA);
 
+    private static List<MetacardType> mockMetacardTypeList;
+
     @org.junit.Before
     public void setUp()
             throws URISyntaxException, SourceUnavailableException, UnsupportedQueryException,
             FederationException, ParseException, IngestException {
         filterBuilder = new GeotoolsFilterBuilder();
         FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
-        queryFactory = new CswQueryFactory(filterBuilder, filterAdapter, getCswMetacardType());
+
+        mockMetacardTypeList = new ArrayList<>();
+        //mockMetacardTypeList.add()
+
+        queryFactory = new CswQueryFactory(filterBuilder, filterAdapter, getCswMetacardType(), mockMetacardTypeList);
         polygon = new WKTReader().read(POLYGON_STR);
         gmlObjectFactory = new net.opengis.gml.v_3_1_1.ObjectFactory();
         filterObjectFactory = new ObjectFactory();
@@ -320,8 +326,8 @@ public class CswQueryFactoryTest {
         assertThat(frameworkQuery.getFilter(), instanceOf(PropertyIsLike.class));
         PropertyIsLike like = (PropertyIsLike) frameworkQuery.getFilter();
         assertThat(like.getLiteral(), is(CQL_CONTEXTUAL_PATTERN));
-        assertThat(((AttributeExpressionImpl) like.getExpression()).getPropertyName(), is(
-                CQL_FRAMEWORK_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) like.getExpression()).getPropertyName(),
+                is(CQL_FRAMEWORK_TEST_ATTRIBUTE));
     }
 
     @Test
@@ -577,7 +583,8 @@ public class CswQueryFactoryTest {
             throws CswException, UnsupportedQueryException, SourceUnavailableException,
             FederationException {
 
-        String[] cqlTextValues = new String[] {CswConstants.CSW_NO_PREFIX_CREATED, CQL_BEFORE, TIMESTAMP};
+        String[] cqlTextValues =
+                new String[] {CswConstants.CSW_NO_PREFIX_CREATED, CQL_BEFORE, TIMESTAMP};
         String cqlText = StringUtils.join(cqlTextValues, " ");
         cqlTemporalQuery(Core.CREATED, cqlText, new Class[] {Before.class});
     }
@@ -682,8 +689,8 @@ public class CswQueryFactoryTest {
         N spatial = (N) frameworkQuery.getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
-        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(), is(
-                SPATIAL_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
+                is(SPATIAL_TEST_ATTRIBUTE));
     }
 
     /**
@@ -723,8 +730,8 @@ public class CswQueryFactoryTest {
         N spatial = (N) frameworkQuery.getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
-        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(), is(
-                SPATIAL_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
+                is(SPATIAL_TEST_ATTRIBUTE));
 
         assertThat(spatial.getDistanceUnits(), is(UomOgcMapping.METRE.name()));
         assertThat(spatial.getDistance(), is(EXPECTED_GEO_DISTANCE));
@@ -765,25 +772,19 @@ public class CswQueryFactoryTest {
     private String createDistanceBufferQuery(String comparison) {
         String query =
                 "      <ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\">"
-                        +
-                        "        <ogc:" + comparison + ">" +
-                        "          <ogc:PropertyName>" + SPATIAL_TEST_ATTRIBUTE
-                        + "</ogc:PropertyName>" +
-                        "          <gml:Polygon gml:id=\"Pl001\">" +
-                        "            <gml:exterior>" +
-                        "              <gml:LinearRing>" +
-                        "                <gml:pos>10 10</gml:pos>" +
-                        "                <gml:pos>10 25</gml:pos>" +
-                        "                <gml:pos>40 25</gml:pos>" +
-                        "                <gml:pos>40 10</gml:pos>" +
-                        "                <gml:pos>10 10</gml:pos>" +
-                        "              </gml:LinearRing>" +
-                        "            </gml:exterior>" +
-                        "          </gml:Polygon>" +
-                        "          <ogc:Distance units=\"" + REL_GEO_UNITS + "\">"
-                        + REL_GEO_DISTANCE + "</ogc:Distance>" +
-                        "        </ogc:" + comparison + ">" +
-                        "      </ogc:Filter>";
+                        + "        <ogc:" + comparison + ">" + "          <ogc:PropertyName>"
+                        + SPATIAL_TEST_ATTRIBUTE + "</ogc:PropertyName>"
+                        + "          <gml:Polygon gml:id=\"Pl001\">" + "            <gml:exterior>"
+                        + "              <gml:LinearRing>"
+                        + "                <gml:pos>10 10</gml:pos>"
+                        + "                <gml:pos>10 25</gml:pos>"
+                        + "                <gml:pos>40 25</gml:pos>"
+                        + "                <gml:pos>40 10</gml:pos>"
+                        + "                <gml:pos>10 10</gml:pos>"
+                        + "              </gml:LinearRing>" + "            </gml:exterior>"
+                        + "          </gml:Polygon>" + "          <ogc:Distance units=\""
+                        + REL_GEO_UNITS + "\">" + REL_GEO_DISTANCE + "</ogc:Distance>"
+                        + "        </ogc:" + comparison + ">" + "      </ogc:Filter>";
 
         return query;
     }
@@ -854,8 +855,8 @@ public class CswQueryFactoryTest {
         N spatial = (N) frameworkQuery.getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
-        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(), is(
-                SPATIAL_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
+                is(SPATIAL_TEST_ATTRIBUTE));
     }
 
     /**
@@ -897,8 +898,8 @@ public class CswQueryFactoryTest {
         N spatial = (N) frameworkQuery.getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
-        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(), is(
-                SPATIAL_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
+                is(SPATIAL_TEST_ATTRIBUTE));
     }
 
     /**
@@ -940,8 +941,8 @@ public class CswQueryFactoryTest {
         N spatial = (N) frameworkQuery.getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
-        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(), is(
-                SPATIAL_TEST_ATTRIBUTE));
+        assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
+                is(SPATIAL_TEST_ATTRIBUTE));
     }
 
     /**
@@ -966,8 +967,8 @@ public class CswQueryFactoryTest {
         assertThat(filter, instanceOf(clz));
 
         N temporal = (N) filter;
-        assertThat(((AttributeExpressionImpl) temporal.getExpression1()).getPropertyName(), is(
-                expectedAttr));
+        assertThat(((AttributeExpressionImpl) temporal.getExpression1()).getPropertyName(),
+                is(expectedAttr));
     }
 
     /**
@@ -1062,8 +1063,8 @@ public class CswQueryFactoryTest {
             assertThat(frameworkQuery.getFilter(), instanceOf(classes[0]));
             temporal = (N) frameworkQuery.getFilter();
         }
-        assertThat(((AttributeExpressionImpl) temporal.getExpression1()).getPropertyName(), is(
-                expectedAttr));
+        assertThat(((AttributeExpressionImpl) temporal.getExpression1()).getPropertyName(),
+                is(expectedAttr));
     }
 
     /**

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -203,7 +203,7 @@ public class CswQueryFactoryTest {
 
     private static QName cswQnameOutPutSchema = new QName(CswConstants.CSW_OUTPUT_SCHEMA);
 
-    private static List<MetacardType> mockMetacardTypeList;
+    private static List<MetacardType> metacardTypeList;
 
     @org.junit.Before
     public void setUp()
@@ -212,10 +212,10 @@ public class CswQueryFactoryTest {
         filterBuilder = new GeotoolsFilterBuilder();
         FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
 
-        mockMetacardTypeList = new ArrayList<>();
-        //mockMetacardTypeList.add()
+        metacardTypeList = new ArrayList<>();
 
-        queryFactory = new CswQueryFactory(filterBuilder, filterAdapter, getCswMetacardType(), mockMetacardTypeList);
+        queryFactory = new CswQueryFactory(filterBuilder, filterAdapter, getCswMetacardType(),
+                metacardTypeList);
         polygon = new WKTReader().read(POLYGON_STR);
         gmlObjectFactory = new net.opengis.gml.v_3_1_1.ObjectFactory();
         filterObjectFactory = new ObjectFactory();
@@ -772,19 +772,25 @@ public class CswQueryFactoryTest {
     private String createDistanceBufferQuery(String comparison) {
         String query =
                 "      <ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\">"
-                        + "        <ogc:" + comparison + ">" + "          <ogc:PropertyName>"
-                        + SPATIAL_TEST_ATTRIBUTE + "</ogc:PropertyName>"
-                        + "          <gml:Polygon gml:id=\"Pl001\">" + "            <gml:exterior>"
-                        + "              <gml:LinearRing>"
-                        + "                <gml:pos>10 10</gml:pos>"
-                        + "                <gml:pos>10 25</gml:pos>"
-                        + "                <gml:pos>40 25</gml:pos>"
-                        + "                <gml:pos>40 10</gml:pos>"
-                        + "                <gml:pos>10 10</gml:pos>"
-                        + "              </gml:LinearRing>" + "            </gml:exterior>"
-                        + "          </gml:Polygon>" + "          <ogc:Distance units=\""
-                        + REL_GEO_UNITS + "\">" + REL_GEO_DISTANCE + "</ogc:Distance>"
-                        + "        </ogc:" + comparison + ">" + "      </ogc:Filter>";
+                        +
+                        "        <ogc:" + comparison + ">" +
+                        "          <ogc:PropertyName>" + SPATIAL_TEST_ATTRIBUTE
+                        + "</ogc:PropertyName>" +
+                        "          <gml:Polygon gml:id=\"Pl001\">" +
+                        "            <gml:exterior>" +
+                        "              <gml:LinearRing>" +
+                        "                <gml:pos>10 10</gml:pos>" +
+                        "                <gml:pos>10 25</gml:pos>" +
+                        "                <gml:pos>40 25</gml:pos>" +
+                        "                <gml:pos>40 10</gml:pos>" +
+                        "                <gml:pos>10 10</gml:pos>" +
+                        "              </gml:LinearRing>" +
+                        "            </gml:exterior>" +
+                        "          </gml:Polygon>" +
+                        "          <ogc:Distance units=\"" + REL_GEO_UNITS + "\">"
+                        + REL_GEO_DISTANCE + "</ogc:Distance>" +
+                        "        </ogc:" + comparison + ">" +
+                        "      </ogc:Filter>";
 
         return query;
     }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/TestCswRecordMapperFilterVisitor.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/TestCswRecordMapperFilterVisitor.java
@@ -20,7 +20,9 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import javax.xml.namespace.QName;
 
@@ -79,6 +81,8 @@ public class TestCswRecordMapperFilterVisitor {
 
     private static MetacardType metacardType;
 
+    private static List<MetacardType> mockMetacardTypeList;
+
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         factory = new FilterFactoryImpl();
@@ -92,12 +96,17 @@ public class TestCswRecordMapperFilterVisitor {
                         Core.CREATED,
                         CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
         metacardType = CswQueryFactoryTest.getCswMetacardType();
-        visitor = new CswRecordMapperFilterVisitor(metacardType);
+
+        mockMetacardTypeList = new ArrayList<>();
+        mockMetacardTypeList.add(metacardType);
+
+        visitor = new CswRecordMapperFilterVisitor(metacardType, mockMetacardTypeList);
     }
 
     @Test
     public void testVisitWithUnmappedName() {
-        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType);
+        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType,
+                mockMetacardTypeList);
 
         PropertyName propertyName = (PropertyName) visitor.visit(attrExpr, null);
 
@@ -110,7 +119,8 @@ public class TestCswRecordMapperFilterVisitor {
                 CswConstants.DUBLIN_CORE_SCHEMA,
                 CswConstants.OWS_BOUNDING_BOX,
                 CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
-        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType);
+        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType,
+                mockMetacardTypeList);
 
         PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -124,7 +134,8 @@ public class TestCswRecordMapperFilterVisitor {
                 CswConstants.CSW_ALTERNATIVE,
                 CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
 
-        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType);
+        CswRecordMapperFilterVisitor visitor = new CswRecordMapperFilterVisitor(metacardType,
+                mockMetacardTypeList);
 
         PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -216,7 +227,7 @@ public class TestCswRecordMapperFilterVisitor {
 
     @Test
     public void testVisitPropertyIsFuzzy() {
-        visitor = new CswRecordMapperFilterVisitor(metacardType);
+        visitor = new CswRecordMapperFilterVisitor(metacardType, mockMetacardTypeList);
         Expression val1 = factory.property("fooProperty");
         Expression val2 = factory.literal("fooLiteral");
 

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswFilterDelegate.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswFilterDelegate.java
@@ -144,7 +144,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
                     convertDateToIso8601Format(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -155,8 +155,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName, Integer.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
+                    Integer.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }
@@ -169,7 +170,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
                     Short.valueOf(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -182,7 +183,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
                     Long.valueOf(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -195,7 +196,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
                     new Float(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -208,7 +209,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
                     new Double(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -219,8 +220,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName, Boolean.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsEqualToFilter(propertyName,
+                    Boolean.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }
@@ -247,7 +249,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
                     this.convertDateToIso8601Format(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -258,8 +260,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.NOT_EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName, Integer.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
+                    Integer.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }
@@ -270,8 +273,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.NOT_EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName, Short.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
+                    Short.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }
@@ -282,8 +286,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.NOT_EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName, Long.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
+                    Long.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }
@@ -296,7 +301,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
                     new Float(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -309,7 +314,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isPropertyQueryable(propertyName)) {
             return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
                     new Double(literal),
-                    false);
+                    true);
         } else {
             return new FilterType();
         }
@@ -320,8 +325,9 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         isComparisonOperationSupported(ComparisonOperatorType.NOT_EQUAL_TO);
         propertyName = mapPropertyName(propertyName);
         if (isPropertyQueryable(propertyName)) {
-            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName, Boolean.valueOf(
-                    literal), false);
+            return cswFilterFactory.buildPropertyIsNotEqualToFilter(propertyName,
+                    Boolean.valueOf(literal),
+                    true);
         } else {
             return new FilterType();
         }

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswFilterDelegate.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswFilterDelegate.java
@@ -81,7 +81,6 @@ import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.impl.types.TopicAttributes;
 import ddf.catalog.data.types.Core;
-
 import net.opengis.filter.v_1_1_0.AbstractIdType;
 import net.opengis.filter.v_1_1_0.ComparisonOperatorType;
 import net.opengis.filter.v_1_1_0.ComparisonOperatorsType;
@@ -198,7 +197,7 @@ public class TestCswFilterDelegate {
 
     private final boolean booleanLiteral = true;
 
-    private final boolean isCaseSensitive = false;
+    private final boolean isCaseSensitive = true;
 
     private final String stringLowerBoundary = "5";
 
@@ -740,8 +739,8 @@ public class TestCswFilterDelegate {
 
         POS_LIST_GEO_FILTER_PROP_MAP.put(USE_POS_LIST_GEO_FILTER_PROP_MAP_KEY, "true");
 
-        SAMPLE_DISTANCE_GEO_FILTER_PROP_MAP.put(DISTANCE_GEO_FILTER_PROP_MAP_KEY, Double.toString(
-                SAMPLE_DISTANCE));
+        SAMPLE_DISTANCE_GEO_FILTER_PROP_MAP.put(DISTANCE_GEO_FILTER_PROP_MAP_KEY,
+                Double.toString(SAMPLE_DISTANCE));
 
         SAMPLE_DISTANCE_POS_LIST_GEO_FILTER_PROP_MAP.put(USE_POS_LIST_GEO_FILTER_PROP_MAP_KEY,
                 "true");
@@ -969,7 +968,7 @@ public class TestCswFilterDelegate {
                     + isCaseSensitive + "\"";
         } else if (comparisonOp.getComparatorType()
                 == ComparisonOperator.ComparisonStringOperatorType.STRING) {
-            expression += " matchCase=\"false\"";
+            expression += " matchCase=\"true\"";
         }
 
         expression += ">" + "<ns3:PropertyName>" + propertyName + "</ns3:PropertyName>";
@@ -1031,8 +1030,7 @@ public class TestCswFilterDelegate {
             String... expressions) {
         String compoundExpression = null;
 
-        if (compoundOperator != null && expressions != null &&
-                expressions.length > 0) {
+        if (compoundOperator != null && expressions != null && expressions.length > 0) {
             compoundExpression = getXmlHeaderString() + "<ns3:" + compoundOperator + ">";
 
             for (String expression : expressions) {
@@ -1074,8 +1072,8 @@ public class TestCswFilterDelegate {
         }
 
         for (int ii = 0; ii + 1 < coordinatesArray.length; ii = ii + 2) {
-            pointStr += "<ns4:pos>" + coordinatesArray[ii] + " " +
-                    coordinatesArray[ii + 1] + "</ns4:pos>";
+            pointStr += "<ns4:pos>" + coordinatesArray[ii] + " " + coordinatesArray[ii + 1]
+                    + "</ns4:pos>";
         }
 
         return pointStr;
@@ -1117,8 +1115,8 @@ public class TestCswFilterDelegate {
     private String createPointFilterString(String pointCoordinatesString) {
         int numCoords = pointCoordinatesString.split(" ").length;
         if (numCoords != 2) {
-            throw new IllegalArgumentException("Invalid pointString \"" +
-                    pointCoordinatesString + "\"");
+            throw new IllegalArgumentException(
+                    "Invalid pointString \"" + pointCoordinatesString + "\"");
         }
 
         return "<ns4:Point>" + createPosElementsString(pointCoordinatesString) + "</ns4:Point>";
@@ -1145,8 +1143,7 @@ public class TestCswFilterDelegate {
 
         for (int ii = 0; ii + 1 < coordinates.length; ii = ii + 2) {
             multiPointMembersFilter += "<ns4:pointMember>" + createPointFilterString(
-                    coordinates[ii] + " " + coordinates[ii + 1]) +
-                    "</ns4:pointMember>";
+                    coordinates[ii] + " " + coordinates[ii + 1]) + "</ns4:pointMember>";
         }
 
         return multiPointMembersFilter;
@@ -1441,8 +1438,8 @@ public class TestCswFilterDelegate {
             throws JAXBException, ParseException, SAXException, IOException {
 
         LOGGER.debug("Input date: {}", SAMPLE_NON_ISO_8601_DATE);
-        LOGGER.debug("ISO 8601 formatted date: {}", convertDateToIso8601Format(
-                SAMPLE_NON_ISO_8601_DATE));
+        LOGGER.debug("ISO 8601 formatted date: {}",
+                convertDateToIso8601Format(SAMPLE_NON_ISO_8601_DATE));
         FilterType filterType = cswFilterDelegateLatLon.propertyIsEqualTo(propertyName,
                 SAMPLE_NON_ISO_8601_DATE);
         assertXMLEqual(propertyIsEqualToXmlWithNonIso8601Date, getXmlFromMarshaller(filterType));
@@ -2593,13 +2590,13 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         CswFilterDelegate localCswFilterDelegate = initCswFilterDelegate(
-                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(BBOX), Arrays.asList(
-                        "Envelope")),
+                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(BBOX),
+                        Arrays.asList("Envelope")),
                 initCswSourceConfiguration(CswAxisOrder.LAT_LON, false, CswConstants.CSW_TYPE));
 
         FilterType filterType = localCswFilterDelegate.intersects(propName, polygonWkt);
-        Diff diff = XMLUnit.compareXML(bboxXmlPropertyOwsBoundingBox, getXmlFromMarshaller(
-                filterType));
+        Diff diff = XMLUnit.compareXML(bboxXmlPropertyOwsBoundingBox,
+                getXmlFromMarshaller(filterType));
         assertThat(diff.similar(), is(true));
     }
 
@@ -2612,8 +2609,8 @@ public class TestCswFilterDelegate {
         cswSourceConfiguration.putMetacardCswMapping(Metacard.CONTENT_TYPE, CswConstants.CSW_TYPE);
 
         CswFilterDelegate localCswFilterDelegate = initCswFilterDelegate(
-                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(DISJOINT), Arrays.asList(
-                        "Polygon")),
+                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(DISJOINT),
+                        Arrays.asList("Polygon")),
                 initCswSourceConfiguration(CswAxisOrder.LAT_LON, false, CswConstants.CSW_TYPE));
 
         FilterType filterType = localCswFilterDelegate.intersects(propName, polygonWkt);
@@ -2808,8 +2805,8 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         FilterType filterType = cswFilterDelegateLatLon.intersects(propName, lineStringWkt);
-        assertXMLEqual(intersectsLineStringXmlPropertyOwsBoundingBox, getXmlFromMarshaller(
-                filterType));
+        assertXMLEqual(intersectsLineStringXmlPropertyOwsBoundingBox,
+                getXmlFromMarshaller(filterType));
     }
 
     @Test
@@ -2818,8 +2815,8 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         FilterType filterType = cswFilterDelegateLatLon.intersects(propName, multiPolygonWkt);
-        assertXMLEqual(intersectsMultiPolygonXmlPropertyOwsBoundingBox, getXmlFromMarshaller(
-                filterType));
+        assertXMLEqual(intersectsMultiPolygonXmlPropertyOwsBoundingBox,
+                getXmlFromMarshaller(filterType));
     }
 
     @Test
@@ -2828,8 +2825,8 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         FilterType filterType = cswFilterDelegateLatLon.intersects(propName, multiPointWkt);
-        assertXMLEqual(intersectsMultiPointXmlPropertyOwsBoundingBox, getXmlFromMarshaller(
-                filterType));
+        assertXMLEqual(intersectsMultiPointXmlPropertyOwsBoundingBox,
+                getXmlFromMarshaller(filterType));
     }
 
     @Test
@@ -2838,74 +2835,74 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         FilterType filterType = cswFilterDelegateLatLon.intersects(propName, multiLineStringWkt);
-        assertXMLEqual(intersectsMultiLineStringXmlPropertyOwsBoundingBox, getXmlFromMarshaller(
-                filterType));
+        assertXMLEqual(intersectsMultiLineStringXmlPropertyOwsBoundingBox,
+                getXmlFromMarshaller(filterType));
     }
 
     @Test
     public void testCrossesPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(crossesPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                CROSSES,
-                polygonWkt));
+        assertXMLEqual(crossesPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        CROSSES,
+                        polygonWkt));
     }
 
     @Test
     public void testCrossesPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(crossesPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                CROSSES,
-                polygonWkt));
+        assertXMLEqual(crossesPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        CROSSES,
+                        polygonWkt));
     }
 
     @Test
     public void testWithinPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(withinPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                WITHIN,
-                polygonWkt));
+        assertXMLEqual(withinPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        WITHIN,
+                        polygonWkt));
     }
 
     @Test
     public void testWithinPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(withinPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                WITHIN,
-                polygonWkt));
+        assertXMLEqual(withinPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        WITHIN,
+                        polygonWkt));
     }
 
     @Test
     public void testContainsPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(containsPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                CONTAINS,
-                polygonWkt));
+        assertXMLEqual(containsPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        CONTAINS,
+                        polygonWkt));
     }
 
     @Test
     public void testContainsPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(containsPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                CONTAINS,
-                polygonWkt));
+        assertXMLEqual(containsPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        CONTAINS,
+                        polygonWkt));
     }
 
     @Test
@@ -2914,8 +2911,8 @@ public class TestCswFilterDelegate {
 
         String propName = CswConstants.BBOX_PROP;
         CswFilterDelegate localCswFilterDelegate = initCswFilterDelegate(
-                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(CONTAINS), Arrays.asList(
-                        "Polygon")),
+                getMockFilterCapabilitiesForSpatialFallback(Arrays.asList(CONTAINS),
+                        Arrays.asList("Polygon")),
                 initCswSourceConfiguration(CswAxisOrder.LAT_LON, false, CswConstants.CSW_TYPE));
 
         FilterType filterType = localCswFilterDelegate.within(propName, polygonWkt);
@@ -2935,88 +2932,88 @@ public class TestCswFilterDelegate {
     public void testDWithinPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(dwithinPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                D_WITHIN,
-                polygonWkt));
+        assertXMLEqual(dwithinPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        D_WITHIN,
+                        polygonWkt));
     }
 
     @Test
     public void testDWithinPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(dwithinPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                D_WITHIN,
-                polygonWkt));
+        assertXMLEqual(dwithinPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        D_WITHIN,
+                        polygonWkt));
     }
 
     @Test
     public void testTouchesPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(touchesPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                TOUCHES,
-                polygonWkt));
+        assertXMLEqual(touchesPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        TOUCHES,
+                        polygonWkt));
     }
 
     @Test
     public void testTouchesPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(touchesPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                TOUCHES,
-                polygonWkt));
+        assertXMLEqual(touchesPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        TOUCHES,
+                        polygonWkt));
     }
 
     @Test
     public void testOverlapsPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(overlapsPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                OVERLAPS,
-                polygonWkt));
+        assertXMLEqual(overlapsPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        OVERLAPS,
+                        polygonWkt));
     }
 
     @Test
     public void testOverlapsPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(overlapsPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                OVERLAPS,
-                polygonWkt));
+        assertXMLEqual(overlapsPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        OVERLAPS,
+                        polygonWkt));
     }
 
     @Test
     public void testDisjointPropertyOwsBoundingBoxPolygon()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(disjointPolygonXmlPropertyOwsBoundingBox, getXmlProperty(
-                cswFilterDelegateLatLon,
-                CswConstants.BBOX_PROP,
-                DISJOINT,
-                polygonWkt));
+        assertXMLEqual(disjointPolygonXmlPropertyOwsBoundingBox,
+                getXmlProperty(cswFilterDelegateLatLon,
+                        CswConstants.BBOX_PROP,
+                        DISJOINT,
+                        polygonWkt));
     }
 
     @Test
     public void testDisjointPropertyOwsBoundingBoxPolygonPosList()
             throws JAXBException, SAXException, IOException {
 
-        assertXMLEqual(disjointPolygonXmlPropertyOwsBoundingBoxPosList, getXmlProperty(
-                cswFilterDelegateLatLonPosList,
-                CswConstants.BBOX_PROP,
-                DISJOINT,
-                polygonWkt));
+        assertXMLEqual(disjointPolygonXmlPropertyOwsBoundingBoxPosList,
+                getXmlProperty(cswFilterDelegateLatLonPosList,
+                        CswConstants.BBOX_PROP,
+                        DISJOINT,
+                        polygonWkt));
     }
 
     private String getXmlProperty(CswFilterDelegate localCswFilterDelegate, String propName,
@@ -3251,15 +3248,7 @@ public class TestCswFilterDelegate {
     }
 
     private enum ComparisonOperator {
-        PROPERTY_IS_BETWEEN,
-        PROPERTY_IS_EQUAL_TO,
-        PROPERTY_IS_NOT_EQUAL_TO,
-        PROPERTY_IS_NULL,
-        PROPERTY_IS_GREATER_THAN,
-        PROPERTY_IS_GREATER_THAN_OR_EQUAL_TO,
-        PROPERTY_IS_LESS_THAN,
-        PROPERTY_IS_LESS_THAN_OR_EQUAL_TO,
-        PROPERTY_IS_LIKE;
+        PROPERTY_IS_BETWEEN, PROPERTY_IS_EQUAL_TO, PROPERTY_IS_NOT_EQUAL_TO, PROPERTY_IS_NULL, PROPERTY_IS_GREATER_THAN, PROPERTY_IS_GREATER_THAN_OR_EQUAL_TO, PROPERTY_IS_LESS_THAN, PROPERTY_IS_LESS_THAN_OR_EQUAL_TO, PROPERTY_IS_LIKE;
 
         @Override
         public String toString() {
@@ -3340,8 +3329,7 @@ public class TestCswFilterDelegate {
      * <PropertyName> elements of Filter strings.
      */
     private enum GeospatialPropertyName {
-        BOUNDING_BOX("ows", "BoundingBox"),
-        SPATIAL("dct", "Spatial");
+        BOUNDING_BOX("ows", "BoundingBox"), SPATIAL("dct", "Spatial");
 
         String namespace = "";
 

--- a/distribution/test/itests/test-itests-common/src/main/resources/csw-query.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/csw-query.xml
@@ -17,16 +17,15 @@
         service="CSW" version="2.0.2" xmlns:ns2="http://www.opengis.net/ogc"
         xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
         >
-<ns10:Query typeNames="csw:Record" xmlns="" xmlns:ns10="http://www.opengis.net/cat/csw/2.0.2">
-<ns10:ElementSetName>full</ns10:ElementSetName>
-<ns10:Constraint version="1.1.0">
-    <ns2:Filter>
-        <ns2:PropertyIsLike wildCard="*" singleChar="#" escapeChar="!">
-            <ns2:PropertyName>$propertyName$</ns2:PropertyName>
-            <ns2:Literal>$literal$</ns2:Literal>
-        </ns2:PropertyIsLike>
-
-    </ns2:Filter>
-</ns10:Constraint>
-</ns10:Query>
-        </csw:GetRecords>
+    <ns10:Query typeNames="csw:Record" xmlns="" xmlns:ns10="http://www.opengis.net/cat/csw/2.0.2">
+        <ns10:ElementSetName>full</ns10:ElementSetName>
+            <ns10:Constraint version="1.1.0">
+                <ns2:Filter>
+                    <ns2:PropertyIsLike wildCard="*" singleChar="#" escapeChar="!">
+                        <ns2:PropertyName>$propertyName$</ns2:PropertyName>
+                        <ns2:Literal>$literal$</ns2:Literal>
+                    </ns2:PropertyIsLike>
+            </ns2:Filter>
+        </ns10:Constraint>
+    </ns10:Query>
+</csw:GetRecords>

--- a/distribution/test/itests/test-itests-common/src/main/resources/xml/record/testNumerical.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/xml/record/testNumerical.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:gml="http://www.opengis.net/gml"
+          gml:id="3775f8b4ae50451fa1d2520d47ca5171">
+    <type>pdf</type>
+    <source>ddf.distribution</source>
+    <string name="contact.creator-name">
+        <value>Jessica Johnson</value>
+    </string>
+    <string name="checksum">
+        <value>b0e9968e</value>
+    </string>
+    <string name="datatype">
+        <value>Document</value>
+    </string>
+    <base64Binary name="thumbnail">
+        <value>
+            /9j/4AAQSkZJRgABAgEALAAsAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAB/AGIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD+/iiiigAormfFfjDQPBOnW+q+Irm7trO71Ox0e2+w6PrOuXU+o6lIYrO2i0/QdP1PUHMrq26UWpghVTJPLFGC1fMlr+3j+zLceGJPGt14p+IHh/wlaz67Bq3iPxl8AP2hfAukeGj4csH1HU7jxje+MvhZoUPgyw8iKWHTdS8Vto2n65qMUukaHdajqsb2SgHb/tb/ALUHwz/Ys/Zr+Mn7VHxig8X3fw2+CPgvUPGviiw8BeF73xj4x1S3tZILSx0fw9oVm0EMmo6xqt5YaXFqeu6joPhDw+t22v8AjfxR4V8H6ZrniPS8XwX+1j8O/Eeo/EUeKZIvhZ4e8I/G34VfAbwprfxK1GHwff8Ajzxz8Yvgr8E/i/4I0ebwn4ig0nxJ8O/FGvX3xw0D4Z6J8PPiJZeHviJq3xAsG0WLwvDceIPCkOt+KftJeIv2Jf2vvhDe/A747af4w+Ivwo+KnghPEM3hx/hD8crzwzrml+JIvG3hnw5qGp29p8P7jw9qHizw1q/h/W/GXgrwt4str/XPBHjrwt4G+Lul+GtM8UeGvh14rsfRPAnx9/Zb+JmrXV14P17xtrXiz4h6D4G8VX8s3gH47+HvGd5oNtfyeG/CVhNZ6j4S0PXfCVpoOrNq+q33w9t7Tw/F4R1LVfGHjvXvDGj3Gv8AinX78Aval/wUD/YT0jVdW8P3v7ZX7Lw8S6Dbtd614TtPjt8M9R8X6Xaxs6zXF94S07xLdeJLeG1Ec0l5JJparZQW91cXRhgtbiSL+f7/AIOF/wBn/wD4Jy/8FMP2Wx8V9X/bU8Jp8ZP2Qf2Zv24fjf8AsxfDH4VfGj4My3vxz1nTPgX4d+NmrxzeEdas/EPjDx34RtPDXwY8LeMI9R+HL6fHcfDjXrzxlbaxceH9T0TXYP3M8QftF/sjaXDqvibUviT8ZXsPifreh3N9e6FP+11qukaPqPgfUhHpMNjbeGLe80z4M6Trd7YXMVzp+lW/gbQPizbWOsxanbeMdPtNXWP+b/8A4Oi/+C0/jX9l/wCD3gb9k39m/TPhb400L9tr4AftH+Av2gJ/ip8OPjBaeKvCnwy+JPw2+GmieAPFPwj1ZfEfw58O/wBo654c+Knj9ptQ1DSviJpuk+KPDFvomtaTperaB4h0G8AP8zmiiigAooooAKKKKAP9/ckAZJAGQMkgDLEKo57liAB1JIA5NLXzp+1pD8ULr9nX4o2Xwa+G+m/F/wCIuo6NY6Zovwz1jUPAml6V4ystT17SbDxNo+o3nxOstR8BCzk8KXOtzXFv4msbrT76OFrEQtcXMFfBWsfAr4x+L9J8R3lx+znZaLf+KtZ0rWIPDniT9n79g/XbLSrnwV4a1J/B0+tSWnxr1WSS70e1fXfhZ4Sv/wC3/HWo+F9L8ey6jHepp82rTaF7OW5XgcdDnxXEeTZNL2zp+yzKhxDVnyL2FsRfJ8hzal7GXtalo+09v/s1fmoLmw31jOc5R+GjUqaXvB0lrrp+8q03fRdLarXe37AUZGcZGfTv2/xH5j1r84fG3w0/aL1Xw5PLaaQ3iLxHpWt3mq6Imt/Bz9ly4mjm8V+IfEVvr2p6e2ofEaXThe6Bb6Fa+ObS2ml0K98W33jfwppeveKI7s+N5fh/x+n/AAZ+Luo3E8k/wal8Jx/FPXNQl8ViP4E/sRXn/CLwazrNhrerar8RBB8W9Ul11rvxnqF342uY9CuPixqOoXHhyLxDf3EviK+Tw3edyyDKmk/9duGFdzTTwnGd4qMoRTduEWrVFJzhyuTUac1NQm4RnPtZ/wDQNW6a82H63/6f302em70urtfqYrK4JRlYBnUlSGAZGKOpIJG5HVkcdVZSpAIIrjL/AMK6hqXiqXXl+IHjKz0j/hGz4efwHpzeErfwvFqxv21JPGIvh4Vfx3H4oS0mj0wWp8ZjwlJpaxSTeFJdRLak/wAIeGv2ZfD0Uun+NfE/7Nhb4g6tYeFvBHiS60L4UfsI2ctjep4JDeIvi1ZXd1o17rcel6l4h1XbrPhu88c+Lbmx8UeF4rbw34MvPAu7VPFv0d4B/ZX+G3wvuNMl8Ax2PhK207SrPRn07wz8MPgB4atNR0/zvD9z4jt72bw78HdJ1KK38cXWgvdeKrLTL/TrCS41nUJNDtND+w+Gh4f+cqwjTq1KcKtOvCFScI16SqqlWjGTjGrTVenRrKnUSU4KtRpVVFpVKcJ3itU7pNpptJ2drrydm1dbOza7No9S07wPrVlq+japN8U/iFqkGlXuo3d9ol8ngH+x/ES32iJpMNhrIsvAlnqkFlpN4JPEWmroOqaJdHWp3j1G61HQorTRLf8AhG/4Pm2Vj/wS8AYEof22VcAglWK/sjOFYD7pKsrYODtZT0IJ/tzh/Zn8CW994u1qGaCLxR49l1dfGni+L4afAKLxL4r0rWrLTLO78PeJdRT4PKPEWjZ057po9ch1G+vZ9Qu4tVv9RsYNJs9M/gw/4PQvg34d+Ddj/wAE0dJ8LXjHRdRuv22ZrDRIfCHwr8H6T4cs0v8A9l28tNI0Wz+GPw88BJLpunwaqml2Q1463fRafplkzX0moz6xqGq5jP4YKKKKACiiigAooooA/wB9Dxr4P0bx/wCFNd8GeIJfEFvo3iLT5dOv7nwp4v8AFvgDxPaxSlWW68P+N/Aet+G/GnhTWLWVI7jT9f8AC+v6PrmmXUcV1p2o2tzGkq+C6H8G/Cvw01ND4Z8LftL+LH+yXt5/a+u/tQfE/wAfwCfTLu0tbHSZB8Xf2i77UJJ9Sglub/SkNlJpFvaf20mqXmlX+rTWWqfUVeYeOfI0jTX1yHwv8T/F1xpUlxPDovgbxPqVlqV9LqOvaTHcRJY3vjjwrpuoRwG5fUrePULk2Wn6DpurWemmFZoNK1EA+Ubv4V6Z4hsNUg1X9nv9tHSjomoaudAudI/bM1vRPE+v2mr6Zd3czJ4i8M/tn6bqtlZadqOr69onhTRNX18WHg6C+M/hWLQLDUb2Gy9mlttXs9Sl8VaV8GPj1ceINN8NGz07StQ+Omm2/hfUYdS8V+H9autLl0EfHjVPDD+JNNkae4g1zUvDchsPD+ka/wCDdE8SroGswaNr/lt34U0fwN4u1q80f4U/t0+M1isLGO3ktP2k/HOu+EbyW31+NbuTRdK8dftSafLHfm3vYtSvjqem2lndaBo8lhoazalNe6Rq137NYaj4djln+B37bloZNRtpP7J/4X94ksvEUTX/AIe1LxDfzSahp/7VKgados13P4eubMa28UviFtNsvDVlq1lp2n31kAbR+Ha6a15qSfCz9p7VofEeiTWl3pkP7W/jbU9X0iPwfqvw5Ph22bR/En7R9h4U8PeIvFFxpF/qja34L8RXs9/4e0LW4fG3iBNS+JHiHwxf42meFbz4Y694c8ceC/gN+2L4z12H4c6b4YTRvE/7Xl5408O6Ulxpel30Vh4q8F/Fj9rvXPh/rfjDSbuKXRPFHxPi0fxX4vbU7W6n0TxJ4u0fVZ9Wn9O0r40anZ22laPY/s+/tGzRWUdrpE0uq6d4Ru7nTzbaHpN/A2q674i+KD3niOSS31CC0utesNR8SLc65bataahqkmp2OolLcfxz8RNpE+rTfs4ftBWrW6s50uTS/hbcavKqSBJDBa2HxXvI5mSNlnWNJzLPGSlsk9ykkCAGvpnxP+IN7cWtvffs4fFjR1eFZL29uvE3wFubC3l+VJILU6f8ZrvUbw+bIskMkum2McllFdTSm3vEtdOvP4Uf+D4LV9Q1Uf8ABMM3/hbXfDRgb9tpYhrdx4ZnN4BefsrWwe2/4RzxFr4VWhtLfUALs2r/AGPVLFGVb+PU7HTv71vhn4+uviPoF3r118PfiH8NXtNe1jQV0H4maTpGi+ILv+xrgWkutWlno2v+IreTQb+5WdNH1CS8iOq29udSs4JdJutOv73+Eb/g+c/5xdf93s/++j0AfwB0UUUAFFFFABRRRQB/v8V8V/tI/Eu78GfFP4R+G28Z6/4c0/xhpni+0js7LWfGPh3w6NSuNPk8Mw694j8QeFv2ZvizpWlSaK3im3vtDbx38Vvh34YXUrRfEJ0HxDL4UmurD7UrzTXr/wCIFnrsWn6Vpt/qen6jo/iCeLXNN0bwodF8PahYn7VodnrCa58SdG8R32oapH/xLYTo+hXuj3Nzi51K+8KW4MrgH5pp8WWtl1jQbn9qP4zPc66/hnw3c6ZBq+o32m6ZF4g0TVbGTX9G8f2//BPuPXtFvbS0sPDdhc6paaxa6Hpt8+seJdf1Lwz44i1O/wDGXbav+0/vsrnx14L+JuuTaB43+JnhjUNB0jxDffEXQNa03wVJ4f1PSPEkeofD/Vf2EPGnjT4ciyutT8MXun+D9btEtNd1DQW1q++JPhGeLxvZeLvp/wAPX/7SOuW134q1QTeFLHS9Qvpbb4Zar8LvAC+MvE9qLCIWUNv4i0X9p3xh4TttMee+nkjTUNT8Ma5JqGk263k+n6as6a91WpT/ABy1abxVDok9v4QtrDxBof8AYVzrvw88M+IrjWPDc+n39zr9vo0ulfH63jk1OK5vdK0+x1zxRpPhmHSdR0TUpJPCXi/SNWtb61APiHxx8dPF32i20XQvi14z1rwNr2gXr6t43h+IPgfwd460zVPh58P5JLjR9B8LWn7GV5dwWnxZ8W38tp4m8QajrXhPxLbzaXp2rfAHSbi8ml8APyun/tD/ALXHxF0C4134YeBptW8VWPiHRtI1zwtafHPUtN8KaTY+NvFnijxampDXNa/4Jra/4kuI/CulaFp/w20CSLwVHpV14Q1rVLzx7r+m+OdE0LxxrX2Zput/tNa4+r6Hf6N4h8HzQW1x9k8aSfDr4OPpF69zC2h7dG0m1/aq8batFf2F9qFl420uXxBpcWnLpXh7XtG1W31bUdU0TT6nt9X/AGnbVPBDX2nXOr6he6vo+q+MDp3w0+Guj+HbHwvqtx4ettU8G3NjeftV6nr2ieMvDwttY1GXxpoWufEjw1FpupajBY+FPGmqWOh28wB86av4p/bD06TQ5tY8JePb690RNes7XQNF+KcFz4e8e3vgbxV4b1bStY+IXiPwZ+wKNW8OXHifSdU8QW2pW/hJtE8K6taeG9C8NeGtI8cx6/4s8ReHf4qf+DyDxl8YvFV7/wAE44fi74DfwNfWfhr9o/U4rS08Ta14q8NQa9r+lfswXPijw74Y1nWvgx8J7vWbDw29rpC3PiO7m1HVtbvdTmbV/CHwuubRPCzf30of2ktX8AwTLquo+FvFt5dXdhPBe/DD4YXviHS7lPGGvXqeIEsrL9oXWvBK+EJ/C6aLoel6N/wkeueL4bJodY1e7k1681Gx0T+E7/g9P1H4n319/wAE6IfiHp15Y2mnXv7Zun+HLm68NeEtAi1uO3k/ZaTUNd0x/DHxg+KN1c6TqUY0yWztfEen+DdZ0/Epn0+6N49vpAB/C7RRRQAUUUUAFFFFAH+/xXgnxa+HDeO9R0HSbfUPElpusvE+p3DeH/2i/jH8Hdc3WiWH2OOw0r4cXCw69pU+q39nZazqmpzRr4QtLm0Ol6Zq02ox2cX4+f8AEUd/wQo/6Pm/81m/bD/+h9ryrWv+DnL/AIIiRy3M+j/tK/C3V3k1G7uHk1T4F/tmaTdXUVw2svLfyGH9i7WUOq3rT2huLeW5MTSavrBk1WQWUb6wAftZcfCrxrJa6pDp9neNbX2kS6XEs/7XH7SDXNxDfXmk6xcXEOsw6cbvw/eR3OhWGn6fq+jxy63a6ZqWsC11S303UdZ8P+IMdP2edRutQt4NXv8Ax5b6Ovg3wvpsY0r9tH9rqDV4tb0e8iXVY5ZI/FljHq9pcWd0oTxXO9n4p1O806NPEaanF4gJ8Pfhhov/AAck/wDBDmwtdavx8W/2b9F1/wAR+Htd8M+IYtF+B/7Zclrr2g6Z4Y0rSfA/hrWtZ/4d/aVe6p4e1QWSeGNd0++0m4s/B/hjStKn0iw8Ybh4f0/iY/8Ag4Q/4IHvZeHXuPEH7HKX+jaNJe29pH+z1+1zPZeHPFc/g25+0ab4dvn/AOCccE39jS+LLfSvCkniWPTtG1KXwbNc+K38Mf2lp1t4D1AA/o50/wCGfirTYf7Fumubzw4NZ8P2tnft+0P8foPEtn4ZOlabYaq95qmpajrmpa94ks9Q8NaA2m+ZrulW/iVdb8S3GrXWlape69c+Nc5fhP4u+Ick7/Fq11XwmZdSF24+Df7V/wC0XpEM7QR3tnBdxwaDZ/C1tMgmtrHRbmTwzY3LaNHda1rf2ufWLvRbPV/EH4M23/Byh/wQ6t76F4/jP+z3bQWsWkQ2t5bfA39stb63iu7p7nxNDDbr+wPCkMWnTRWl1pCR3wXxDdF31BfDj20Us/GeHv8Ag4k/4IOz6JpXhLxZ4u/ZO0bwpB4Y1Dw6fD/hn4AftdeKNA0nT7TxTaeN9B8MWWi6t/wTw8GWEnhW88W2ieLr2OG2to9G8X2lhrNroWr327VbIA/o51z9nbwR4h1HWNWfxl8edNvtZvvtF+dA/aX+P+kadCp1S31O70/StAs/iSvhzw7a3Qhk01l0DSNLutP0u7uLbR7nTHFtNb/wh/8AB658PdL+HOkf8EvNG0vXfHniGEz/ALc8q3vxA+IPjH4h6vHBda1+y/rNvZLq/jHWdYv2g0wazJpNjPLPJqMui6fo9lqd9qLaZazJ+4Ogf8HDH/BuxqXht7Dxv8Y/gLpNxf2r2Oq+HdA/ZC/ai8X+G5rGVJGls3vdX/Y68HPf2rzXmoK9vc+HYIXSaSVl33c0Uf8AKd/wdGf8FCf+CbP7d6/sNr/wTz8feEvG6/CyX9p+f4vr4V+B/wASfgyumTfEB/2fZPBE1+PiF8MvhyPEkuqSeEPGrxyaR/bL6Y9pcNqZsG1SyN8AfyX0UUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAE0dxPDt8qRk2OJEIxlJFIIdDjKtkA5UgkqpOSq4kN7ctI0rSBpHeSRiY4iN8oYOQpTaMhmAAACg4UAAYq0V6VLOc4oUaeHoZtmVGhSqU61KhSx2Kp0aVWkrUqtOlCqoQqU1pTnGKlBaRaIdOm226cG2mm3CLbT3TbV7PquorMWZmOMsSxwAoyTk4VQFAz0AAA6AAUlFFedKUpylOcnKUm5SlJuUpSk7uUm7ttttttttu7L22CiiikAUUUUAFFFFABRRRQAUUUUAFFFFAEsMLzyLEhiVnzgzTQ28Y2qWO6a4kihTgEDe67mwq5ZlBtSadPHIInlsNxExDJqemzR/6Ou6TMsN1JGCVz5ILA3LfJbCaQhTQor1cJWySnhZQx2XZpicd9apThiMLnGFwWDjglKk62HngquR46vPFVIKvGli45hTpUZVKM54KuqM4YiJKo5JxnCMbO6lTlKTlrZqSqRSjtePI29bSV01p3GlXNvF5xlsZUVImlNtqNlcCF5jc+VC7RTsjTulrLJ5ULSsqbN21nC1VuLSa1OJfJYb2jDwXNtdRs6JDIwWW1lmicKs8eWVyu4tHnzI5FStRXTmOK4ar0639mZLnGX1nDDRoSxXEOEzHD05U6lZYmpWow4dwNavLE4d4ZRVPFYeFDF08ViIxnh8TQwOCmEaya56lOa1vy0pQbulaz9tJKz5r3i7xcVo4uUiiiivBNQooooAKKKKAP/Z
+        </value>
+    </base64Binary>
+    <string name="title">
+        <value>sample.pdf</value>
+    </string>
+    <dateTime name="metacard.created">
+        <value>2016-10-17T23:07:46.394+00:00</value>
+    </dateTime>
+    <string name="media.type">
+        <value>application/pdf</value>
+    </string>
+    <string name="resource-download-url">
+        <value>
+            https://localhost:8993/services/catalog/sources/ddf.distribution/3775f8b4ae50451fa1d2520d47ca5171?transform=resource
+        </value>
+    </string>
+    <string name="metacard-tags">
+        <value>resource</value>
+        <value>VALID</value>
+    </string>
+    <dateTime name="created">
+        <value>2014-08-12T23:50:40.000+00:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2014-08-12T23:53:12.000+00:00</value>
+    </dateTime>
+    <dateTime name="metacard.modified">
+        <value>2016-10-17T23:07:46.394+00:00</value>
+    </dateTime>
+    <string name="resource-uri">
+        <value>content:3775f8b4ae50451fa1d2520d47ca5171</value>
+    </string>
+    <string name="checksum-algorithm">
+        <value>Adler32</value>
+    </string>
+    <string name="resource-size">
+        <value>677046</value>
+    </string>
+    <int name="media.width-pixels">
+        <value>12</value>
+    </int>
+</metacard>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -720,6 +720,42 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testCswNumericalQuery() throws IOException {
+        //ingest test record
+        String id = ingestXmlFromResource(XML_RECORD_RESOURCE_PATH + "/testNumerical.xml");
+
+        //query for it by the numerical query
+        String numericalQuery = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<GetRecords resultType=\"results\"\n"
+                + "            outputFormat=\"application/xml\"\n"
+                + "            outputSchema=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
+                + "            startPosition=\"1\"\n" + "            maxRecords=\"10\"\n"
+                + "            service=\"CSW\"\n" + "            version=\"2.0.2\"\n"
+                + "            xmlns=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
+                + "            xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\"\n"
+                + "            xmlns:ogc=\"http://www.opengis.net/ogc\">\n"
+                + "  <Query typeNames=\"csw:Record\">\n"
+                + "    <ElementSetName>full</ElementSetName>\n"
+                + "    <Constraint version=\"1.1.0\">\n" + "      <ogc:Filter>\n"
+                + "        <ogc:PropertyIsEqualTo wildCard=\"*\" singleChar=\"#\" escapeChar=\"!\" matchCase=\"true\">\n"
+                + "          <ogc:PropertyName>media.width-pixels</ogc:PropertyName>\n"
+                + "          <ogc:Literal>12</ogc:Literal>\n" + "        </ogc:PropertyIsEqualTo>\n"
+                + "      </ogc:Filter>\n" + "    </Constraint>\n" + "  </Query>\n"
+                + "</GetRecords>\n";
+
+        given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
+                .body(numericalQuery)
+                .post(CSW_PATH.getUrl())
+                .then()
+                .assertThat()
+                .statusCode(equalTo(200))
+                .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned='1']"));
+
+        deleteMetacard(id);
+    }
+
+    @Test
     public void testGetRecordById() throws IOException, XPathExpressionException {
         final Response firstResponse = ingestCswRecord();
         final Response secondResponse = ingestCswRecord();


### PR DESCRIPTION
#### What does this PR do?
CSW numerical queries were getting no results due to being rejected thanks to a default matchcase of "false". Now numerical queries will default to true.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann 
@harrison-tarr 
@jrnorth 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@kcwire

#### How should this be tested?
Full build and ingest a metacard that will have a numerical attribute. Confirm that a refined search over a CSW endpoint on that numerical attribute gets results.

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [x] Update / Add Integration Tests
