### PR TITLE
DDF-2621 Refactored the AttributeRegistry to dynamically register attributes from all MetacardTypes as they become available

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeRegistry.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/AttributeRegistry.java
@@ -24,25 +24,23 @@ import java.util.Optional;
  */
 public interface AttributeRegistry {
     /**
-     * Registers a new attribute. Returns false if an attribute with the same name already exists
-     * (in which case the attribute is not registered) and true otherwise.
+     * Registers a new attribute.
      *
      * @param attributeDescriptor the {@link AttributeDescriptor} describing the attribute
-     * @return whether the attribute was registered
      * @throws IllegalArgumentException if {@code attributeDescriptor} or
      *                                  {@link AttributeDescriptor#getName()} is null
      */
-    boolean register(AttributeDescriptor attributeDescriptor);
+    void register(AttributeDescriptor attributeDescriptor);
 
     /**
      * Removes an attribute from the registry.
      * <p>
-     * Does nothing if no attribute by the name {@code name} exists in the registry.
+     * Does nothing if the attributeDescriptor does not exist in the registry.
      *
-     * @param name the name of the attribute to remove
-     * @throws IllegalArgumentException if {@code name} is null
+     * @param attributeDescriptor an attributeDescriptor for the attribute
+     * @throws IllegalArgumentException if {@code attributeDescriptor} is null
      */
-    void deregister(String name);
+    void deregister(AttributeDescriptor attributeDescriptor);
 
     /**
      * Gets the {@link AttributeDescriptor} for the attribute with the given name.

--- a/catalog/core/catalog-core-attributeregistry/src/main/java/ddf/catalog/data/impl/AttributeRegistryImpl.java
+++ b/catalog/core/catalog-core-attributeregistry/src/main/java/ddf/catalog/data/impl/AttributeRegistryImpl.java
@@ -15,55 +15,74 @@ package ddf.catalog.data.impl;
 
 import static org.apache.commons.lang.Validate.notNull;
 
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.MetacardType;
 
 public class AttributeRegistryImpl implements AttributeRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(AttributeRegistryImpl.class);
 
-    private final Map<String, AttributeDescriptor> attributeMap = new ConcurrentHashMap<>();
-
-    public AttributeRegistryImpl() {
-        BasicTypes.BASIC_METACARD.getAttributeDescriptors()
-                .stream()
-                .forEach(this::register);
-    }
+    private final ListMultimap<String, AttributeDescriptor> attributeMap =
+            Multimaps.synchronizedListMultimap(LinkedListMultimap.create());
 
     @Override
-    public boolean register(final AttributeDescriptor attributeDescriptor) {
+    public void register(final AttributeDescriptor attributeDescriptor) {
         notNull(attributeDescriptor, "The attribute descriptor cannot be null.");
         notNull(attributeDescriptor.getName(), "The attribute name cannot be null.");
-
-        final String name = attributeDescriptor.getName();
-
-        if (attributeMap.putIfAbsent(name, attributeDescriptor) == null) {
-            return true;
-        }
-
-        LOGGER.debug(
-                "Attempted to register an attribute with name '{}', but an attribute with that name already exists.",
-                name);
-        return false;
+        attributeMap.put(attributeDescriptor.getName(), attributeDescriptor);
     }
 
     @Override
-    public void deregister(final String name) {
-        notNull(name, "The attribute name cannot be null.");
-
-        attributeMap.remove(name);
+    public void deregister(final AttributeDescriptor attributeDescriptor) {
+        notNull(attributeDescriptor, "The attribute descriptor cannot be null.");
+        notNull(attributeDescriptor.getName(), "The attribute name cannot be null.");
+        attributeMap.remove(attributeDescriptor.getName(), attributeDescriptor);
     }
 
     @Override
     public Optional<AttributeDescriptor> lookup(final String name) {
         notNull(name, "The attribute name cannot be null.");
+        return attributeMap.get(name)
+                .stream()
+                .findFirst();
+    }
 
-        return Optional.ofNullable(attributeMap.get(name));
+    public void registerMetacardType(MetacardType metacardType) {
+        if (metacardType != null) {
+            registerMetacardTypeAttributes(metacardType);
+        }
+    }
+
+    public void deregisterMetacardType(MetacardType metacardType) {
+        if (metacardType != null) {
+            deregisterMetacardTypeAttributes(metacardType);
+        }
+    }
+
+    private void registerMetacardTypeAttributes(MetacardType metacardType) {
+        LOGGER.debug("Adding attributes from {} metacard type", metacardType.getName());
+        metacardType.getAttributeDescriptors()
+                .stream()
+                .filter(attributeDescriptor -> attributeDescriptor != null)
+                .filter(attributeDescriptor -> attributeDescriptor.getName() != null)
+                .forEach(this::register);
+    }
+
+    private void deregisterMetacardTypeAttributes(MetacardType metacardType) {
+        LOGGER.debug("Removing attributes from {} metacard type", metacardType.getName());
+        metacardType.getAttributeDescriptors()
+                .stream()
+                .filter(attributeDescriptor -> attributeDescriptor != null)
+                .filter(attributeDescriptor -> attributeDescriptor.getName() != null)
+                .forEach(this::deregister);
     }
 }

--- a/catalog/core/catalog-core-attributeregistry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-attributeregistry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,11 @@
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <bean id="attributeRegistry" class="ddf.catalog.data.impl.AttributeRegistryImpl"/>
+    <reference-list id="metacardList" interface="ddf.catalog.data.MetacardType" member-type="service-object">
+        <reference-listener bind-method="registerMetacardType" unbind-method="deregisterMetacardType" ref="attributeRegistry"/>
+    </reference-list>
+
+    <bean id="attributeRegistry" class="ddf.catalog.data.impl.AttributeRegistryImpl" />
 
     <service ref="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
 

--- a/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
+++ b/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
@@ -216,7 +216,7 @@ public class ValidationParser implements ArtifactInstaller {
 
             staged.add(() -> {
                 attributeRegistry.register(descriptor);
-                changeset.attributes.add(descriptor.getName());
+                changeset.attributes.add(descriptor);
                 return true;
             });
         }
@@ -450,7 +450,7 @@ public class ValidationParser implements ArtifactInstaller {
         metacardValidatorServices.forEach(ServiceRegistration::unregister);
     }
 
-    private void undoAttributes(Set<String> attributes) {
+    private void undoAttributes(Set<AttributeDescriptor> attributes) {
         attributes.forEach(attributeRegistry::deregister);
     }
 
@@ -547,7 +547,7 @@ public class ValidationParser implements ArtifactInstaller {
         private final List<ServiceRegistration<MetacardValidator>> metacardValidatorServices =
                 new ArrayList<>();
 
-        private final Set<String> attributes = new HashSet<>();
+        private final Set<AttributeDescriptor> attributes = new HashSet<>();
 
         private final List<Outer.Default> defaults = new ArrayList<>();
 

--- a/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpecTest.groovy
+++ b/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpecTest.groovy
@@ -9,6 +9,7 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl
 import ddf.catalog.data.impl.AttributeRegistryImpl
 import ddf.catalog.data.impl.BasicTypes
 import ddf.catalog.data.impl.MetacardTypeImpl
+import ddf.catalog.data.impl.types.CoreAttributes
 import ddf.catalog.validation.AttributeValidatorRegistry
 import ddf.catalog.validation.MetacardValidator
 import org.junit.Rule
@@ -50,10 +51,13 @@ class ValidationParserSpecTest extends Specification {
 
         attributeValidatorRegistry = new AttributeValidatorRegistryImpl()
 
+        attributeRegistry.registerMetacardType(new MetacardTypeImpl("testMetacard", Arrays.asList(new CoreAttributes())))
+
         defaultAttributeValueRegistry = new DefaultAttributeValueRegistryImpl()
 
         validationParser = new ValidationParser(attributeRegistry, attributeValidatorRegistry,
                 defaultAttributeValueRegistry)
+
 
         file = temporaryFolder.newFile("temp.json")
     }


### PR DESCRIPTION
#### What does this PR do?
This PR registers attributes of MetacardTypes when they are registered in DDF. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@lcrosenbu @jrnorth 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Run / `log:set DEBUG ddf.catalog.data.impl` / Install / Observe attribute registration for each metacard type.
#### Any background context you want to provide?
Extensions of DDF ( e.x. Alliance) contain additional attributes on Metacards that should be registered in the AttributeRegistry.
#### What are the relevant tickets?
[DDF-2621](https://codice.atlassian.net/browse/DDF-2621)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…