### PR TITLE
DDF-2594 Added readLock to content directory monitor Camel routes

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -260,7 +260,10 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                String inbox = "file:" + monitoredDirectory + "?moveFailed=.errors";
+                // Configure the camel route to ignore changing file (larger files that are in the process of being copied)
+                // Set the readLockTimeout to continuously poll the directory so long as the directory monitor exists
+                // Set the readLockCheckInterval to check every 5 seconds
+                String inbox = "file:" + monitoredDirectory + "?moveFailed=.errors&readLock=changed&readLockTimeout=0&readLockCheckInterval=5000";
                 if (copyIngestedFiles) {
                     inbox += "&move=.ingested";
                 } else {

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
@@ -232,7 +232,7 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
 
         LOGGER.debug("uri = {}", uri);
 
-        String expectedUri = "file:" + monitoredDirectory + "?moveFailed=.errors";
+        String expectedUri = "file:" + monitoredDirectory + "?moveFailed=.errors&readLock=changed&readLockTimeout=0&readLockCheckInterval=5000";
         if (copyIngestedFiles) {
             expectedUri += "&move=.ingested";
         } else {


### PR DESCRIPTION
#### What does this PR do?
This PR adds a readLock to Camel Routes in the Content Directory Monitor so large files can be ingested properly.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lcrosenbu @brendan-hofmann 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure CDM / Ingest Large File / Observe Correct Behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2594](https://codice.atlassian.net/browse/DDF-2594)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

