### PR TITLE
DDF-2502: Add a key-value parser for expressing new attributes to be added on metacards

### DIFF
--- a/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-plugin-metacardingest-network</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Metacard Ingest :: Network</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParser.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParser.java
@@ -19,6 +19,7 @@ import static org.apache.commons.lang.Validate.notNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,7 @@ public class KeyValueParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyValueParser.class);
 
-    private static final String KEY_VALUE_REGEX = "[^=]+[=][^=]+";
+    private static final Pattern KEY_VALUE_PATTERN = Pattern.compile("[^=]+[=][^=]+");
 
     private static final String SPLIT_REGEX = "=";
 
@@ -71,8 +72,8 @@ public class KeyValueParser {
      */
     public boolean validatePair(final String pair) {
         notNull(pair);
-        return pair.trim()
-                .matches(KEY_VALUE_REGEX);
+        return KEY_VALUE_PATTERN.matcher(pair.trim())
+                .matches();
     }
 
     /**
@@ -88,7 +89,8 @@ public class KeyValueParser {
         for (String pair : pairList) {
             if (pair != null) {
                 pair = pair.trim();
-                if (pair.matches(KEY_VALUE_REGEX)) {
+                if (KEY_VALUE_PATTERN.matcher(pair)
+                        .matches()) {
                     String[] pairSplit = pair.split(SPLIT_REGEX, SPLIT_LIMIT);
                     pairMap.put(pairSplit[0].trim(), pairSplit[1].trim());
                 } else if (failFast) {

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParser.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParser.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class used for parsing key-value pairs in the format of <i>'key = value'</i>. Uses a regex
+ * under the hood. In plain English, the rule states that any {@link String} is a valid key-value
+ * pair if, for key {@code K} and for value {@code V}, the representation is {@code K=V} where the
+ * alphabet for {@code K} and {@code V} is <i>any</i> symbol except {@code =}.
+ * <p>
+ * Note that neither {@code K} or {@code V} can be empty. Any whitespace leading or tailing the key
+ * and value after parsing is removed. Whitespace <i>within</i> the key or value is preserved, but
+ * a key or value cannot consist entirely of whitespace.
+ */
+public class KeyValueParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyValueParser.class);
+
+    private static final String KEY_VALUE_REGEX = "[^=]+[=][^=]+";
+
+    private static final String SPLIT_REGEX = "=";
+
+    private static final int SPLIT_LIMIT = 2;
+
+    private final boolean failFast;
+
+    /**
+     * Setup a default instance of {@link KeyValueParser}.
+     */
+    public KeyValueParser() {
+        this.failFast = false;
+    }
+
+    /**
+     * Sets up an instance of {@link KeyValueParser} that throws an {@link IllegalArgumentException}
+     * on the first failure during batch operations.
+     *
+     * @param failFast Parsing failures throw exceptions if true; otherwise they are silently ignored.
+     */
+    public KeyValueParser(final boolean failFast) {
+        this.failFast = failFast;
+    }
+
+    /**
+     * Given a string, returns true if it is a valid key-value pair. This method is useful for
+     * external policy validation.
+     *
+     * @param pair The string suspected to be of the form "key=value"
+     * @return {@code True} if the input is a valid key-value pair. False otherwise.
+     */
+    public boolean validatePair(final String pair) {
+        notNull(pair);
+        return pair.trim()
+                .matches(KEY_VALUE_REGEX);
+    }
+
+    /**
+     * Transforms a {@link List} of strings representing key-value pairs into a {@link Map} with
+     * only the valid mappings.
+     *
+     * @param pairList The list of strings of the form "key=value".
+     * @return A map of key -> value for only the validated key-value strings in the given list.
+     */
+    public Map<String, String> parsePairsToMap(final List<String> pairList) {
+        notNull(pairList);
+        Map<String, String> pairMap = new HashMap<>();
+        for (String pair : pairList) {
+            if (pair != null) {
+                pair = pair.trim();
+                if (pair.matches(KEY_VALUE_REGEX)) {
+                    String[] pairSplit = pair.split(SPLIT_REGEX, SPLIT_LIMIT);
+                    pairMap.put(pairSplit[0].trim(), pairSplit[1].trim());
+                } else if (failFast) {
+                    throw new IllegalArgumentException(format(
+                            "Invalid key-value pair String encountered: %s",
+                            pair));
+                } else {
+                    LOGGER.debug("Invalid key-value pair: \"{}\"", pair);
+                }
+            }
+        }
+        return pairMap;
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParserTest.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/KeyValueParserTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests the behavior of {@link KeyValueParser}.
+ */
+@RunWith(JUnit4.class)
+public class KeyValueParserTest {
+
+    private static final List<String> TEST_CASES = Arrays.asList("name=factoryName",
+            null,
+            "ser=vice=3.2.1",
+            "whitespace=   ",
+            "   =5.4.56",
+            "description = hello there",
+            "=",
+            "",
+            " ",
+            " = ",
+            null,
+            "etc=/hosts/be=gin",
+            "etc = /hosts/stuff",
+            "======",
+            "= = = =    ",
+            "    name = value = stuff = hello");
+
+    private static final Map.Entry EXPECTED_MAP_ENTRY_1 = new AbstractMap.SimpleEntry<>("name",
+            "factoryName");
+
+    private static final Map.Entry EXPECTED_MAP_ENTRY_2 = new AbstractMap.SimpleEntry<>(
+            "description",
+            "hello there");
+
+    private static final Map.Entry EXPECTED_MAP_ENTRY_3 = new AbstractMap.SimpleEntry<>("etc",
+            "/hosts/stuff");
+
+    private static final int EXPECTED_MAP_SIZE = 3;
+
+    private KeyValueParser parser;
+
+    @Before
+    public void setup() throws Exception {
+        parser = new KeyValueParser();
+    }
+
+    @Test
+    public void testCorrectKeyValue() throws Exception {
+        assertThat(parser.validatePair("key=value"), is(true));
+    }
+
+    @Test
+    public void testCorrectKeyValueWithWhiteSpace() throws Exception {
+        assertThat(parser.validatePair(" key = value "), is(true));
+    }
+
+    @Test
+    public void testBadKeyValueWithNoKey() throws Exception {
+        assertThat(parser.validatePair(" = value "), is(false));
+    }
+
+    @Test
+    public void testBadKeyValueWithNoValue() throws Exception {
+        assertThat(parser.validatePair(" key = "), is(false));
+    }
+
+    @Test
+    public void testBadKeyValueDoubleEquals() throws Exception {
+        assertThat(parser.validatePair(" key == value "), is(false));
+    }
+
+    @Test
+    public void testBadKeyValueExtraEqualsWithKey() throws Exception {
+        assertThat(parser.validatePair(" k=ey = value "), is(false));
+    }
+
+    @Test
+    public void testBadKeyValueExtraEqualsWithValue() throws Exception {
+        assertThat(parser.validatePair(" key = val=ue "), is(false));
+    }
+
+    @Test
+    public void testCreateMap() throws Exception {
+        runMapTest(parser);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateMapNullList() throws Exception {
+        KeyValueParser parser = new KeyValueParser();
+        parser.parsePairsToMap(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateMapFailFast() throws Exception {
+        runMapTest(new KeyValueParser(true));
+    }
+
+    private void runMapTest(KeyValueParser givenParser) {
+        Map<String, String> pairs = givenParser.parsePairsToMap(TEST_CASES);
+        assertThat(pairs.values(), hasSize(EXPECTED_MAP_SIZE));
+        assertThat(pairs.get(EXPECTED_MAP_ENTRY_1.getKey()), is(EXPECTED_MAP_ENTRY_1.getValue()));
+        assertThat(pairs.get(EXPECTED_MAP_ENTRY_2.getKey()), is(EXPECTED_MAP_ENTRY_2.getValue()));
+        assertThat(pairs.get(EXPECTED_MAP_ENTRY_3.getKey()), is(EXPECTED_MAP_ENTRY_3.getValue()));
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -33,5 +33,6 @@
         <module>catalog-plugin-expirationdate</module>
         <module>catalog-plugin-content-uri</module>
         <module>catalog-plugin-clientinfo</module>
+        <module>catalog-plugin-metacardingest-network</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
Provides a helper class for the core ticket. This one in particular is for parsing strings of the form `key = value`. 

If context is desired for how this will be used, see the [massive, feature complete PR](https://github.com/codice/ddf/pull/1353) for all the code. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lessarderic 
@figliold 
@shaundmorris 
@brjeter 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
If unit tests pass, along with the full build, this is sufficient for now. 

#### Any background context you want to provide?
This is a small piece of a much bigger change-set that will allow admins to add attributes to metacards based on the originating IP, hostname, scheme, or context path. 

#### What are the relevant tickets?
[DDF-2502](https://codice.atlassian.net/browse/DDF-2502)