### PR TITLE
DDF-2598 - Improves and increases logging during exam setup for itests.

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AdminConfig.java
@@ -15,16 +15,13 @@ package org.codice.ddf.itests.common;
 
 import java.io.IOException;
 import java.util.Dictionary;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.itests.common.config.ConfigurationPredicate;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class AdminConfig {
     public static final String LOG_CONFIG_PID = "org.ops4j.pax.logging";
@@ -72,51 +69,6 @@ public class AdminConfig {
 
     public Configuration[] listConfigurations(String s) throws IOException, InvalidSyntaxException {
         return configAdmin.listConfigurations(s);
-    }
-
-    /**
-     * Waits until a {@link ConfigurationPredicate} returns {@code true}.
-     *
-     * @param pid       ID of the {@link Configuration} object that the {@link ConfigurationPredicate}
-     *                  will use to validate the condition
-     * @param predicate predicate to wait on
-     * @param timeoutMs wait timeout
-     * @return {@link Configuration} object
-     * @throws IOException          thrown if the {@link Configuration} object cannot be accessed
-     * @throws InterruptedException thrown if the wait times out
-     * @deprecated Use {@link WaitCondition} instead.
-     */
-    public Configuration waitForConfiguration(String pid, ConfigurationPredicate predicate,
-            long timeoutMs) throws IOException, InterruptedException {
-        LOGGER.debug("Waiting for condition {} in Configuration object [{}] to be true",
-                predicate.toString(),
-                pid);
-
-        Configuration configuration = configAdmin.getConfiguration(pid, null);
-
-        int waitPeriod = 0;
-
-        while ((waitPeriod < timeoutMs) && !predicate.test(configuration)) {
-            TimeUnit.MILLISECONDS.sleep(CONFIG_WAIT_POLLING_INTERVAL);
-            waitPeriod += CONFIG_WAIT_POLLING_INTERVAL;
-            configuration = configAdmin.getConfiguration(pid, null);
-        }
-
-        LOGGER.debug("Waited for {}ms", waitPeriod);
-
-        if (waitPeriod >= timeoutMs) {
-            LOGGER.error(
-                    "Timed out after waiting {}ms for condition {} to be true on configuration object {}",
-                    waitPeriod,
-                    predicate.toString(),
-                    pid);
-            throw new InterruptedException(String.format(
-                    "Timed out waiting for condition [%s] to be true in configuration object [%s]",
-                    predicate.toString(),
-                    pid));
-        }
-
-        return configuration;
     }
 
     public void setLogLevels() throws IOException {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/CatalogBundle.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/CatalogBundle.java
@@ -55,7 +55,7 @@ public class CatalogBundle {
 
     public CatalogProvider waitForCatalogProvider() throws InterruptedException {
         LOGGER.info("Waiting for CatalogProvider to become available.");
-        serviceManager.printInactiveBundles();
+        serviceManager.printInactiveBundlesInfo();
 
         CatalogProvider provider = null;
         long timeoutLimit = System.currentTimeMillis() + CATALOG_PROVIDER_TIMEOUT;

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManager.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManager.java
@@ -123,6 +123,8 @@ public interface ServiceManager {
 
     void printInactiveBundles();
 
+    void printInactiveBundlesInfo();
+
     <S> ServiceReference<S> getServiceReference(Class<S> aClass);
 
     <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> aClass, String s)


### PR DESCRIPTION
#### What does this PR do?
- Raises the default level for printing inactive bundles to ERROR
- Logs any failed config files from the etc directory that do not start in time
- Adds printing of inactive bundles to many more of the failure condition states, as failed bundles are a likely underlying cause

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mweser @vinamartin @emanns95 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
N/A

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Intentionally breaking a bundle so it cannot resolve and then running an itest that relies on that bundle would trigger the logging of inactive bundles.
Creating a configuration file that does not deploy would trigger the logging of unstarted/remaining config files, followed by the logging of inactive bundles.

For my testing, I ran an itest through the debugger in order to force some of the failure conditions - it is trivial to run through the `waitForAllConfigurations` method and then set the `files` array and `timeoutLimit` from within the debugger to trigger a failure state; however, it would be better if in heroing the failure conditions were created more naturally.

#### Any background context you want to provide?
We too often have `exam setup failures` in our CI environments without sufficient information logged to help analyze the problems. As they are intermittent issues that rarely present on our development boxes, they are difficult to track down and resolve.

#### What are the relevant tickets?
DDF-2598

[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
