### PR TITLE
DDF-2664: Embedded LDAP default configs should not be installed when …

### DIFF
--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -120,20 +120,31 @@
     <feature name="security-sts-ldaplogin" install="manual" version="${project.version}"
              description="DDF Security STS JAAS LDAP Login.">
         <bundle>mvn:ddf.security.sts/security-sts-ldaplogin/${project.version}</bundle>
-        <configfile
-                finalname="/etc/ddf.ldap.ldaplogin.LdapLoginConfig.config"
-                override="false">
-            mvn:ddf.security/security-services-app/${project.version}/config/ddf.ldap.ldaplogin.LdapLoginConfig
-        </configfile>
     </feature>
 
     <feature name="security-sts-ldapclaimshandler" install="manual" version="${project.version}"
              description="Retrieves claims attributes from an LDAP store.">
         <bundle>mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}</bundle>
+    </feature>
+
+    <feature name="ldap-embedded-default-configs" install="manual" version="${project.version}" description="Installs default embedded ldap claims handler and login configs">
+        <feature>ldap-embedded-default-claimshandler-config</feature>
+        <feature>ldap-embedded-default-stslogin-config</feature>
+    </feature>
+
+    <feature name="ldap-embedded-default-claimshandler-config" install="manual" version="${project.version}" description="Installs a default embedded ldap login config">
         <configfile
                 finalname="/etc/ddf.security.sts.claimsHandler.ClaimsHandlerManager.config"
                 override="false">
             mvn:ddf.security/security-services-app/${project.version}/config/ddf.security.sts.claimsHandler.ClaimsHandlerManager
+        </configfile>
+    </feature>
+
+    <feature name="ldap-embedded-default-stslogin-config" install="manual" version="${project.version}" description="Installs a default embedded ldap claims handler config">
+        <configfile
+                finalname="/etc/ddf.ldap.ldaplogin.LdapLoginConfig.config"
+                override="false">
+            mvn:ddf.security/security-services-app/${project.version}/config/ddf.ldap.ldaplogin.LdapLoginConfig
         </configfile>
     </feature>
 


### PR DESCRIPTION
…starting LDAP related features

  - Removed default configs being installed by security-sts-ldapclaimshandler & security-sts-ldaplogin features
  - Created feature ldap-embedded-default-configs to install instead

#### What does this PR do?
Removes default configs being created when ldap features were started
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@roelens8 @garrettfreibott @adimka 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security] @stustison 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
@stustison
#### How should this be tested? (List steps with links to updated documentation)
- Ensure no managed services are created when starting features security-sts-ldapclaimshandler and security-sts-ldaplogin
- Change an endpoint to only allow login via the ldap realm
- Login as a user in the embedded ldap
#### Any background context you want to provide?
#### What are the relevant tickets?
(https://codice.atlassian.net/browse/DDF-2664)
(https://codice.atlassian.net/browse/DDF-2070)
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Change Log Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
