### PR TITLE
DDF-2630: Adding logic to retrieve the Subject correctly so that Point of Contact is actually set on the metacard.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
@@ -37,6 +37,8 @@ import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,8 +77,6 @@ import ddf.catalog.source.IngestException;
 import ddf.catalog.source.InternalIngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.util.impl.Requests;
-import ddf.security.SecurityConstants;
-import ddf.security.Subject;
 
 /**
  * Support class for create delegate operations for the {@code CatalogFrameworkImpl}.
@@ -212,7 +212,7 @@ public class CreateOperations {
 
         // Operation populates the metacardMap, contentItems, and tmpContentPaths
         opsMetacardSupport.generateMetacardAndContentItems(streamCreateRequest.getContentItems(),
-                (Subject) streamCreateRequest.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                retrieveSubject(),
                 metacardMap,
                 contentItems,
                 tmpContentPaths);
@@ -678,6 +678,20 @@ public class CreateOperations {
             }
         }
         return createStorageRequest;
+    }
+
+    private ddf.security.Subject retrieveSubject() {
+        ddf.security.Subject subjectToReturn = null;
+        try {
+            Subject subject = SecurityUtils.getSubject();
+            if (subject instanceof ddf.security.Subject) {
+                subjectToReturn = (ddf.security.Subject) subject;
+            }
+        } catch (Exception exception) {
+            LOGGER.debug("No security subject found during metacard generation.");
+        }
+
+        return subjectToReturn;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
#### What does this PR do?
Fixes the logic to retrieve the `Subject` using `SecurityUtils` since the `SecurityPlugin` has not processed and set it on the `CreateRequest`'s properties yet. This way, the Point of Contact attribute is set on the metacard correctly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lessarderic @Lambeaux @shaundmorris  
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
- Run a full build.
- Deploy DDF and ingest a product. Verify the associated metacard's Point of Contact is set.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2630](https://codice.atlassian.net/browse/DDF-2630)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests