### PR TITLE
DDF-2578 Add API to XMLUtils class

### DIFF
--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
@@ -16,8 +16,6 @@ package org.codice.ddf.platform.util;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 
@@ -148,22 +146,6 @@ public class XMLUtils {
         });
     }
 
-    public static boolean hasNamespace(String xml, String namespace) {
-        List<String> ns = new ArrayList<>();
-        ProcessingResult<Boolean> result = new ProcessingResult();
-        processElements(xml, result, (xmlStreamReader) -> {
-            result.setValue(xmlStreamReader.getNamespaceURI()
-                    .equals(namespace));
-            ns.add(xmlStreamReader.getNamespaceURI());
-            LOGGER.warn(xmlStreamReader.getNamespaceURI());
-            //result.done();
-
-        });
-
-        int x = 8;
-        return false;
-    }
-
     /**
      *
      * @param xml   The XML to process
@@ -191,6 +173,7 @@ public class XMLUtils {
                 }
             }
         } catch (XMLStreamException e) {
+            result.setValue(null);
             LOGGER.debug(XMLUtils.class.getSimpleName() + " is unable to parse XML", e);
         } finally {
             if (xmlStreamReader != null) {

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
@@ -145,33 +145,6 @@ public class XMLUtils {
         });
     }
 
-    /**
-     * Iterate through the elements of an XML document.
-     * <p>
-     * It uses a lambda function and an instance of the the internal class Holder. The holder
-     * stores the return value. The lambda function has a change to process every element
-     * in the document. To store a result, call set() on the holder object.
-     * <p>
-     * If the lambda function returns false, processing continues to the next element.
-     * <p>
-     * When the last element in the document is processed, the value in the holder object
-     * is returned.
-     * <p>
-     * If the function encounters a processing exception, the value of the holder object is
-     * set to null, processing stops, and the value returned to the caller is null.
-     * <p>
-     * If the lambda function return true, processing terminate processing, During processing Set the value in the ProcessingResult to be the return value of this method.
-     * To stop processing, set the value "done" in ProcessingResult to true.
-     * For an example, see the getRootNamespace() method.
-     * <p>
-     * //     * @param xml                    The XML to process
-     * //     * @param result                 Instance of ProcessingResult
-     * //     * @param processElementFunction Function that accepts an instance of XMLStreamReader
-     * //     *                               and holder. The function must retrun a boolean.
-     * //     * @param <T>                    The type of the holders value
-     * //     * @return The value stored in the result holder object
-     */
-
     private static void transformation(Source sourceXml, TransformerProperties transformProperties,
             Result result) {
         ClassLoader tccl = Thread.currentThread()
@@ -198,25 +171,21 @@ public class XMLUtils {
     }
 
     /**
-     * Iterate through the elements of an XML document.
+     * Iterate through the elements of an XML document. The processor calls
+     * the processElementFunction for each element.
+     * Call result.set() to change the value that will be returned.
      * <p>
-     * It uses a lambda function and an instance of the the internal class ResultHolder. The result
-     * stores the return value. The lambda function has a change to process every element
-     * in the document. To store a result, call set() on the result object.
-     * <p>
-     * If the lambda function returns false, processing continues to the next element.
-     * <p>
-     * When the last element in the document is processed, the value in the holder object
+     * If the function returns true, processing continues to the next element.
+     * When the last element in the document is processed, the value in the result
      * is returned.
      * <p>
-     * If the function encounters a processing exception and the value returned to the caller is null.
+     * If the lambda function returns false, processing stops. The value of the result is returned.
      * <p>
-     * If the lambda function return true, processing terminate processing, During processing Set the value in the ProcessingResult to be the return value of this method.
-     * To stop processing, set the value "done" in ProcessingResult to true.
-     * For an example, see the getRootNamespace() method.
+     * If the function encounters a processing exception, processing stops and null is returned.
      *
      * @param xml                    The XML to process
-     * @param processElementFunction Function that accepts an instance of XMLStreamReader and result holder. The function must return a boolean.
+     * @param processElementFunction Function that accepts an instance of XMLStreamReader and result holder.
+     *                               The function must return a boolean.
      * @return <T>  The result of the processing
      */
 
@@ -226,17 +195,14 @@ public class XMLUtils {
         initializeXMLInputFactory();
         XMLStreamReader xmlStreamReader = null;
         ResultHolder<T> result = new ResultHolder<>();
-        boolean keepProcessing;
+        boolean keepProcessing = true;
 
         try (StringReader strReader = new StringReader(xml)) {
             xmlStreamReader = xmlInputFactory.createXMLStreamReader(strReader);
-            while (xmlStreamReader.hasNext()) {
+            while (keepProcessing && xmlStreamReader.hasNext()) {
                 int event = xmlStreamReader.next();
                 if (event == XMLStreamConstants.START_ELEMENT) {
                     keepProcessing = processElementFunction.apply(result, xmlStreamReader);
-                    if (!keepProcessing) {
-                        break;
-                    }
                 }
             }
         } catch (XMLStreamException e) {
@@ -256,9 +222,8 @@ public class XMLUtils {
     }
 
     /**
-     * This class is used with the processElements method. It works in conjunction with the
-     * processElementFunction. Inside the function, set the value of the ProcessingResult and that
-     * value will be returned by the processElements method.
+     * This class is used with the processElements method. Inside the function, set the value
+     * of the result holder. That value is then returned by the processElementsFunction.
      */
 
     public static class ResultHolder<T> {

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
@@ -141,7 +141,7 @@ public class XMLUtils {
 
         return processElements(xml, (result, xmlStreamReader) -> {
             result.set(xmlStreamReader.getNamespaceURI());
-            return true;
+            return false;
         });
     }
 

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
@@ -147,26 +147,11 @@ public class XMLUtils {
     }
 
     /**
-     * This method lets clients parse through the elements of an XML document with less
-     * boiler-plate code. This methods handles the configuration of the
-     * XML factory and disables security risks like macro expansion.
-     * This methods also catches the several exceptions that can be thrown during the creation
-     * and use of an XML parser.
-     * <p>
-     * Example: Get the first three elements whose local name is "Fizz".
-     * <p>
-     * String xml = "my XML document"; // The string representation of the XML document to parse
-     * <p>
-     * XMLUtils.ProcessingResult<List<String>> result =
-     * new XMLUtils.ProcessingResult<>(new ArrayList<String>());
-     * <p>
-     * List<String> output = XMLUtils.processElements(xml, result, (xmlReader) -> {
-     * if (xmlReader.getLocalName().equals("Fizz")) {
-     * if (result.getValue().size() < 3) {
-     * result.getValue().add(xmlReader.getElementText());
-     * } else { result.done(); }
-     * }
-     * });
+     * Parse the elements of an XML document.
+     * It uses a lambda function and an instance of the the internal class ProcessingResults.
+     * Set the value in the ProcessingResult to be the return value of this method.
+     * To stop processing, set the value "done" in ProcessingResult to true.
+     * For an example, see the getRootNamespace() method.
      *
      * @param xml                    The XML to process
      * @param result                 Instance of ProcessingResult
@@ -187,14 +172,14 @@ public class XMLUtils {
                 int event = xmlStreamReader.next();
                 if (event == XMLStreamConstants.START_ELEMENT) {
                     processElementFunction.accept(xmlStreamReader);
-                    if (result.isDone) {
+                    if (result.isDone()) {
                         break;
                     }
                 }
             }
         } catch (XMLStreamException e) {
             result.setValue(null);
-            LOGGER.debug(XMLUtils.class.getSimpleName() + " is unable to parse XML", e);
+            LOGGER.debug("{} ", XMLUtils.class.getSimpleName(), e);
         } finally {
             if (xmlStreamReader != null) {
                 try {
@@ -234,7 +219,7 @@ public class XMLUtils {
     }
 
     // This class is used with the processElements method. It works in conjunction with the
-    // #processElementFunction. Inside the function, set the value of the ProcessingResult and
+    // processElementFunction. Inside the function, set the value of the ProcessingResult and
     // call done() to stop processing the XML document.
     public static class ProcessingResult<T> {
         boolean isDone = false;
@@ -260,13 +245,10 @@ public class XMLUtils {
             return isDone;
         }
 
-        public void setDone(boolean done) {
-            isDone = done;
+        public void done() {
+            isDone = true;
         }
 
-        public void done() {
-            setDone(true);
-        }
     }
 
 }

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/XMLUtils.java
@@ -45,7 +45,7 @@ public class XMLUtils {
 
     protected static volatile XMLInputFactory xmlInputFactory;
 
-    private static void initializeXMLInputFactory() {
+    private static synchronized void initializeXMLInputFactory() {
         if (xmlInputFactory == null) {
             xmlInputFactory = XMLInputFactory.newInstance();
         }
@@ -147,12 +147,32 @@ public class XMLUtils {
     }
 
     /**
+     * This method lets clients parse through the elements of an XML document with less
+     * boiler-plate code. This methods handles the configuration of the
+     * XML factory and disables security risks like macro expansion.
+     * This methods also catches the several exceptions that can be thrown during the creation
+     * and use of an XML parser.
+     * <p>
+     * Example: Get the first three elements whose local name is "Fizz".
+     * <p>
+     * String xml = "my XML document"; // The string representation of the XML document to parse
+     * <p>
+     * XMLUtils.ProcessingResult<List<String>> result =
+     * new XMLUtils.ProcessingResult<>(new ArrayList<String>());
+     * <p>
+     * List<String> output = XMLUtils.processElements(xml, result, (xmlReader) -> {
+     * if (xmlReader.getLocalName().equals("Fizz")) {
+     * if (result.getValue().size() < 3) {
+     * result.getValue().add(xmlReader.getElementText());
+     * } else { result.done(); }
+     * }
+     * });
      *
-     * @param xml   The XML to process
-     * @param result    Instance of processing result
-     * @param processElementFunction    Function that accepts an instance of XMLStreamReader
-     *                                  and updates the processing result
-     * @param <T> The type that of the processing result's value
+     * @param xml                    The XML to process
+     * @param result                 Instance of ProcessingResult
+     * @param processElementFunction Function that accepts an instance of XMLStreamReader
+     *                               and updates the processing result
+     * @param <T>                    The type of the processing result's value
      * @return Processing results's value
      */
     public static <T> T processElements(String xml, ProcessingResult<T> result,
@@ -213,9 +233,9 @@ public class XMLUtils {
         }
     }
 
-    // This class is used with the processElements method. Pass a function and an instance of
-    // ProcessingResult into the processElements method. Inside the function, set
-    // use setResult to the return value and call done() to stop processing the XML document.
+    // This class is used with the processElements method. It works in conjunction with the
+    // #processElementFunction. Inside the function, set the value of the ProcessingResult and
+    // call done() to stop processing the XML document.
     public static class ProcessingResult<T> {
         boolean isDone = false;
 

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/XMLUtilsTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/XMLUtilsTest.java
@@ -13,7 +13,9 @@
  */
 package org.codice.ddf.platform.util;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -52,6 +54,11 @@ public class XMLUtilsTest {
 
     private static final String XML_WITH_NAMESPACE =
             "<?xml version=\"1.0\"?><dog:Dog xmlns:dog=\"doggy-namespace\"></dog:Dog>";
+
+    private static final String XML_MULTIPLE_NODES =
+            "<bookstore>\n" + "  <book category=\"children\">\n"
+                    + "    <title>Harry Potter</title>\n" + "    <author>J K. Rowling</author>\n"
+                    + "    <year>2005</year>\n" + "    <price>29.99</price>\n" + "  </book>";
 
     @Test
     public void testFormatSource() throws ParserConfigurationException, IOException, SAXException {
@@ -115,6 +122,32 @@ public class XMLUtilsTest {
     @Test
     public void testGetRootNamespace() {
         assert "doggy-namespace".equals(XMLUtils.getRootNamespace(XML_WITH_NAMESPACE));
+    }
+
+    @Test
+    public void testProcessElementException() {
+
+        XMLUtils.ProcessingResult<Object> result = new XMLUtils.ProcessingResult<>(new Object());
+        assertThat(result.getValue(), is(notNullValue()));
+        XMLUtils.processElements("", result, (x) -> {
+        });
+        assertThat("Processing result should be null if an exception was thrown",
+                result.getValue(),
+                is(nullValue()));
+    }
+
+    @Test
+    public void testProcessingStop() {
+        XMLUtils.ProcessingResult<Integer> result = new XMLUtils.ProcessingResult<>(0);
+        assertThat("Expected processing result to default to 'not done'",
+                result.isDone(),
+                is(false));
+        XMLUtils.processElements(XML_MULTIPLE_NODES, result, (xmlStreamReader) -> {
+            result.setValue(result.getValue() + 1);
+            result.done();
+        });
+
+        assertThat("Expected result value to be 1", result.getValue(), equalTo(1));
     }
 
     private TransformerProperties setTransformerProperties() {


### PR DESCRIPTION
#### What does this PR do?
There is a lot of boilerplate code setting up an XML parser, writing a loop to catch events, and handling checked errors. This PR adds a public method that accepts a function and an instance of a new inner class. Developers who create new modules that require XML parsing can make use of this method.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann @tbatie @mweser @AzGoalie 

#### Choose 2 committers to review/merge the PR 
@coyotesqrl
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
There are unit tests for the changes in XMLUtilsTest class
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [N/A ] Documentation Updated
- [ N/A] Change Log Updated
- [ Yes] Update / Add Unit Tests
- [ N/A] Update / Add Integration Tests
