### PR TITLE
(2.9.x) DDF-2557 Resolve system properties in endpoint url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,7 @@ replace with next unreleased version
 
 ### BUG FIXES
 
+- [DDF-2557](https://codice.atlassian.net/browse/DDF-2557) CSW (and possibly other sources) fail to resolve the default URIs
 - [DDF-2506](https://codice.atlassian.net/browse/DDF-2506): Sorting by distance can take minutes.
 - [DDF-2459](https://codice.atlassian.net/browse/DDF-2459): Content directory monitor stops finding new files, requiring administrators to refresh configuration settings to trigger updates
 - [DDF-2480](https://codice.atlassian.net/browse/DDF-2480): Search UI upload dialog cannot be re-opened if closed when file upload in progress

--- a/platform/security/rest/security-rest-cxfwrapper/pom.xml
+++ b/platform/security/rest/security-rest-cxfwrapper/pom.xml
@@ -80,6 +80,11 @@
             <groupId>ddf.security</groupId>
             <artifactId>ddf-security-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -30,6 +30,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.shiro.subject.Subject;
+import org.codice.ddf.configuration.PropertyResolver;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,12 @@ public class SecureCxfClientFactory<T> {
         this(endpointUrl, interfaceClass, null, null, false, false, null, null, username, password);
     }
 
+    public SecureCxfClientFactory(String endpointUrl, Class<T> interfaceClass, List<?> providers,
+            Interceptor<? extends Message> interceptor, boolean disableCnCheck,
+            boolean allowRedirects) {
+        this(endpointUrl, interfaceClass, providers, interceptor, disableCnCheck, allowRedirects,
+                new PropertyResolver(endpointUrl));
+    }
     /**
      * Constructs a factory that will return security-aware cxf clients. Once constructed,
      * use the getClient* methods to retrieve a fresh client  with the same configuration.
@@ -91,10 +98,17 @@ public class SecureCxfClientFactory<T> {
      */
     public SecureCxfClientFactory(String endpointUrl, Class<T> interfaceClass, List<?> providers,
             Interceptor<? extends Message> interceptor, boolean disableCnCheck,
-            boolean allowRedirects) {
+            boolean allowRedirects, PropertyResolver propertyResolver) {
         if (StringUtils.isEmpty(endpointUrl) || interfaceClass == null) {
             throw new IllegalArgumentException(
                     "Called without a valid URL, will not be able to connect.");
+        }
+
+        if (propertyResolver != null) {
+            endpointUrl = propertyResolver.getResolvedString();
+        } else {
+            LOGGER.warn(
+                    "Called without a valid propertyResolver, system properties in URI may not resolve.");
         }
 
         this.interfaceClass = interfaceClass;


### PR DESCRIPTION
#### What does this PR do?

This PR fixes an issue where the CSW source would fail to resolve the default URIs.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@brendan-hofmann @ahoffer @timothytierney
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith 
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)

Build DDF and create a new CSW source in the catalog, verify that the URI resolves and no exceptions are thrown in the log.
#### What are the relevant tickets?

[DDF-2557](https://codice.atlassian.net/browse/DDF-2557)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Added a call to PropertyResolver.resolveProperties to parse out
and resolve any system properties which may be in the endpointUrl passed
to the SecureCxfClientFactory.
