### PR TITLE
DDF-2637 Remove tight dependencies on BrandingPlugin

### DIFF
--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpoint.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -35,7 +36,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistry;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.slf4j.Logger;
@@ -105,8 +106,6 @@ public class KmlEndpoint {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KmlEndpoint.class);
 
-    private BrandingPlugin branding;
-
     private CatalogFramework framework;
 
     private Kml styleDoc;
@@ -131,15 +130,15 @@ public class KmlEndpoint {
 
     private ClassPathTemplateLoader templateLoader;
 
-    public KmlEndpoint(BrandingPlugin brandingPlugin, CatalogFramework catalogFramework) {
+    public KmlEndpoint(BrandingRegistry brandingPlugin, CatalogFramework catalogFramework) {
+        Optional<BrandingRegistry> brandingRegistry = Optional.ofNullable(brandingPlugin);
         LOGGER.trace("ENTERING: KML Endpoint Constructor");
-        this.branding = brandingPlugin;
         this.framework = catalogFramework;
         templateLoader = new ClassPathTemplateLoader();
         templateLoader.setPrefix("/templates");
         templateLoader.setSuffix(".hbt");
-        this.productName = branding.getProductName()
-                .split(" ")[0];
+        this.productName = brandingRegistry.map(BrandingRegistry::getProductName)
+                .orElse("");
         LOGGER.trace("EXITING: KML Endpoint Constructor");
     }
 

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,8 +19,7 @@
 
   http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
 
-    <!-- The BrandingPlugin gives access to the Product name and version -->
-    <reference id="branding" interface="org.codice.ddf.branding.BrandingPlugin"/>
+   <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry"/>
 
     <reference id="framework" interface="ddf.catalog.CatalogFramework"/>
 
@@ -37,7 +36,7 @@
     </jaxrs:server>
 
     <bean id="kmlEndpoint" class="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint">
-        <argument ref="branding"/>
+        <argument ref="brandingRegistry"/>
         <argument ref="framework"/>
         <cm:managed-properties persistent-id="org.codice.ddf.spatial.kml.endpoint.KmlEndpoint"
                                update-strategy="container-managed"/>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/TestKmlEndpoint.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.UriBuilderException;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.io.IOUtils;
-import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistry;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
 import org.junit.BeforeClass;
@@ -83,7 +83,7 @@ public class TestKmlEndpoint {
 
     private static Set<SourceDescriptor> descriptors = new HashSet<>();
 
-    private static BrandingPlugin mockBranding = mock(BrandingPlugin.class);
+    private static BrandingRegistry mockBranding = mock(BrandingRegistry.class);
 
     private static byte[] bomberBytes;
 

--- a/catalog/ui/search-ui/simple/src/main/java/org/codice/ddf/ui/searchui/simple/properties/ConfigurationStore.java
+++ b/catalog/ui/search-ui/simple/src/main/java/org/codice/ddf/ui/searchui/simple/properties/ConfigurationStore.java
@@ -14,8 +14,9 @@
 
 package org.codice.ddf.ui.searchui.simple.properties;
 
-import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.branding.BrandingPlugin;
+import java.util.Optional;
+
+import org.codice.ddf.branding.BrandingRegistry;
 
 /**
  * Stores external configuration properties.
@@ -33,7 +34,7 @@ public class ConfigurationStore {
 
     private String background = "";
 
-    private BrandingPlugin branding;
+    private Optional<BrandingRegistry> branding = Optional.empty();
 
     private ConfigurationStore() {
         header = "";
@@ -87,20 +88,16 @@ public class ConfigurationStore {
     }
 
     public String getProductName() {
-        if (branding != null) {
-            // Remove the version number
-            return StringUtils.substringBeforeLast(branding.getProductName(), " ");
-        } else {
-            return "";
-        }
+        return branding.map(BrandingRegistry::getProductName)
+                .orElse("");
     }
 
-    public BrandingPlugin getBranding() {
-        return branding;
+    public BrandingRegistry getBranding() {
+        return branding.orElse(null);
     }
 
-    public void setBranding(BrandingPlugin branding) {
-        this.branding = branding;
+    public void setBranding(BrandingRegistry branding) {
+        this.branding = Optional.ofNullable(branding);
     }
 
     public Object clone() throws CloneNotSupportedException {

--- a/catalog/ui/search-ui/simple/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/simple/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,14 +16,13 @@
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <reference id="webBranding" interface="org.codice.ddf.branding.BrandingPlugin"/>
-
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry" />
     <bean id="configurationStore"
           class="org.codice.ddf.ui.searchui.simple.properties.ConfigurationStore"
           factory-method="getInstance">
         <cm:managed-properties persistent-id="org.codice.ddf.ui.search.simple.properties"
                                update-strategy="container-managed"/>
-        <property name="branding" ref="webBranding"/>
+        <property name="branding" ref="brandingRegistry"/>
     </bean>
 
 </blueprint>

--- a/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
+++ b/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -42,7 +43,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.collections.Factory;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistry;
 import org.codice.proxy.http.HttpProxyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +112,7 @@ public class ConfigurationStore {
 
     private Boolean isIngest = true;
 
-    private BrandingPlugin branding;
+    private Optional<BrandingRegistry> branding = Optional.empty();
 
     private Integer timeout = 15000;
 
@@ -129,7 +130,7 @@ public class ConfigurationStore {
 
     private Boolean isExternalAuthentication = false;
 
-    private Map<String, Set<String>> typeNameMapping = new HashMap<String, Set<String>>();
+    private Map<String, Set<String>> typeNameMapping = new HashMap<>();
 
     public ConfigurationStore() {
 
@@ -179,29 +180,21 @@ public class ConfigurationStore {
     }
 
     public String getProductName() {
-        if (branding != null) {
-            // Remove the version number
-            return StringUtils.substringBeforeLast(branding.getProductName(), " ");
-        } else {
-            return "";
-        }
+        return branding.map(BrandingRegistry::getProductName)
+                .orElse("");
     }
 
     public String getProductVersion() {
-        if (branding != null) {
-            // Remove the version number
-            return StringUtils.substringAfterLast(branding.getProductName(), " ");
-        } else {
-            return "";
-        }
+        return branding.map(BrandingRegistry::getProductVersion)
+                .orElse("");
     }
 
-    public BrandingPlugin getBranding() {
-        return branding;
+    public BrandingRegistry getBranding() {
+        return branding.orElse(null);
     }
 
-    public void setBranding(BrandingPlugin branding) {
-        this.branding = branding;
+    public void setBranding(BrandingRegistry branding) {
+        this.branding = Optional.ofNullable(branding);
     }
 
     public String getFormat() {
@@ -285,8 +278,9 @@ public class ConfigurationStore {
         proxiedImageryProviders.clear();
         for (Map<String, Object> newImageryProvider : newImageryProviders) {
             HashMap<String, Object> map = new HashMap<>(newImageryProvider);
-            map.put(URL, SERVLET_PATH + "/" + urlToProxyMap.get(newImageryProvider.get(URL)
-                    .toString()));
+            map.put(URL,
+                    SERVLET_PATH + "/" + urlToProxyMap.get(newImageryProvider.get(URL)
+                            .toString()));
             proxiedImageryProviders.add(map);
         }
         imageryProviderMaps = newImageryProviders;

--- a/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,7 +17,7 @@
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <reference id="webBranding" interface="org.codice.ddf.branding.BrandingPlugin"/>
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry"/>
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="proxyCamelContext"/>
 
@@ -38,7 +38,7 @@
           destroy-method="destroy">
         <cm:managed-properties persistent-id="org.codice.ddf.ui.search.standard.properties"
                                update-strategy="container-managed"/>
-        <property name="branding" ref="webBranding"/>
+        <property name="branding" ref="brandingRegistry"/>
         <property name="httpProxy" ref="httpProxyService"/>
         <property name="imageryProviders"
                   value='{"type" "WMS" "url" "http://geoint.nrlssc.navy.mil/nrltileserver/wms" "layers" ["bluemarble"]  "alpha" 1},{"type" "OSM" "url" "http://a.tile.openstreetmap.org" "fileExtension" "png" "alpha" 0.3 }'/>

--- a/distribution/ddf-branding-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/ddf-branding-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,7 +15,7 @@
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <service interface="org.codice.ddf.branding.BrandingPlugin">
+    <service interface="org.codice.ddf.branding.BrandingPlugin" ranking="-1">
         <bean class="org.codice.ddf.branding.impl.DdfBrandingPlugin" init-method="init">
             <argument value="/META-INF/branding.properties"/>
         </bean>

--- a/platform/admin/ui/src/main/java/org/codice/admin/ui/configuration/Configuration.java
+++ b/platform/admin/ui/src/main/java/org/codice/admin/ui/configuration/Configuration.java
@@ -15,6 +15,7 @@ package org.codice.admin.ui.configuration;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
@@ -25,7 +26,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class Configuration {
 
     private String disabledInstallerApps = "";
 
-    private BrandingPlugin branding;
+    private Optional<BrandingRegistry> branding = Optional.empty();
 
     private Configuration() {
         header = "";
@@ -204,20 +205,15 @@ public class Configuration {
     }
 
     public String getProductName() {
-        if (branding != null) {
-            // Remove the version number
-            return branding.getProductName();
-        } else {
-            return "";
-        }
+        return branding.map(BrandingRegistry::getProductName).orElse("");
     }
 
-    public BrandingPlugin getBranding() {
-        return branding;
+    public BrandingRegistry getBranding() {
+        return branding.orElse(null);
     }
 
-    public void setBranding(BrandingPlugin branding) {
-        this.branding = branding;
+    public void setBranding(BrandingRegistry branding) {
+        this.branding = Optional.ofNullable(branding);
     }
 
 }

--- a/platform/admin/ui/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/ui/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,13 +17,13 @@
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <reference id="webBranding" interface="org.codice.ddf.branding.BrandingPlugin"/>
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry" />
 
     <bean id="configurationStore" class="org.codice.admin.ui.configuration.Configuration"
           factory-method="getInstance">
         <cm:managed-properties persistent-id="org.codice.admin.ui.configuration"
                                update-strategy="container-managed"/>
-        <property name="branding" ref="webBranding"/>
+        <property name="branding" ref="brandingRegistry"/>
     </bean>
 
     <jaxrs:server id="restService" address="/admin">

--- a/platform/branding-api/pom.xml
+++ b/platform/branding-api/pom.xml
@@ -25,6 +25,18 @@
     <artifactId>branding-api</artifactId>
     <name>DDF :: Distribution :: Branding API</name>
     <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -35,6 +47,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>
+                        <Embed-Dependency>commons-lang3, platform-util</Embed-Dependency>
                         <Export-Package>
                             org.codice.ddf.branding
                         </Export-Package>

--- a/platform/branding-api/src/main/java/org/codice/ddf/branding/BrandingRegistry.java
+++ b/platform/branding-api/src/main/java/org/codice/ddf/branding/BrandingRegistry.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.branding;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface BrandingRegistry {
+
+    /**
+     * This method returns the name portion of the name & version of the product, as defined
+     * by the highest priority {@link BrandingPlugin} in the system..
+     * E.g, if the full name is "DDF v1.0.0", this will return "DDF"
+     *
+     * @return a String representing the name of the product or in the case where the name cannot be found, the String "DDF"
+     */
+    String getProductName();
+
+    /**
+     * This method takes in a {@link BrandingPlugin} method reference (a {@link BrandingRegistryImpl.BrandingMethod}
+     * and calls it on the highest priority {@link BrandingPlugin} in the system.
+     *
+     * @return a String with the value of the {@link BrandingPlugin}'s method call or if the method call cannot be evaluated, an empty String ""
+     */
+    String getAttributeFromBranding(BrandingMethod supplier);
+
+    /**
+     * This method returns the version number portion of the name & version of the product, as defined
+     * by the highest priority {@link BrandingPlugin} in the system..
+     * E.g, if the full name is "DDF v1.0.0", this will return "v1.0.0"
+     *
+     * @return a String representing the version number of the product or in the case where the version number cannot be found, an empty String ""
+     */
+    String getProductVersion();
+
+    /**
+     * Sets the {@link List} of {@link BrandingPlugin}s on the {@link BrandingRegistry}
+     *
+     * @param brandingPlugins list of branding plugins associated with the system
+     */
+    void setBrandingPlugins(List<BrandingPlugin> brandingPlugins);
+
+    /**
+     * Gets the {@link List} of {@link BrandingPlugin}s from the {@link BrandingRegistry}
+     *
+     * @return the list of branding plugins associated with the system
+     */
+    List<BrandingPlugin> getBrandingPlugins();
+
+    /**
+     * A functional interface for {@link BrandingPlugin} methods (cannot use {@link java.util.function.Function} since some of them throw Exceptions)
+     */
+    @FunctionalInterface
+    interface BrandingMethod {
+        String apply(BrandingPlugin b) throws IOException;
+    }
+}

--- a/platform/branding-api/src/main/java/org/codice/ddf/branding/BrandingRegistryImpl.java
+++ b/platform/branding-api/src/main/java/org/codice/ddf/branding/BrandingRegistryImpl.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.branding;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BrandingRegistryImpl implements BrandingRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrandingRegistryImpl.class);
+
+    private List<BrandingPlugin> brandingPlugins = Collections.emptyList();
+
+    @Override
+    public String getProductName() {
+        return getBrandingPlugins().stream()
+                .map(plugin -> StringUtils.substringBeforeLast(plugin.getProductName(), " "))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse("DDF");
+    }
+    
+    @Override
+    public String getAttributeFromBranding(BrandingMethod supplier) {
+        return getBrandingPlugins().stream()
+                .map(plugin -> {
+                    try {
+                        return supplier.apply(plugin);
+                    } catch (IOException e) {
+                        LOGGER.warn("Could not get the requested attribute from the Branding Plugin", e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse("");
+    }
+
+    @Override
+    public String getProductVersion() {
+        return getBrandingPlugins().stream()
+                .map(plugin -> StringUtils.substringAfterLast(plugin.getProductName(), " "))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse("");
+    }
+
+    @Override
+    public List<BrandingPlugin> getBrandingPlugins() {
+        return brandingPlugins;
+    }
+
+    @Override
+    public void setBrandingPlugins(List<BrandingPlugin> brandingPlugins) {
+        this.brandingPlugins = brandingPlugins;
+    }
+
+}

--- a/platform/branding-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/branding-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <bean id="brandingRegistry" class="org.codice.ddf.branding.BrandingRegistryImpl">
+        <property name="brandingPlugins" ref="brandingPlugins"/>
+    </bean>
+
+    <service ref="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry"/>
+
+    <bean id="brandingPlugins" class="org.codice.ddf.platform.util.SortedServiceList">
+    </bean>
+    <reference-list id="branding" interface="org.codice.ddf.branding.BrandingPlugin">
+        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin"
+                            ref="brandingPlugins"/>
+    </reference-list>
+
+</blueprint>

--- a/platform/branding-api/src/test/java/org/codice/ddf/branding/BrandingRegistryTest.java
+++ b/platform/branding-api/src/test/java/org/codice/ddf/branding/BrandingRegistryTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.branding;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class BrandingRegistryTest {
+    @Test
+    public void testEmptyGetProductName() {
+        assertThat(getEmptyBrandingRegistry().getProductName(), is("DDF"));
+    }
+
+    @Test
+    public void testEmptyGetVersion() {
+        assertThat(getEmptyBrandingRegistry().getProductVersion(), is(""));
+    }
+
+    @Test
+    public void testGetProductName() {
+        assertThat(getBrandingRegistry().getProductName(), is("DDF1"));
+    }
+
+    @Test
+    public void testGetProductVersion() {
+        assertThat(getBrandingRegistry().getProductVersion(), is("v1.0.0"));
+    }
+
+    @Test
+    public void testGetAttributeFromBranding() throws IOException {
+        assertThat(getBrandingRegistry().getAttributeFromBranding(BrandingPlugin::getProductName),
+                is("DDF1 v1.0.0"));
+    }
+
+    @Test
+    public void testGetProductNameMultiplePlugins() {
+        assertThat(getBrandingRegistryMultiplePlugins("DDF1 v1.0.0",
+                "DDF2 v2.0.0").getProductName(), is("DDF1"));
+    }
+
+    @Test
+    public void testGetProductNameMultiplePluginsFirstNull() {
+        assertThat(getBrandingRegistryMultiplePlugins(null, "DDF2 v2.0.0").getProductName(),
+                is("DDF2"));
+    }
+
+    @Test
+    public void testGetProductVersionMultiplePlugins() {
+        assertThat(getBrandingRegistryMultiplePlugins("DDF1 v1.0.0",
+                "DDF2 v2.0.0").getProductVersion(), is("v1.0.0"));
+    }
+
+    @Test
+    public void testGetProductVersionMultiplePluginsFirstNull() {
+        assertThat(getBrandingRegistryMultiplePlugins(null, "DDF2 v2.0.0").getProductVersion(),
+                is("v2.0.0"));
+    }
+
+    @Test
+    public void testGetAttributeFromBrandingMultiplePlugins() throws IOException {
+        assertThat(getBrandingRegistryMultiplePlugins("DDF1 v1.0.0",
+                "DDF2 v2.0.0").getAttributeFromBranding(BrandingPlugin::getProductName), is("DDF1 v1.0.0"));
+    }
+
+    @Test
+    public void testGetAttributeFromBrandingMultiplePluginsFirstNull() throws IOException {
+        assertThat(getBrandingRegistryMultiplePlugins(null, "DDF2 v2.0.0").getAttributeFromBranding(BrandingPlugin::getProductName),
+                is("DDF2 v2.0.0"));
+    }
+
+    private BrandingRegistry getEmptyBrandingRegistry() {
+        return new BrandingRegistryImpl();
+    }
+
+    private BrandingRegistry getBrandingRegistry() {
+        BrandingPlugin plugin = mock(BrandingPlugin.class);
+        when(plugin.getProductName()).thenReturn("DDF1 v1.0.0");
+        BrandingRegistry registry = new BrandingRegistryImpl();
+        registry.setBrandingPlugins(Collections.singletonList(plugin));
+        return registry;
+    }
+
+    private BrandingRegistry getBrandingRegistryMultiplePlugins(String firstReturnValue,
+            String secondReturnValue) {
+        BrandingPlugin plugin = mock(BrandingPlugin.class);
+        when(plugin.getProductName()).thenReturn(firstReturnValue);
+        BrandingRegistry registry = new BrandingRegistryImpl();
+        BrandingPlugin plugin2 = mock(BrandingPlugin.class);
+        when(plugin2.getProductName()).thenReturn(secondReturnValue);
+        registry.setBrandingPlugins(Arrays.asList(plugin, plugin2));
+        return registry;
+    }
+}

--- a/platform/landing-page/pom.xml
+++ b/platform/landing-page/pom.xml
@@ -99,6 +99,7 @@
                         </Import-Package>
                         <Export-Package/>
                         <Embed-Dependency>
+                            platform-util,
                             handlebars,
                             commons-lang3,
                             antlr4-runtime

--- a/platform/landing-page/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/landing-page/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,7 +25,7 @@
     <bean id="landingPage" class="org.codice.ddf.landing.LandingPage">
         <cm:managed-properties persistent-id="org.codice.ddf.distribution.landing-page.properties"
                                update-strategy="container-managed"/>
-        <property name="branding" ref="branding"/>
+        <property name="branding" ref="brandingRegistry"/>
         <property name="description"
                   value="As a common data layer, DDF provides secure enterprise-wide data access for both users and systems."/>
         <property name="phone" value=""/>
@@ -50,8 +50,6 @@
         </service-properties>
     </service>
 
-    <!-- The BrandingPlugin gives access to the Product name and version to
-        be displayed on the Landing Page -->
-    <reference id="branding" interface="org.codice.ddf.branding.BrandingPlugin"/>
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry" />
 
 </blueprint>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -1034,6 +1034,7 @@
     <feature name="landing-page" install="manual" version="${project.version}"
              description="Landing page and branding support.">
         <feature prerequisite="true">platform-dependencies</feature>
+        <feature>ddf-branding</feature>
         <bundle>mvn:ddf.platform/landing-page/${project.version}</bundle>
     </feature>
 

--- a/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-configuration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,8 +20,6 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <reference id="branding" interface="org.codice.ddf.branding.BrandingPlugin"/>
-
     <!--
     The list of managedServices that are interested in updates to the DDF System Settings.
     These managedServices register their interest in updates to the DDF System Settings as they
@@ -47,10 +45,12 @@
         <argument ref="configurationAdmin"/>
     </bean>
 
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry" />
+
     <bean id="PlatformUiConfiguration" class="org.codice.ddf.configuration.PlatformUiConfiguration">
         <cm:managed-properties persistent-id="ddf.platform.ui.config"
                                update-strategy="container-managed"/>
-        <property name="branding" ref="branding"/>
+        <property name="branding" ref="brandingRegistry"/>
     </bean>
 
     <jaxrs:server id="platformConfigurationService" address="/platform">

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
@@ -15,13 +15,16 @@ package org.codice.ddf.configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Collections;
 
 import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistryImpl;
 import org.junit.Test;
 
 import net.minidev.json.JSONObject;
@@ -37,15 +40,15 @@ public class PlatformUiConfigurationTest {
         if (!(obj instanceof JSONObject)) {
             fail("PlatformUiConfiguration is not a JSON Object.");
         }
-
-        BrandingPlugin brandingPlugin = mock(BrandingPlugin.class);
-        when(brandingPlugin.getProductName()).thenReturn("product");
-        when(brandingPlugin.getBase64ProductImage()).thenReturn(Base64.getEncoder()
-                .encodeToString("image".getBytes()));
-        when(brandingPlugin.getBase64FavIcon()).thenReturn(Base64.getEncoder()
+        BrandingPlugin branding = mock(BrandingPlugin.class);
+        when(branding.getBase64FavIcon()).thenReturn(Base64.getEncoder()
                 .encodeToString("fav".getBytes()));
-
-        configuration.setProvider();
+        when(branding.getBase64ProductImage()).thenReturn(Base64.getEncoder()
+                .encodeToString("image".getBytes()));
+        BrandingRegistryImpl brandingPlugin = mock(BrandingRegistryImpl.class);
+        when(brandingPlugin.getProductName()).thenReturn("product");
+        when(brandingPlugin.getBrandingPlugins()).thenReturn(Collections.singletonList(branding));
+        when(brandingPlugin.getAttributeFromBranding(any())).thenCallRealMethod();
 
         configuration.setBranding(brandingPlugin);
 
@@ -64,7 +67,7 @@ public class PlatformUiConfigurationTest {
         assertEquals("footer", jsonObject.get(PlatformUiConfiguration.FOOTER));
         assertEquals("background", jsonObject.get(PlatformUiConfiguration.BACKGROUND));
         assertEquals("color", jsonObject.get(PlatformUiConfiguration.COLOR));
-        assertEquals("product", jsonObject.get(PlatformUiConfiguration.VERSION));
+        assertEquals("product", jsonObject.get(PlatformUiConfiguration.TITLE));
         assertEquals("image",
                 new String(Base64.getMimeDecoder()
                         .decode((String) jsonObject.get(PlatformUiConfiguration.PRODUCT_IMAGE))));

--- a/platform/security/handler/security-handler-guest/src/main/java/org/codice/ddf/security/handler/guest/configuration/Configuration.java
+++ b/platform/security/handler/security-handler-guest/src/main/java/org/codice/ddf/security/handler/guest/configuration/Configuration.java
@@ -15,6 +15,7 @@ package org.codice.ddf.security.handler.guest.configuration;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
@@ -25,8 +26,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.lang.StringUtils;
-import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.branding.BrandingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +54,7 @@ public class Configuration {
 
     private String textColor = "";
 
-    private BrandingPlugin branding;
+    private Optional<BrandingRegistry> branding = Optional.empty();
 
     private Configuration() {
     }
@@ -124,20 +124,16 @@ public class Configuration {
     }
 
     public String getProductName() {
-        if (branding != null) {
-            // Remove the version number
-            return StringUtils.substringBeforeLast(branding.getProductName(), " ");
-        } else {
-            return "";
-        }
+        return branding.map(BrandingRegistry::getProductName)
+                .orElse("");
     }
 
-    public BrandingPlugin getBranding() {
-        return branding;
+    public BrandingRegistry getBranding() {
+        return branding.orElse(null);
     }
 
-    public void setBranding(BrandingPlugin branding) {
-        this.branding = branding;
+    public void setBranding(BrandingRegistry branding) {
+        this.branding = Optional.ofNullable(branding);
     }
 
     public void setMimeType(String mimeType) {

--- a/platform/security/handler/security-handler-guest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-guest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,7 +34,7 @@
              ranking="0">
     </service>
 
-    <reference id="webBranding" interface="org.codice.ddf.branding.BrandingPlugin"/>
+    <reference id="brandingRegistry" interface="org.codice.ddf.branding.BrandingRegistry"/>
 
     <bean id="configurationStore"
           class="org.codice.ddf.security.handler.guest.configuration.Configuration"
@@ -42,6 +42,6 @@
         <cm:managed-properties
                 persistent-id="org.codice.ddf.security.handler.guest.configuration"
                 update-strategy="container-managed"/>
-        <property name="branding" ref="webBranding"/>
+        <property name="branding" ref="brandingRegistry"/>
     </bean>
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?

When using implementations of the BrandingPlugin other than the DdfBrandingPlugin, these can be installed at a late enough stage that the LandingPage times out waiting for the dependency.
Instead, the LandingPage should always start the DdfBrandingPlugin and then when another implementation becomes available, should use that instead.

In addition, this PR takes the fix from the LandingPage java and blueprint and applies it to any other classes that use a BrandingPlugin in DDF.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@roelens8 
@brendan-hofmann 
@jrnorth 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 
@jaymcnallie 
#### How should this be tested? (List steps with links to updated documentation)
Build and run DDF. Hot deploy a different branding plugin implementation with a ranking higher than 0. Verify that in branded places, the branding is replaced. (Eg, landing page, admin ui, search ui, etc)
#### Any background context you want to provide?

The landing page was timing out on startup during itests in sufficiently slow systems. This protects it from happening in the future.
#### What are the relevant tickets?
[DDF-2637](https://codice.atlassian.net/browse/DDF-2637)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

