### PR TITLE
DDF-2601 Fixed NPE in AbstractCswSource.java

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -1160,31 +1160,40 @@ public abstract class AbstractCswSource extends MaskableImpl
             sortBy = new SortByType();
             SortPropertyType sortProperty = new SortPropertyType();
             PropertyNameType propertyName = new PropertyNameType();
-            String propName = query.getSortBy()
-                    .getPropertyName()
-                    .getPropertyName();
-            if (propName != null) {
-                if (Result.TEMPORAL.equals(propName) || Metacard.ANY_DATE.equals(propName)) {
-                    propName = Core.MODIFIED;
-                } else if (Result.RELEVANCE.equals(propName)
-                        || Metacard.ANY_TEXT.equals(propName)) {
-                    propName = Core.TITLE;
-                } else if (Result.DISTANCE.equals(propName) || Metacard.ANY_GEO.equals(propName)) {
-                    return null;
-                }
-            }
 
-            propertyName.setContent(Arrays.asList((Object) cswFilterDelegate.mapPropertyName(
-                    propName)));
-            sortProperty.setPropertyName(propertyName);
-            if (SortOrder.DESCENDING.equals(query.getSortBy()
-                    .getSortOrder())) {
-                sortProperty.setSortOrder(SortOrderType.DESC);
+            String propName;
+            if (query.getSortBy()
+                    .getPropertyName() != null) {
+                propName = query.getSortBy()
+                        .getPropertyName()
+                        .getPropertyName();
+
+                if (propName != null) {
+                    if (Result.TEMPORAL.equals(propName) || Metacard.ANY_DATE.equals(propName)) {
+                        propName = Core.MODIFIED;
+                    } else if (Result.RELEVANCE.equals(propName) || Metacard.ANY_TEXT.equals(
+                            propName)) {
+                        propName = Core.TITLE;
+                    } else if (Result.DISTANCE.equals(propName)
+                            || Metacard.ANY_GEO.equals(propName)) {
+                        return null;
+                    }
+
+                    propertyName.setContent(Arrays.asList((Object) cswFilterDelegate.mapPropertyName(
+                            propName)));
+                    sortProperty.setPropertyName(propertyName);
+                    if (SortOrder.DESCENDING.equals(query.getSortBy()
+                            .getSortOrder())) {
+                        sortProperty.setSortOrder(SortOrderType.DESC);
+                    } else {
+                        sortProperty.setSortOrder(SortOrderType.ASC);
+                    }
+                    sortBy.getSortProperty()
+                            .add(sortProperty);
+                }
             } else {
-                sortProperty.setSortOrder(SortOrderType.ASC);
+                return null;
             }
-            sortBy.getSortProperty()
-                    .add(sortProperty);
         }
 
         return sortBy;

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
@@ -274,6 +274,106 @@ public class TestCswSource extends TestCswSourceBase {
     }
 
     @Test
+     public void testQueryWitNaturalSorting()
+            throws JAXBException, UnsupportedQueryException, DatatypeConfigurationException,
+            SAXException, IOException, SecurityServiceException {
+        // Setup
+        final String searchPhrase = "*";
+        final int pageSize = 1;
+        final int numRecordsReturned = 1;
+        final long numRecordsMatched = 1;
+
+        setupMockContextForMetacardTypeRegistrationAndUnregistration(getDefaultContentTypes());
+
+        try {
+            configureMockCsw(numRecordsReturned, numRecordsMatched, CswConstants.VERSION_2_0_2);
+        } catch (CswException e) {
+            fail("Could not configure Mock Remote CSW: " + e.getMessage());
+        }
+
+        QueryImpl query = new QueryImpl(builder.attribute(Metacard.ANY_TEXT)
+                .is()
+                .like()
+                .text(searchPhrase));
+        query.setPageSize(pageSize);
+        query.setSortBy(SortBy.NATURAL_ORDER);
+
+        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext);
+        cswSource.setCswUrl(URL);
+        cswSource.setId(ID);
+
+        // Perform test
+        SourceResponse response = cswSource.query(new QueryRequestImpl(query));
+
+        // Verify
+        Assert.assertNotNull(response);
+        assertThat(response.getResults()
+                .size(), is(numRecordsReturned));
+        assertThat(response.getHits(), is(numRecordsMatched));
+        ArgumentCaptor<GetRecordsType> captor = ArgumentCaptor.forClass(GetRecordsType.class);
+        try {
+            verify(mockCsw, atLeastOnce()).getRecords(captor.capture());
+        } catch (CswException e) {
+            fail("Could not verify mock CSW record count: " + e.getMessage());
+        }
+        GetRecordsType getRecordsType = captor.getValue();
+
+        QueryType cswQuery = (QueryType) getRecordsType.getAbstractQuery()
+                .getValue();
+        assertThat(cswQuery.getSortBy(), nullValue());
+    }
+
+    @Test
+    public void testQueryWitNullSorting()
+            throws JAXBException, UnsupportedQueryException, DatatypeConfigurationException,
+            SAXException, IOException, SecurityServiceException {
+        // Setup
+        final String searchPhrase = "*";
+        final int pageSize = 1;
+        final int numRecordsReturned = 1;
+        final long numRecordsMatched = 1;
+
+        setupMockContextForMetacardTypeRegistrationAndUnregistration(getDefaultContentTypes());
+
+        try {
+            configureMockCsw(numRecordsReturned, numRecordsMatched, CswConstants.VERSION_2_0_2);
+        } catch (CswException e) {
+            fail("Could not configure Mock Remote CSW: " + e.getMessage());
+        }
+
+        QueryImpl query = new QueryImpl(builder.attribute(Metacard.ANY_TEXT)
+                .is()
+                .like()
+                .text(searchPhrase));
+        query.setPageSize(pageSize);
+        query.setSortBy(null);
+
+        AbstractCswSource cswSource = getCswSource(mockCsw, mockContext);
+        cswSource.setCswUrl(URL);
+        cswSource.setId(ID);
+
+        // Perform test
+        SourceResponse response = cswSource.query(new QueryRequestImpl(query));
+
+        // Verify
+        Assert.assertNotNull(response);
+        assertThat(response.getResults()
+                .size(), is(numRecordsReturned));
+        assertThat(response.getHits(), is(numRecordsMatched));
+        ArgumentCaptor<GetRecordsType> captor = ArgumentCaptor.forClass(GetRecordsType.class);
+        try {
+            verify(mockCsw, atLeastOnce()).getRecords(captor.capture());
+        } catch (CswException e) {
+            fail("Could not verify mock CSW record count: " + e.getMessage());
+        }
+        GetRecordsType getRecordsType = captor.getValue();
+
+        QueryType cswQuery = (QueryType) getRecordsType.getAbstractQuery()
+                .getValue();
+        assertThat(cswQuery.getSortBy(), nullValue());
+    }
+
+    @Test
     public void testQueryWithSorting()
             throws JAXBException, UnsupportedQueryException, DatatypeConfigurationException,
             SAXException, IOException, SecurityServiceException {


### PR DESCRIPTION
#### What does this PR do?
This PR removes the potential for an NPE in AbstractCswSource when creating the sort order.  This was observed when using SortBy.NATURAL_ORDERING.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @lcrosenbu 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure Federated CSW / Observe No NPE
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2601](https://codice.atlassian.net/browse/DDF-2601)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

