### PR TITLE
DDF-2534 Add autocomplete/suggestion support to the registry node modal fields

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/index.html
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/index.html
@@ -23,7 +23,7 @@
     <link href="lib/font-awesome/css/font-awesome.min.css" rel="stylesheet"/>
     <link href="lib/bootswatch/flatly/bootstrap.min.css" rel="stylesheet"/>
     <link href="lib/perfect-scrollbar/min/perfect-scrollbar.min.css" rel="stylesheet"/>
-
+    <link href="lib/jquery-ui/themes/base/jquery-ui.css"  rel="stylesheet"/>
     <link href="css/styles.css" rel="stylesheet"/>
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/js/view/Field.view.js
@@ -42,6 +42,7 @@ define([
                 "change:error": "showHideError",
                 "change": "fieldChanged"
             },
+
             initialize: function (options) {
                 this.readOnly = options.readOnly;
                 this.modelBinder = new Backbone.ModelBinder();
@@ -53,6 +54,16 @@ define([
             onRender: function () {
                 var bindings = Backbone.ModelBinder.createDefaultBindings(this.el, 'name');
                 this.modelBinder.bind(this.model, this.$el, bindings);
+                var possibleValues = this.model.get('possibleValues');
+                if(possibleValues){
+                    this.$('.'+this.model.get('key')).autocomplete({
+                        source: possibleValues,
+                        change: function(event) {
+                           $(event.target).change();
+                        }
+                    });
+                }
+
             },
             addValue: function () {
                 this.model.addValue('');

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/less/styles.less
@@ -307,3 +307,7 @@ input[type=number]::-webkit-outer-spin-button {
   margin-left: 20px;
 }
 
+.ui-front {
+  z-index: 10000 !important;
+}
+

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
@@ -33,16 +33,18 @@
                 {{#each value}}
                     <tr>
                         <td>
-                            <input type="text" class="string-table-input {{../key}}
-                                {{#if ../validationError}}
-                                    {{#each ../../errorIndices}}
-                                        {{#is @../index this}}validation-error{{/is}}
-                                    {{/each}}
-                                {{/if}}"
-                                   name="value{{@index}}" value="{{this}}"
-                                   {{#unless ../../editable}}readonly{{/unless}}/>
+                            <div class="ui-widget">
+                                <input type="text" class="string-table-input {{../key}}
+                                    {{#if ../validationError}}
+                                        {{#each ../../errorIndices}}
+                                            {{#is @../index this}}validation-error{{/is}}
+                                        {{/each}}
+                                    {{/if}}"
+                                       name="value{{@index}}" value="{{this}}"
+                                       {{#unless ../../editable}}readonly{{/unless}}/>
+                            </div>
                         </td>
-                        {{#if editable}}
+                        {{#if ../../editable}}
                             <td>
                                 <a href="#" name="{{@index}}"
                                    class="remove-value fa fa-minus-square fa-lg minus-button"></a>

--- a/distribution/docs/src/main/resources/_contents/_draft-registry-contents/managing-registry-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_draft-registry-contents/managing-registry-contents.adoc
@@ -41,6 +41,77 @@ include::{adoc-include}/_tables/conf-Registry_Configuration_Event_Handler-table-
 
 |===
 
+=== Customizing ${ddf-registry} Fields
+
+All the fields that appear in a registry node are customizable. This is done through a JSON configuration file located at ``<${branding}_HOME>/etc/registry/registry-custom-slots.json`` that defines the registry fields. In this file there are JSON objects that relate to each part of the edit registry modal.
+These objects are
+
+* General
+* Service
+** ServiceBinding
+* Organization
+* Person (Contact)
+* Content (Content Collection)
+
+Each of the objects listed above is a JSON array of field objects that can be modified. There are some other objects in the JSON file like *PersonName*, *Address*, *TelephoneNumber*, and *EmailAddress* that should not be modified.
+
+.Field Properties
+|===
+|Property Key |Required |Property Value
+
+|key
+|yes
+|The string value that will be used to identify this field. Must be unique within field grouping array. This value is what will show up in the generated EBRIM xml.
+
+|displayName
+|yes
+|The string name that will be displayed in the edit node dialog for this field
+
+|description
+|yes
+|A brief description of what the field represents or is used for. Shown when user hovers or click the question mark icon for the field.
+
+|value
+|no
+|The initial or default value of the field. For most cases this should be left as an empty array or string.
+
+|type
+|yes
+|Identifies what type of field this is. Value must be one of *string*, *date*, *number*, *boolean*, *point*, or *bounds*
+
+|required
+|no
+|Indicates if this field must be filled out. *Default is false*. If true an asterisk will be displayed next to the field name.
+
+|possibleValues
+|no
+|An array of values that could be used for this field. If *multiValued=true* this list will be used for suggestions for autocomplete. If *multiValued=false* this list will be used to populate a dropdown.
+
+|multiValued
+|no
+|Flag indicating if this field accepts multiple values or not. *Default is false*.
+
+|isSlot
+|no
+|Indicates that this field represents a slot value in the EBRIM document. If this is false the key must match a valid EBRIM attribute for the parent object. *Default is true*.
+
+|advanced
+|no
+|A flag indicating if this field should be placed under the *Advanced* section of the edit modal ui. *Default is false*.
+
+|regex
+|no
+|A regular expression for validating users input.
+
+|regexMessage
+|no
+|A message to show the user if the regular expression test fails.
+
+|isGroup, constructTitle
+|N/A
+|These fields are used for nesting objects and should not be modified
+|===
+
 === Using ${ddf-registry}
 
 The *Node Information* and *Remote Registries* tabs appear in both the ${ddf-registry} application and the ${ddf-catalog} application.

--- a/distribution/docs/src/main/resources/_contents/_registry-contents/managing-registry-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_registry-contents/managing-registry-contents.adoc
@@ -16,6 +16,7 @@ To use the ${ddf-registry}, the following apps/features must be installed:
 
 === Configuring ${ddf-registry}
 
+
 .Registry Configuration Tab
 [cols="1,1m,1" options="header"]
 |===
@@ -221,6 +222,78 @@ To use the ${ddf-registry}, the following apps/features must be installed:
 |yes
 
 |===
+
+=== Customizing ${ddf-registry} Fields
+
+All the fields that appear in a registry node are customizable. This is done through a JSON configuration file located at ``<${branding}_HOME>/etc/registry/registry-custom-slots.json`` that defines the registry fields. In this file there are JSON objects that relate to each part of the edit registry modal.
+These objects are
+
+* General
+* Service
+** ServiceBinding
+* Organization
+* Person (Contact)
+* Content (Content Collection)
+
+Each of the objects listed above is a JSON array of field objects that can be modified. There are some other objects in the JSON file like *PersonName*, *Address*, *TelephoneNumber*, and *EmailAddress* that should not be modified.
+
+.Field Properties
+|===
+|Property Key |Required |Property Value
+
+|key
+|yes
+|The string value that will be used to identify this field. Must be unique within field grouping array. This value is what will show up in the generated EBRIM xml.
+
+|displayName
+|yes
+|The string name that will be displayed in the edit node dialog for this field
+
+|description
+|yes
+|A brief description of what the field represents or is used for. Shown when user hovers or click the question mark icon for the field.
+
+|value
+|no
+|The initial or default value of the field. For most cases this should be left as an empty array or string.
+
+|type
+|yes
+|Identifies what type of field this is. Value must be one of *string*, *date*, *number*, *boolean*, *point*, or *bounds*
+
+|required
+|no
+|Indicates if this field must be filled out. *Default is false*. If true an asterisk will be displayed next to the field name.
+
+|possibleValues
+|no
+|An array of values that could be used for this field. If *multiValued=true* this list will be used for suggestions for autocomplete. If *multiValued=false* this list will be used to populate a dropdown.
+
+|multiValued
+|no
+|Flag indicating if this field accepts multiple values or not. *Default is false*.
+
+|isSlot
+|no
+|Indicates that this field represents a slot value in the EBRIM document. If this is false the key must match a valid EBRIM attribute for the parent object. *Default is true*.
+
+|advanced
+|no
+|A flag indicating if this field should be placed under the *Advanced* section of the edit modal ui. *Default is false*.
+
+|regex
+|no
+|A regular expression for validating users input.
+
+|regexMessage
+|no
+|A message to show the user if the regular expression test fails.
+
+|isGroup, constructTitle
+|N/A
+|These fields are used for nesting objects and should not be modified
+|===
+
 
 === Using ${ddf-registry}
 


### PR DESCRIPTION
#### What does this PR do?
Addes the ability to set autocomplete suggestions for registry fields.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@andrewkfiedler @mcalcote @ricklarsen 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold 
@pklinef

#### How should this be tested?
After unzipping a ddf edit the etc/registry/registry-custom-slots.json and add the following for the securityLevel object  `"possibleValues": ["attribute1=val1","attribute2=val2","something=else"],`.
Install the ddf with the registry and go to the Node Information tab and open up the identity node.
Add a field to the security attributes and start typing 'a' and verify that you see suggestions from the list you entered earlier.
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
DDF-2534
#### Screenshots (if appropriate)
![screen shot 2016-10-10 at 9 13 25 am](https://cloud.githubusercontent.com/assets/5248090/19242856/eeeaba76-8ec9-11e6-87d5-5db8a4e09f3a.png)

Documentation section added
![screen shot 2016-10-12 at 12 58 05 pm](https://cloud.githubusercontent.com/assets/5248090/19325568/9fda7210-907b-11e6-8675-a3646ccf605a.png)


#### Checklist:
- [x] Documentation Updated
	- [ ] Change log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
