### PR TITLE
DDF-2553 fixed example maven property in docs

### DIFF
--- a/distribution/docs/src/main/resources/_contents/extending-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/extending-contents.adoc
@@ -727,16 +727,16 @@ All bundles are then packaged into the KAR archive.
 	            same feature twice.
 	            Refer to Karaf forum posting at http://karaf.922171.n3.nabble.com/Duplicate-feature-repository-entry-using-archive-kar-to-build-deployable-applications-td3650850.html
 	            -->
-	            <resourcesDir>${project.build.directory}/doesNotExist</resourcesDir>
+	            <resourcesDir>${variable-prefix}project.build.directory}/doesNotExist</resourcesDir>
 
 	            <!--
-	            Location of the features.xml file. If it references properties that need to be filtered, e.g., ${project.version}, it will need to be
+	            Location of the features.xml file. If it references properties that need to be filtered, e.g., ${variable-prefix}project.version}, it will need to be
 	            filtered by the maven-resources-plugin.
 	            -->
-	            <featuresFile>${basedir}/target/classes/features.xml</featuresFile>
+	            <featuresFile>${variable-prefix}basedir}/target/classes/features.xml</featuresFile>
 
-	            <!-- Name of the kar file (.kar extension added by default). If not specified, defaults to ${project.build.finalName} -->
-	            <finalName>${ddf-branding-lowercase}-ifis-${project.version}</finalName>
+	            <!-- Name of the kar file (.kar extension added by default). If not specified, defaults to ${variable-prefix}project.build.finalName} -->
+	            <finalName>${branding-lowercase}-ifis-${project.version}</finalName>
 	        </configuration>
 	    </execution>
     </executions>


### PR DESCRIPTION
#### What does this PR do?

fixes maven property in example pom file that should not resolve to a local path. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@coyotesqrl @kcwire @shaundmorris 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@kcwire
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

`Creating a KAR file` section of Extending documentation should have `${project.build.directory} instead of local users home directory.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2553](https://codice.atlassian.net/browse/DDF-2553)

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

