### PR TITLE
DDF-2633: Config file users.attributes now gets migrated

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -876,6 +876,8 @@ public class TestConfiguration extends AbstractIntegrationTest {
                 .exists(), is(true));
         assertThat(getExportSubDirectory(exportDirectory, "users.properties").toFile()
                 .exists(), is(true));
+        assertThat(getExportSubDirectory(exportDirectory, "users.attributes").toFile()
+                .exists(), is(true));
         assertThat(getExportSubDirectory(exportDirectory,
                 "org.codice.ddf.admin.applicationlist.properties").toFile()
                 .exists(), is(true));

--- a/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
+++ b/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
@@ -20,8 +20,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import javax.validation.constraints.NotNull;
-
 import org.codice.ddf.migration.ConfigurationMigratable;
 import org.codice.ddf.migration.DescribableBean;
 import org.codice.ddf.migration.MigrationException;
@@ -48,6 +46,8 @@ public class PlatformMigratable extends DescribableBean implements Configuration
 
     private static final Path USERS_PROPERTIES = Paths.get("etc", "users.properties");
 
+    private static final Path USERS_ATTRIBUTES = Paths.get("etc", "users.attributes");
+
     private static final Path DDF_METACARD_ATTRIBUTE_RULESET = Paths.get("etc",
             "pdp",
             "ddf-metacard-attribute-ruleset.cfg");
@@ -63,8 +63,7 @@ public class PlatformMigratable extends DescribableBean implements Configuration
 
     private final MigratableUtil migratableUtil;
 
-    public PlatformMigratable(@NotNull DescribableBean info,
-            @NotNull MigratableUtil migratableUtil) {
+    public PlatformMigratable(DescribableBean info, MigratableUtil migratableUtil) {
 
         super(info);
 
@@ -82,13 +81,17 @@ public class PlatformMigratable extends DescribableBean implements Configuration
 
     private void exportSystemFiles(Path exportDirectory,
             Collection<MigrationWarning> migrationWarnings) {
-        LOGGER.debug("Exporting system files: [{}], [{}], and [{}]",
+        LOGGER.debug("Exporting system files: [{}], [{}], [{}], and [{}]",
                 SYSTEM_PROPERTIES.toString(),
                 USERS_PROPERTIES.toString(),
+                USERS_ATTRIBUTES.toString(),
                 APPLICATION_LIST.toString());
+
         migratableUtil.copyFile(SYSTEM_PROPERTIES, exportDirectory, migrationWarnings);
         migratableUtil.copyFile(USERS_PROPERTIES, exportDirectory, migrationWarnings);
+        migratableUtil.copyFile(USERS_ATTRIBUTES, exportDirectory, migrationWarnings);
         migratableUtil.copyFile(APPLICATION_LIST, exportDirectory, migrationWarnings);
+
         migratableUtil.copyFile(DDF_METACARD_ATTRIBUTE_RULESET, exportDirectory, migrationWarnings);
         migratableUtil.copyFile(DDF_USER_ATTRIBUTE_RULESET, exportDirectory, migrationWarnings);
         migratableUtil.copyFile(FIPS_TO_ISO, exportDirectory, migrationWarnings);

--- a/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
+++ b/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
@@ -57,6 +57,8 @@ public class PlatformMigratableTest {
 
     private static final Path USERS_PROPERTIES_REL_PATH = Paths.get("etc", "users.properties");
 
+    private static final Path USERS_ATTRIBUTES_REL_PATH = Paths.get("etc", "users.attributes");
+
     private static final Path APPLICATION_LIST = Paths.get("etc",
             "org.codice.ddf.admin.applicationlist.properties");
 
@@ -248,10 +250,13 @@ public class PlatformMigratableTest {
     private void assertSystemPropertiesFilesExport(MigratableUtil mockMigratableUtil) {
         verify(mockMigratableUtil).copyFile(eq(SYSTEM_PROPERTIES_REL_PATH),
                 eq(exportDirectory),
-                Matchers.<Collection<MigrationWarning>>any());
+                Matchers.any());
         verify(mockMigratableUtil).copyFile(eq(USERS_PROPERTIES_REL_PATH),
                 eq(exportDirectory),
-                Matchers.<Collection<MigrationWarning>>any());
+                Matchers.any());
+        verify(mockMigratableUtil).copyFile(eq(USERS_ATTRIBUTES_REL_PATH),
+                eq(exportDirectory),
+                Matchers.any());
     }
 
     private void assertKeystoresExport(MigratableUtil mockMigratableUtil) {


### PR DESCRIPTION
#### What does this PR do?
Adds the `users.attributes` file to the list of migrated files in `PlatformMigratable` and updates the tests accordingly. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@oconnormi 
@brjeter 
@shaundmorris 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
* Ensure a full build passes with all tests - pay special attention to `TestConfiguration`
* Spin up DDF and complete the install procedure; then run the `migration:export` command and ensure that the `users.attributes` file is in `$DDF_ROOT$/etc/exported`
* Repeat the process when specifying an external export target

#### Any background context you want to provide?
This bug fix will help address possible security issues and ease efforts for high-availability. 

#### What are the relevant tickets?
[DDF-2633](https://codice.atlassian.net/browse/DDF-2633)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

