### PR TITLE
DDF-2588 Create a retry utility and update TFBOS to use it

### DIFF
--- a/catalog/core/catalog-core-backupplugin/pom.xml
+++ b/catalog/core/catalog-core-backupplugin/pom.xml
@@ -42,7 +42,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>catalog-core-api-impl;scope=!test</Embed-Dependency>
+                        <Embed-Dependency>
+                            catalog-core-api-impl;scope=!test
+                        </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.backup,
                             ddf.catalog.data.impl.*,

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>
-            <version>0.9.3</version>
+            <version>${jodah-failsafe.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -117,8 +117,7 @@
                             catalog-core-api-impl,
                             ddf-security-common,
                             platform-util,
-                            platform-util-unavailableurls,
-                            failsafe
+                            platform-util-unavailableurls
                         </Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -287,6 +287,11 @@
             <artifactId>platform-country-converter-local</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>${jodah-failsafe.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in used in platform-app's features.xml

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -727,6 +727,7 @@
 
     <feature name="platform-api" install="manual" version="${project.version}"
              description="Top Level Platform API">
+        <bundle dependency="true">wrap:mvn:net.jodah/failsafe/${jodah-failsafe.version}</bundle>
         <bundle>mvn:ddf.platform.api/platform-api/${project.version}</bundle>
     </feature>
 
@@ -1091,6 +1092,7 @@
     <feature name="platform-paxweb-jettyconfig" install="manual" version="${project.version}"
              description="Custom Session Manager">
         <feature>pax-jetty</feature>
+        <bundle dependency="true">wrap:mvn:net.jodah/failsafe/${jodah-failsafe.version}</bundle>
         <bundle>mvn:ddf.platform/platform-paxweb-jettyconfig/${project.version}</bundle>
     </feature>
 

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -49,6 +49,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>${jodah-failsafe.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
         <spatial4j.version>0.6</spatial4j.version>
         <spring-osgi.version>1.1.0</spring-osgi.version>
         <felix.configadmin.version>1.8.8</felix.configadmin.version>
+        <jodah-failsafe.version>0.9.5</jodah-failsafe.version>
     </properties>
     <!--
     NOTE: The properties ddf.scm.connection.url, snapshots.repository.url and releases.repository.url should be defined


### PR DESCRIPTION
#### What does this PR do?

* Create an retry utility that will re-execute an operation if that operation throws an exception
* Update TemporaryFileBackedOutputStream to use the retry utility when resetting the underlying FileBackedOutputStream (google).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining 
@rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[IO](https://github.com/orgs/codice/teams/IO)
@coyotesqrl 

[Core APIs](https://github.com/orgs/codice/teams/core-apis)
@dcruver 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison
#### How should this be tested? (List steps with links to updated documentation)

To directly test the retry code, run the unit tests in org.codice.ddf.platform.util.OperationRunnerTest.

To directly test TFBOS (and thus indirectly test the retry code), exercise any part of the system that uses TFBOS. For example, anything that calls InputTransformerProducer#generateMetacard.

#### Any background context you want to provide?

It was discovered that in a windows vm, the TFBOS was unable to delete its temporary file, even though no other code should be locking/using the file. Adding a simple retry mechanism gave the  windows os time release the lock. 

#### What are the relevant tickets?
[DFF-2588](https://codice.atlassian.net/browse/DDF-2588)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

