### PR TITLE
DDF-2549: DDF projects should reference project.version for mvn release plugin

### DIFF
--- a/catalog/admin/admin-poller-service/pom.xml
+++ b/catalog/admin/admin-poller-service/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>ddf.lib</groupId>
             <artifactId>spock-shaded</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/spatial/geocoding/spatial-geocoding-localsearch/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-localsearch/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>geospatial</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/spatial/geocoding/spatial-geocoding-plugin/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-plugin/pom.xml
@@ -27,17 +27,17 @@
         <dependency>
             <groupId>org.codice.ddf.spatial</groupId>
             <artifactId>spatial-geocoding-geocoder</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>geospatial</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -23,6 +23,7 @@
     <name>DDF DOCS</name>
     <properties>
         <skipTests>true</skipTests>
+        <ddf.version>${project.version}</ddf.version>
     </properties>
     <build>
         <plugins>

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>ddf.test.thirdparty</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>${ddf.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
         <ddf-branding>DDF</ddf-branding>
         <ddf-branding-lowercase>ddf</ddf-branding-lowercase>
         <ddf-branding-expanded>Distributed Data Framework</ddf-branding-expanded>
-        <ddf.version>${project.version}</ddf.version>
         <!--default url substitutions-->
         <public_url>http://localhost:8181</public_url>
         <secure_url>https://localhost:8993</secure_url>


### PR DESCRIPTION
#### What does this PR do?
Updates ddf.version to project.version for DDF modules in order for the mvn release plugin to run correctly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@peterhuffer 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@oconnormi 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Run:
mvn release:prepare
Once you choose a version number for the release and the pom files are updated the release will start building. Previously it would fail while updating pom files.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2549

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests