### PR TITLE
DDF-2585 Add locale to system.properties

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -186,6 +186,8 @@ karaf.secured.services=(&(osgi.command.scope=*)(osgi.command.function=*))
 #org.osgi.framework.trust.repositories=${karaf.home}/etc/trustStore.ks
 ws-security.subject.cert.constraints = .*
 security.audit.roles=group,admin,manager,viewer,system-admin,system-history,systembundles
+user.language="en"
+user.country="US"
 
 #
 # Disable Hazelcast version check


### PR DESCRIPTION
#### What does this PR do?
Creates two fields in system.properties denoting the locale. This is useful for future cases where a string comparison may rely on a locale's capitalization standards to avoid unpredictable character behaviours. 

#### Relevant tickets:
DDF-2585


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @bdeining  

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
If it builds, it is good.

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
