### PR TITLE
DDF-2057 Updated csw url suggestion text in add remote registry modal

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/HandlebarsHelpers.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/HandlebarsHelpers.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'icanhaz'
+    ],
+    function (ich) {
+        "use strict";
+
+        // The module to be exported
+        var helper, helpers = {
+            is: function (value, test, options) {
+                if (value === test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            containsCsw: function(value, options) {
+                if (value.includes("CSW")) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            isnt: function (value, test, options) {
+                if (value !== test) {
+                    return options.fn(this);
+                } else {
+                    return options.inverse(this);
+                }
+            },
+            debug : function() {
+                console.log("Current Context");
+                console.log("====================");
+                console.log(this);
+
+            }
+        };
+
+        // Export helpers
+        for (helper in helpers) {
+            if (helpers.hasOwnProperty(helper)) {
+                ich.addHelper(helper, helpers[helper]);
+            }
+        }
+    });

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/main.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/main.js
@@ -95,7 +95,7 @@
         'marionette',
         'icanhaz',
         'js/application',
-        '../../../admin/js/HandlebarsHelpers',
+        'js/HandlebarsHelpers',
         'modelbinder',
         'bootstrap'
     ], function ($, Backbone, Marionette, ich, Application) {

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/configuration/configurationItem.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/configuration/configurationItem.handlebars
@@ -28,7 +28,7 @@
             {{#is optionValues.length 0}}
                 <input type="{{#is type 1}}text{{/is}}{{#is type 5}}text{{/is}}{{#is type 6}}text{{/is}}{{#is type 7}}text{{/is}}{{#is type 8}}text{{/is}}{{#is type 9}}text{{/is}}{{#is type 10}}text{{/is}}{{#is type 12}}password{{/is}}{{#is type 2}}number{{/is}}{{#is type 3}}number{{/is}}{{#is type 4}}number{{/is}}"
                        class="{{id}} metatype form-control input-sm" name="{{id}}" id="{{id}}"
-                       {{#is id "cswUrl"}}placeholder="https://hostname.here:port#/services/csw"{{/is}}
+                    {{#is id "registryUrl"}}{{#containsCsw description}}placeholder="https://hostname.here:port#/services/csw"{{/containsCsw}}{{/is}}
                        value="{{#defaultValue}}{{.}}{{/defaultValue}}">
             {{/is}}
             {{#isnt optionValues.length 0}}
@@ -41,7 +41,7 @@
         {{else}}
             <input type="{{#is type 1}}text{{/is}}{{#is type 5}}text{{/is}}{{#is type 6}}text{{/is}}{{#is type 7}}text{{/is}}{{#is type 8}}text{{/is}}{{#is type 9}}text{{/is}}{{#is type 10}}text{{/is}}{{#is type 12}}password{{/is}}{{#is type 2}}number{{/is}}{{#is type 3}}number{{/is}}{{#is type 4}}number{{/is}}"
                    class="{{id}} metatype form-control input-sm" name="{{id}}" id="{{id}}"
-                   {{#is id "cswUrl"}}placeholder="https://hostname.here:port#/services/csw"{{/is}}
+                {{#is id "registryUrl"}}{{#containsCsw description}}placeholder="https://hostname.here:port#/services/csw"{{/containsCsw}}{{/is}}
                    value="{{#defaultValue}}{{.}}{{/defaultValue}}">
         {{/if}}
 


### PR DESCRIPTION
#### What does this PR do?
Adds the suggested csw url text of `https://hostname.here:port#/services/csw` to the Registry Url field when adding a new registry from the remote tab in the DDF Registry.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brianfelix @gordocanchola @vinamartin 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Build changes, Boot DDF, Install DDF Registry App, Navigate to Remote Registry Tab in the Registry App, Click the + button to add a new Registry, Observe the suggested greyed out text in the url field

#### Any background context you want to provide?
This change should detect if the registry type is described as a csw type and shouldn't appear if another custom registry store was to be implemented as long as it wasn't described as "CSW". 

#### What are the relevant tickets?
[DDF-2057](https://codice.atlassian.net/browse/DDF-2057)
#### Screenshots (if appropriate)
<img width="861" alt="screen shot 2016-11-14 at 8 12 20 pm" src="https://cloud.githubusercontent.com/assets/11355332/20291887/bb9f11be-aaa6-11e6-8526-a35d14a9453f.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

