### PR TITLE
DDF-2545 Removes itest start/stop of catalog-plugin-metacard-validation feature

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -799,18 +799,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 .all().assertThat().body(assertion[0], assertion);
         // @formatter:on
 
-        // Start metacard validation plugin; this will add on [validation-warnings = null] AND [validation-errors = null]
-        // filter to query
-        getServiceManager().startFeature(true, "catalog-plugin-metacard-validation");
-
         // Assert that response is the same as without the plugin
         // @formatter:off
         given().contentType(ContentType.XML).body(query).when().post(CSW_PATH.getUrl()).then().log()
                 .all().assertThat().body(assertion[0], assertion);
         // @formatter:on
-
-        // Turn off plugin to not interfere with other tests
-        getServiceManager().stopFeature(true, "catalog-plugin-metacard-validation");
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Attempts to shut down this feature appear to be thwarted by the karaf dependency graph; as it is turned on by default, it should be left turned on for all itests to ensure there are no conflicts caused by it.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@jrnorth @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Docs](https://github.com/orgs/codice/teams/docs)
[UI](https://github.com/orgs/codice/teams/ui)
[Security](https://github.com/orgs/codice/teams/security)
[Continuous Integration](https://github.com/orgs/codice/teams/continuous-integration)
[Solr](https://github.com/orgs/codice/teams/solr)
[IO](https://github.com/orgs/codice/teams/IO)
[OGC](https://github.com/orgs/codice/teams/OGC)
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Full build/itest run is sufficient; this is only an itest change.

#### Any background context you want to provide?
Recently, the `TestFederation` itest class has been taking a very long time - ~16 minutes - to run. This has been caused by a ten-minute delay attempting to stop this feature that should not be stopped.

#### What are the relevant tickets?
DDF-2545
[](https://codice.atlassian.net/browse/)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
