### PR TITLE
DDF-2515 Deduplicates command argument alias.

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CqlCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CqlCommands.java
@@ -66,7 +66,7 @@ public abstract class CqlCommands extends CatalogCommands {
     String cqlFilter = null;
 
     @Option(name = "--temporal", required = false, aliases = {
-            "-t"}, multiValued = false, description =
+            "-dt"}, multiValued = false, description =
             "Option to use temporal criteria to filter. The default is to use \"keyword like "
                     + WILDCARD + " \".")
     boolean isUseTemporal = false;

--- a/distribution/docs/src/main/resources/_contents/running-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/running-contents.adoc
@@ -372,7 +372,7 @@ OPTIONS
         --searchPhrase, -phrase, -like
                 Option to filter by a specific phrase. NOTE: Does not apply to CQL filters. Does not stack with other --lastXXXX options. --lastXXXX options take precedence over this option.
                 (defaults to *)
-        --temporal, -t
+        --temporal, -dt
                 Option to use temporal criteria to filter. The default is to use "keyword like * ".
         --endDate, -end
                 Flag to specify a start date range to by which to filter. Dates should be formatted as MM-dd-yyyy such as 06-10-2014.


### PR DESCRIPTION
#### What does this PR do?
During a refactor and extension of functionality, the `DumpCommand` was made to extend a new `CqlCommands` base class, giving it additional query flexibility. That change duplicated the `-t` alias for a command argument. This changes the alias for the `--temporal` argument to be `-dt` so it will not conflict with the `--transformer` alias.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Docs](https://github.com/orgs/codice/teams/docs)
[UI](https://github.com/orgs/codice/teams/ui)
[Security](https://github.com/orgs/codice/teams/security)
[Continuous Integration](https://github.com/orgs/codice/teams/continuous-integration)
[Solr](https://github.com/orgs/codice/teams/solr)
[IO](https://github.com/orgs/codice/teams/IO)
[OGC](https://github.com/orgs/codice/teams/OGC)
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
Full build and test run. Then install DDF and ensure that the `catalog:dump` command correctly interprets the `-t` alias for `--transformer`.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
DDF-2515

[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
N/A

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests