### PR TITLE
DDF-2602 allow for a user cert dn to be overridden

### DIFF
--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/AttributeMapLoader.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/AttributeMapLoader.java
@@ -108,9 +108,10 @@ public class AttributeMapLoader {
      * @param defaultBaseDN the default DN to fall back to
      * @return the base DN
      */
-    public static String getBaseDN(Principal principal, String defaultBaseDN) {
+    public static String getBaseDN(Principal principal, String defaultBaseDN,
+            boolean overrideCertDn) {
         String baseDN = null;
-        if (principal instanceof X500Principal) {
+        if (principal instanceof X500Principal && !overrideCertDn) {
             Predicate<RDN> predicate = rdn -> !rdn.getTypesAndValues()[0].getType()
                     .equals(BCStyle.CN);
             baseDN = SubjectUtils.filterDN((X500Principal) principal, predicate);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -53,6 +53,8 @@ public class ClaimsHandlerManager {
 
     public static final String START_TLS = "startTls";
 
+    public static final String OVERRIDE_CERT_DN = "overrideCertDn";
+
     public static final String LDAP_BIND_USER_DN = "ldapBindUserDn";
 
     public static final String PASSWORD = "password";
@@ -121,6 +123,13 @@ public class ClaimsHandlerManager {
         String userNameAttribute = (String) props.get(ClaimsHandlerManager.USER_NAME_ATTRIBUTE);
         String propertyFileLocation =
                 (String) props.get(ClaimsHandlerManager.PROPERTY_FILE_LOCATION);
+        Boolean overrideCertDn;
+        if (props.get(ClaimsHandlerManager.OVERRIDE_CERT_DN) instanceof String) {
+            overrideCertDn = Boolean.valueOf(
+                    (String) props.get(ClaimsHandlerManager.OVERRIDE_CERT_DN));
+        } else {
+            overrideCertDn = (Boolean) props.get(ClaimsHandlerManager.OVERRIDE_CERT_DN);
+        }
         try {
             if (encryptService != null) {
                 password = encryptService.decryptValue(password);
@@ -135,13 +144,15 @@ public class ClaimsHandlerManager {
                     memberNameAttribute,
                     groupBaseDn,
                     userDn,
-                    password);
+                    password,
+                    overrideCertDn);
             registerLdapClaimsHandler(connection2,
                     propertyFileLocation,
                     userBaseDn,
                     userNameAttribute,
                     userDn,
-                    password);
+                    password,
+                    overrideCertDn);
 
         } catch (Exception e) {
             LOGGER.warn(
@@ -219,7 +230,7 @@ public class ClaimsHandlerManager {
      */
     private void registerRoleClaimsHandler(LDAPConnectionFactory connection, String propertyFileLoc,
             String userBaseDn, String userNameAttr, String objectClass, String memberNameAttribute,
-            String groupBaseDn, String userDn, String password) {
+            String groupBaseDn, String userDn, String password, boolean overrideCertDn) {
         RoleClaimsHandler roleHandler = new RoleClaimsHandler();
         roleHandler.setLdapConnectionFactory(connection);
         roleHandler.setPropertyFileLocation(propertyFileLoc);
@@ -230,6 +241,7 @@ public class ClaimsHandlerManager {
         roleHandler.setGroupBaseDn(groupBaseDn);
         roleHandler.setBindUserDN(userDn);
         roleHandler.setBindUserCredentials(password);
+        roleHandler.setOverrideCertDn(overrideCertDn);
         LOGGER.debug("Registering new role claims handler.");
         roleHandlerRegistration = registerClaimsHandler(roleHandler, roleHandlerRegistration);
     }
@@ -243,7 +255,8 @@ public class ClaimsHandlerManager {
      * @param userNameAttr    Identifier that defines the user.
      */
     private void registerLdapClaimsHandler(LDAPConnectionFactory connection, String propertyFileLoc,
-            String userBaseDn, String userNameAttr, String userDn, String password) {
+            String userBaseDn, String userNameAttr, String userDn, String password,
+            boolean overrideCertDn) {
         LdapClaimsHandler ldapHandler = new LdapClaimsHandler();
         ldapHandler.setLdapConnectionFactory(connection);
         ldapHandler.setPropertyFileLocation(propertyFileLoc);
@@ -251,6 +264,7 @@ public class ClaimsHandlerManager {
         ldapHandler.setUserNameAttribute(userNameAttr);
         ldapHandler.setBindUserDN(userDn);
         ldapHandler.setBindUserCredentials(password);
+        ldapHandler.setOverrideCertDn(overrideCertDn);
         LOGGER.debug("Registering new ldap claims handler.");
         ldapHandlerRegistration = registerClaimsHandler(ldapHandler, ldapHandlerRegistration);
     }
@@ -343,6 +357,11 @@ public class ClaimsHandlerManager {
     public void setPropertyFileLocation(String propertyFileLocation) {
         LOGGER.trace("Setting propertyFileLocation: {}", propertyFileLocation);
         ldapProperties.put(PROPERTY_FILE_LOCATION, propertyFileLocation);
+    }
+
+    public void setOverrideCertDn(boolean overrideCertDn) {
+        LOGGER.trace("Setting propertyFileLocation: {}", overrideCertDn);
+        ldapProperties.put(OVERRIDE_CERT_DN, overrideCertDn);
     }
 
     public void configure() {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
@@ -51,6 +51,8 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
 
     private String bindUserDN;
 
+    private boolean overrideCertDn = false;
+
     public LdapClaimsHandler() {
         super();
     }
@@ -115,7 +117,8 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
                 BindResult bindResult = connection.bind(bindUserDN,
                         bindUserCredentials.toCharArray());
                 if (bindResult.isSuccess()) {
-                    String baseDN = AttributeMapLoader.getBaseDN(principal, getUserBaseDN());
+                    String baseDN = AttributeMapLoader.getBaseDN(principal, getUserBaseDN(),
+                            overrideCertDn);
                     LOGGER.trace("Executing ldap search with base dn of {} and filter of {}",
                             baseDN,
                             filter.toString());
@@ -193,5 +196,9 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
 
     public void setBindUserCredentials(String bindUserCredentials) {
         this.bindUserCredentials = bindUserCredentials;
+    }
+
+    public void setOverrideCertDn(boolean overrideCertDn) {
+        this.overrideCertDn = overrideCertDn;
     }
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -44,6 +44,8 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoleClaimsHandler.class);
 
+    private boolean overrideCertDn = false;
+
     private Map<String, String> claimsLdapAttributeMapping;
 
     private LDAPConnectionFactory connectionFactory;
@@ -198,7 +200,8 @@ public class RoleClaimsHandler implements ClaimsHandler {
             }
 
             AndFilter filter = new AndFilter();
-            String userBaseDN = AttributeMapLoader.getBaseDN(principal, getUserBaseDn());
+            String userBaseDN = AttributeMapLoader.getBaseDN(principal, getUserBaseDn(),
+                    overrideCertDn);
             filter.and(new EqualsFilter("objectClass", getObjectClass()))
                     .and(new EqualsFilter(getMemberNameAttribute(),
                             getUserNameAttribute() + "=" + user + "," + userBaseDN));
@@ -266,5 +269,9 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
     public void setBindUserCredentials(String bindUserCredentials) {
         this.bindUserCredentials = bindUserCredentials;
+    }
+
+    public void setOverrideCertDn(boolean overrideCertDn) {
+        this.overrideCertDn = overrideCertDn;
     }
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,6 +58,7 @@
             <property name="memberNameAttribute" value="member"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="propertyFileLocation" value="${ddf.home}/etc/ws-security/attributeMap.properties"/>
+            <property name="overrideCertDn" value="false" />
             <cm:managed-properties persistent-id=""
                                    update-strategy="component-managed" update-method="update"/>
         </cm:managed-component>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -48,6 +48,11 @@
             description="Full LDAP path to where users can be found.">
 	    </AD>
 
+		<AD name="Override User Certificate DN:" id="overrideCertDn" required="true" type="Boolean"
+			default="false"
+			description="When checked, this setting will ignore the DN of a user and instead use the LDAP Base User DN value.">
+		</AD>
+
         <AD name="LDAP Group ObjectClass:" id="objectClass" required="true" type="String"
             default="groupOfNames"
             description="ObjectClass that defines structure for group membership in LDAP. Usually this is groupOfNames or groupOfUniqueNames.">

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/AttributeMapLoaderTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/AttributeMapLoaderTest.java
@@ -103,17 +103,27 @@ public class AttributeMapLoaderTest {
     public void testGetBaseDnX500() {
         Principal principal = new X500Principal(X500_DN);
 
-        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN);
+        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
         String[] split = baseDN.replaceAll("\\s", "").split(",");
         assertArrayEquals(X500_BASE_DN_ARR, split);
     }
 
     @Test
+    public void testGetBaseDnX500Override() {
+        Principal principal = new X500Principal(X500_DN);
+
+        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, true);
+
+        String[] split = baseDN.replaceAll("\\s", "").split(",");
+        assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);
+    }
+
+    @Test
     public void testGetBaseDnX500EmptyDN() {
         Principal principal = new X500Principal("CN=FOOBAR");
 
-        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN);
+        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
         String[] split = baseDN.replaceAll("\\s", "").split(",");
         assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);
@@ -123,7 +133,7 @@ public class AttributeMapLoaderTest {
     public void testGetBaseDnNonX500() {
         Principal principal = new KerberosPrincipal(KERBEROS_PRINCIPAL);
 
-        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN);
+        String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
         String[] split = baseDN.replaceAll("\\s", "").split(",");
         assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
@@ -87,6 +87,7 @@ public class ClaimsHandlerManagerTest {
         manager.setMemberNameAttribute("member");
         manager.setPassword("secret");
         manager.setPropertyFileLocation("etc/ws-security/attributeMap.properties");
+        manager.setOverrideCertDn(false);
         manager.configure();
 
         // verify initial registration


### PR DESCRIPTION
#### What does this PR do?
Adds a config option to the LDAP claims handlers to allow an admin to override user cert DNs with the specified base user DN
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@pklinef @tbatie @adimka 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

