### PR TITLE
DDF-2581: TestFederation testAsyncDownloadActionPresentUsingCometDClient fails intermittently

### DIFF
--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -35,3 +35,6 @@ The runtime folder used during the test will be available under `target/exam/<GU
 
 ## Adjusting the Log Level
 By default, itests are run at a log level of `warn` for increased performance. If you want to change the logging level, use the flag `-DitestLogLevel=<level>`. Valid levels are defined by the [SLF4J API](http://www.slf4j.org/api/org/apache/commons/logging/Log.html).
+
+## Run unstable tests
+By default, all tests that include a call to `unstableTest` will not be run. To include them as part of a build, add the `-DincludeUnstableTests=true` property to the Maven command.

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -2255,6 +2255,8 @@ public class TestFederation extends AbstractIntegrationTest {
      */
     @Test
     public void testAsyncDownloadActionPresentUsingCometDClient() throws Exception {
+        unstableTest(); // TODO: DDF-2581
+
         getCatalogBundle().setupCaching(true);
         String src = "ddf.distribution";
         String metacardId = ingestXmlWithProduct(String.format("%s.txt", testName.getMethodName()));


### PR DESCRIPTION
#### What does this PR do?
Added the ability to mark specific unit tests as unstable and be able to enable or disable them using a system property.

Updated the README.md file to include this new flag.

Also marked `TestFederation.testAsyncDownloadActionPresentUsingCometDClient()` as unstable until the root cause of the intermittent failures is addressed in a follow on PR.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@tbatie 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Run integration tests with and without the `-DincludeUnstableTests=true` flag and make sure the unstable test is ran or skipped.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2581](https://codice.atlassian.net/browse/DDF-2581)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
