### PR TITLE
DDF-2566 Add File Extensions to NITF Content Resolver

### DIFF
--- a/platform/platform-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
+++ b/platform/platform-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
@@ -1,4 +1,4 @@
-customMimeTypes=["nitf\=image/nitf","ntf\=image/nitf","nsf\=image/nitf","nsif\=image/nitf"]
+customMimeTypes=["nitf\=image/nitf","ntf\=image/nitf","nsf\=image/nitf","nsif\=image/nitf","r0\=image/nitf","r1\=image/nitf","r2\=image/nitf","r3\=image/nitf","r4\=image/nitf","r5\=image/nitf","r6\=image/nitf","r7\=image/nitf"]
 name="NITF\ Content\ Resolver"
 priority=I"10"
 service.factoryPid="DDF_Custom_Mime_Type_Resolver"


### PR DESCRIPTION
#### What does this PR do?
Adds support to file extensions beyond ".nitf" to ".r0" to ".r7". Enables extracting metadata from such files with such extensions.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@troymohl @bdeining @peterhuffer @emmberk  

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith 

#### How should this be tested? (List steps with links to updated documentation)
1. Run instance of DDF
2. Attempt ingestion of sample .r5 file in search UI
3. If metadata extracted (no error at upload), then it is successful.

#### Screenshots (if appropriate)
![screen shot 2016-10-31 at 3 45 16 pm](https://cloud.githubusercontent.com/assets/6527301/19874376/f0feee2c-9f81-11e6-9189-3bf141378ce9.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

