### PR TITLE
DDF-2582 Derived Resource Action Titles

### DIFF
--- a/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
@@ -16,6 +16,7 @@ package org.codice.ddf.catalog.content.resource.reader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -130,7 +131,7 @@ public class DerivedContentActionProvider implements MultiActionProvider {
     private String getQualifierForRemoteResource(String uriString) throws URISyntaxException {
         final String QUALIFIER_KEY = "qualifier";
 
-        return URLEncodedUtils.parse(new URI(uriString), "UTF-8")
+        return URLEncodedUtils.parse(new URI(uriString), StandardCharsets.UTF_8.name())
                 .stream()
                 .filter(pair -> QUALIFIER_KEY.equals(pair.getName()))
                 .map(NameValuePair::getValue)

--- a/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
@@ -43,7 +43,7 @@ import ddf.catalog.data.Metacard;
 
 public class DerivedContentActionProviderTest {
 
-    public static final String EXAMPLE_URL = "https://exmaple.com/other";
+    public static final String EXAMPLE_URL = "https://example.com/other";
 
     private static DerivedContentActionProvider actionProvider;
 
@@ -64,7 +64,8 @@ public class DerivedContentActionProviderTest {
 
     @BeforeClass
     public static void init() throws URISyntaxException {
-        actionUri = new URI("https://example.com/download?transform=resource");
+        actionUri = new URI(
+                "https://example.com/download?transform=resource&qualifier=" + QUALIFIER_VALUE);
         derivedResourceUri = new URI(ContentItem.CONTENT_SCHEME, CONTENT_ID, QUALIFIER_VALUE);
         actionProvider = new DerivedContentActionProvider(mockResourceActionProvider);
 
@@ -79,7 +80,6 @@ public class DerivedContentActionProviderTest {
 
     @Test
     public void testGetActions() throws Exception {
-
         ActionImpl expectedAction = new ActionImpl("expected",
                 "expected",
                 "expected",
@@ -93,11 +93,10 @@ public class DerivedContentActionProviderTest {
         assertThat(actions.get(0)
                 .getUrl()
                 .getQuery(), containsString(ContentItem.QUALIFIER + "=" + QUALIFIER_VALUE));
-
     }
 
     @Test
-    public void testGetActionsNonContentUri() throws Exception {
+    public void testGetActionsNonContentUriDefault() throws Exception {
         ActionImpl expectedAction = new ActionImpl("expected",
                 "expected",
                 "expected",
@@ -111,6 +110,24 @@ public class DerivedContentActionProviderTest {
                 .getUrl(), notNullValue());
         assertThat(actions.get(0)
                 .getUrl(), is(new URL(EXAMPLE_URL)));
+    }
+
+    @Test
+    public void testGetActionsNonContentUriWithQualifier() throws Exception {
+        ActionImpl expectedAction = new ActionImpl("expected",
+                "expected",
+                "expected",
+                actionUri.toURL());
+        when(mockResourceActionProvider.getAction(any(Metacard.class))).thenReturn(expectedAction);
+        when(attribute.getValues()).thenReturn(Arrays.asList(actionUri));
+        List<Action> actions = actionProvider.getActions(metacard);
+        assertThat(actions, hasSize(1));
+        assertThat(actions.get(0), notNullValue());
+        assertThat(actions.get(0).getUrl(), notNullValue());
+        assertThat(actions.get(0)
+                .getUrl().toString(), is(actionUri.toString()));
+        assertThat(actions.get(0)
+                .getTitle(), is("View " + QUALIFIER_VALUE));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Custom checking on derived resource URI for remote resources, which are not formatted the same as local resources. Fixes issue where actions display a URL as the action title, due to failure of URI parsing.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining @dcruver @glenhein 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
- This bug presented itself originally in Alliance. For testing, build and run the latest Alliance on top of this version of DDF. 
- Configure a CSW loopback source under `DDF Spatial` --> `CSW Specification Profile Federated Source` to mimic a remote source. 
 -- Add Source ID name
 -- Change CSW URL to local:   `https://localhost:8993/services/csw`
 -- Change “Output Schema” to:    `urn:catalog:metacard`
- Ingest a NITF formatted file, then perform a search to find the ingested file.
- For the actions tab on the remote source, verify that the action titles `View original` and `View overview` do not contain the URL to the derived resource.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2582

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

