### PR TITLE
DDF-2567: Added binary type support to persistence store

### DIFF
--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
@@ -89,7 +89,7 @@ public class PersistentItem extends HashMap<String, Object> {
         addProperty(name, DATE_SUFFIX, value);
     }
 
-    public void addProperty(String name, byte[] value) {
+    public void addBinaryProperty(String name, String value) {
         addProperty(name, BINARY_SUFFIX, value);
     }
 
@@ -127,8 +127,8 @@ public class PersistentItem extends HashMap<String, Object> {
         return (Date) getProperty(name + DATE_SUFFIX);
     }
 
-    public byte[] getBinaryProperty(String name) {
-        return (byte[]) getProperty(name + BINARY_SUFFIX);
+    public String getBinaryProperty(String name) {
+        return (String) getProperty(name + BINARY_SUFFIX);
     }
 
     public Set<String> getTextSetProperty(String name) {

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
@@ -89,7 +89,7 @@ public class PersistentItem extends HashMap<String, Object> {
         addProperty(name, DATE_SUFFIX, value);
     }
 
-    public void addBinaryProperty(String name, String value) {
+    public void addProperty(String name, byte[] value) {
         addProperty(name, BINARY_SUFFIX, value);
     }
 

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentItem.java
@@ -35,8 +35,11 @@ public class PersistentItem extends HashMap<String, Object> {
 
     public static final String DATE_SUFFIX = "_tdt";
 
+    public static final String BINARY_SUFFIX = "_bin";
+
     private static final String[] SUFFIXES =
-            new String[] {TEXT_SUFFIX, XML_SUFFIX, INT_SUFFIX, LONG_SUFFIX, DATE_SUFFIX};
+            new String[] {TEXT_SUFFIX, XML_SUFFIX, INT_SUFFIX, LONG_SUFFIX, DATE_SUFFIX,
+                    BINARY_SUFFIX};
 
     private static final long serialVersionUID = 6030726429622527480L;
 
@@ -86,6 +89,10 @@ public class PersistentItem extends HashMap<String, Object> {
         addProperty(name, DATE_SUFFIX, value);
     }
 
+    public void addProperty(String name, byte[] value) {
+        addProperty(name, BINARY_SUFFIX, value);
+    }
+
     public void addProperty(String name, String suffix, Object value) {
         if (StringUtils.isNotBlank(name) && StringUtils.isNotBlank(suffix)) {
             if (name.endsWith(suffix)) {
@@ -118,6 +125,10 @@ public class PersistentItem extends HashMap<String, Object> {
 
     public Date getDateProperty(String name) {
         return (Date) getProperty(name + DATE_SUFFIX);
+    }
+
+    public byte[] getBinaryProperty(String name) {
+        return (byte[]) getProperty(name + BINARY_SUFFIX);
     }
 
     public Set<String> getTextSetProperty(String name) {

--- a/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
+++ b/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
@@ -215,7 +215,7 @@ public class PersistentStoreImpl implements PersistentStore {
                     } else if (name.endsWith(PersistentItem.DATE_SUFFIX)) {
                         result.addProperty(name, (Date) doc.getFirstValue(name));
                     } else if (name.endsWith(PersistentItem.BINARY_SUFFIX)) {
-                        result.addProperty(name, (byte[]) doc.getFirstValue(name));
+                        result.addProperty(name, (String) doc.getFirstValue(name));
                     } else {
                         LOGGER.debug("Not adding field {} because it has invalid suffix", name);
                     }

--- a/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
+++ b/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
@@ -215,7 +215,7 @@ public class PersistentStoreImpl implements PersistentStore {
                     } else if (name.endsWith(PersistentItem.DATE_SUFFIX)) {
                         result.addProperty(name, (Date) doc.getFirstValue(name));
                     } else if (name.endsWith(PersistentItem.BINARY_SUFFIX)) {
-                        result.addProperty(name, (String) doc.getFirstValue(name));
+                        result.addProperty(name, (byte[]) doc.getFirstValue(name));
                     } else {
                         LOGGER.debug("Not adding field {} because it has invalid suffix", name);
                     }

--- a/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
+++ b/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
@@ -214,6 +214,8 @@ public class PersistentStoreImpl implements PersistentStore {
                         result.addProperty(name, (Integer) doc.getFirstValue(name));
                     } else if (name.endsWith(PersistentItem.DATE_SUFFIX)) {
                         result.addProperty(name, (Date) doc.getFirstValue(name));
+                    } else if (name.endsWith(PersistentItem.BINARY_SUFFIX)) {
+                        result.addProperty(name, (byte[]) doc.getFirstValue(name));
                     } else {
                         LOGGER.debug("Not adding field {} because it has invalid suffix", name);
                     }


### PR DESCRIPTION
#### What does this PR do?
see title
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

[Solr](https://github.com/orgs/codice/teams/solr)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith @stustison 

#### Any background context you want to provide?
Currently if you wish to store a large blob of data in the persistence store you must use TEXT, which has a hard limit of 32k. This adds support for binary which can be much bigger.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2567

