### PR TITLE
(2.9.x) DDF-2273 Added catch for DataUsageLimitExceededException in REST endpoint

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -93,6 +93,7 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.resource.DataUsageLimitExceededException;
 import ddf.catalog.resource.Resource;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.InternalIngestException;
@@ -553,12 +554,14 @@ public class RESTEndpoint implements RESTService {
                         "Specified query is unsupported.  Change query and resubmit: ";
                 LOGGER.warn(exceptionMessage, e);
                 throw new ServerErrorException(exceptionMessage, Status.BAD_REQUEST);
-                // The catalog framework will throw this if any of the transformers blow up. We need to
-
-                // catch this exception
-                // here or else execution will return to CXF and we'll lose this message and end up with
-                // a huge stack trace
-                // in a GUI or whatever else is connected to this endpoint
+            } catch (DataUsageLimitExceededException e) {
+                String exceptionMessage = "Unable to process request. Data usage limit exceeded: ";
+                LOGGER.warn(exceptionMessage, e);
+                throw new ServerErrorException(exceptionMessage, Status.REQUEST_ENTITY_TOO_LARGE);
+                // The catalog framework will throw this if any of the transformers blow up.
+                // We need to catch this exception here or else execution will return to CXF and
+                // we'll lose this message and end up with a huge stack trace in a GUI or whatever
+                // else is connected to this endpoint
             } catch (RuntimeException | UnsupportedEncodingException e) {
                 String exceptionMessage = "Unknown error occurred while processing request: ";
                 LOGGER.warn(exceptionMessage, e);

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -556,7 +556,7 @@ public class RESTEndpoint implements RESTService {
                 throw new ServerErrorException(exceptionMessage, Status.BAD_REQUEST);
             } catch (DataUsageLimitExceededException e) {
                 String exceptionMessage = "Unable to process request. Data usage limit exceeded: ";
-                LOGGER.warn(exceptionMessage, e);
+                LOGGER.debug(exceptionMessage, e);
                 throw new ServerErrorException(exceptionMessage, Status.REQUEST_ENTITY_TOO_LARGE);
                 // The catalog framework will throw this if any of the transformers blow up.
                 // We need to catch this exception here or else execution will return to CXF and


### PR DESCRIPTION
#### What does this PR do?

This PR adds a catch for DataUsageLimitExceededException so a client knows why their download failed.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@lcrosenbu @jrnorth   
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
@lessarderic 
#### How should this be tested?

Build DDF Development, Ingest a resource, Download the resource, Set the Usage Limit for the current user to a small number, Attempt to Download again and observe the error message.
#### Any background context you want to provide?
#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2273
#### Screenshots (if appropriate)

https://codice.atlassian.net/browse/DDF-2273
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
