### PR TITLE
DDF-2556: Corrected caching logic to clone metacards on cache ingest

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
@@ -26,10 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.slf4j.Logger;
@@ -166,15 +163,13 @@ public class MetacardImpl implements Metacard {
             setSourceId(metacard.getSourceId());
         }
 
-        map = metacard.getMetacardType()
-                .getAttributeDescriptors()
-                .stream()
-                .filter(Objects::nonNull)
-                .filter(attributeDescriptor -> attributeDescriptor.getName() != null)
-                .filter(attributeDescriptor -> metacard.getAttribute(attributeDescriptor.getName())
-                        != null)
-                .map(AttributeDescriptor::getName)
-                .collect(Collectors.toConcurrentMap(Function.identity(), metacard::getAttribute));
+        map = new HashMap<>();
+        for (AttributeDescriptor attribute : metacard.getMetacardType()
+                .getAttributeDescriptors()) {
+            if(attribute != null && attribute.getName() != null) {
+                map.put(attribute.getName(), metacard.getAttribute(attribute.getName()));
+            }
+        }
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
@@ -174,7 +174,7 @@ public class MetacardImpl implements Metacard {
                 .filter(attributeDescriptor -> metacard.getAttribute(attributeDescriptor.getName())
                         != null)
                 .map(AttributeDescriptor::getName)
-                .collect(Collectors.toMap(Function.identity(), metacard::getAttribute));
+                .collect(Collectors.toConcurrentMap(Function.identity(), metacard::getAttribute));
     }
 
     @Override

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/ResultImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/ResultImpl.java
@@ -42,6 +42,21 @@ public class ResultImpl implements Result {
     }
 
     /**
+     * This constructor creates a clone of the provided result
+     *
+     * @param result
+     */
+    public ResultImpl(final Result result) {
+        if (result.getMetacard() != null) {
+            this.metacard = new MetacardImpl(result.getMetacard(),
+                    result.getMetacard()
+                            .getMetacardType());
+        }
+        this.distance = result.getDistanceInMeters();
+        this.relevance = result.getRelevanceScore();
+    }
+
+    /**
      * Instantiates a new metacard result.
      *
      * @param metacard
@@ -51,10 +66,9 @@ public class ResultImpl implements Result {
         this.metacard = metacard;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see ddf.catalog.Result#getDistanceInMeters()
+    /**
+     * @return distance in meters
+     * @see ddf.catalog.data.Result#getDistanceInMeters()
      */
     @Override
     public Double getDistanceInMeters() {
@@ -64,7 +78,7 @@ public class ResultImpl implements Result {
     /**
      * Sets the distance in meters.
      *
-     * @param distance
+     * @param inDistance
      *            the new distance in meters
      */
     public void setDistanceInMeters(Double inDistance) {
@@ -82,7 +96,7 @@ public class ResultImpl implements Result {
     /**
      * Sets the relevance score.
      *
-     * @param relevance
+     * @param inRelevance
      *            the new relevance score
      */
     public void setRelevanceScore(Double inRelevance) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
@@ -29,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.codice.ddf.configuration.PropertyResolver;
 import org.codice.ddf.configuration.SystemInfo;
@@ -41,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import ddf.catalog.Constants;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteResponse;
@@ -553,7 +556,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
                         @Override
                         public void run() {
                             try {
-                                cacheBulkProcessor.add(sourceResponse.getResults());
+                                cacheBulkProcessor.add(copyResults(sourceResponse.getResults()));
                             } catch (Throwable throwable) {
                                 LOGGER.warn("Unable to add results for bulk processing", throwable);
                             }
@@ -564,6 +567,14 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
             return sourceResponse;
         }
+    }
+
+    private List<Result> copyResults(final List<Result> inResults) {
+
+        return inResults.stream()
+                .filter(Objects::nonNull)
+                .map(ResultImpl::new)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/catalog/transformer/catalog-transformer-geojson-queryresponse/src/test/java/ddf/catalog/transformer/queryresponse/geojson/TestGeoJsonQueryResponseTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-queryresponse/src/test/java/ddf/catalog/transformer/queryresponse/geojson/TestGeoJsonQueryResponseTransformer.java
@@ -102,7 +102,7 @@ public class TestGeoJsonQueryResponseTransformer {
     public void testNullMetacard() throws CatalogTransformerException {
 
         List<Result> results = new LinkedList<Result>();
-        Result result = new ResultImpl(null);
+        Result result = new ResultImpl((Metacard)null);
 
         results.add(result);
 

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
@@ -15,6 +15,7 @@ package ddf.catalog.transformer.xml.adapter;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -188,11 +189,11 @@ public class AdaptedMetacard implements Metacard {
         if (Metacard.ID.equals(name)) {
             return this.id;
         }
-        for (Attribute attribute : attributes) {
-            if (attribute == null || StringUtils.isEmpty(attribute.getName())) {
-                continue;
-            } else if (name.equals(attribute.getName())) {
-                return attribute;
+        for (Attribute attribute : Collections.unmodifiableList(attributes)) {
+            if (attribute != null && !StringUtils.isEmpty(attribute.getName())) {
+                if (name.equals(attribute.getName())) {
+                    return attribute;
+                }
             }
         }
         return null;

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
@@ -15,7 +15,7 @@ package ddf.catalog.transformer.xml.adapter;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -189,7 +189,7 @@ public class AdaptedMetacard implements Metacard {
         if (Metacard.ID.equals(name)) {
             return this.id;
         }
-        for (Attribute attribute : Collections.unmodifiableList(attributes)) {
+        for (Attribute attribute : Arrays.asList((attributes.toArray(new Attribute[attributes.size()])))) {
             if (attribute != null && !StringUtils.isEmpty(attribute.getName())) {
                 if (name.equals(attribute.getName())) {
                     return attribute;

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
@@ -189,7 +189,7 @@ public class AdaptedMetacard implements Metacard {
         if (Metacard.ID.equals(name)) {
             return this.id;
         }
-        for (Attribute attribute : Arrays.asList((attributes.toArray(new Attribute[attributes.size()])))) {
+        for (Attribute attribute : Arrays.asList((attributes.toArray(new Attribute[0])))) {
             if (attribute != null && !StringUtils.isEmpty(attribute.getName())) {
                 if (name.equals(attribute.getName())) {
                     return attribute;


### PR DESCRIPTION
#### What does this PR do?
- Added defensive copy of metacards on CacheBulkProcessor.add()
- Added .equals() to MetacardImpl and fixed .hashCode()
- Updated MetacardImpl to use ConcurrentHashMap
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining @rzwiefel @lcrosenbu @kcwire 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Solr](https://github.com/orgs/codice/teams/solr)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)

Full clean build - verify unit and integration tests pass.

The issue was originally triggered with the Catalog UI.  
- Add the Catalog UI app
- add a federated source (CSW loopback for example)
- ingest some data
- perform a federated search from the Catalog UI.  
- Verify no caching exceptions in the log. 
- Verify the cache is populated (search --cache *)
#### Any background context you want to provide?
#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2556
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
