### PR TITLE
DDF-2538: Properly escapes strings in the metacard.handlebars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,7 @@ replace with next unreleased version
 - [DDF-2150](https://codice.atlassian.net/browse/DDF-2150) Windows attribute .cfg files do not get parsed properly in AbstractExpansion
 - [DDF-2090](https://codice.atlassian.net/browse/DDF-2090) GeoJSON input transformer doesn't handle multiple values correctly
 - [DDF-2339](https://codice.atlassian.net/browse/DDF-2339) Fix typo in CSW Metatype Metacard Mappings
+- [DDF-2538](https://codice.atlassian.net/browse/DDF-2538) Updated metacard.handlebars template to properly escape strings
 	- [Jira view of all issues resolved](https://codice.atlassian.net/issues/?jql=project%3DDDF%20AND%20type%20%3D%20Bug%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20%3D%20ddf-2.10.0%20ORDER%20BY%20resolutiondate)
 	in this version.
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/templates/metacard.handlebars
+++ b/catalog/ui/search-ui/standard/src/main/webapp/templates/metacard.handlebars
@@ -147,17 +147,17 @@
                                         <td>
                                             {{#each this}}
                                                 {{#isUrl this}}
-                                                    <a target='_blank' href='{{safeString this}}'>{{safeString this}}</a>
+                                                    <a target='_blank' href='{{this}}'>{{this}}</a>
                                                 {{/isUrl}}
                                             {{/each}}
                                         </td>
                                     {{else}}
                                         {{#isUrl this}}
                                             <td>
-                                                <a target='_blank' title="{{propertyTitle @key}}" href='{{safeString this}}'>{{safeString this}}</a>
+                                                <a target='_blank' title="{{propertyTitle @key}}" href='{{this}}'>{{this}}</a>
                                             </td>
                                         {{else}}
-                                            <td>{{safeString this}}</td>
+                                            <td>{{this}}</td>
                                         {{/isUrl}}
                                      {{/is}}
                                 {{/is}}
@@ -179,7 +179,7 @@
                         <tr>
                             <td>Content Type</td>
                             <td>
-                                {{safeString mappedType}}
+                                {{mappedType}}
                             </td>
                         </tr>
                     {{/if}}


### PR DESCRIPTION
#### What does this PR do?
Some fields in the Search UI weren't correctly escaping some characters. This PR updates the metacard.handlebars template to properly escape the strings. 

I'll be adding some test coverage to this, however, just wanted to get a preliminary review up to see if this seems like the correct solution. If you know of anywhere else where we are using `safeString` in our templates, please let me know. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@garrettfreibott @andrewkfiedler @djblue @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested?
[xss-check-metacard.txt](https://github.com/codice/ddf/files/527626/xss-check-metacard.txt)
Change this file to a `.xml` file and then ingest. 
Execute a search and make sure the search UI has escaped the metacard contents. 
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2538
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

