### PR TITLE
DDF-2654 - Results are returned from all federated sources when querying a specific source from the Standard Search UI

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -541,8 +541,14 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
         @Override
         public SourceResponse call() throws Exception {
-            final SourceResponse sourceResponse =
-                    source.query(new QueryRequestImpl(request.getQuery(), request.getProperties()));
+            QueryRequest queryRequest;
+            if (CACHE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE)) || INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                queryRequest = new QueryRequestImpl(request.getQuery(), false, request.getSourceIds(), request.getProperties());
+            } else {
+                queryRequest = new QueryRequestImpl(request.getQuery(), request.getProperties());
+            }
+
+            final SourceResponse sourceResponse = source.query(queryRequest);
 
             if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
                 cacheCommitPhaser.add(sourceResponse.getResults());


### PR DESCRIPTION
#### What does this PR do?
  This PR adds sources to the SolrCacheSource's query request. This will allow the solr query to filter on sourceIds provided. Returning results for only the sources selected.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote @vinamartin @brianfelix 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Install multiple instances of the DDF (or use loopback sources)
Open the Search UI one each instance and injest at least one product.
Select an instance to federate to the other sources
Open the admin console for the selected instance and create a source for each of the other instances
Open the Search UI for the selected instance and perform a search of all source
Verify all expected results are returned.
Perform other searches using Specific Sources
Verify only the expected products from the selected sources are returned.

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2654
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Adding source ids to the queryRequest used to query the SolrCacheSource