### PR TITLE
DDF-2596 Reduce number of log entries by ApplicationImpl

### DIFF
--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -12,7 +12,7 @@
  *
  **/
 -->
-<features name="ddf-itest-dependencies">
+<features name="ddf-itest-dependencies-${project.version}">
 
     <feature name="ddf-itest-dependencies">
         <feature>third-party-dependencies</feature>
@@ -26,7 +26,9 @@
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
         <bundle>mvn:ddf.test.thirdparty/rest-assured/${project.version}</bundle>
 
-        <bundle>wrap:mvn:ddf.security/ddf-security-common/${project.version}$Bundle-SymbolicName=itest-test-security-common</bundle>
+        <bundle>
+            wrap:mvn:ddf.security/ddf-security-common/${project.version}$Bundle-SymbolicName=itest-test-security-common
+        </bundle>
         <bundle>mvn:ddf.test.itests/test-itests-common/${project.version}</bundle>
 
         <bundle>mvn:ddf.test.thirdparty/restito/${project.version}</bundle>
@@ -34,14 +36,24 @@
 
     <feature name="third-party-dependencies">
         <bundle>mvn:commons-io/commons-io/2.5</bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-codec/${commons-codec.servicemix.version}</bundle>
+        <bundle>
+            mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-codec/${commons-codec.servicemix.version}
+        </bundle>
         <bundle>wrap:mvn:commons-logging/commons-logging/1.2</bundle>
         <bundle>wrap:mvn:commons-net/commons-net/3.5</bundle>
 
-        <bundle>wrap:mvn:org.cometd.java/cometd-java-client/${cometd.version}$Export-Package=*;version=${cometd.version}</bundle>
-        <bundle>wrap:mvn:org.cometd.java/bayeux-api/${cometd.version}$Export-Package=*;version=${cometd.version}</bundle>
-        <bundle>wrap:mvn:org.cometd.java/cometd-java-common/${cometd.version}$Export-Package=*;version=${cometd.version}</bundle>
+        <bundle>
+            wrap:mvn:org.cometd.java/cometd-java-client/${cometd.version}$Export-Package=*;version=${cometd.version}
+        </bundle>
+        <bundle>
+            wrap:mvn:org.cometd.java/bayeux-api/${cometd.version}$Export-Package=*;version=${cometd.version}
+        </bundle>
+        <bundle>
+            wrap:mvn:org.cometd.java/cometd-java-common/${cometd.version}$Export-Package=*;version=${cometd.version}
+        </bundle>
 
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.hamcrest/${hamcrest-all.servicemix.version}</bundle>
+        <bundle>
+            mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.hamcrest/${hamcrest-all.servicemix.version}
+        </bundle>
     </feature>
 </features>


### PR DESCRIPTION
#### What does this PR do?
Stops printing the log entry "Error occured while trying to parse information for application. Application created but may have missing information." Problem in string parsing routines that expected the format "xml-specs-api-2.5.0". Names like "test-dependencies" caused the error.

New behavior tolerates both formats.
New behavior exposes exception if repository cannot be loaded. Repository methods getName(), getFeatures(), both attempt to load the repository.
Updates two features.xml files. Names conform to expectations.
New behavior throws exception if name cannot be parsed unambiguously.
 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brendan-hofmann @vinamartin @pklinef 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
@garrettfreibott 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
The hero build should NOT contains the log entry "Error occured while trying to parse information for application. Application created but may have missing information." 
#### Any background context you want to provide?
Part of the effort to remove unnecessary log entries.
#### What are the relevant tickets?
[DDF-2596](https://codice.atlassian.net/browse/DDF-2596/)
#### Screenshots (if appropriate)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Change Log Updated
- [Yes ] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
