### PR TITLE
DDF-2657 Closed InputStream of zip file generated by dump command

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
@@ -192,10 +193,12 @@ public class DumpCommand extends CqlCommands {
             if (StringUtils.isNotBlank(zipFileName)) {
                 try {
                     Optional<QueryResponseTransformer> zipCompression = getZipCompression();
-
                     if (zipCompression.isPresent()) {
-                        zipCompression.get()
+                        BinaryContent binaryContent = zipCompression.get()
                                 .transform(response, zipArgs);
+                        if (binaryContent != null) {
+                            IOUtils.closeQuietly(binaryContent.getInputStream());
+                        }
                         Long resultSize = (long) response.getResults()
                                 .size();
                         printStatus(resultCount.addAndGet(resultSize));


### PR DESCRIPTION
#### What does this PR do?
This PR closes the InputStream of the Zip file generated by the DumpCommand
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest / catalog:dump --include-content / verify file can be deleted and is not being used by java
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2657](https://codice.atlassian.net/browse/DDF-2657)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests