### PR TITLE
DDF-2613 Latitude and Longitude attributes should not be editable

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-local-ui/src/main/webapp/templates/field.handlebars
@@ -72,7 +72,8 @@
                name="value" value="{{value}}" {{#unless editable}}readonly{{/unless}}/>
     {{/is}}
     {{#is type "boolean"}}
-        <input type="checkbox" name="value" value="{{value}}" {{#unless editable}}disabled{{/unless}}/>
+        <input type="checkbox" name="value" value="{{value}}"
+               {{#unless editable}}disabled{{/unless}}/>
     {{/is}}
     {{#is type "date"}}
         <input type="date" name="valueDate" value="{{valueDate}}"
@@ -86,12 +87,18 @@
     {{/is}}
     {{#is type "point"}}
         <div class="coords">
-            <label>Lat:</label><input class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number" min="-90" max="90"
-                                      name="valueLat"
-                                      value="{{valueLat}}"/>
-            <label>Lon:</label><input class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number" min="-180" max="180"
-                                      name="valueLon"
-                                      value="{{valueLon}}"/>
+            <label>Lat:</label><input
+                class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number"
+                min="-90" max="90"
+                name="valueLat"
+                value="{{valueLat}}"
+                {{#unless editable}}readonly{{/unless}}/>
+            <label>Lon:</label><input
+                class="lat-lon-input {{#if validationError}}validation-error{{/if}}" type="number"
+                min="-180" max="180"
+                name="valueLon"
+                value="{{valueLon}}"
+                {{#unless editable}}readonly{{/unless}}/>
         </div>
     {{/is}}
     {{#is type "bounds"}}


### PR DESCRIPTION
What does this PR do?

The latitude and longitude of remote repositories should not be editable locally.

Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@clockard @mcalcote

Select at least one member from relevant component team(s) from below (at least one

@mcalcote

Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@lessarderic
@shaundmorris

How should this be tested? (List steps with links to updated documentation)
Install the registry application.
Add a remote repository.
View the node information of the remote repository.
Latitude and longitude attributes should be read-only

Any background context you want to provide?
No.

What are the relevant tickets?

DDF-2613

Checklist:
[N/A] Documentation Updated
[N/A] Change Log Updated
[N/A] Update / Add Unit Tests
[N/A] Update / Add Integration Tests