### PR TITLE
DDF-2546 Added date to announcement tooltip on landing page configura…

### DIFF
--- a/platform/landing-page/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/landing-page/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -36,7 +36,7 @@
                 default=""
                 />
         <AD
-                description="Announcements that will be displayed on the landing page."
+                description="Announcements that will be displayed on the landing page. You can prefix the announcement with a date in the form mm/dd/yy."
                 name="Announcements" id="announcements" required="true" type="String"
                 cardinality="100"
                 />


### PR DESCRIPTION
#### What does this PR do?
Adds a description of how to add a date to the tooltip of the configuration page for announcements on the landing page.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann @emanns95 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
No testing required.
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2546)
#### Screenshots (if appropriate)
![screen shot 2016-10-19 at 12 26 22 pm](https://cloud.githubusercontent.com/assets/9749143/19534281/032159c0-95f8-11e6-9ebd-6af57a809875.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests