### PR TITLE
DDF-2604 Latitude and Longitude attributes should not be editable

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
@@ -72,7 +72,8 @@
                name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
     {{/is}}
     {{#is type "boolean"}}
-        <input type="checkbox" name="value" value="{{value}}" {{#unless editable}}disabled{{/unless}}/>
+        <input type="checkbox" name="value" value="{{value}}"
+               {{#unless editable}}disabled{{/unless}}/>
     {{/is}}
     {{#is type "date"}}
         <input type="date" name="valueDate" value="{{valueDate}}"
@@ -86,12 +87,18 @@
     {{/is}}
     {{#is type "point"}}
         <div class="coords">
-            <label>Lat:</label><input class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number" min="-90" max="90"
-                                      name="valueLat"
-                                      value="{{valueLat}}"/>
-            <label>Lon:</label><input class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number" min="-180" max="180"
-                                      name="valueLon"
-                                      value="{{valueLon}}"/>
+            <label>Lat:</label><input
+                class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number"
+                min="-90" max="90"
+                name="valueLat"
+                value="{{valueLat}}"
+                {{#unless editable}}readonly{{/unless}}/>
+            <label>Lon:</label><input
+                class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number"
+                min="-180" max="180"
+                name="valueLon"
+                value="{{valueLon}}"
+                {{#unless editable}}readonly{{/unless}}/>
         </div>
     {{/is}}
     {{#is type "bounds"}}


### PR DESCRIPTION
#### What does this PR do?
The latitude and longitude of remote repositories should not be editable locally.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote 
#### Select at least one member from relevant component team(s) from below (at least one 
@mcalcote 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Build, unzip, and start DDF.
Install the registry application.
Add a remote repository.
View the node information of the remote repository.
Latitude and longitude attributes should be read-only
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2604
#### Screenshots (if appropriate)
![good-geographic-information-readonly](https://cloud.githubusercontent.com/assets/133284/20357432/3500bcb2-abe5-11e6-9abb-be10b0784716.png)
![bad-geographic-location-editable](https://cloud.githubusercontent.com/assets/133284/20357433/36c4bb98-abe5-11e6-9d54-f02d1343ced4.png)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Change Log Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
