### PR TITLE
DDF-2616 Protect against DTD and entity expansion

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
@@ -236,6 +236,14 @@ public class ApplicationFileInstaller {
         }
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+
+        try {
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (ParserConfigurationException e) {
+            LOGGER.debug("Unable to set features on document builder.", e);
+        }
+
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
         Document doc = dBuilder.parse(zipFile.getInputStream(featureZipEntry));
 


### PR DESCRIPTION
#### What does this PR do?
Adds protections against DTD entity expansion vulnerabilities by setting features in new instances of DocumentBuilderFactory. Disables `load-dtd-grammar` and `load-external-dtd`.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @spearskw @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Ticket does not touch any tests, so a normal build should suffice.

#### Any background context you want to provide?
Flagged issue from Fortify static analysis.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2616)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

