### PR TITLE
DDF-2581: TestFederation testAsyncDownloadActionPresentUsingCometDClient fails intermittently

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -15,8 +15,6 @@ package org.codice.ddf.itests.common;
 
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SECURE_ROOT;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeThat;
 import static org.ops4j.pax.exam.CoreOptions.cleanCaches;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -55,6 +53,7 @@ import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.shell.api.console.SessionFactory;
 import org.codice.ddf.itests.common.annotations.PaxExamRule;
 import org.codice.ddf.itests.common.annotations.PostTestConstruct;
+import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
 import org.codice.ddf.itests.common.security.SecurityPolicyConfigurator;
 import org.junit.Rule;
@@ -109,8 +108,6 @@ public abstract class AbstractIntegrationTest {
 
     protected static String ddfHome;
 
-    private static final String INCLUDE_UNSTABLE_TESTS_PROPERTY = "includeUnstableTests";
-
     @Rule
     public PaxExamRule paxExamRule = new PaxExamRule(this);
 
@@ -146,10 +143,6 @@ public abstract class AbstractIntegrationTest {
 
     protected static final String[] DEFAULT_REQUIRED_APPS =
             {"catalog-app", "solr-app", "spatial-app", "sdk-app"};
-
-    private static final String INCLUDE_UNSTABLE_TESTS = System.getProperty(
-            INCLUDE_UNSTABLE_TESTS_PROPERTY,
-            "false");
 
     /**
      * An enum that returns a port number based on the class variable {@link #basePort}. Used to allow parallel itests
@@ -359,17 +352,6 @@ public abstract class AbstractIntegrationTest {
     }
 
     /**
-     * Indicates that a test should only be run if the {@value INCLUDE_UNSTABLE_TESTS_PROPERTY}
-     * system property is set to {@code true}.
-     * <p>
-     * To use, simply add as the first line of a test method that is currently unstable or fails
-     * intermittently.
-     */
-    protected void unstableTest() {
-        assumeThat(INCLUDE_UNSTABLE_TESTS, is("true"));
-    }
-
-    /**
      * Combines all the {@link Option} objects contained in multiple {@link Option} arrays.
      *
      * @param options arrays of {@link Option} objects to combine. Arrays can be {@code null} or
@@ -514,10 +496,9 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected Option[] configureIncludeUnstableTests() {
-        return options(when(System.getProperty(INCLUDE_UNSTABLE_TESTS_PROPERTY) != null).useOptions(
-                systemProperty(INCLUDE_UNSTABLE_TESTS_PROPERTY).value(System.getProperty(
-                        INCLUDE_UNSTABLE_TESTS_PROPERTY,
-                        ""))));
+        return options(when(System.getProperty(SkipUnstableTest.INCLUDE_UNSTABLE_TESTS_PROPERTY)
+                != null).useOptions(systemProperty(SkipUnstableTest.INCLUDE_UNSTABLE_TESTS_PROPERTY).value(
+                System.getProperty(SkipUnstableTest.INCLUDE_UNSTABLE_TESTS_PROPERTY, ""))));
     }
 
     protected Option[] configureVmOptions() {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/annotations/ConditionalIgnoreRule.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/annotations/ConditionalIgnoreRule.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/*******************************************************************************
+ * Copyright (c) 2013,2014 Rüdiger Herrmann
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Rüdiger Herrmann - initial API and implementation
+ *   Matt Morrissette - allow to use non-static inner IgnoreConditions
+ ******************************************************************************/
+package org.codice.ddf.itests.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+import org.junit.Assume;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConditionalIgnoreRule implements MethodRule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConditionalIgnoreRule.class);
+
+    public interface IgnoreCondition {
+        boolean isSatisfied();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    public @interface ConditionalIgnore {
+        Class<? extends IgnoreCondition> condition();
+    }
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        Statement result = base;
+        if (hasConditionalIgnoreAnnotation(method)) {
+            IgnoreCondition condition = getIgnoreContition(target, method);
+            if (condition.isSatisfied()) {
+                LOGGER.warn("IgnoreCondition {} applies, ignoring test {}",
+                        condition.getClass()
+                                .getSimpleName(),
+                        method.getName());
+                result = new IgnoreStatement(condition);
+            }
+        }
+        return result;
+    }
+
+    private static boolean hasConditionalIgnoreAnnotation(FrameworkMethod method) {
+        return method.getAnnotation(ConditionalIgnore.class) != null;
+    }
+
+    private static IgnoreCondition getIgnoreContition(Object target, FrameworkMethod method) {
+        ConditionalIgnore annotation = method.getAnnotation(ConditionalIgnore.class);
+        return new IgnoreConditionCreator(target, annotation).create();
+    }
+
+    private static class IgnoreConditionCreator {
+        private final Object target;
+
+        private final Class<? extends IgnoreCondition> conditionType;
+
+        IgnoreConditionCreator(Object target, ConditionalIgnore annotation) {
+            this.target = target;
+            this.conditionType = annotation.condition();
+        }
+
+        IgnoreCondition create() {
+            checkConditionType();
+            try {
+                return createCondition();
+            } catch (RuntimeException re) {
+                throw re;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private IgnoreCondition createCondition() throws Exception {
+            IgnoreCondition result;
+            if (isConditionTypeStandalone()) {
+                result = conditionType.newInstance();
+            } else {
+                result = conditionType.getDeclaredConstructor(target.getClass())
+                        .newInstance(target);
+            }
+            return result;
+        }
+
+        private void checkConditionType() {
+            if (!isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget()) {
+                String msg = "Conditional class '%s' is a member class "
+                        + "but was not declared inside the test case using it.\n"
+                        + "Either make this class a static class, "
+                        + "standalone class (by declaring it in it's own file) "
+                        + "or move it inside the test case using it";
+                throw new IllegalArgumentException(String.format(msg, conditionType.getName()));
+            }
+        }
+
+        private boolean isConditionTypeStandalone() {
+            return !conditionType.isMemberClass()
+                    || Modifier.isStatic(conditionType.getModifiers());
+        }
+
+        private boolean isConditionTypeDeclaredInTarget() {
+            return target.getClass()
+                    .isAssignableFrom(conditionType.getDeclaringClass());
+        }
+    }
+
+    private static class IgnoreStatement extends Statement {
+        private final IgnoreCondition condition;
+
+        IgnoreStatement(IgnoreCondition condition) {
+            this.condition = condition;
+        }
+
+        @Override
+        public void evaluate() {
+            Assume.assumeTrue("Ignored by " + condition.getClass()
+                    .getSimpleName(), false);
+        }
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/annotations/SkipUnstableTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/annotations/SkipUnstableTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.itests.common.annotations;
+
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule.IgnoreCondition;
+
+/**
+ * Condition used by the {@link ConditionalIgnoreRule.IgnoreCondition} to indicates that a test
+ * should only be run if the {@value INCLUDE_UNSTABLE_TESTS_PROPERTY} system property is set to
+ * {@code true}.
+ * <p>
+ * Example:
+ * <pre>
+ *   @Test
+ *   @ConditionalIgnore(condition = SkipUnstableTest.class)
+ *   public void unstableTestMethod() throws Exception {
+ *       // ...
+ *   }
+ * </pre>
+ */
+public class SkipUnstableTest implements IgnoreCondition {
+    public static final String INCLUDE_UNSTABLE_TESTS_PROPERTY = "includeUnstableTests";
+
+    @Override
+    public boolean isSatisfied() {
+        return !System.getProperty(INCLUDE_UNSTABLE_TESTS_PROPERTY, "false")
+                .equals("true");
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ConditionalIgnoreTest.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/ConditionalIgnoreTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.common.test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule.ConditionalIgnore;
+import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+public class ConditionalIgnoreTest {
+
+    public static class AnnotatedTest {
+
+        @Rule
+        public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
+
+        @Test
+        public void stableTest() {
+        }
+
+        @Test
+        @ConditionalIgnore(condition = SkipUnstableTest.class)
+        public void unstableTest() {
+        }
+    }
+
+    private static class SkippedTestsCollector extends RunListener {
+        List<Failure> skippedTests = new ArrayList<>();
+
+        @Override
+        public void testAssumptionFailure(Failure failure) {
+            skippedTests.add(failure);
+            super.testAssumptionFailure(failure);
+        }
+    }
+
+    private JUnitCore core;
+
+    private SkippedTestsCollector skippedTestsCollector;
+
+    @Before
+    public void setup() {
+        core = new JUnitCore();
+        skippedTestsCollector = new SkippedTestsCollector();
+        core.addListener(skippedTestsCollector);
+    }
+
+    @Test
+    public void testIncludeUnstableTestIsNotSet() {
+        System.clearProperty("includeUnstableTests");
+
+        Result result = core.run(AnnotatedTest.class);
+
+        assertThat(result.wasSuccessful(), is(true));
+        assertThat(result.getRunCount(), is(2));
+        assertThat(result.getFailureCount(), is(0));
+        assertThat(result.getIgnoreCount(), is(0));
+        assertThat(skippedTestsCollector.skippedTests, hasSize(1));
+        assertThat(skippedTestsCollector.skippedTests.get(0)
+                .getTestHeader(), startsWith("unstableTest"));
+    }
+
+    @Test
+    public void testIncludeUnstableTestIsFalse() {
+        System.setProperty("includeUnstableTests", "false");
+
+        Result result = core.run(AnnotatedTest.class);
+
+        assertThat(result.wasSuccessful(), is(true));
+        assertThat(result.getRunCount(), is(2));
+        assertThat(result.getFailureCount(), is(0));
+        assertThat(result.getIgnoreCount(), is(0));
+        assertThat(skippedTestsCollector.skippedTests, hasSize(1));
+        assertThat(skippedTestsCollector.skippedTests.get(0)
+                .getTestHeader(), startsWith("unstableTest"));
+    }
+
+    @Test
+    public void testIncludeUnstableTestIsTrue() {
+        System.setProperty("includeUnstableTests", "true");
+
+        Result result = core.run(AnnotatedTest.class);
+
+        assertThat(result.wasSuccessful(), is(true));
+        assertThat(result.getRunCount(), is(2));
+        assertThat(result.getFailureCount(), is(0));
+        assertThat(result.getIgnoreCount(), is(0));
+        assertThat(skippedTestsCollector.skippedTests, hasSize(0));
+    }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -82,6 +82,9 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.bundle.core.BundleService;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule.ConditionalIgnore;
+import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.cometd.CometDClient;
 import org.codice.ddf.itests.common.cometd.CometDMessageValidator;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
@@ -218,6 +221,9 @@ public class TestFederation extends AbstractIntegrationTest {
 
     @Rule
     public TestName testName = new TestName();
+
+    @Rule
+    public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
 
     private List<String> metacardsToDelete = new ArrayList<>();
 
@@ -2254,9 +2260,8 @@ public class TestFederation extends AbstractIntegrationTest {
      * @throws Exception
      */
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)  // TODO: DDF-2581
     public void testAsyncDownloadActionPresentUsingCometDClient() throws Exception {
-        unstableTest(); // TODO: DDF-2581
-
         getCatalogBundle().setupCaching(true);
         String src = "ddf.distribution";
         String metacardId = ingestXmlWithProduct(String.format("%s.txt", testName.getMethodName()));


### PR DESCRIPTION
#### What does this PR do?
Replaced `unstableTest()` method with jUnit Rule and annotation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@tbatie 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Run the integration tests with and without the `-DincludeUnstableTests` and make sure `testAsyncDownloadActionPresentUsingCometDClient` is run or skipped based on the system property.

#### Any background context you want to provide?
This is a follow up of https://github.com/codice/ddf/pull/1404

#### What are the relevant tickets?
[DDF-2581](https://codice.atlassian.net/browse/DDF-2581)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
