### PR TITLE
DDF-2641 TransactionRequestConverter uses AttributeRegistry to determ…

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
@@ -132,6 +132,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attributeregistry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TransactionMessageBodyReader.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TransactionMessageBodyReader.java
@@ -34,6 +34,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.MetacardType;
 
 @Provider
@@ -43,9 +44,13 @@ public class TransactionMessageBodyReader implements MessageBodyReader<CswTransa
 
     private MetacardType metacardType;
 
-    public TransactionMessageBodyReader(Converter converter, MetacardType metacardType) {
+    private AttributeRegistry registry;
+
+    public TransactionMessageBodyReader(Converter converter, MetacardType metacardType,
+            AttributeRegistry registry) {
         this.cswRecordConverter = converter;
         this.metacardType = metacardType;
+        this.registry = registry;
     }
 
     @Override
@@ -61,7 +66,7 @@ public class TransactionMessageBodyReader implements MessageBodyReader<CswTransa
             throws IOException, WebApplicationException {
         XStream xStream = new XStream(new Xpp3Driver());
         TransactionRequestConverter transactionRequestConverter = new TransactionRequestConverter(
-                cswRecordConverter);
+                cswRecordConverter, registry);
         transactionRequestConverter.setCswRecordConverter(new CswRecordConverter(metacardType));
         xStream.registerConverter(transactionRequestConverter);
         xStream.alias("csw:" + CswConstants.TRANSACTION, CswTransactionRequest.class);

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -121,10 +121,13 @@
     <reference id="transformProvider" interface="com.thoughtworks.xstream.converters.Converter"
                filter="(id=csw)"/>
 
+    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+
     <bean id="transactionMessageBodyReader"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.reader.TransactionMessageBodyReader">
         <argument ref="transformProvider"/>
         <argument ref="cswMetacardType"/>
+        <argument ref="attributeRegistry" />
     </bean>
 
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TestTransactionMessageBodyReader.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TestTransactionMessageBodyReader.java
@@ -44,7 +44,15 @@ import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeRegistryImpl;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.TopicAttributes;
 import ddf.catalog.data.types.Topic;
 
 import net.opengis.cat.csw.v_2_0_2.QueryConstraintType;
@@ -218,15 +226,23 @@ public class TestTransactionMessageBodyReader {
 
     private CswRecordConverter cswRecordConverter;
 
+    private AttributeRegistry registry = new AttributeRegistryImpl();
+
     @Before
     public void setup() {
         cswRecordConverter = new CswRecordConverter(CswQueryFactoryTest.getCswMetacardType());
+        new CoreAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
+        new ContactAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
+        new LocationAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
+        new MediaAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
+        new TopicAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
+        new AssociationsAttributes().getAttributeDescriptors().stream().forEach(d -> registry.register(d));
     }
 
     @Test
     public void testIsReadable() throws Exception {
         TransactionMessageBodyReader reader = new TransactionMessageBodyReader(cswRecordConverter,
-                CswQueryFactoryTest.getCswMetacardType());
+                CswQueryFactoryTest.getCswMetacardType(), registry);
         assertThat(reader.isReadable(CswTransactionRequest.class, null, null, null), is(true));
         assertThat(reader.isReadable(Object.class, null, null, null), is(false));
     }
@@ -238,7 +254,7 @@ public class TestTransactionMessageBodyReader {
         when(mockConverter.unmarshal(any(HierarchicalStreamReader.class),
                 any(UnmarshallingContext.class))).thenReturn(mock(Metacard.class));
         TransactionMessageBodyReader reader = new TransactionMessageBodyReader(mockConverter,
-                CswQueryFactoryTest.getCswMetacardType());
+                CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -267,7 +283,7 @@ public class TestTransactionMessageBodyReader {
     public void testReadDeleteWithFilterFrom() throws IOException {
         TransactionMessageBodyReader reader =
                 new TransactionMessageBodyReader(mock(Converter.class),
-                        CswQueryFactoryTest.getCswMetacardType());
+                        CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -299,7 +315,7 @@ public class TestTransactionMessageBodyReader {
     public void testReadDeleteWithCqlFrom() throws IOException {
         TransactionMessageBodyReader reader =
                 new TransactionMessageBodyReader(mock(Converter.class),
-                        CswQueryFactoryTest.getCswMetacardType());
+                        CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -336,7 +352,7 @@ public class TestTransactionMessageBodyReader {
                 any(UnmarshallingContext.class))).thenReturn(mock(Metacard.class));
 
         TransactionMessageBodyReader reader = new TransactionMessageBodyReader(mockConverter,
-                CswQueryFactoryTest.getCswMetacardType());
+                CswQueryFactoryTest.getCswMetacardType(), registry);
 
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
@@ -376,7 +392,7 @@ public class TestTransactionMessageBodyReader {
     @Test
     public void testReadUpdateByNewRecordFrom() throws IOException, ParseException {
         TransactionMessageBodyReader reader = new TransactionMessageBodyReader(cswRecordConverter,
-                CswQueryFactoryTest.getCswMetacardType());
+                CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -417,7 +433,7 @@ public class TestTransactionMessageBodyReader {
     public void testReadUpdateByConstraintFrom() throws IOException, ParseException {
         TransactionMessageBodyReader reader =
                 new TransactionMessageBodyReader(mock(Converter.class),
-                        CswQueryFactoryTest.getCswMetacardType());
+                        CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -479,7 +495,7 @@ public class TestTransactionMessageBodyReader {
     @Test
     public void testReadMultipleUpdatesFrom() throws IOException, ParseException {
         TransactionMessageBodyReader reader = new TransactionMessageBodyReader(cswRecordConverter,
-                CswQueryFactoryTest.getCswMetacardType());
+                CswQueryFactoryTest.getCswMetacardType(), registry);
         CswTransactionRequest request = reader.readFrom(CswTransactionRequest.class,
                 null,
                 null,
@@ -542,7 +558,7 @@ public class TestTransactionMessageBodyReader {
     public void testConversionExceptionWhenNoNameInUpdateRecordProperty() throws IOException {
         TransactionMessageBodyReader reader =
                 new TransactionMessageBodyReader(mock(Converter.class),
-                        CswQueryFactoryTest.getCswMetacardType());
+                        CswQueryFactoryTest.getCswMetacardType(), registry);
         reader.readFrom(CswTransactionRequest.class, null, null, null, null, IOUtils.toInputStream(
                 UPDATE_REQUEST_NO_RECORDPROPERTY_NAME_XML));
     }
@@ -551,7 +567,7 @@ public class TestTransactionMessageBodyReader {
     public void testConversionExceptionWhenNoConstraintInUpdate() throws IOException {
         TransactionMessageBodyReader reader =
                 new TransactionMessageBodyReader(mock(Converter.class),
-                        CswQueryFactoryTest.getCswMetacardType());
+                        CswQueryFactoryTest.getCswMetacardType(), registry);
         reader.readFrom(CswTransactionRequest.class, null, null, null, null, IOUtils.toInputStream(
                 UPDATE_REQUEST_NO_CONSTRAINT_XML));
     }

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/writer/CswTransactionRequestWriter.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/writer/CswTransactionRequestWriter.java
@@ -38,7 +38,7 @@ public class CswTransactionRequestWriter implements MessageBodyWriter<CswTransac
 
     public CswTransactionRequestWriter(Converter delegatingTransformer) {
         xStream = new XStream(new Xpp3Driver());
-        xStream.registerConverter(new TransactionRequestConverter(delegatingTransformer));
+        xStream.registerConverter(new TransactionRequestConverter(delegatingTransformer, null));
         xStream.alias(CswConstants.CSW_TRANSACTION, CswTransactionRequest.class);
     }
 

--- a/catalog/spatial/csw/spatial-csw-transformer/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/pom.xml
@@ -109,6 +109,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attributeregistry</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
@@ -80,7 +80,7 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
 
     private static XMLInputFactory factory;
 
-    private static MetacardType metacardType;
+    private MetacardType metacardType;
 
     static {
         factory = XMLInputFactory.newInstance();
@@ -296,28 +296,6 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
     }
 
     /**
-     * Converts the CSW record property {@code reader} is currently at to the specified Metacard
-     * attribute format.
-     *
-     * @param attributeName the String corresponding to the type that the value
-     *                      in {@code reader} should be converted to
-     * @param reader        the reader at the element whose value you want to convert
-     * @param cswAxisOrder  the order of the coordinates in the XML being read by {@code reader}
-     * @return the value that was extracted from {@code reader} and is of the type described by
-     * {@code attributeFormat}
-     */
-    public static Serializable convertRecordPropertyToMetacardAttribute(String attributeName,
-            HierarchicalStreamReader reader, CswAxisOrder cswAxisOrder) {
-        AttributeDescriptor attributeDescriptor =
-                metacardType.getAttributeDescriptor(attributeName);
-        if (attributeDescriptor != null) {
-            return CswUnmarshallHelper.convertRecordPropertyToMetacardAttribute(attributeDescriptor.getType()
-                    .getAttributeFormat(), reader, cswAxisOrder);
-        }
-        return null;
-    }
-
-    /**
      * Takes a CSW attribute as a name and value and returns an {@link Attribute} whose value is
      * {@code cswAttributeValue} converted to the type of the attribute
      * {@code metacardAttributeName} in a {@link Metacard}.
@@ -330,7 +308,7 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
      * {@code cswAttributeValue} converted to the type of the attribute
      * {@code metacardAttributeName} in a {@code Metacard}.
      */
-    public static Attribute getMetacardAttributeFromCswAttribute(String cswAttributeName,
+    public Attribute getMetacardAttributeFromCswAttribute(String cswAttributeName,
             Serializable cswAttributeValue, String metacardAttributeName) {
         return CswUnmarshallHelper.getMetacardAttributeFromCswAttribute(metacardType,
                 cswAttributeName,

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestTransactionRequestConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestTransactionRequestConverter.java
@@ -14,7 +14,10 @@
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.commons.io.IOUtils;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.CswTransactionRequest;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transaction.DeleteAction;
@@ -38,8 +42,15 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.impl.AttributeRegistryImpl;
 import ddf.catalog.data.impl.MetacardImpl;
-
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.TopicAttributes;
 import net.opengis.cat.csw.v_2_0_2.DeleteType;
 import net.opengis.cat.csw.v_2_0_2.QueryConstraintType;
 
@@ -75,12 +86,33 @@ public class TestTransactionRequestConverter {
 
     private XStream xStream;
 
+    private AttributeRegistry mockRegistry = new AttributeRegistryImpl();
+
     @Before
     public void setup() {
         cswRecordConverter = mock(Converter.class);
         when(cswRecordConverter.canConvert(any())).thenReturn(true);
+        new CoreAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
+        new ContactAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
+        new LocationAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
+        new MediaAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
+        new TopicAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
+        new AssociationsAttributes().getAttributeDescriptors()
+                .stream()
+                .forEach(d -> mockRegistry.register(d));
         xStream = new XStream(new Xpp3Driver());
-        xStream.registerConverter(new TransactionRequestConverter(cswRecordConverter));
+        xStream.registerConverter(new TransactionRequestConverter(cswRecordConverter,
+                mockRegistry));
         xStream.alias(CswConstants.CSW_TRANSACTION, CswTransactionRequest.class);
     }
 
@@ -101,6 +133,8 @@ public class TestTransactionRequestConverter {
         transactionRequest.setVersion(CswConstants.VERSION_2_0_2);
 
         String xml = xStream.toXML(transactionRequest);
+        System.out.println("xml = " + xml);
+        System.out.println("EXPECTED_INSERT_XML = " + EXPECTED_INSERT_XML);
         Diff diff = XMLUnit.compareXML(xml, EXPECTED_INSERT_XML);
         assertThat(diff.similar(), is(true));
     }
@@ -181,5 +215,74 @@ public class TestTransactionRequestConverter {
         String xml = xStream.toXML(transactionRequest);
         Diff diff = XMLUnit.compareXML(xml, EXPECTED_MULTI_OP_XML);
         assertThat(diff.similar(), is(true));
+    }
+
+    @Test
+    public void testUnmarshalInsert() throws Exception {
+        String insertRequest =
+                IOUtils.toString(TestTransactionRequestConverter.class.getResourceAsStream(
+                        "/insertRequest.xml"));
+        CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(insertRequest);
+        assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
+        assertThat(request.getUpdateActions(), emptyCollectionOf(UpdateAction.class));
+        assertThat(request.getInsertActions(), hasSize(1));
+        InsertAction action = request.getInsertActions()
+                .get(0);
+        assertThat(action.getTypeName(), is(CswConstants.CSW_RECORD));
+    }
+
+    @Test
+    public void testUnmarshalUpdateWholeRecord() throws Exception {
+        String updateRequest =
+                IOUtils.toString(TestTransactionRequestConverter.class.getResourceAsStream(
+                        "/updateWholeRecordRequest.xml"));
+        CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(updateRequest);
+        assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
+        assertThat(request.getUpdateActions(), hasSize(1));
+        assertThat(request.getInsertActions(), emptyCollectionOf(InsertAction.class));
+        UpdateAction action = request.getUpdateActions()
+                .get(0);
+        assertThat(action.getTypeName(), is(CswConstants.CSW_RECORD));
+    }
+
+    @Test
+    public void testUnmarshalByProperty() throws Exception {
+        String updateRequest =
+                IOUtils.toString(TestTransactionRequestConverter.class.getResourceAsStream(
+                        "/updateByPropertyRequest.xml"));
+        CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(updateRequest);
+        assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
+        assertThat(request.getUpdateActions(), hasSize(1));
+        assertThat(request.getInsertActions(), emptyCollectionOf(InsertAction.class));
+        UpdateAction action = request.getUpdateActions()
+                .get(0);
+        assertThat(action.getTypeName(), is(CswConstants.CSW_RECORD));
+        assertThat(action.getConstraint(), notNullValue());
+        assertThat(action.getRecordProperties()
+                .size(), is(5));
+        assertThat(action.getRecordProperties()
+                .get("title"), is("Updated Title"));
+        assertThat(action.getRecordProperties()
+                .get("created"), is(CswUnmarshallHelper.convertToDate("2015-08-25")));
+        assertThat(action.getRecordProperties()
+                .get("datatype"), is(Arrays.asList("ABC", "DEF", "GHI")));
+        assertThat(action.getRecordProperties()
+                .get("language"), is(""));
+        assertThat(action.getRecordProperties()
+                .get("language"), is(""));
+    }
+
+    @Test
+    public void testUnmarshalDelete() throws Exception {
+        String deleteRequest =
+                IOUtils.toString(TestTransactionRequestConverter.class.getResourceAsStream(
+                        "/deleteRequest.xml"));
+        CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(deleteRequest);
+        assertThat(request.getDeleteActions(), hasSize(1));
+        assertThat(request.getUpdateActions(), emptyCollectionOf(UpdateAction.class));
+        assertThat(request.getInsertActions(), emptyCollectionOf(InsertAction.class));
+        DeleteAction action = request.getDeleteActions()
+                .get(0);
+        assertThat(action.getTypeName(), is(CswConstants.CSW_RECORD));
     }
 }

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/deleteRequest.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/deleteRequest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:Transaction service="CSW" version="2.0.2"
+                 xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                 xmlns:gml="http://www.opengis.net/gml"
+                 xmlns:ogc="http://www.opengis.net/ogc">
+    <csw:Delete typeName="csw:Record" handle="something">
+        <csw:Constraint version="2.0.0">
+            <ogc:Filter>
+                <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>SpatialReferenceSystem</ogc:PropertyName>
+                    <ogc:Literal>WGS-84</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+            </ogc:Filter>
+        </csw:Constraint>
+    </csw:Delete>
+</csw:Transaction>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/insertRequest.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/insertRequest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:Transaction
+        service="CSW"
+        version="2.0.2"
+        verboseResponse="true"
+        xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <csw:Insert typeName="csw:Record">
+        <csw:Record
+                xmlns:ows="http://www.opengis.net/ows"
+                xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <dc:identifier></dc:identifier>
+            <dc:title>Aliquam fermentum purus quis arcu</dc:title>
+            <dc:type>http://purl.org/dc/dcmitype/Text</dc:type>
+            <dc:subject>Hydrography--Dictionaries</dc:subject>
+            <dc:format>application/pdf</dc:format>
+            <dc:date>2006-05-12</dc:date>
+            <dct:abstract>Vestibulum quis ipsum sit amet metus imperdiet vehicula. Nulla scelerisque cursus mi.</dct:abstract>
+            <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+                <ows:LowerCorner>44.792 -6.171</ows:LowerCorner>
+                <ows:UpperCorner>51.126 -2.228</ows:UpperCorner>
+            </ows:BoundingBox>
+        </csw:Record>
+    </csw:Insert>
+</csw:Transaction>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/updateByPropertyRequest.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/updateByPropertyRequest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:Transaction
+        service="CSW"
+        version="2.0.2"
+        xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+        xmlns:ogc="http://www.opengis.net/ogc">
+    <csw:Update>
+        <csw:RecordProperty>
+            <csw:Name>title</csw:Name>
+            <csw:Value>Updated Title</csw:Value>
+        </csw:RecordProperty>
+        <csw:RecordProperty>
+            <csw:Name>created</csw:Name>
+            <csw:Value>2015-08-25</csw:Value>
+        </csw:RecordProperty>
+        <csw:RecordProperty>
+            <csw:Name>datatype</csw:Name>
+            <csw:Value>ABC</csw:Value>
+            <csw:Value>DEF</csw:Value>
+            <csw:Value>GHI</csw:Value>
+        </csw:RecordProperty>
+        <csw:RecordProperty>
+            <csw:Name>language</csw:Name>
+            <csw:Value></csw:Value>
+        </csw:RecordProperty>
+        <csw:RecordProperty>
+            <csw:Name>checksum</csw:Name>
+        </csw:RecordProperty>
+        <csw:Constraint version="2.0.0">
+            <ogc:Filter>
+                <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>title</ogc:PropertyName>
+                    <ogc:Literal>Aliquam fermentum purus quis arcu</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+            </ogc:Filter>
+        </csw:Constraint>
+    </csw:Update>
+</csw:Transaction>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/updateWholeRecordRequest.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/resources/updateWholeRecordRequest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<csw:Transaction
+        service="CSW"
+        version="2.0.2"
+        xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+    <csw:Update>
+        <csw:Record
+                xmlns:ows="http://www.opengis.net/ows"
+                xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <dc:identifier>2dbcfba3f3e24e3e8f68c50f5a98a4d1</dc:identifier>
+            <dc:title>Aliquam fermentum purus quis arcu</dc:title>
+            <dc:type>http://purl.org/dc/dcmitype/Text</dc:type>
+            <dc:subject>Hydrography--Dictionaries</dc:subject>
+            <dc:format>application/pdf</dc:format>
+            <dc:date>2008-08-10</dc:date>
+            <dct:abstract>Vestibulum quis ipsum sit amet metus imperdiet vehicula. Nulla scelerisque cursus mi.</dct:abstract>
+            <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+                <ows:LowerCorner>44.792 -6.171</ows:LowerCorner>
+                <ows:UpperCorner>51.126 -2.228</ows:UpperCorner>
+            </ows:BoundingBox>
+        </csw:Record>
+    </csw:Update>
+</csw:Transaction>


### PR DESCRIPTION
#### What does this PR do?
The TransactionRequestConverter was previously only using the CswMetacardType to evaluate attribute values. It now uses the AttributeRegistry which contains all attributes available.  There is also a fix for multi-valued attributes (before it would only use the first value in a list)
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@jlcsmith 
@glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[IO](https://github.com/orgs/codice/teams/IO)
[OGC](https://github.com/orgs/codice/teams/OGC)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Use the new test requests in the unit tests and verify additional attributes can be updated on a metacard via CSW. (Postman should make it easy).
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2641](https://codice.atlassian.net/browse/DDF-2641)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…ine the attribtue type.