### PR TITLE
[2.9.X] DDF-2555: Changed password field in CSW Federation Profile Source con…

### DIFF
--- a/catalog/spatial/csw/spatial-csw-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,7 +34,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -133,7 +133,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
     </OCD>
 
     <OCD name="GMD CSW ISO Federated Source" id="Gmd_Csw_Federated_Source"


### PR DESCRIPTION
#### What does this PR do?
Changed the type of the password field to be "Password" in the configuration page of CSW Federation Profile Source. This will mask the characters typed into the field.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @bdeining @emmberk

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Docs](https://github.com/orgs/codice/teams/docs)
[UI](https://github.com/orgs/codice/teams/ui)
[Security](https://github.com/orgs/codice/teams/security)
[Continuous Integration](https://github.com/orgs/codice/teams/continuous-integration)
[Solr](https://github.com/orgs/codice/teams/solr)
[IO](https://github.com/orgs/codice/teams/IO)
[OGC](https://github.com/orgs/codice/teams/OGC)
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
* Run a `mvn clean install` on an empty .m2 repo.
* Test that the field masks characters.
 * Run DDF locally.
 * Go to `DDF Catalog` in the Admin Console.
 * Add a new Source under the `Sources` tab.
 * Go to `CSW Federation Profile Source`.
 * Type in the `Password` field and verify characters are masked.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2555](https://codice.atlassian.net/browse/DDF-2555)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…fig to have "Password" type.

- This will mask any characters typed into this field.