### PR TITLE
(2.9.x) DDF-2320 Updated CatalogFramework to try all InputTransformers before failing ingest

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
 import org.apache.tika.detect.DefaultProbDetector;
@@ -662,35 +664,26 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             throws MetacardCreationException, MimeTypeParseException {
 
         Metacard generatedMetacard = null;
-        InputTransformer transformer;
-        StringBuilder causeMessage = new StringBuilder();
 
         MimeType mimeType = new MimeType(mimeTypeRaw);
 
-        List<InputTransformer> listOfCandidates = frameworkProperties.getMimeTypeToTransformerMapper().findMatches(InputTransformer.class, mimeType);
+        List<InputTransformer> listOfCandidates =
+                frameworkProperties.getMimeTypeToTransformerMapper()
+                        .findMatches(InputTransformer.class, mimeType);
+        List<String> stackTraceList = new ArrayList<>();
 
         LOGGER.debug("List of matches for mimeType [{}]: {}", mimeType, listOfCandidates);
 
         for (InputTransformer candidate : listOfCandidates) {
-            transformer = candidate;
-
-            try (InputStream transformerStream = com.google.common.io.Files.asByteSource(tmpContentPath.toFile()).openStream()) {
-                generatedMetacard = transformer.transform(transformerStream);
+            try (InputStream transformerStream = com.google.common.io.Files.asByteSource(
+                    tmpContentPath.toFile())
+                    .openStream()) {
+                generatedMetacard = candidate.transform(transformerStream);
             } catch (CatalogTransformerException | IOException e) {
-                causeMessage.append(String.format("Transformer [%s] could not create metacard.", transformer));
-                /*
-                    The caught exception more than likely does not have the root cause message
-                    that is needed to inform the caller as to why things have failed.  Therefore
-                    we need to iterate through the chain of cause exceptions and gather up
-                    all of their message details.
-                */
-                causeMessage.append(mimeTypeRaw).append(". Reason: ").append(System.lineSeparator()).append(e.getMessage());
-                Throwable cause = e.getCause();
-                while (cause != null && cause != cause.getCause()) {
-                    causeMessage.append(System.lineSeparator()).append(cause.getMessage());
-                    cause = cause.getCause();
-                }
-                LOGGER.debug("Transformer [{}] could not create metacard.", transformer, e);
+                List<String> stackTraces = Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
+                stackTraceList.add(String.format("Transformer [%s] could not create metacard.", candidate));
+                stackTraceList.addAll(stackTraces);
+                LOGGER.debug("Transformer [{}] could not create metacard.", candidate, e);
             }
 
             if (generatedMetacard != null) {
@@ -699,7 +692,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
         }
 
         if (generatedMetacard == null) {
-            throw new MetacardCreationException(causeMessage.toString());
+            throw new MetacardCreationException(String.format("Could not create metacard with mimeType %s : %s", mimeTypeRaw, stackTraceList.stream()
+                    .collect(Collectors.joining("\n"))));
         }
 
         if (id != null) {
@@ -1069,8 +1063,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             }
 
             createRequest.getProperties()
-                    .put(Constants.OPERATION_TRANSACTION_KEY,
-                            new OperationTransactionImpl(OperationTransaction.OperationType.CREATE,
+                    .put(Constants.OPERATION_TRANSACTION_KEY, new OperationTransactionImpl(
+                                    OperationTransaction.OperationType.CREATE,
                                     new ArrayList<>()));
 
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
@@ -1348,8 +1342,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                     new UpdateRequestImpl(Iterables.toArray(metacardMap.values()
                             .stream()
                             .map(Metacard::getId)
-                            .collect(Collectors.toList()), String.class),
-                            new ArrayList<>(metacardMap.values()));
+                            .collect(Collectors.toList()), String.class), new ArrayList<>(
+                            metacardMap.values()));
             updateRequest.setProperties(streamUpdateRequest.getProperties());
             updateResponse = update(updateRequest);
         } catch (Exception e) {
@@ -1471,8 +1465,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             }
 
             updateRequest.getProperties()
-                    .put(Constants.OPERATION_TRANSACTION_KEY,
-                            new OperationTransactionImpl(OperationTransaction.OperationType.UPDATE,
+                    .put(Constants.OPERATION_TRANSACTION_KEY, new OperationTransactionImpl(
+                                    OperationTransaction.OperationType.UPDATE,
                                     metacardMap.values()));
 
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
@@ -1637,8 +1631,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
 
             deleteRequest = rewriteRequestToAvoidHistoryConflicts(deleteRequest, query);
             deleteRequest.getProperties()
-                    .put(Constants.OPERATION_TRANSACTION_KEY,
-                            new OperationTransactionImpl(OperationTransaction.OperationType.DELETE,
+                    .put(Constants.OPERATION_TRANSACTION_KEY, new OperationTransactionImpl(
+                                    OperationTransaction.OperationType.DELETE,
                                     metacards));
 
             deleteStorageRequest = new DeleteStorageRequestImpl(metacards,
@@ -1662,8 +1656,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
             }
 
             deleteRequest.getProperties()
-                    .put(Constants.OPERATION_TRANSACTION_KEY,
-                            new OperationTransactionImpl(OperationTransaction.OperationType.DELETE,
+                    .put(Constants.OPERATION_TRANSACTION_KEY, new OperationTransactionImpl(
+                                    OperationTransaction.OperationType.DELETE,
                                     metacards));
 
             for (PreIngestPlugin plugin : frameworkProperties.getPreIngest()) {
@@ -2219,8 +2213,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                     }
 
                     if (!sourceFound) {
-                        exceptions.add(new ProcessingDetailsImpl(id,
-                                new SourceUnavailableException("Source id is not found")));
+                        exceptions.add(new ProcessingDetailsImpl(id, new SourceUnavailableException(
+                                "Source id is not found")));
                     }
                 }
             }
@@ -2754,10 +2748,8 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
                     String metacardId = (String) value;
                     LOGGER.debug("metacardId = {},   site = {}", metacardId, site);
                     QueryRequest queryRequest = new QueryRequestImpl(createMetacardIdQuery(
-                            metacardId),
-                            isEnterprise,
-                            Collections.singletonList(site == null ? this.getId() : site),
-                            resourceRequest.getProperties());
+                            metacardId), isEnterprise, Collections.singletonList(
+                            site == null ? this.getId() : site), resourceRequest.getProperties());
 
                     QueryResponse queryResponse = query(queryRequest, null, true);
                     if (queryResponse.getResults()


### PR DESCRIPTION
#### What does this PR do?
When multiple InputTransformers are present that all handle a given mime-type (e.g. text/xml) they should each be called until one successfully creates a metacard. Currently, if any of them throw an exception, the processing chain is stopped and the other InputTransformers are not called.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / log:set DEBUG ddf.catalog.impl / Ingest XML and observe multiple transformers are called
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2320](https://codice.atlassian.net/browse/DDF-2320)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests