### PR TITLE
DDF-2500: Expose client info within request properties using a PreAuthorizationPlugin and a servlet filter (backport).

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -12,7 +12,10 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.catalog</groupId>
@@ -481,6 +484,11 @@
         <dependency>
             <groupId>ddf.catalog.plugin</groupId>
             <artifactId>catalog-plugin-content-uri</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-clientinfo</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -398,5 +398,12 @@
         <feature>catalog-core-api</feature>
         <feature>catalog-core</feature>
     </feature>
-    
+
+    <feature name="catalog-metacard-enrichment" install="auto" version="${project.version}"
+             description="Conditional, rule-based enhancement and modification to metacards">
+        <feature prerequisite="true">catalog-core-api</feature>
+        <feature prerequisite="true">clientinfo-filter</feature>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-clientinfo/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreAuthorizationPlugin.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreAuthorizationPlugin.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.plugin;
+
+import java.util.Map;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+
+/**
+ * The {@link PreAuthorizationPlugin} extension point allows for request/response processing before any
+ * security rules (policy and access) are implemented at the beginning of the plugin chain. That is,
+ * pre-processing occurs before policy, access, and the catalog framework. Post-processing occurs after
+ * the catalog framework but before the second round of policy and access.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface PreAuthorizationPlugin {
+
+    /**
+     * Process a {@link CreateRequest} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link CreateRequest} to process
+     * @return the value of the processed {@link CreateRequest} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException;
+
+    /**
+     * Process an {@link UpdateRequest} for use cases that occur prior to security rules.
+     *
+     * @param input             the {@link UpdateRequest} to process
+     * @param existingMetacards the Map of {@link Metacard}s that currently exist
+     * @return the value of the processed {@link UpdateRequest} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    UpdateRequest processPreUpdate(UpdateRequest input, Map<String, Metacard> existingMetacards)
+            throws StopProcessingException;
+
+    /**
+     * Process a {@link DeleteRequest} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link DeleteRequest} to process
+     * @return the value of the processed {@link DeleteRequest} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException;
+
+    /**
+     * Process a {@link DeleteResponse} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link DeleteResponse} to process
+     * @return the value of the processed {@link DeleteResponse} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    DeleteResponse processPostDelete(DeleteResponse input) throws StopProcessingException;
+
+    /**
+     * Process a {@link QueryRequest} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link QueryRequest} to process
+     * @return the value of the processed {@link QueryRequest} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException;
+
+    /**
+     * Process a {@link QueryResponse} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link QueryResponse} to process
+     * @return the value of the processed {@link QueryResponse} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    QueryResponse processPostQuery(QueryResponse input) throws StopProcessingException;
+
+    /**
+     * Process a {@link ResourceRequest} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link ResourceRequest} to process
+     * @return the value of the processed {@link QueryRequest} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    ResourceRequest processPreResource(ResourceRequest input) throws StopProcessingException;
+
+    /**
+     * Process a {@link ResourceResponse} for use cases that occur prior to security rules.
+     *
+     * @param input the {@link ResourceResponse} to process
+     * @return the value of the processed {@link ResourceResponse} to pass to the next {@link PreAuthorizationPlugin}
+     * @throws StopProcessingException thrown to halt processing when a critical issue occurs during processing. This is
+     *                                 intended to prevent other plugins from processing as well.
+     */
+    ResourceResponse processPostResource(ResourceResponse input, Metacard metacard)
+            throws StopProcessingException;
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -153,6 +153,7 @@ import ddf.catalog.plugin.PolicyResponse;
 import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.plugin.PostQueryPlugin;
 import ddf.catalog.plugin.PostResourcePlugin;
+import ddf.catalog.plugin.PreAuthorizationPlugin;
 import ddf.catalog.plugin.PreIngestPlugin;
 import ddf.catalog.plugin.PreQueryPlugin;
 import ddf.catalog.plugin.PreResourcePlugin;
@@ -1053,6 +1054,11 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             Map<String, Serializable> unmodifiablePropertiesMap = Collections.unmodifiableMap(
                     createRequest.getProperties());
             HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
+
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                createRequest = plugin.processPreCreate(createRequest);
+            }
+
             for (Metacard metacard : createRequest.getMetacards()) {
                 HashMap<String, Set<String>> itemPolicyMap = new HashMap<>();
                 for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
@@ -1436,6 +1442,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                 throw new IngestException("Could not find all metacards specified in request");
             }
 
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                updateRequest = plugin.processPreUpdate(updateRequest, metacardMap);
+            }
+
             HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
             for (Entry<Serializable, Metacard> update : updateRequest.getUpdates()) {
                 HashMap<String, Set<String>> itemPolicyMap = new HashMap<>();
@@ -1650,6 +1660,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             deleteStorageRequest = new DeleteStorageRequestImpl(metacards,
                     deleteRequest.getProperties());
 
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                deleteRequest = plugin.processPreDelete(deleteRequest);
+            }
+
             HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
             Map<String, Serializable> unmodifiableProperties = Collections.unmodifiableMap(
                     deleteRequest.getProperties());
@@ -1713,6 +1727,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                     deleteResponse.getProcessingErrors()
                             .addAll(remoteDeleteResponse.getProcessingErrors());
                 }
+            }
+
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                deleteResponse = plugin.processPostDelete(deleteResponse);
             }
 
             HashMap<String, Set<String>> responsePolicyMap = new HashMap<>();
@@ -1871,6 +1889,15 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                         queryRequest.getProperties());
             }
 
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                try {
+                    queryReq = plugin.processPreQuery(queryReq);
+                } catch (StopProcessingException e) {
+                    throw new RuntimeException(
+                            "Processing signaled to stop prior to query in a PreAuthorization Plugin");
+                }
+            }
+
             HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
             Map<String, Serializable> unmodifiableProperties =
                     Collections.unmodifiableMap(queryReq.getProperties());
@@ -1923,6 +1950,15 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             queryResponse = doQuery(queryReq, fedStrategy);
 
             queryResponse = validateFixQueryResponse(queryResponse, overrideFanoutRename);
+
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                try {
+                    queryResponse = plugin.processPostQuery(queryResponse);
+                } catch (StopProcessingException e) {
+                    throw new RuntimeException(
+                            "Processing signaled to stop after the query in a PreAuthorization Plugin");
+                }
+            }
 
             HashMap<String, Set<String>> responsePolicyMap = new HashMap<>();
             unmodifiableProperties = Collections.unmodifiableMap(queryResponse.getProperties());
@@ -2501,6 +2537,16 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         }
 
         validateGetResourceRequest(resourceReq);
+
+        for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+            try {
+                resourceReq = plugin.processPreResource(resourceReq);
+            } catch (StopProcessingException e) {
+                throw new RuntimeException(
+                        "Processing signaled to stop prior to resource in a PreAuthorization Plugin");
+            }
+        }
+
         try {
             HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
             for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
@@ -2603,6 +2649,15 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             resourceResponse = putPropertiesInResponse(resourceReq, resourceResponse);
 
             resourceResponse = validateFixGetResourceResponse(resourceResponse, resourceReq);
+
+            for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthPlugins()) {
+                try {
+                    resourceResponse = plugin.processPostResource(resourceResponse, metacard);
+                } catch (StopProcessingException e) {
+                    throw new RuntimeException(
+                            "Processing signaled to stop after the resource in a PreAuthorization Plugin");
+                }
+            }
 
             HashMap<String, Set<String>> responsePolicyMap = new HashMap<>();
             for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/FrameworkProperties.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/FrameworkProperties.java
@@ -36,6 +36,7 @@ import ddf.catalog.plugin.PolicyPlugin;
 import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.plugin.PostQueryPlugin;
 import ddf.catalog.plugin.PostResourcePlugin;
+import ddf.catalog.plugin.PreAuthorizationPlugin;
 import ddf.catalog.plugin.PreIngestPlugin;
 import ddf.catalog.plugin.PreQueryPlugin;
 import ddf.catalog.plugin.PreResourcePlugin;
@@ -72,6 +73,8 @@ public class FrameworkProperties {
     private List<PreResourcePlugin> preResource = new ArrayList<>();
 
     private List<PostResourcePlugin> postResource = new ArrayList<>();
+
+    private List<PreAuthorizationPlugin> preAuthPlugins = new ArrayList<>();
 
     private List<PolicyPlugin> policyPlugins = new ArrayList<>();
 
@@ -177,6 +180,14 @@ public class FrameworkProperties {
 
     public void setPostResource(List<PostResourcePlugin> postResource) {
         this.postResource = postResource;
+    }
+
+    public List<PreAuthorizationPlugin> getPreAuthPlugins() {
+        return preAuthPlugins;
+    }
+
+    public void setPreAuthPlugins(List<PreAuthorizationPlugin> preAuthPlugins) {
+        this.preAuthPlugins = preAuthPlugins;
     }
 
     public List<PolicyPlugin> getPolicyPlugins() {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -64,6 +64,8 @@
     </bean>
     <bean id="resourceReaderSortedList" class="ddf.catalog.util.impl.SortedServiceList">
     </bean>
+    <bean id="preAuthSortedList" class="ddf.catalog.util.impl.SortedServiceList">
+    </bean>
     <bean id="policySortedList" class="ddf.catalog.util.impl.SortedServiceList">
     </bean>
     <bean id="accessSortedList" class="ddf.catalog.util.impl.SortedServiceList">
@@ -196,6 +198,12 @@
                     availability="optional">
         <reference-listener bind-method="bindPlugin"
                             unbind-method="unbindPlugin" ref="resourceReaderSortedList"/>
+    </reference-list>
+
+    <reference-list id="preAuthPlugins" interface="ddf.catalog.plugin.PreAuthorizationPlugin"
+                    availability="optional">
+        <reference-listener bind-method="bindPlugin"
+                            unbind-method="unbindPlugin" ref="preAuthSortedList"/>
     </reference-list>
 
     <reference-list id="policyPlugins" interface="ddf.catalog.plugin.PolicyPlugin"
@@ -393,6 +401,7 @@
                 <property name="downloadsStatusEventPublisher" ref="retrieveStatusEventPublisher"/>
                 <property name="reliableResourceDownloadManager"
                           ref="reliableResourceDownloadManager"/>
+                <property name="preAuthPlugins" ref="preAuthSortedList"/>
                 <property name="policyPlugins" ref="policySortedList"/>
                 <property name="accessPlugins" ref="accessSortedList"/>
                 <property name="filterBuilder" ref="filterBuilder"/>

--- a/catalog/plugin/catalog-plugin-clientinfo/pom.xml
+++ b/catalog/plugin/catalog-plugin-clientinfo/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.9.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-plugin-clientinfo</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Client Info Setup Plugin</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency/>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-clientinfo/src/main/java/org/codice/ddf/catalog/plugin/clientinfo/ClientInfoSetupPlugin.java
+++ b/catalog/plugin/catalog-plugin-clientinfo/src/main/java/org/codice/ddf/catalog/plugin/clientinfo/ClientInfoSetupPlugin.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.clientinfo;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.apache.shiro.util.ThreadContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.PreAuthorizationPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+
+/**
+ * Injects client-specific information, if any exists for the current thread, into request properties.
+ */
+public class ClientInfoSetupPlugin implements PreAuthorizationPlugin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientInfoSetupPlugin.class);
+
+    private static final String CLIENT_INFO_KEY = "client-info";
+
+    @Override
+    public CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public UpdateRequest processPreUpdate(UpdateRequest input,
+            Map<String, Metacard> existingMetacards) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public DeleteResponse processPostDelete(DeleteResponse input) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public QueryResponse processPostQuery(QueryResponse input) throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public ResourceRequest processPreResource(ResourceRequest input)
+            throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    @Override
+    public ResourceResponse processPostResource(ResourceResponse input, Metacard metacard)
+            throws StopProcessingException {
+        injectClientInfo(input.getProperties());
+        return input;
+    }
+
+    /**
+     * Assuming a client info map was added to the shiro {@link ThreadContext}, we retrieve
+     * the value and put it into the request properties. The corresponding CXF filter in
+     * {@code platform-filter-clientinfo} is responsible for removing the data to prevent leak.
+     *
+     * @param properties the request properties for the catalog framework.
+     */
+    private void injectClientInfo(Map<String, Serializable> properties) {
+        Object clientInfo = ThreadContext.get(CLIENT_INFO_KEY);
+        if (clientInfo == null) {
+            LOGGER.debug("No client info was stored for this thread [{}]",
+                    Thread.currentThread()
+                            .getName());
+        } else {
+            properties.put(CLIENT_INFO_KEY, (Serializable) clientInfo);
+        }
+    }
+}

--- a/catalog/plugin/catalog-plugin-clientinfo/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-clientinfo/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="clientInfoInjectorPlugin"
+          class="org.codice.ddf.catalog.plugin.clientinfo.ClientInfoSetupPlugin"/>
+    <service ref="clientInfoInjectorPlugin" interface="ddf.catalog.plugin.PreAuthorizationPlugin"/>
+</blueprint>

--- a/catalog/plugin/catalog-plugin-clientinfo/src/test/java/org/codice/ddf/catalog/plugin/clientinfo/ClientInfoSetupPluginTest.java
+++ b/catalog/plugin/catalog-plugin-clientinfo/src/test/java/org/codice/ddf/catalog/plugin/clientinfo/ClientInfoSetupPluginTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.clientinfo;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.shiro.util.ThreadContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.Operation;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+
+/**
+ * Ensure that client information is available to the catalog framework.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ClientInfoSetupPluginTest {
+
+    private static final String CLIENT_INFO_KEY = "client-info";
+
+    @Mock
+    private CreateRequest mockCreateRequest;
+
+    @Mock
+    private UpdateRequest mockUpdateRequest;
+
+    @Mock
+    private DeleteRequest mockDeleteRequest;
+
+    @Mock
+    private QueryRequest mockQueryRequest;
+
+    @Mock
+    private ResourceRequest mockResourceRequest;
+
+    @Mock
+    private DeleteResponse mockDeleteResponse;
+
+    @Mock
+    private QueryResponse mockQueryResponse;
+
+    @Mock
+    private ResourceResponse mockResourceResponse;
+
+    @Mock
+    private Map<String, Metacard> mockMetacardMap;
+
+    @Mock
+    private Metacard mockMetacard;
+
+    private Object testableValue;
+
+    private ClientInfoSetupPlugin plugin;
+
+    private Map<String, Serializable> properties;
+
+    @Before
+    public void setup() throws Exception {
+        testableValue = new Serializable() {
+        };
+        ThreadContext.put(CLIENT_INFO_KEY, testableValue);
+        plugin = new ClientInfoSetupPlugin();
+        properties = new HashMap<>();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        ThreadContext.remove(CLIENT_INFO_KEY);
+    }
+
+    @Test
+    public void testNoClientInfoDoesNothing() throws Exception {
+        ThreadContext.remove(CLIENT_INFO_KEY);
+        prepareMockOperation(mockCreateRequest);
+        plugin.processPreCreate(mockCreateRequest);
+        assertThat(properties.get(CLIENT_INFO_KEY), nullValue());
+    }
+
+    @Test
+    public void testPreCreate() throws Exception {
+        prepareMockOperation(mockCreateRequest);
+        plugin.processPreCreate(mockCreateRequest);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPreUpdate() throws Exception {
+        prepareMockOperation(mockUpdateRequest);
+        plugin.processPreUpdate(mockUpdateRequest, mockMetacardMap);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPreDelete() throws Exception {
+        prepareMockOperation(mockDeleteRequest);
+        plugin.processPreDelete(mockDeleteRequest);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPreQuery() throws Exception {
+        prepareMockOperation(mockQueryRequest);
+        plugin.processPreQuery(mockQueryRequest);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPreResource() throws Exception {
+        prepareMockOperation(mockResourceRequest);
+        plugin.processPreResource(mockResourceRequest);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPostDelete() throws Exception {
+        prepareMockOperation(mockDeleteResponse);
+        plugin.processPostDelete(mockDeleteResponse);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPostQuery() throws Exception {
+        prepareMockOperation(mockQueryResponse);
+        plugin.processPostQuery(mockQueryResponse);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    @Test
+    public void testPostResource() throws Exception {
+        prepareMockOperation(mockResourceResponse);
+        plugin.processPostResource(mockResourceResponse, mockMetacard);
+        assertThat(properties.get(CLIENT_INFO_KEY), is(testableValue));
+    }
+
+    private void prepareMockOperation(Operation request) throws Exception {
+        when(request.getProperties()).thenReturn(properties);
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -31,5 +31,6 @@
         <module>catalog-plugin-videothumbnail</module>
         <module>catalog-plugin-versioning</module>
         <module>catalog-plugin-content-uri</module>
+        <module>catalog-plugin-clientinfo</module>
     </modules>
 </project>

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -270,6 +270,11 @@
             <artifactId>security-interceptor-logger</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-filter-clientinfo</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in used in platform-app's features.xml

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -1013,6 +1013,12 @@
         <feature>banana</feature>
     </feature>
 
+    <feature name="clientinfo-filter" install="auto" version="${project.version}"
+             description="Servlet filter to extract client information from the request">
+        <feature prerequisite="true">security-core-api</feature>
+        <bundle>mvn:ddf.platform/platform-filter-clientinfo/${project.version}</bundle>
+    </feature>
+
     <feature name="platform-security-session" install="manual" version="${project.version}"
              description="Custom Session Manager">
         <feature>pax-jetty</feature>

--- a/platform/platform-filter-clientinfo/pom.xml
+++ b/platform/platform-filter-clientinfo/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>platform</artifactId>
+        <groupId>ddf.platform</groupId>
+        <version>2.9.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>platform-filter-clientinfo</artifactId>
+    <name>DDF :: Platform :: Client Info Filter</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency/>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.91</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.56</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.83</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/platform/platform-filter-clientinfo/src/main/java/org/codice/ddf/platform/filter/clientinfo/constants/ClientInfoKeys.java
+++ b/platform/platform-filter-clientinfo/src/main/java/org/codice/ddf/platform/filter/clientinfo/constants/ClientInfoKeys.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.filter.clientinfo.constants;
+
+/**
+ * Constants for working with the client info map.
+ *
+ * The information currently all comes from the servlet API; specifically a select few getters
+ * within {@link javax.servlet.ServletRequest}. The format of the keys follows the format of java
+ * beans. The keys are camel-cased names without the preceeding 'get' found in the method name.
+ *
+ * For example, the key associated with {@link javax.servlet.ServletRequest#getRemoteAddr()} would
+ * be the string {@code remoteAddr}.
+ *
+ * The only exception to this rule, {@link ClientInfoKeys#CLIENT_INFO_KEY}, which holds a value string
+ * of {@code client-info}, is the key used to access the entire client information map. It may contain
+ * different kinds of data that does not necessarily correlate to the servlet API.
+ */
+public class ClientInfoKeys {
+    public static final String CLIENT_INFO_KEY = "client-info";
+
+    public static final String SERVLET_REMOTE_ADDR = "remoteAddr";
+
+    public static final String SERVLET_REMOTE_HOST = "remoteHost";
+
+    public static final String SERVLET_SCHEME = "scheme";
+
+    public static final String SERVLET_CONTEXT_PATH = "contextPath";
+}

--- a/platform/platform-filter-clientinfo/src/main/java/org/codice/ddf/platform/filter/clientinfo/impl/ClientInfoFilter.java
+++ b/platform/platform-filter-clientinfo/src/main/java/org/codice/ddf/platform/filter/clientinfo/impl/ClientInfoFilter.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.filter.clientinfo.impl;
+
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.CLIENT_INFO_KEY;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_CONTEXT_PATH;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_REMOTE_ADDR;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_REMOTE_HOST;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_SCHEME;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.shiro.util.ThreadContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This servlet filter extracts client-specific information and places it in the shiro {@link ThreadContext}
+ * so it can be forwarded to useful areas of interest.
+ */
+public class ClientInfoFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientInfoFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain filterChain) throws IOException, ServletException {
+        ThreadContext.put(CLIENT_INFO_KEY, createClientInfoMap(servletRequest));
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            ThreadContext.remove(CLIENT_INFO_KEY);
+        }
+    }
+
+    private Map<String, String> createClientInfoMap(ServletRequest request) {
+        Map<String, String> clientInfoMap = new HashMap<>();
+        clientInfoMap.put(SERVLET_REMOTE_ADDR, request.getRemoteAddr());
+        clientInfoMap.put(SERVLET_REMOTE_HOST, request.getRemoteHost());
+        clientInfoMap.put(SERVLET_SCHEME, request.getScheme());
+        clientInfoMap.put(SERVLET_CONTEXT_PATH,
+                request.getServletContext()
+                        .getContextPath());
+        LOGGER.debug("Creating client info map with the following pairs, {}",
+                clientInfoMap.toString());
+        return clientInfoMap;
+    }
+}

--- a/platform/platform-filter-clientinfo/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-filter-clientinfo/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="clientInfoFilter"
+          class="org.codice.ddf.platform.filter.clientinfo.impl.ClientInfoFilter"/>
+    <service ref="clientInfoFilter" interface="javax.servlet.Filter">
+        <service-properties>
+            <entry key="filter-name" value="clientinfo-filter"/>
+            <entry key="urlPatterns" value="/*"/>
+        </service-properties>
+    </service>
+</blueprint>

--- a/platform/platform-filter-clientinfo/src/test/java/org/codice/ddf/platform/filter/clientinfo/impl/ClientInfoFilterTest.java
+++ b/platform/platform-filter-clientinfo/src/test/java/org/codice/ddf/platform/filter/clientinfo/impl/ClientInfoFilterTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.filter.clientinfo.impl;
+
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.CLIENT_INFO_KEY;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_CONTEXT_PATH;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_REMOTE_ADDR;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_REMOTE_HOST;
+import static org.codice.ddf.platform.filter.clientinfo.constants.ClientInfoKeys.SERVLET_SCHEME;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.shiro.util.ThreadContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Ensure our client info properties get set during the life time of the filter, and are
+ * cleaned up after the fact.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ClientInfoFilterTest {
+    private static final String MOCK_REMOTE_ADDRESS = "0.0.0.0";
+
+    private static final String MOCK_REMOTE_HOST = "localhost";
+
+    private static final String MOCK_SCHEME = "http";
+
+    private static final String MOCK_CONTEXT_PATH = "/example/path";
+
+    @Mock
+    private ServletContext mockServletContext;
+
+    @Mock
+    private ServletRequest mockServletRequest;
+
+    @Mock
+    private ServletResponse mockServletResponse;
+
+    @Mock
+    private FilterChain mockFilterChain;
+
+    private ClientInfoFilter clientInfoFilter;
+
+    @Before
+    public void setup() throws Exception {
+        when(mockServletRequest.getRemoteAddr()).thenReturn(MOCK_REMOTE_ADDRESS);
+        when(mockServletRequest.getRemoteHost()).thenReturn(MOCK_REMOTE_HOST);
+        when(mockServletRequest.getScheme()).thenReturn(MOCK_SCHEME);
+        when(mockServletRequest.getServletContext()).thenReturn(mockServletContext);
+        when(mockServletContext.getContextPath()).thenReturn(MOCK_CONTEXT_PATH);
+
+        clientInfoFilter = new ClientInfoFilter();
+    }
+
+    @Test
+    public void testClientInfoPresentInMap() throws Exception {
+        doAnswer(invocationOnMock -> assertThatMapIsAccurate()).when(mockFilterChain)
+                .doFilter(mockServletRequest, mockServletResponse);
+        clientInfoFilter.doFilter(mockServletRequest, mockServletResponse, mockFilterChain);
+        assertThatMapIsNull();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testClientInfoCleansUpOnException() throws Exception {
+        doThrow(RuntimeException.class).when(mockFilterChain)
+                .doFilter(mockServletRequest, mockServletResponse);
+        try {
+            clientInfoFilter.doFilter(mockServletRequest, mockServletResponse, mockFilterChain);
+        } finally {
+            assertThatMapIsNull();
+        }
+    }
+
+    private Object assertThatMapIsAccurate() throws Exception {
+        Map<String, String> clientInfoMap =
+                (Map<String, String>) ThreadContext.get(CLIENT_INFO_KEY);
+        assertThat(clientInfoMap, notNullValue());
+        assertThat(clientInfoMap.get(SERVLET_REMOTE_ADDR), is(MOCK_REMOTE_ADDRESS));
+        assertThat(clientInfoMap.get(SERVLET_REMOTE_HOST), is(MOCK_REMOTE_HOST));
+        assertThat(clientInfoMap.get(SERVLET_SCHEME), is(MOCK_SCHEME));
+        assertThat(clientInfoMap.get(SERVLET_CONTEXT_PATH), is(MOCK_CONTEXT_PATH));
+        return null;
+    }
+
+    private void assertThatMapIsNull() throws Exception {
+        Map<String, String> clientInfoMap =
+                (Map<String, String>) ThreadContext.get(CLIENT_INFO_KEY);
+        assertThat(clientInfoMap, nullValue());
+    }
+}

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -372,5 +372,6 @@
         <module>admin</module>
         <module>landing-page</module>
         <module>platform-app</module>
+        <module>platform-filter-clientinfo</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
* Adds a servlet filter for extraction information from the servlet API and placing it into the `ThreadContext` provided by Shiro. 
* Adds a `PreAuthorizationPlugin` extension point and implementation for placing the servlet info into catalog framework request/response properties. 

See PR #1318 for more information. This is the backport for DDF-2500. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@coyotesqrl 
@lessarderic 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison

#### How should this be tested?
Full build. 
