### PR TITLE
[2.9.x]DDF-2590: Suppressing OWASP warning because security vulnerability does not exist

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -116,6 +116,13 @@
     </suppress>
 
     <suppress>
+        <notes>
+            CVE-2016-1000031: Applies to commons-fileupload-1.2.1, suppressing because the vulnerable class DiskFileItem is not used in the project
+        </notes>
+        <cve>CVE-2016-1000031</cve>
+    </suppress>
+
+    <suppress>
         <notes><![CDATA[
         false positive the effected camel version is 2.12 this uses a later version and does use the XSLT component
       file name: proxy-camel-servlet-2.9.0-SNAPSHOT.jar

--- a/platform/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
+++ b/platform/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
@@ -17,6 +17,13 @@
         <cve>CVE-2016-3720</cve>
     </suppress>
 
+    <suppress>
+        <notes>
+            CVE-2016-1000031: Applies to commons-fileupload-1.2.1, suppressing because the vulnerable class DiskFileItem is not used in the project
+        </notes>
+        <cve>CVE-2016-1000031</cve>
+    </suppress>
+
     <!--
     CVE-2008-0660 is a stack based buffer overflow vulnerability related to ActiveX and
     several image uploaders. This is unrelated to presto-parser, so marking as a false positive.


### PR DESCRIPTION
#### What does this PR do?
Suppresses the OWASP warning for this vulnerability since our project does not use the Java class that has the vulnerabilty.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lessarderic @shaundmorris @Lambeaux

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Security](https://github.com/orgs/codice/teams/security)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
Run a successful build with the owasp profile `mvn clean install -Powasp`
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2590](https://codice.atlassian.net/browse/DDF-2590)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests