### PR TITLE
DDF-2636 resolve querying with wildcards on fields containing hyphens

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -211,8 +211,9 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
                 .map(String::toLowerCase)
                 .collect(Collectors.joining("~ +", "(+", "~)"));
 
-        if (Metacard.ANY_TEXT.equals(propertyName)) {
-            return new SolrQuery(anyTextSolrQuery(fuzzyPhrase, false));
+        if (searchPhrase.contains(SOLR_WILDCARD_CHAR) || searchPhrase.contains(
+                SOLR_SINGLE_WILDCARD_CHAR) || Metacard.ANY_TEXT.equals(propertyName)) {
+            return new SolrQuery(wildcardSolrQuery(fuzzyPhrase, propertyName, false));
         } else {
             String mappedPropertyName = getMappedPropertyName(propertyName,
                     AttributeFormat.STRING,
@@ -227,17 +228,20 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
         verifyInputData(propertyName, pattern);
 
         String searchPhrase = escapeSpecialCharacters(pattern);
-        if (!searchPhrase.contains(SOLR_WILDCARD_CHAR) && !searchPhrase.contains(
+        if (searchPhrase.contains(SOLR_WILDCARD_CHAR) || searchPhrase.contains(
                 SOLR_SINGLE_WILDCARD_CHAR)) {
+            searchPhrase = "(" + searchPhrase + ")";
+        } else {
             // Not an exact phrase
             searchPhrase = QUOTE + searchPhrase + QUOTE;
-        } else {
-            searchPhrase = "(" + searchPhrase + ")";
         }
 
-        if (Metacard.ANY_TEXT.equals(propertyName)) {
-            return new SolrQuery(anyTextSolrQuery(searchPhrase, isCaseSensitive));
+        if (searchPhrase.contains(SOLR_WILDCARD_CHAR) || searchPhrase.contains(
+                SOLR_SINGLE_WILDCARD_CHAR) || Metacard.ANY_TEXT.equals(propertyName)) {
+
+            return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, isCaseSensitive));
         } else {
+
             String mappedPropertyName = getMappedPropertyName(propertyName,
                     AttributeFormat.STRING,
                     false);
@@ -260,8 +264,9 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
 
         String searchPhrase = QUOTE + escapeSpecialCharacters(literal) + QUOTE;
 
-        if (Metacard.ANY_TEXT.equals(propertyName)) {
-            return new SolrQuery(anyTextSolrQuery(searchPhrase, true));
+        if (searchPhrase.contains(SOLR_WILDCARD_CHAR) || searchPhrase.contains(
+                SOLR_SINGLE_WILDCARD_CHAR) || Metacard.ANY_TEXT.equals(propertyName)) {
+            return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, true));
         } else {
             String mappedPropertyName = getMappedPropertyName(propertyName,
                     AttributeFormat.STRING,
@@ -270,18 +275,31 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
         }
     }
 
-    private String anyTextSolrQuery(String searchPhrase, boolean isCaseSensitive) {
-        String solrQuery = resolver.anyTextFields()
-                .map(resolver::getWhitespaceTokenizedField)
-                .map((whitespaceField) -> {
-                    if (isCaseSensitive) {
-                        return resolver.getCaseSensitiveField(whitespaceField);
-                    } else {
-                        return whitespaceField;
-                    }
-                })
-                .map((field) -> field + ":" + searchPhrase)
-                .collect(Collectors.joining(" "));
+    private String wildcardSolrQuery(String searchPhrase, String propertyName,
+            boolean isCaseSensitive) {
+        String solrQuery = "";
+        if (Metacard.ANY_TEXT.equals(propertyName)) {
+            solrQuery = resolver.anyTextFields()
+                    .map(resolver::getWhitespaceTokenizedField)
+                    .map((whitespaceField) -> {
+                        if (isCaseSensitive) {
+                            return resolver.getCaseSensitiveField(whitespaceField);
+                        } else {
+                            return whitespaceField;
+                        }
+                    })
+                    .map((field) -> field + ":" + searchPhrase)
+                    .collect(Collectors.joining(" "));
+        } else {
+            String whitespaceField = resolver.getWhitespaceTokenizedField(getMappedPropertyName(
+                    propertyName,
+                    AttributeFormat.STRING,
+                    true));
+            if (isCaseSensitive) {
+                whitespaceField = resolver.getCaseSensitiveField(whitespaceField);
+            }
+            solrQuery = whitespaceField + ":" + searchPhrase;
+        }
         return "(" + solrQuery + ")";
     }
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
@@ -105,10 +105,12 @@ public class TestSolrFilterDelegate {
     @Test
     public void reservedSpecialCharactersIsLike() {
         // given a tokenized text property
-        stub(mockResolver.getField("testProperty", AttributeFormat.STRING, false)).toReturn(
-                "testProperty_txt_index");
-        stub(mockResolver.getCaseSensitiveField("testProperty_txt_index")).toReturn(
-                "testProperty_txt_index_tokenized");
+        stub(mockResolver.getField("testProperty", AttributeFormat.STRING, true)).toReturn(
+                "testProperty_txt");
+        stub(mockResolver.getWhitespaceTokenizedField("testProperty_txt")).toReturn(
+                "testProperty_txt_ws");
+        stub(mockResolver.getCaseSensitiveField("testProperty_txt_ws")).toReturn(
+                "testProperty_txt_ws_tokenized");
 
         // when searching for like reserved characters
         SolrQuery likeQuery = toTest.propertyIsLike("testProperty",
@@ -117,7 +119,7 @@ public class TestSolrFilterDelegate {
 
         // then return escaped special characters in the query
         assertThat(likeQuery.getQuery(),
-                is("testProperty_txt_index_tokenized:(\\+ \\- \\&& \\|| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\\" \\~ \\: \\*?)"));
+                is("(testProperty_txt_ws_tokenized:(\\+ \\- \\&& \\|| \\! \\( \\) \\{ \\} \\[ \\] \\^ \\\" \\~ \\: \\*?))"));
     }
 
     /*

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
@@ -65,7 +65,6 @@ import org.geotools.temporal.object.DefaultPeriodDuration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 import org.opengis.filter.Filter;
@@ -2788,7 +2787,6 @@ public class TestSolrProvider extends SolrProviderTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore
     public void testContextualAnyText() throws Exception {
 
         deleteAllIn(provider);
@@ -2816,6 +2814,69 @@ public class TestSolrProvider extends SolrProviderTestCase {
                         .is()
                         .like()
                         .text(soughtWord));
+    }
+
+    /**
+     * Testing Tokenization of the search phrase.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWhitespaceTokenizedFieldWithWildcardSearch() throws Exception {
+
+        deleteAllIn(provider);
+
+        List<Metacard> list = new ArrayList<Metacard>();
+
+        String title = "AB-12.yz_file";
+
+        MockMetacard metacard1 = new MockMetacard(Library.getFlagstaffRecord());
+
+        metacard1.setTitle(title);
+
+        String searchPhrase1 = "AB*12.yz_file";
+        String searchPhrase2 = "AB-12*yz_file";
+        String searchPhrase3 = "AB-12.yz*file";
+        String searchPhrase4 = "AB-12.*_file";
+        String searchPhrase5 = "Flagstaff Chamb*";
+        String searchPhrase6 = "Flagstaff Cmmerce";
+
+        list.add(metacard1);
+
+        create(list);
+
+        queryAndVerifyCount(1,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .like()
+                        .text(searchPhrase1));
+        queryAndVerifyCount(1,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .like()
+                        .text(searchPhrase2));
+        queryAndVerifyCount(1,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .like()
+                        .text(searchPhrase3));
+        queryAndVerifyCount(1,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .like()
+                        .text(searchPhrase4));
+        // Matching Phrase with wildcard
+        queryAndVerifyCount(1,
+                filterBuilder.attribute(Metacard.ANY_TEXT)
+                        .is()
+                        .like()
+                        .text(searchPhrase5));
+        // Non-Matching Phrase without wildcard
+        queryAndVerifyCount(0,
+                filterBuilder.attribute(Metacard.ANY_TEXT)
+                        .is()
+                        .like()
+                        .text(searchPhrase6));
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
Makes querying consistent when querying between ANY_TEXT or fields directly when a query contains a wildcard and the field contains hyphens.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@jlcsmith 
@brendan-hofmann 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Ingest metacard with title containing hyphens and verify that can be retrieved by the exact field with a query that contains a wildcard (i.e. "title like "abc-12*")
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2636 ](https://codice.atlassian.net/browse/DDF-2636)
#### Checklist:
- [N/A] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests

