### PR TITLE
DDF-2502: Added an AttributeHelper for creating new attributes on metacards

### DIFF
--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/AttributeFactory.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/AttributeFactory.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import static org.apache.commons.lang.Validate.notEmpty;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.lang.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Support class for working with and constructing {@link Attribute}s. The default method for handling
+ * multi-valued attributes as a single string is to delimit each value with a comma.
+ */
+public class AttributeFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttributeFactory.class);
+
+    private static final String MULTI_VALUED_SPLIT_REGEX = ",";
+
+    /**
+     * Attempts to create an {@link Attribute} according to the provided {@link AttributeDescriptor}
+     * whose value is represented by the given string {@param value}. Throws an exception if
+     * {@param value} could not be parsed.
+     *
+     * @param attributeDescriptor The descriptor used to create the attribute.
+     * @param value               The non-empty string to use to create an attribute value. Multi-valued
+     *                            entities should be separated by commas.
+     * @return An {@link Attribute} conforming to the given {@link AttributeDescriptor} with a value
+     * of {@param value} that was parsed and processed to {@link Serializable}.
+     * @throws IllegalArgumentException If the given value could not be parsed or if the inputs were
+     *                                  null or empty.
+     */
+    public Attribute createAttribute(AttributeDescriptor attributeDescriptor, String value) {
+        notNull(attributeDescriptor);
+        notEmpty(value);
+
+        if (attributeDescriptor.isMultiValued()) {
+            LOGGER.trace("Found multi-valued attribute descriptor {} for value {}",
+                    attributeDescriptor.getName(),
+                    value);
+            List<String> values = convertMultiValuedStringToList(value);
+            notEmpty(values);
+            List<Serializable> serializables = values.stream()
+                    .map(string -> parseAttributeValue(attributeDescriptor, string))
+                    .peek(Validate::notNull)
+                    .collect(Collectors.toList());
+            return doCreate(attributeDescriptor, serializables);
+        }
+
+        Serializable attributeValue = parseAttributeValue(attributeDescriptor, value);
+        notNull(attributeValue);
+        LOGGER.trace("Creating single-valued attribute using descriptor {} for value {}",
+                attributeDescriptor.getName(),
+                attributeValue);
+        return doCreate(attributeDescriptor, Collections.singletonList(attributeValue));
+    }
+
+    /**
+     * Attempts to parse a value for an {@link Attribute} according to the provided {@link AttributeDescriptor}
+     * whose value is represented by the given string {@param value}. Returns {@code null} if {@param value}
+     * could not be parsed.
+     * <p>
+     * The input {@param value} must be effectively {@link Serializable}.
+     *
+     * @param attributeDescriptor The descriptor to use to parse the value.
+     * @param value               The string containing the value to be parsed.
+     * @return The deserialized object of {@param value} according to {@param attributeDescriptor}.
+     */
+    @Nullable
+    public Serializable parseAttributeValue(AttributeDescriptor attributeDescriptor, String value) {
+        try {
+            notNull(attributeDescriptor);
+            notEmpty(value);
+
+            Serializable deserializedValue;
+            AttributeType attributeType = attributeDescriptor.getType();
+            AttributeType.AttributeFormat attributeFormat = attributeType.getAttributeFormat();
+
+            switch (attributeFormat) {
+
+            case INTEGER:
+                deserializedValue = Integer.parseInt(value);
+                break;
+
+            case FLOAT:
+                deserializedValue = Float.parseFloat(value);
+                break;
+
+            case DOUBLE:
+                deserializedValue = Double.parseDouble(value);
+                break;
+
+            case SHORT:
+                deserializedValue = Short.parseShort(value);
+                break;
+
+            case LONG:
+                deserializedValue = Long.parseLong(value);
+                break;
+
+            case DATE:
+                Calendar calendar = DatatypeConverter.parseDateTime(value);
+                deserializedValue = calendar.getTime();
+                break;
+
+            case BOOLEAN:
+                deserializedValue = Boolean.parseBoolean(value);
+                break;
+
+            case BINARY:
+                deserializedValue = value.getBytes(Charset.forName("UTF-8"));
+                break;
+
+            case OBJECT:
+            case STRING:
+            case GEOMETRY:
+            case XML:
+                deserializedValue = value;
+                break;
+
+            default:
+                return null;
+            }
+
+            return deserializedValue;
+
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Any time a single string is presented for any {@link AttributeDescriptor} where that descriptor's
+     * {@link AttributeDescriptor#isMultiValued()} is true, this method defines the parsing strategy.
+     * <p>
+     * The default is to treat the string as a comma-separated list of values.
+     * <p>
+     * <i>This method could get promoted to <b>protected</b> in the future.</i>
+     *
+     * @param valueWithMultipleValues A comma-separated list of values to insert on attributes.
+     * @return The list of values that were in the string as {@link Serializable}s.
+     */
+    private List<String> convertMultiValuedStringToList(String valueWithMultipleValues) {
+        String[] entities = valueWithMultipleValues.split(MULTI_VALUED_SPLIT_REGEX, 0);
+        return Arrays.stream(entities)
+                .map(String::trim)
+                .filter(str -> !str.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Factory-method for performing the actual instantiation of the desired {@link Attribute}
+     * instance. Separated from the rest of the code since it causes coupling to a DDF core impl.
+     * <p>
+     * <i>This method could get promoted to <b>protected</b> in the future.</i>
+     *
+     * @param descriptor The descriptor used to create and validate the resulting {@link Attribute}.
+     * @param values     The values for the resulting {@link Attribute}.
+     * @return A new instance of {@link Attribute} containing {@param values} and conforming to
+     * {@param descriptor}.
+     */
+    private Attribute doCreate(AttributeDescriptor descriptor, List<Serializable> values) {
+        return new AttributeImpl(descriptor.getName(), values);
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/MetacardServices.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/main/java/org/codice/ddf/catalog/plugin/metacard/util/MetacardServices.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+
+/**
+ * Support and bulk operations for {@link Metacard}s. Contains state relevant to the provided
+ * services.
+ */
+public class MetacardServices {
+
+    private final List<MetacardType> systemMetacardTypes;
+
+    /**
+     * Initializes the services with an empty list of system {@link MetacardType}s.
+     */
+    public MetacardServices() {
+        this.systemMetacardTypes = new ArrayList<>();
+    }
+
+    /**
+     * Initializes the services with the provided list of {@link MetacardType}s.
+     *
+     * @param systemMetacardTypes The list of metacard types to use.
+     */
+    public MetacardServices(List<MetacardType> systemMetacardTypes) {
+        this.systemMetacardTypes = systemMetacardTypes;
+    }
+
+    /**
+     * Iterates over each {@link Metacard} in the {@param metacards} collection and applies each
+     * attribute in the {@param attributeMap} only if the attribute is not already set on the
+     * {@link Metacard}. That is, the attribute must be {@code null} or not in the {@link Metacard}'s
+     * map.
+     *
+     * @param metacards        The list of metacards to attempt to add the attributes to. Can be empty.
+     * @param attributeMap     The map of attributes to attempt to add. Attributes already set on any
+     *                         given {@link Metacard} will not be changed. For multi-valued attributes,
+     *                         the value string should separate different entities with commas.
+     * @param attributeFactory The factory to use to create attributes.
+     */
+    public void setAttributesIfAbsent(List<Metacard> metacards, Map<String, String> attributeMap,
+            AttributeFactory attributeFactory) {
+
+        if (metacards.isEmpty() || attributeMap.isEmpty()) {
+            return;
+        }
+
+        List<MetacardType> systemMetacardTypesCopy = ImmutableList.copyOf(systemMetacardTypes);
+
+        Map<String, AttributeDescriptor> systemAndMetacardDescriptors = Stream.concat(
+                systemMetacardTypesCopy.stream()
+                        .map(MetacardType::getAttributeDescriptors)
+                        .flatMap(Set::stream)
+                        .filter(Objects::nonNull),
+                metacards.stream()
+                        .map(Metacard::getMetacardType)
+                        .map(MetacardType::getAttributeDescriptors)
+                        .flatMap(Set::stream)
+                        .filter(Objects::nonNull))
+
+                .collect(Collectors.toMap(AttributeDescriptor::getName,
+                        Function.identity(),
+                        (oldValue, newValue) -> oldValue));
+
+        metacards.forEach(metacard -> attributeMap.keySet()
+                .stream()
+                .filter(key -> metacard.getAttribute(key) == null)
+                .map(systemAndMetacardDescriptors::get)
+                .map(descriptor -> attributeFactory.createAttribute(descriptor,
+                        attributeMap.get(descriptor.getName())))
+                .filter(Objects::nonNull)
+                .forEach(metacard::setAttribute));
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/AttributeFactoryTest.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/AttributeFactoryTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static ddf.catalog.data.AttributeType.AttributeFormat.BINARY;
+import static ddf.catalog.data.AttributeType.AttributeFormat.BOOLEAN;
+import static ddf.catalog.data.AttributeType.AttributeFormat.DATE;
+import static ddf.catalog.data.AttributeType.AttributeFormat.DOUBLE;
+import static ddf.catalog.data.AttributeType.AttributeFormat.FLOAT;
+import static ddf.catalog.data.AttributeType.AttributeFormat.GEOMETRY;
+import static ddf.catalog.data.AttributeType.AttributeFormat.INTEGER;
+import static ddf.catalog.data.AttributeType.AttributeFormat.LONG;
+import static ddf.catalog.data.AttributeType.AttributeFormat.OBJECT;
+import static ddf.catalog.data.AttributeType.AttributeFormat.SHORT;
+import static ddf.catalog.data.AttributeType.AttributeFormat.STRING;
+import static ddf.catalog.data.AttributeType.AttributeFormat.XML;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+
+/**
+ * Validate the behavior for {@link AttributeFactory}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeFactoryTest {
+
+    private static final String SAMPLE_JSON_STRING = "{ \"id\": \"j8k767bjav592j2\"}";
+
+    private static final String LANGUAGE = "language";
+
+    private static final String ENGLISH = "English";
+
+    private static final String FRENCH = "French";
+
+    private static final String GERMAN = "German";
+
+    private static final String COMMA_SEPARATED_INTS_WITH_STRING = "8, 3, 103, star";
+
+    private static final String COMMA_SEPARATED_WHITE_SPACE = "  ,  ,  ,  ";
+
+    private static final String COMMA_SEPARATED_LANGUAGES = format("%s, %s, %s",
+            ENGLISH,
+            FRENCH,
+            GERMAN);
+
+    @Mock
+    private AttributeDescriptor mockDescriptor;
+
+    @Mock
+    private AttributeType mockType;
+
+    private AttributeFactory attributeFactory;
+
+    @Before
+    public void setup() throws Exception {
+        when(mockDescriptor.getType()).thenReturn(mockType);
+        attributeFactory = new AttributeFactory();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateAttributeWithIllegalArgument() throws Exception {
+        when(mockType.getAttributeFormat()).thenReturn(INTEGER);
+        Attribute attribute = attributeFactory.createAttribute(mockDescriptor, "1874xyz");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateAttributeWithNullDescriptor() throws Exception {
+        attributeFactory.createAttribute(null, "value");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateAttributeWithNullParseValue() throws Exception {
+        attributeFactory.createAttribute(mockDescriptor, null);
+    }
+
+    @Test
+    public void testCreateMultiValuedAttributeFromCommaSeparatedList() throws Exception {
+        when(mockDescriptor.isMultiValued()).thenReturn(true);
+        when(mockDescriptor.getName()).thenReturn(LANGUAGE);
+        when(mockType.getAttributeFormat()).thenReturn(STRING);
+
+        Attribute attribute = attributeFactory.createAttribute(mockDescriptor,
+                COMMA_SEPARATED_LANGUAGES);
+        List<Serializable> languages = attribute.getValues();
+
+        assertThat(languages, hasSize(3));
+        assertThat(languages, containsInAnyOrder(ENGLISH, FRENCH, GERMAN));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateMultiValuedAttributeWithTypeMismatch() throws Exception {
+        when(mockDescriptor.isMultiValued()).thenReturn(true);
+        when(mockDescriptor.getName()).thenReturn(LANGUAGE);
+        when(mockType.getAttributeFormat()).thenReturn(INTEGER);
+
+        attributeFactory.createAttribute(mockDescriptor, COMMA_SEPARATED_INTS_WITH_STRING);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateMultiValuedAttributesWithEmptyElements() throws Exception {
+        when(mockDescriptor.isMultiValued()).thenReturn(true);
+        when(mockDescriptor.getName()).thenReturn(LANGUAGE);
+        when(mockType.getAttributeFormat()).thenReturn(STRING);
+
+        attributeFactory.createAttribute(mockDescriptor, COMMA_SEPARATED_WHITE_SPACE);
+    }
+
+    @Test
+    public void testParseAttributeValueInteger() throws Exception {
+        runParameterizedAttributeValueTest(INTEGER, "186", 186);
+    }
+
+    @Test
+    public void testParseAttributeValueDouble() throws Exception {
+        runParameterizedAttributeValueTest(DOUBLE, "0.8866432", 0.8866432);
+    }
+
+    @Test
+    public void testParseAttributeValueFloat() throws Exception {
+        runParameterizedAttributeValueTest(FLOAT, "0.123", 0.123f);
+    }
+
+    @Test
+    public void testParseAttributeValueShort() throws Exception {
+        runParameterizedAttributeValueTest(SHORT, "16", (short) 16);
+    }
+
+    @Test
+    public void testParseAttributeValueLong() throws Exception {
+        runParameterizedAttributeValueTest(LONG, "123456789", 123456789L);
+    }
+
+    @Test
+    public void testParseAttributeValueBoolean() throws Exception {
+        runParameterizedAttributeValueTest(BOOLEAN, "true", true);
+    }
+
+    @Test
+    public void testParseAttributeValueBinary() throws Exception {
+        String binaryString = "0100101010110110010010110110010";
+        runParameterizedAttributeValueTest(BINARY, binaryString, binaryString.getBytes());
+    }
+
+    @Test
+    public void testParseAttributeValueDate() throws Exception {
+        String lexicalXsdDateTime = "2001-10-26T21:32:52";
+        runParameterizedAttributeValueTest(DATE,
+                lexicalXsdDateTime,
+                DatatypeConverter.parseDateTime(lexicalXsdDateTime)
+                        .getTime());
+    }
+
+    @Test
+    public void testParseAttributeValueString() throws Exception {
+        runParameterizedAttributeValueTest(STRING, SAMPLE_JSON_STRING, SAMPLE_JSON_STRING);
+    }
+
+    @Test
+    public void testParseAttributeValueObject() throws Exception {
+        runParameterizedAttributeValueTest(OBJECT, SAMPLE_JSON_STRING, SAMPLE_JSON_STRING);
+    }
+
+    @Test
+    public void testParseAttributeValueGeometry() throws Exception {
+        runParameterizedAttributeValueTest(GEOMETRY, SAMPLE_JSON_STRING, SAMPLE_JSON_STRING);
+    }
+
+    @Test
+    public void testParseAttributeValueXml() throws Exception {
+        runParameterizedAttributeValueTest(XML, SAMPLE_JSON_STRING, SAMPLE_JSON_STRING);
+    }
+
+    @Test
+    public void testParseAttributeValueWithIllegalArgument() throws Exception {
+        when(mockType.getAttributeFormat()).thenReturn(INTEGER);
+        Serializable serializable = attributeFactory.parseAttributeValue(mockDescriptor, "1874xyz");
+        assertNull(serializable);
+    }
+
+    @Test
+    public void testParseAttributeValueWithNullDescriptor() throws Exception {
+        attributeFactory.parseAttributeValue(null, "anyValue");
+    }
+
+    @Test
+    public void testParseAttributeValueWithNullValue() throws Exception {
+        attributeFactory.parseAttributeValue(mockDescriptor, null);
+    }
+
+    private void runParameterizedAttributeValueTest(AttributeType.AttributeFormat format,
+            String rawValue, Object value) {
+        when(mockType.getAttributeFormat()).thenReturn(format);
+        Serializable serializable = attributeFactory.parseAttributeValue(mockDescriptor, rawValue);
+        assertThat(serializable, is(value));
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/MetacardServicesTest.java
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/src/test/java/org/codice/ddf/catalog/plugin/metacard/util/MetacardServicesTest.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+
+/**
+ * Validate all the helpers within the {@link MetacardServices} utility operations class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MetacardServicesTest {
+
+    private static final String METACARD_TITLE = "Metacard Title";
+
+    private static final String METACARD_DESCRIPTION = "Hello from the metacard";
+
+    private static final String DESCRIPTION_KEY = "description";
+
+    private AttributeFactory attributeFactory;
+
+    private MetacardServices metacardServices;
+
+    @Before
+    public void setup() throws Exception {
+        attributeFactory = new AttributeFactory();
+        metacardServices = new MetacardServices();
+    }
+
+    @Test
+    public void testApplyNewAttributesOnEmptyList() throws Exception {
+        List<Metacard> metacards = ImmutableList.of();
+        Map<String, String> attributeMap = ImmutableMap.of();
+
+        List<MetacardType> mockMetacardTypes = mock(List.class);
+        metacardServices = new MetacardServices(mockMetacardTypes);
+        AttributeFactory mockAttributeFactory = mock(AttributeFactory.class);
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, mockAttributeFactory);
+        verifyZeroInteractions(mockMetacardTypes, mockAttributeFactory);
+    }
+
+    @Test
+    public void testApplyNewAttributesWithEmptyMap() throws Exception {
+        Metacard metacard = createMetacard();
+        List<Metacard> metacards = ImmutableList.of(metacard);
+        Map<String, String> attributeMap = ImmutableMap.of();
+
+        List<MetacardType> mockMetacardTypes = mock(List.class);
+        metacardServices = new MetacardServices(mockMetacardTypes);
+        AttributeFactory mockAttributeFactory = mock(AttributeFactory.class);
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, mockAttributeFactory);
+        verifyZeroInteractions(mockMetacardTypes, mockAttributeFactory);
+        assertThatMetacardHasExpectedTitleAndDescription(metacard);
+    }
+
+    @Test
+    public void testApplyNewAttributes() throws Exception {
+
+        Metacard metacard = createMetacard();
+        List<Metacard> metacards = ImmutableList.of(metacard);
+        Map<String, String> attributeMap = ImmutableMap.of(
+
+                "point-of-contact", "contact",
+
+                "metadata", "<? xml version=1.0 ?><Root><Child/></Root>");
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, attributeFactory);
+
+        assertThatMetacardHasExpectedTitleAndDescription(metacard);
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacard, attributeMap);
+    }
+
+    @Test
+    public void testApplyNewAttributesToMultipleMetacards() throws Exception {
+
+        Metacard metacard1 = createMetacard();
+        Metacard metacard2 = createMetacard();
+        List<Metacard> metacards = ImmutableList.of(metacard1, metacard2);
+        Map<String, String> attributeMap = ImmutableMap.of(
+
+                "point-of-contact", "contact",
+
+                "metadata", "<? xml version=1.0 ?><Root><Child/></Root>");
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, attributeFactory);
+
+        assertThatMetacardHasExpectedTitleAndDescription(metacard1);
+        assertThatMetacardHasExpectedTitleAndDescription(metacard2);
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacard1, attributeMap);
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacard2, attributeMap);
+    }
+
+    @Test
+    public void testDoNotApplyAnyAttributesBecauseAllExist() throws Exception {
+
+        Metacard metacard = createMetacard();
+        List<Metacard> metacards = ImmutableList.of(metacard);
+        Map<String, String> attributeMap = ImmutableMap.of(
+
+                "title", "canned title",
+
+                "description", "canned description");
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, attributeFactory);
+
+        assertThatMetacardHasExpectedTitleAndDescription(metacard);
+    }
+
+    @Test
+    public void testApplyNewAttributesWithoutOverwrite() throws Exception {
+
+        Metacard metacard = createMetacard();
+        List<Metacard> metacards = ImmutableList.of(metacard);
+
+        Map<String, String> attributesThatShouldBeOnMetacard = ImmutableMap.of("point-of-contact",
+                "contact",
+
+                "metadata",
+                "<? xml version=1.0 ?><Root><Child/></Root>");
+
+        Map<String, String> attributesThatShouldNOTBeOnMetacard = ImmutableMap.of(
+
+                "title", "canned title",
+
+                "description", "canned description");
+
+        Map attributeMap = ImmutableMap.builder()
+                .putAll(attributesThatShouldBeOnMetacard)
+                .putAll(attributesThatShouldNOTBeOnMetacard)
+                .build();
+
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, attributeFactory);
+
+        assertThatMetacardHasExpectedTitleAndDescription(metacard);
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacard,
+                attributesThatShouldBeOnMetacard);
+    }
+
+    @Test
+    public void testApplyNewAttributesThatDifferPerMetacard() throws Exception {
+
+        MetacardImpl metacardWithMetadataNoExpectedTitleOrDescription = new MetacardImpl();
+        metacardWithMetadataNoExpectedTitleOrDescription.setMetadata("<html><body/></html>");
+
+        MetacardImpl metacardWithPoc = createMetacard();
+        metacardWithPoc.setPointOfContact("my name here");
+
+        MetacardImpl metacardWithCreatedDate = createMetacard();
+        metacardWithCreatedDate.setCreatedDate(DatatypeConverter.parseDateTime("2001-10-26T21:32:52")
+                .getTime());
+
+        List<Metacard> metacards =
+                ImmutableList.of(metacardWithMetadataNoExpectedTitleOrDescription,
+                        metacardWithPoc,
+                        metacardWithCreatedDate);
+
+        Map<String, String> attributesTitleAndDescription = ImmutableMap.of(
+
+                "title", "canned title",
+
+                "description", "canned description");
+
+        Map<String, String> attributeMetadata = ImmutableMap.of("metadata",
+                "<? xml version=1.0 ?><Root><Child/></Root>");
+        Map<String, String> attributePoc = ImmutableMap.of("point-of-contact", "contact");
+        Map<String, String> attributeCreated = ImmutableMap.of("created", "2001-10-26T21:32:52");
+
+        Map attributeMap = ImmutableMap.builder()
+                .putAll(attributesTitleAndDescription)
+                .putAll(attributeMetadata)
+                .putAll(attributePoc)
+                .putAll(attributeCreated)
+                .build();
+        metacardServices.setAttributesIfAbsent(metacards, attributeMap, attributeFactory);
+
+        assertThatMetacardHasExpectedTitleAndDescription(metacardWithPoc);
+        assertThatMetacardHasExpectedTitleAndDescription(metacardWithCreatedDate);
+
+        Map metadataResult = ImmutableMap.builder()
+                .putAll(attributesTitleAndDescription)
+                .putAll(attributePoc)
+                .putAll(attributeCreated)
+                .build();
+        assertThatMetacardHasAttributesEqualToThoseInMap(
+                metacardWithMetadataNoExpectedTitleOrDescription,
+                metadataResult);
+
+        Map pocResult = ImmutableMap.builder()
+                .putAll(attributeMetadata)
+                .putAll(attributeCreated)
+                .build();
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacardWithPoc, pocResult);
+
+        Map createdResult = ImmutableMap.builder()
+                .putAll(attributeMetadata)
+                .putAll(attributePoc)
+                .build();
+        assertThatMetacardHasAttributesEqualToThoseInMap(metacardWithCreatedDate, createdResult);
+    }
+
+    private MetacardImpl createMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setTitle(METACARD_TITLE);
+        metacard.setDescription(METACARD_DESCRIPTION);
+        return metacard;
+    }
+
+    private void assertThatMetacardHasExpectedTitleAndDescription(Metacard metacard) {
+        assertThat(metacard.getTitle(), is(METACARD_TITLE));
+        assertThat(metacard.getAttribute(DESCRIPTION_KEY)
+                .getValue(), is(METACARD_DESCRIPTION));
+    }
+
+    private void assertThatMetacardHasAttributesEqualToThoseInMap(Metacard metacard,
+            Map<String, String> attributeMap) {
+        attributeMap.entrySet()
+                .stream()
+                .filter(entry -> metacard.getAttribute(entry.getKey()) != null)
+                .forEach(entry -> {
+                    Serializable serializable = metacard.getAttribute(entry.getKey())
+                            .getValue();
+                    if (serializable instanceof Date) {
+                        Date dateValue = Date.class.cast(serializable);
+                        assertThat(dateValue,
+                                is(DatatypeConverter.parseDateTime(entry.getValue())
+                                        .getTime()));
+                    } else {
+                        assertThat(serializable, is(entry.getValue()));
+                    }
+                });
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Provides a helper class for the core ticket. This one in particular is for adding attributes to metacards, performing correct attribute processing from string values, and iterating over the system's published `MetacardType`s. 

Attributes already set are not overwritten.

If context is desired for how this will be used, see the [massive, feature complete PR](https://github.com/codice/ddf/pull/1353) for all the code. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lessarderic 
@figliold 
@shaundmorris 
@brjeter 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
If unit tests pass, along with the full build, this is sufficient for now. 

#### Any background context you want to provide?
This is a small piece of a much bigger change-set that will allow admins to add attributes to metacards based on the originating IP, hostname, scheme, or context path. 

#### What are the relevant tickets?
[DDF-2502](https://codice.atlassian.net/browse/DDF-2502)