### PR TITLE
DDF-2547 Updated URLResourceReader to use basic auth username/password if present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ replace with next unreleased version
 
 ### BUG FIXES
 
+- [DDF-2547](https://codice.atlassian.net/browse/DDF-2547) Product download fails when using basic auth on a source connected to a non DDF endpoint
 - [DDF-2557](https://codice.atlassian.net/browse/DDF-2557) CSW (and possibly other sources) fail to resolve the default URIs
 - [DDF-2224](https://codice.atlassian.net/browse/DDF-2224) DDF does not work in offline mode
 - [DDF-2506](https://codice.atlassian.net/browse/DDF-2506) Sorting by distance can take minutes on large indexes

--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -84,6 +84,10 @@ public class URLResourceReader implements ResourceReader {
 
     private static final String BYTES_TO_SKIP = "BytesToSkip";
 
+    private static final String USERNAME = "username";
+
+    private static final String PASSWORD = "password";
+
     private static final Set<String> QUALIFIER_SET = ImmutableSet.of(URL_HTTP_SCHEME,
             URL_HTTPS_SCHEME,
             URL_FILE_SCHEME);
@@ -332,7 +336,7 @@ public class URLResourceReader implements ResourceReader {
         try {
             LOGGER.debug("Opening connection to: {}", resourceURI.toString());
 
-            WebClient client = getWebClient(resourceURI.toString());
+            WebClient client = getWebClient(resourceURI.toString(), properties);
 
             Object subjectObj = properties.get(SecurityConstants.SECURITY_SUBJECT);
             if (subjectObj != null) {
@@ -548,8 +552,17 @@ public class URLResourceReader implements ResourceReader {
         return false;
     }
 
-    protected WebClient getWebClient(String uri) {
-        WebClient client = WebClient.create(uri);
+    protected WebClient getWebClient(String uri, Map<String, Serializable> properties) {
+        WebClient client;
+        if (properties.get(USERNAME) != null && properties.get(PASSWORD) != null) {
+            client = WebClient.create(uri,
+                    (String) properties.get(USERNAME),
+                    (String) properties.get(PASSWORD),
+                    null);
+        } else {
+            client = WebClient.create(uri);
+        }
+
         WebClient.getConfig(client).getHttpConduit().getClient()
                 .setAutoRedirect(getFollowRedirects());
         return client;

--- a/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,7 +30,7 @@
         </set>
       </property>
   </bean>
-  
+
   <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>
 
   <service ref="urlReader" interface="ddf.catalog.resource.ResourceReader">
@@ -39,5 +39,5 @@
       <entry key="id" value="URLResourceReader"/>
     </service-properties>
   </service>
-  
+
 </blueprint>

--- a/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/ResourceReaderTest.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/ResourceReaderTest.java
@@ -693,18 +693,18 @@ public class ResourceReaderTest {
     public void testSetRedirect() throws Exception {
         URLResourceReader resourceReader = new URLResourceReader(mimeTypeMapper);
         WebClient client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
-                + JPEG_FILE_NAME_1);
+                + JPEG_FILE_NAME_1, new HashMap<>());
         assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
 
         resourceReader.setFollowRedirects(true);
         client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
-                + JPEG_FILE_NAME_1);
+                + JPEG_FILE_NAME_1, new HashMap<>());
         assertTrue(WebClient.getConfig(client).getHttpConduit().getClient()
                 .isAutoRedirect());
 
         resourceReader.setFollowRedirects(false);
         client = resourceReader.getWebClient(HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH
-                + JPEG_FILE_NAME_1);
+                + JPEG_FILE_NAME_1, new HashMap<>());
         assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
     }
 
@@ -801,7 +801,7 @@ public class ResourceReaderTest {
         }
 
         @Override
-        protected WebClient getWebClient(String uri) {
+        protected WebClient getWebClient(String uri, Map<String, Serializable> properties) {
             return mockWebClient;
         }
     }

--- a/catalog/spatial/ogc/spatial-ogc-urlresourcereader/src/test/java/org/codice/ddf/spatial/ogc/catalog/resource/impl/TestResourceReader.java
+++ b/catalog/spatial/ogc/spatial-ogc-urlresourcereader/src/test/java/org/codice/ddf/spatial/ogc/catalog/resource/impl/TestResourceReader.java
@@ -91,7 +91,7 @@ public class TestResourceReader {
 
         URLResourceReader urlResourceReader = new URLResourceReader(null) {
             @Override
-            protected WebClient getWebClient(String uri) {
+            protected WebClient getWebClient(String uri, Map<String, Serializable> properties) {
                 return mockWebClient;
             }
         };


### PR DESCRIPTION
#### What does this PR do?

Updates the URLResourceReader so it will use basic auth if username/password is present.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@gordocanchola @brianfelix
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Security](https://github.com/orgs/codice/teams/security)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@shaundmorris
@stustison
#### How should this be tested? (List steps with links to updated documentation)

Verify build passes
#### Any background context you want to provide?

This is a port from the 2.9.x branch https://github.com/codice/ddf/pull/1363
#### What are the relevant tickets?

DDF-2547
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
