### PR TITLE
DDF-2518 - Add methods to RegistryPackageTypeHelper that get objects by association

### DIFF
--- a/catalog/spatial/registry/registry-schema-bindings/pom.xml
+++ b/catalog/spatial/registry/registry-schema-bindings/pom.xml
@@ -65,8 +65,8 @@
             <artifactId>commons-collections</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.registry</groupId>
@@ -170,7 +170,8 @@
                         <Embed-Dependency>
                             jaxb2-basics-runtime,
                             registry-common,
-                            catalog-core-api-impl;scope=!test
+                            catalog-core-api-impl;scope=!test,
+                            commons-lang3
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>
@@ -220,7 +221,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelper.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelper.java
@@ -286,17 +286,11 @@ public class RegistryPackageTypeHelper {
      */
     public <T extends RegistryObjectType> List<T> getAssociatedObjects(
             RegistryPackageType registryPackage, String id, Class<T> type) {
-        if (StringUtils.isEmpty(id)) {
-            return Collections.emptyList();
-        }
-        Set<String> targetObjectIds = getAssociationTargetObjectIds(registryPackage, id);
-        if (CollectionUtils.isEmpty(targetObjectIds)) {
+        if (StringUtils.isEmpty(id) || registryPackage == null) {
             return Collections.emptyList();
         }
 
-        return getObjectsFromRegistryObjectList(registryPackage, type).stream()
-                .filter(isAssociatedObject(targetObjectIds))
-                .collect(Collectors.toList());
+        return getAssociatedObjects(registryPackage.getRegistryObjectList(), id, type);
     }
 
     /**
@@ -346,20 +340,6 @@ public class RegistryPackageTypeHelper {
 
     private Predicate<RegistryObjectType> isAssociatedObject(Set<String> associatedIds) {
         return p -> associatedIds.contains(p.getId());
-    }
-
-    private Set<String> getAssociationTargetObjectIds(RegistryPackageType registryPackage,
-            String sourceId) {
-        Set<String> targetObjectIds = new HashSet<>();
-
-        if (registryPackage == null) {
-            return targetObjectIds;
-        }
-
-        if (registryPackage.isSetRegistryObjectList()) {
-            targetObjectIds = getAssociationTargetObjectIds(registryPackage.getRegistryObjectList(), sourceId);
-        }
-        return targetObjectIds;
     }
 
     private Set<String> getAssociationTargetObjectIds(RegistryObjectListType registryObjectList,

--- a/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelper.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelper.java
@@ -15,10 +15,16 @@ package org.codice.ddf.registry.schemabindings.helper;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBElement;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.AssociationType1;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
@@ -36,10 +42,15 @@ public class RegistryPackageTypeHelper {
     private RegistryPackageType registryPackageType;
 
     private List<ServiceBindingType> serviceBindings = new ArrayList<>();
+
     private List<ServiceType> services = new ArrayList<>();
+
     private List<ExtrinsicObjectType> extrinsicObjects = new ArrayList<>();
+
     private List<OrganizationType> organizations = new ArrayList<>();
+
     private List<PersonType> persons = new ArrayList<>();
+
     private List<AssociationType1> associations = new ArrayList<>();
 
     public RegistryPackageTypeHelper() {
@@ -57,113 +68,104 @@ public class RegistryPackageTypeHelper {
     /**
      * This is a convenience method that returns all of the ServiceBindingTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ServiceBindingTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the ServiceBindingTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
     public List<ServiceBindingType> getBindingTypes(RegistryPackageType registryPackage) {
         if (registryPackage == null) {
             return Collections.emptyList();
         }
 
-        return getServices(registryPackage).stream().flatMap(service -> service.getServiceBinding().stream()).collect(Collectors.toList());
+        return getServices(registryPackage).stream()
+                .flatMap(service -> service.getServiceBinding()
+                        .stream())
+                .collect(Collectors.toList());
     }
 
     /**
      * This is a convenience method that returns all of the ServiceBindingTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ServiceBindingTypes found in the RegistryObjectListType
-     *   an empty list if the RegistryObjectListType provided is null
+     * @param registryObjectList the RegistryObjectListType that will be crawled
+     *                           null returns an empty list
+     * @return a List containing the ServiceBindingTypes found in the RegistryObjectListType
+     * an empty list if the RegistryObjectListType provided is null
      */
-    public  List<ServiceBindingType> getBindingTypes(RegistryObjectListType registryObjectList) {
+    public List<ServiceBindingType> getBindingTypes(RegistryObjectListType registryObjectList) {
         if (registryObjectList == null) {
             return Collections.emptyList();
         }
 
-        return getServices(registryObjectList).stream().flatMap(service -> service.getServiceBinding().stream()).collect(Collectors.toList());
+        return getServices(registryObjectList).stream()
+                .flatMap(service -> service.getServiceBinding()
+                        .stream())
+                .collect(Collectors.toList());
     }
 
     /**
      * This is a convenience method that returns the list of ServiceBindingTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the ServiceBindingTypes
+     * @return a List containing the ServiceBindingTypes
      */
-    public  List<ServiceBindingType> getBindingTypes() {
+    public List<ServiceBindingType> getBindingTypes() {
         return serviceBindings;
     }
 
     /**
      * This is a convenience method that returns all of the ServiceTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ServiceTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the ServiceTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
-    public  List<ServiceType> getServices(RegistryPackageType registryPackage) {
+    public List<ServiceType> getServices(RegistryPackageType registryPackage) {
         return getObjectsFromRegistryObjectList(registryPackage, ServiceType.class);
     }
 
     /**
      * This is a convenience method that returns all of the ServiceTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ServiceTypes found in the RegistryObjectListType
-     *   an empty list if the RegistryObjectListType provided is null
+     * @param registryObjectList the RegistryObjectListType that will be crawled
+     *                           null returns an empty list
+     * @return a List containing the ServiceTypes found in the RegistryObjectListType
+     * an empty list if the RegistryObjectListType provided is null
      */
-    public  List<ServiceType> getServices(RegistryObjectListType registryObjectList) {
+    public List<ServiceType> getServices(RegistryObjectListType registryObjectList) {
         return getObjectsFromRegistryObjectList(registryObjectList, ServiceType.class);
     }
 
     /**
      * This is a convenience method that returns the list of ServiceTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the ServiceTypes
+     * @return a List containing the ServiceTypes
      */
-    public  List<ServiceType> getServices() {
+    public List<ServiceType> getServices() {
         return services;
     }
 
     /**
      * This is a convenience method that returns all of the ExtrinsicObjectTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ExtrinsicObjectTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the ExtrinsicObjectTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
-    public  List<ExtrinsicObjectType> getExtrinsicObjects(
-            RegistryPackageType registryPackage) {
+    public List<ExtrinsicObjectType> getExtrinsicObjects(RegistryPackageType registryPackage) {
         return getObjectsFromRegistryObjectList(registryPackage, ExtrinsicObjectType.class);
     }
 
     /**
      * This is a convenience method that returns all of the ExtrinsicObjectTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the ExtrinsicObjectTypes found in the RegistryObjectListType
-     *   an empty list if the RegistryObjectListType provided is null
+     * @param registryObjectList the RegistryObjectListType that will be crawled
+     *                           null returns an empty list
+     * @return a List containing the ExtrinsicObjectTypes found in the RegistryObjectListType
+     * an empty list if the RegistryObjectListType provided is null
      */
-    public  List<ExtrinsicObjectType> getExtrinsicObjects(
+    public List<ExtrinsicObjectType> getExtrinsicObjects(
             RegistryObjectListType registryObjectList) {
         return getObjectsFromRegistryObjectList(registryObjectList, ExtrinsicObjectType.class);
     }
@@ -171,127 +173,212 @@ public class RegistryPackageTypeHelper {
     /**
      * This is a convenience method that returns the list of ExtrinsicObjectTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the ExtrinsicObjectTypes
+     * @return a List containing the ExtrinsicObjectTypes
      */
-    public  List<ExtrinsicObjectType> getExtrinsicObjects() {
+    public List<ExtrinsicObjectType> getExtrinsicObjects() {
         return extrinsicObjects;
     }
 
     /**
      * This is a convenience method that returns all of the OrganizationTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the OrganizationTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the OrganizationTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
-    public  List<OrganizationType> getOrganizations(RegistryPackageType registryPackage) {
+    public List<OrganizationType> getOrganizations(RegistryPackageType registryPackage) {
         return getObjectsFromRegistryObjectList(registryPackage, OrganizationType.class);
     }
 
     /**
      * This is a convenience method that returns all of the OrganizationTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the OrganizationTypes found in the RegistryObjectListType
-     *   an empty list if the RegistryObjectListType provided is null
+     * @param registryObjectList the RegistryObjectListType that will be crawled
+     *                           null returns an empty list
+     * @return a List containing the OrganizationTypes found in the RegistryObjectListType
+     * an empty list if the RegistryObjectListType provided is null
      */
-    public  List<OrganizationType> getOrganizations(
-            RegistryObjectListType registryObjectList) {
+    public List<OrganizationType> getOrganizations(RegistryObjectListType registryObjectList) {
         return getObjectsFromRegistryObjectList(registryObjectList, OrganizationType.class);
     }
 
     /**
      * This is a convenience method that returns the list of OrganizationTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the OrganizationTypes
+     * @return a List containing the OrganizationTypes
      */
-    public  List<OrganizationType> getOrganizations() {
+    public List<OrganizationType> getOrganizations() {
         return organizations;
     }
 
     /**
      * This is a convenience method that returns all of the PersonTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the PersonTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the PersonTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
-    public  List<PersonType> getPersons(RegistryPackageType registryPackage) {
+    public List<PersonType> getPersons(RegistryPackageType registryPackage) {
         return getObjectsFromRegistryObjectList(registryPackage, PersonType.class);
     }
 
     /**
      * This is a convenience method that returns all of the PersonTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the PersonTypes found in the RegistryObjectListType
-     *   an empty list if the RegistryObjectListType provided is null
+     * @param registryObjectList the RegistryObjectListType that will be crawled
+     *                           null returns an empty list
+     * @return a List containing the PersonTypes found in the RegistryObjectListType
+     * an empty list if the RegistryObjectListType provided is null
      */
-    public  List<PersonType> getPersons(RegistryObjectListType registryObjectList) {
+    public List<PersonType> getPersons(RegistryObjectListType registryObjectList) {
         return getObjectsFromRegistryObjectList(registryObjectList, PersonType.class);
     }
 
     /**
      * This is a convenience method that returns the list of PersonTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the PersonTypes
+     * @return a List containing the PersonTypes
      */
-    public  List<PersonType> getPersons() {
+    public List<PersonType> getPersons() {
         return persons;
     }
 
     /**
      * This is a convenience method that returns all of the AssociationTypes found in the provided RegistryPackageType
      *
-     * @param registryPackage
-     *   the RegistryPackageType that will be crawled
-     *   null returns an empty list
-     * @return
-     *   a List containing the AssociationTypes found in the RegistryPackageType
-     *   an empty list if the RegistryPackageType provided is null
+     * @param registryPackage the RegistryPackageType that will be crawled
+     *                        null returns an empty list
+     * @return a List containing the AssociationTypes found in the RegistryPackageType
+     * an empty list if the RegistryPackageType provided is null
      */
-    public  List<AssociationType1> getAssociations(RegistryPackageType registryPackage) {
+    public List<AssociationType1> getAssociations(RegistryPackageType registryPackage) {
         return getObjectsFromRegistryObjectList(registryPackage, AssociationType1.class);
     }
 
     /**
      * This is a convenience method that returns all of the AssociationTypes found in the provided RegistryObjectListType
      *
-     * @param registryObjectList
-     *   the RegistryObjectListType that will be crawled, null returns an empty list
-     * @return
-     *   a List containing the AssociationTypes found in the RegistryObjectListType
+     * @param registryObjectList the RegistryObjectListType that will be crawled, null returns an empty list
+     * @return a List containing the AssociationTypes found in the RegistryObjectListType
      */
-    public  List<AssociationType1> getAssociations(
-            RegistryObjectListType registryObjectList) {
+    public List<AssociationType1> getAssociations(RegistryObjectListType registryObjectList) {
         return getObjectsFromRegistryObjectList(registryObjectList, AssociationType1.class);
     }
 
     /**
      * This is a convenience method that returns the list of AssociationTypes extracted from this class's RegistryPackageType
      *
-     * @return
-     *   a List containing the AssociationTypes
+     * @return a List containing the AssociationTypes
      */
-    public  List<AssociationType1> getAssociations() {
+    public List<AssociationType1> getAssociations() {
         return associations;
     }
 
+    /**
+     * This is a convenience method that returns all Objects associated with the provided id extracted from the provided RegistryPackageType
+     *
+     * @param registryPackage the RegistryPackageType that will be crawled, null returns an empty list
+     * @param id              to be used as the sourceObjectId of the Association
+     * @param type            Type of the object to find associations for
+     * @return a List containing the objects associated to the provided id
+     */
+    public <T extends RegistryObjectType> List<T> getAssociatedObjects(
+            RegistryPackageType registryPackage, String id, Class<T> type) {
+        if (StringUtils.isEmpty(id)) {
+            return Collections.emptyList();
+        }
+        Set<String> targetObjectIds = getAssociationTargetObjectIds(registryPackage, id);
+        if (CollectionUtils.isEmpty(targetObjectIds)) {
+            return Collections.emptyList();
+        }
+
+        return getObjectsFromRegistryObjectList(registryPackage, type).stream()
+                .filter(isAssociatedObject(targetObjectIds))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * This is a convenience method that returns all Objects associated with the provided id extracted from the provided RegistryObjectList
+     *
+     * @param registryObjectList the RegistryObjectList that will be crawled, null returns an empty list
+     * @param id                 to be used as the sourceObjectId of the Association
+     * @param type               Type of the object to find associations for
+     * @return a List containing the objects associated to the provided id
+     */
+    public <T extends RegistryObjectType> List<T> getAssociatedObjects(
+            RegistryObjectListType registryObjectList, String id, Class<T> type) {
+        if (StringUtils.isEmpty(id)) {
+            return Collections.emptyList();
+        }
+
+        Set<String> targetObjectIds = getAssociationTargetObjectIds(registryObjectList, id);
+        if (CollectionUtils.isEmpty(targetObjectIds)) {
+            return Collections.emptyList();
+        }
+
+        return getObjectsFromRegistryObjectList(registryObjectList, type).stream()
+                .filter(isAssociatedObject(targetObjectIds))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * This is a convenience method that returns all Objects associated with the provided id extracted from this class's RegistryPackageType
+     *
+     * @param id   to be used as the sourceObjectId of the Association
+     * @param type Type of the object to find associations for
+     * @return a List containing the objects associated to the provided id
+     */
+    public <T extends RegistryObjectType> List<T> getAssociatedObjects(String id, Class<T> type) {
+        if (StringUtils.isEmpty(id)) {
+            return Collections.emptyList();
+        }
+        Set<String> targetObjectIds = getAssociationTargetObjectIds(id);
+        if (CollectionUtils.isEmpty(targetObjectIds)) {
+            return Collections.emptyList();
+        }
+
+        return getObjectsFromRegistryObjectList(registryPackageType, type).stream()
+                .filter(isAssociatedObject(targetObjectIds))
+                .collect(Collectors.toList());
+    }
+
+    private Predicate<RegistryObjectType> isAssociatedObject(Set<String> associatedIds) {
+        return p -> associatedIds.contains(p.getId());
+    }
+
+    private Set<String> getAssociationTargetObjectIds(RegistryPackageType registryPackage,
+            String sourceId) {
+        Set<String> targetObjectIds = new HashSet<>();
+
+        if (registryPackage == null) {
+            return targetObjectIds;
+        }
+
+        if (registryPackage.isSetRegistryObjectList()) {
+            targetObjectIds = getAssociationTargetObjectIds(registryPackage.getRegistryObjectList(), sourceId);
+        }
+        return targetObjectIds;
+    }
+
+    private Set<String> getAssociationTargetObjectIds(RegistryObjectListType registryObjectList,
+            String sourceId) {
+        if (registryObjectList == null) {
+            return new HashSet<>();
+        }
+        return getAssociations(registryObjectList).stream()
+                .filter(association -> sourceId.equals(association.getSourceObject()))
+                .map(AssociationType1::getTargetObject)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> getAssociationTargetObjectIds(String sourceId) {
+        return getAssociations().stream()
+                .filter(association -> sourceId.equals(association.getSourceObject()))
+                .map(AssociationType1::getTargetObject)
+                .collect(Collectors.toSet());
+    }
 
     private void populateLists() {
         serviceBindings.clear();
@@ -308,7 +395,8 @@ public class RegistryPackageTypeHelper {
         if (registryPackageType.isSetRegistryObjectList()) {
             RegistryObjectListType registryObjectList = registryPackageType.getRegistryObjectList();
             for (JAXBElement<? extends IdentifiableType> identifiableType : registryObjectList.getIdentifiable()) {
-                RegistryObjectType registryObject = (RegistryObjectType) identifiableType.getValue();
+                RegistryObjectType registryObject =
+                        (RegistryObjectType) identifiableType.getValue();
 
                 if (registryObject instanceof ExtrinsicObjectType) {
                     extrinsicObjects.add((ExtrinsicObjectType) registryObject);
@@ -327,7 +415,7 @@ public class RegistryPackageTypeHelper {
         }
     }
 
-    private  <T extends RegistryObjectType> List<T> getObjectsFromRegistryObjectList(
+    private <T extends RegistryObjectType> List<T> getObjectsFromRegistryObjectList(
             RegistryPackageType registryPackage, Class<T> type) {
         List<T> registryObjects = new ArrayList<>();
 
@@ -343,13 +431,17 @@ public class RegistryPackageTypeHelper {
         return registryObjects;
     }
 
-    private  <T extends RegistryObjectType> List<T> getObjectsFromRegistryObjectList(RegistryObjectListType registryObjectList, Class<T> type) {
+    private <T extends RegistryObjectType> List<T> getObjectsFromRegistryObjectList(
+            RegistryObjectListType registryObjectList, Class<T> type) {
         if (registryObjectList == null) {
             return Collections.emptyList();
         }
 
-        return registryObjectList.getIdentifiable().stream().filter(identifiable -> type.isInstance(identifiable.getValue())).map(identifiable -> (T) identifiable.getValue()).collect(
-                Collectors.toList());
+        return registryObjectList.getIdentifiable()
+                .stream()
+                .filter(identifiable -> type.isInstance(identifiable.getValue()))
+                .map(identifiable -> (T) identifiable.getValue())
+                .collect(Collectors.toList());
     }
 
 }

--- a/catalog/spatial/registry/registry-schema-bindings/src/test/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelperTest.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/test/java/org/codice/ddf/registry/schemabindings/helper/RegistryPackageTypeHelperTest.java
@@ -76,7 +76,7 @@ public class RegistryPackageTypeHelperTest {
                         .getPackage()
                         .getName()), RegistryPackageTypeHelperTest.class.getClassLoader());
 
-        registryObject = getRegistryObjectFromResource("/csw-registry-package-smaller.xml");
+        registryObject = getRegistryObjectFromResource("/csw-full-registry-package.xml");
 
         rptHelper = new RegistryPackageTypeHelper((RegistryPackageType) registryObject);
     }
@@ -253,9 +253,101 @@ public class RegistryPackageTypeHelperTest {
         assertThat(associations, is(empty()));
     }
 
+    @Test
+    public void testGetAssociatedObjectWithNullId() throws Exception {
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects(null, OrganizationType.class);
+        assertThat(organizations, is(empty()));
+    }
+
+    @Test
+    public void testGetObjectsAssociatedToService() throws Exception {
+        String testServiceId = "urn:service:id0";
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects(testServiceId,
+                OrganizationType.class);
+        assertThat(organizations, hasSize(1));
+        assertThat(organizations.get(0)
+                .getId(), is(equalTo("urn:organization:id0")));
+
+        List<PersonType> contacts = rptHelper.getAssociatedObjects(testServiceId,
+                PersonType.class);
+        assertThat(contacts, hasSize(1));
+        assertThat(contacts.get(0)
+                .getId(), is(equalTo("urn:contact:id1")));
+    }
+
+    @Test
+    public void testGetObjectsAssociatedToServiceFromRegistryPackage() throws Exception {
+        String testServiceId = "urn:service:id0";
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects((RegistryPackageType) registryObject, testServiceId,
+                OrganizationType.class);
+        assertThat(organizations, hasSize(1));
+        assertThat(organizations.get(0)
+                .getId(), is(equalTo("urn:organization:id0")));
+
+        List<PersonType> contacts = rptHelper.getAssociatedObjects(testServiceId,
+                PersonType.class);
+        assertThat(contacts, hasSize(1));
+        assertThat(contacts.get(0)
+                .getId(), is(equalTo("urn:contact:id1")));
+    }
+
+    @Test
+    public void testGetObjectsAssociatedToServiceFromRegistryObjectList() throws Exception {
+        String testServiceId = "urn:service:id0";
+        RegistryObjectListType registryObjectList =
+                ((RegistryPackageType) registryObject).getRegistryObjectList();
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects(registryObjectList, testServiceId,
+                OrganizationType.class);
+        assertThat(organizations, hasSize(1));
+        assertThat(organizations.get(0)
+                .getId(), is(equalTo("urn:organization:id0")));
+
+        List<PersonType> contacts = rptHelper.getAssociatedObjects(testServiceId,
+                PersonType.class);
+        assertThat(contacts, hasSize(1));
+        assertThat(contacts.get(0)
+                .getId(), is(equalTo("urn:contact:id1")));
+    }
+
+    @Test
+    public void testGetObjectsAssociatedToEndpoint() throws Exception {
+        String testServiceBindingId = "urn:registry:federation:method:csw";
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects(
+                testServiceBindingId,
+                OrganizationType.class);
+        assertThat(organizations, is(empty()));
+
+        List<PersonType> contacts = rptHelper.getAssociatedObjects(testServiceBindingId,
+                PersonType.class);
+        assertThat(contacts, hasSize(2));
+        assertThat(contacts.get(0)
+                .getId(), is(equalTo("urn:contact:id1")));
+        assertThat(contacts.get(1)
+                .getId(), is(equalTo("urn:contact:id2")));
+    }
+
+    @Test
+    public void testGetObjectsAssociatedToNode() throws Exception {
+        String testServiceBindingId = "urn:registry:federation:node";
+        List<OrganizationType> organizations = rptHelper.getAssociatedObjects(
+                testServiceBindingId,
+                OrganizationType.class);
+        assertThat(organizations, hasSize(1));
+        assertThat(organizations.get(0)
+                .getId(), is(equalTo("urn:organization:id0")));
+
+        List<PersonType> contacts = rptHelper.getAssociatedObjects(testServiceBindingId,
+                PersonType.class);
+        assertThat(contacts, hasSize(2));
+        assertThat(contacts.get(0)
+                .getId(), is(equalTo("urn:contact:id1")));
+        assertThat(contacts.get(1)
+                .getId(), is(equalTo("urn:contact:id2")));
+    }
+
     private void assertBindings(List<ServiceBindingType> bindings) {
         // Values from xml file
-        int expectedSize = 1;
+        int expectedSize = 2;
         int numberOfSlots = 4;
         String expectedName = "CSW Federation Method";
         String expectedDescription = "This is the CSW federation method.";
@@ -312,8 +404,8 @@ public class RegistryPackageTypeHelperTest {
 
     private void assertExtrinsicObjects(List<ExtrinsicObjectType> extrinsicObjects) {
         // Values from xml file
-        int expectedSize = 1;
-        int numberOfSlots = 6;
+        int expectedSize = 4;
+        int numberOfSlots = 10;
         String expectedName = "Node Name";
         String expectedDescription =
                 "A little something describing this node in less than 1024 characters";
@@ -379,6 +471,7 @@ public class RegistryPackageTypeHelperTest {
     private void assertOrganizations(List<OrganizationType> organizations) {
         // Values from xml file
         int expectedSize = 1;
+        int expectedOrganizationsSize = 2;
         String expectedName = "Codice";
         String expectedCity = "Phoenix";
         String expectedCountry = "USA";
@@ -397,7 +490,7 @@ public class RegistryPackageTypeHelperTest {
         String expectedParent = "urn:uuid:2014ca7f59ac46f495e32b4a67a51276";
         String expectedPrimaryContact = "somePrimaryContact";
 
-        assertThat(organizations, hasSize(expectedSize));
+        assertThat(organizations, hasSize(expectedOrganizationsSize));
         OrganizationType organization = organizations.get(0);
 
         assertThat(organization.isSetName(), is(true));
@@ -438,6 +531,7 @@ public class RegistryPackageTypeHelperTest {
 
     private void assertPersons(List<PersonType> persons) {
         // Values from xml file
+        int expectedPersonsSize = 3;
         int expectedSize = 1;
         String expectedFirstName = "john";
         String expectedMiddleName = "middleName";
@@ -457,7 +551,7 @@ public class RegistryPackageTypeHelperTest {
 
         String expectedEmail = "emailaddress@something.com";
 
-        assertThat(persons, hasSize(expectedSize));
+        assertThat(persons, hasSize(expectedPersonsSize));
         PersonType person = persons.get(0);
 
         assertThat(person.isSetPersonName(), is(true));
@@ -495,8 +589,8 @@ public class RegistryPackageTypeHelperTest {
 
     private void assertAssociations(List<AssociationType1> associations) {
         // Values from xml file
-        int expectedSize = 1;
-        String expectedId = "urn:assoication:1";
+        int expectedSize = 13;
+        String expectedId = "urn:association:1";
         String expectedAssociationType = "RelatedTo";
         String expectedSourceObject = "urn:registry:node";
         String expectedTargetObject = "urn:contact:id0";

--- a/catalog/spatial/registry/registry-schema-bindings/src/test/resources/csw-full-registry-package.xml
+++ b/catalog/spatial/registry/registry-schema-bindings/src/test/resources/csw-full-registry-package.xml
@@ -13,6 +13,7 @@
  **/
 -->
 <!-- This Registry Package is a realistic example. It is used to test the converters from the top level  -->
+<!-- Added associations so this can also be used to test the RegistryPackageTypeHelper getAssociatedObjects methods -->
 <rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport"
                      objectType="urn:registry:federation:node"
                      xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
@@ -392,21 +393,47 @@
 
         <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
         with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
-        <rim:Association id="urn:assoication:1" associationType="RelatedTo"
-                         sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
-        <rim:Association id="urn:assoication:2" associationType="RelatedTo"
-                         sourceObject="urn:registry:node" targetObject="urn:organization:id0"/>
-        <rim:Association id="urn:assoication:3" associationType="RelatedTo"
-                         sourceObject="urn:contact:person1"
+        <rim:Association id="urn:association:1" associationType="RelatedTo"
+                         sourceObject="urn:registry:node"
+                         targetObject="urn:contact:id0"/>
+        <rim:Association id="urn:association:2" associationType="RelatedTo"
+                         sourceObject="urn:registry:node"
+                         targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:association:3" associationType="RelatedTo"
+                         sourceObject="urn:contact:id1"
                          targetObject="urn:content:collection:id0"/>
-        <rim:Association id="urn:assoication:4" associationType="RelatedTo"
+        <rim:Association id="urn:association:4" associationType="RelatedTo"
                          sourceObject="urn:contact:person2"
                          targetObject="urn:content:collection:id1"/>
-        <rim:Association id="urn:assoication:5" associationType="RelatedTo"
-                         sourceObject="urn:organization:id1" targetObject="urn:service:id0"/>
-        <rim:Association id="urn:assoication:6" associationType="RelatedTo"
+        <rim:Association id="urn:association:5" associationType="RelatedTo"
+                         sourceObject="urn:organization:id1"
+                         targetObject="urn:service:id0"/>
+        <rim:Association id="urn:association:6" associationType="RelatedTo"
                          sourceObject="urn:organization:id0"
                          targetObject="urn:content:collection:id0"/>
+        <rim:Association id="urn:association:7" associationType="RelatedTo"
+                         sourceObject="urn:service:id0"
+                         targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:association:8" associationType="RelatedTo"
+                         sourceObject="urn:service:id0"
+                         targetObject="urn:contact:id1"/>
+        <rim:Association id="urn:association:9" associationType="RelatedTo"
+                         sourceObject="urn:registry:federation:method:csw"
+                         targetObject="urn:contact:id1"/>
+        <rim:Association id="urn:association:10" associationType="RelatedTo"
+                         sourceObject="urn:registry:federation:method:csw"
+                         targetObject="urn:contact:id2"/>
+        <rim:Association id="urn:association:11" associationType="RelatedTo"
+                         sourceObject="urn:registry:federation:node"
+                         targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:association:12" associationType="RelatedTo"
+                         sourceObject="urn:registry:federation:node"
+                         targetObject="urn:contact:id1"/>
+        <rim:Association id="urn:association:13" associationType="RelatedTo"
+                         sourceObject="urn:registry:federation:node"
+                         targetObject="urn:contact:id2"/>
+
+
 
     </rim:RegistryObjectList>
 </rim:RegistryPackage>


### PR DESCRIPTION
#### What does this PR do?
This PR adds methods to the RegistryPackageTypeHelper that get objects associated by id.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)? @clockard @vinamartin @mcalcote @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold 
@shaundmorris 
#### How should this be tested?
Verify the build
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2518
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests


Adding methods to get associated objects by sourceObjectId
Adding tests and updating test xml file