### PR TITLE
[2.9.x]DDF-2630: Adding logic to retrieve the Subject correctly so that Point of Contact is actually set on the metacard.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -56,6 +56,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.Subject;
 import org.apache.tika.detect.DefaultProbDetector;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.metadata.Metadata;
@@ -186,7 +188,6 @@ import ddf.catalog.util.impl.Requests;
 import ddf.catalog.util.impl.SourceDescriptorComparator;
 import ddf.mime.MimeTypeResolutionException;
 import ddf.security.SecurityConstants;
-import ddf.security.Subject;
 import ddf.security.SubjectUtils;
 import ddf.security.common.audit.SecurityLogger;
 import ddf.security.permission.CollectionPermission;
@@ -841,8 +842,7 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                         contentItem.getId(),
                         fileName,
                         size,
-                        (Subject) storageRequest.getProperties()
-                                .get(SecurityConstants.SECURITY_SUBJECT),
+                        retrieveSubject(),
                         tmpPath);
                 metacardMap.put(metacard.getId(), metacard);
 
@@ -3507,5 +3507,19 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         }
 
         return CollectionUtils.containsAny(tags, fanoutTagBlacklist);
+    }
+
+    private ddf.security.Subject retrieveSubject() {
+        ddf.security.Subject subjectToReturn = null;
+        try {
+            Subject subject = SecurityUtils.getSubject();
+            if (subject instanceof ddf.security.Subject) {
+                subjectToReturn = (ddf.security.Subject) subject;
+            }
+        } catch (IllegalStateException exception) {
+            LOGGER.debug("No security subject found during metacard generation.");
+        }
+
+        return subjectToReturn;
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes the logic to retrieve the `Subject` using `SecurityUtils` since the `SecurityPlugin` has not processed and set it on the `CreateRequest`'s properties yet. This way, the Point of Contact attribute is set on the metacard correctly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lessarderic @Lambeaux @shaundmorris  
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
- Run a full build.
- Deploy DDF and ingest a product. Verify the associated metacard's Point of Contact is set.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2630](https://codice.atlassian.net/browse/DDF-2630)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests