### PR TITLE
DDF-2661: Fix point of contact to be set on all created metacards.

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -473,19 +473,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.64</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.54</minimum>
                                         </limit>
-                                        
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
@@ -37,8 +37,6 @@ import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,7 +146,6 @@ public class CreateOperations {
 
         // Operation populates the metacardMap, contentItems, and tmpContentPaths
         opsMetacardSupport.generateMetacardAndContentItems(streamCreateRequest.getContentItems(),
-                retrieveSubject(),
                 metacardMap,
                 contentItems,
                 tmpContentPaths);
@@ -294,7 +291,8 @@ public class CreateOperations {
         // building
         if (INGEST_LOGGER.isDebugEnabled()) {
             INGEST_LOGGER.debug("{} metacards were successfully ingested. {}",
-                    createResponse.getRequest().getMetacards()
+                    createResponse.getRequest()
+                            .getMetacards()
                             .size(),
                     buildIngestLog(createResponse.getRequest()));
         }
@@ -697,20 +695,6 @@ public class CreateOperations {
             }
         }
         return createStorageRequest;
-    }
-
-    private ddf.security.Subject retrieveSubject() {
-        ddf.security.Subject subjectToReturn = null;
-        try {
-            Subject subject = SecurityUtils.getSubject();
-            if (subject instanceof ddf.security.Subject) {
-                subjectToReturn = (ddf.security.Subject) subject;
-            }
-        } catch (Exception exception) {
-            LOGGER.debug("No security subject found during metacard generation.");
-        }
-
-        return subjectToReturn;
     }
 
     @SuppressWarnings("unchecked")

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import javax.activation.MimeType;
@@ -33,8 +32,6 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.mime.MimeTypeToTransformerMapper;
-import ddf.security.Subject;
-import ddf.security.SubjectUtils;
 
 /**
  * Support class for creating metacards for the {@code CatalogFrameworkImpl}.
@@ -55,8 +52,8 @@ public class MetacardFactory {
         this.mimeTypeToTransformerMapper = mimeTypeToTransformerMapper;
     }
 
-    Metacard generateMetacard(String mimeTypeRaw, String id, String fileName, Subject subject,
-            Path tmpContentPath) throws MetacardCreationException, MimeTypeParseException {
+    Metacard generateMetacard(String mimeTypeRaw, String id, String fileName, Path tmpContentPath)
+            throws MetacardCreationException, MimeTypeParseException {
 
         Metacard generatedMetacard = null;
         InputTransformer transformer = null;
@@ -117,11 +114,6 @@ public class MetacardFactory {
         if (StringUtils.isBlank(generatedMetacard.getTitle())) {
             generatedMetacard.setAttribute(new AttributeImpl(Metacard.TITLE, fileName));
         }
-
-        String name = Optional.ofNullable(SubjectUtils.getName(subject))
-                .orElse("");
-
-        generatedMetacard.setAttribute(new AttributeImpl(Metacard.POINT_OF_CONTACT, name));
 
         return generatedMetacard;
     }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -47,11 +47,10 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.impl.FrameworkProperties;
 import ddf.catalog.source.IngestException;
 import ddf.mime.MimeTypeResolutionException;
-import ddf.security.Subject;
 
 /**
  * Support class for working with {@code Metacard}s for the {@code CatalogFrameworkImpl}.
- *
+ * <p>
  * This class contains methods for management/manipulation for metacards for the CFI and its
  * support classes. No operations/support methods should be added to this class except in support
  * of CFI, specific to metacards.
@@ -87,7 +86,7 @@ public class OperationsMetacardSupport {
         return metacard;
     }
 
-    void generateMetacardAndContentItems(List<ContentItem> incomingContentItems, Subject subject,
+    void generateMetacardAndContentItems(List<ContentItem> incomingContentItems,
             Map<String, Metacard> metacardMap, List<ContentItem> contentItems,
             Map<String, Path> tmpContentPaths) throws IngestException {
         for (ContentItem contentItem : incomingContentItems) {
@@ -124,7 +123,6 @@ public class OperationsMetacardSupport {
                 Metacard metacard = metacardFactory.generateMetacard(mimeTypeRaw,
                         contentItem.getId(),
                         fileName,
-                        subject,
                         tmpPath);
                 metacardMap.put(metacard.getId(), metacard);
 
@@ -143,7 +141,6 @@ public class OperationsMetacardSupport {
             }
         }
     }
-
 
     /**
      * Updates any empty metacard attributes with those defined in the

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -78,8 +78,6 @@ import ddf.catalog.source.IngestException;
 import ddf.catalog.source.InternalIngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.util.impl.Requests;
-import ddf.security.SecurityConstants;
-import ddf.security.Subject;
 
 /**
  * Support class for update delegate operations for the {@code CatalogFrameworkImpl}.
@@ -168,7 +166,6 @@ public class UpdateOperations {
 
         // Operation populates the metacardMap, contentItems, and tmpContentPaths
         opsMetacardSupport.generateMetacardAndContentItems(streamUpdateRequest.getContentItems(),
-                (Subject) streamUpdateRequest.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
                 metacardMap,
                 contentItems,
                 tmpContentPaths);
@@ -303,7 +300,8 @@ public class UpdateOperations {
         // building
         if (INGEST_LOGGER.isDebugEnabled()) {
             INGEST_LOGGER.debug("{} metacards were successfully updated. {}",
-                    updateResponse.getRequest().getUpdates()
+                    updateResponse.getRequest()
+                            .getUpdates()
                             .size(),
                     buildUpdateLog(updateResponse.getRequest()));
         }
@@ -719,8 +717,8 @@ public class UpdateOperations {
             LOGGER.debug(
                     "While rewriting the query, did not get a metacardId corresponding to every attribute.");
             LOGGER.debug("Original Update By attribute was: {}", attributeName);
-            LOGGER.debug(
-                    "Metacards unable to get Metacard ID from are: {}", updateRequest.getUpdates()
+            LOGGER.debug("Unable to get Metacard IDs from metacards:: {}",
+                    updateRequest.getUpdates()
                             .stream()
                             .map(Map.Entry::getKey)
                             .map(Object::toString)

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactoryTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactoryTest.groovy
@@ -80,8 +80,7 @@ class MetacardFactoryTest extends Specification {
 
     def 'test metacard generation with bad xformer'() {
         when:
-        metacardFactory.generateMetacard('application/xml-bad', 'idbad', 'filename',
-                null, path)
+        metacardFactory.generateMetacard('application/xml-bad', 'idbad', 'filename', path)
 
         then:
         thrown(MetacardCreationException)
@@ -89,8 +88,7 @@ class MetacardFactoryTest extends Specification {
 
     def 'test plain text metacard with no id or title'() {
         when:
-        def metacard = metacardFactory.generateMetacard('text/plain', null, 'filename',
-                null, path)
+        def metacard = metacardFactory.generateMetacard('text/plain', null, 'filename', path)
 
         then:
         1 * metacardPlain.setAttribute({ it.name == Metacard.ID && isUUID(it.values.first()) })
@@ -98,82 +96,44 @@ class MetacardFactoryTest extends Specification {
         1 * metacardPlain.setAttribute({
             it.name == Metacard.TITLE && it.values.first() == 'filename'
         })
-        1 * metacardPlain.setAttribute({
-            it.name == Metacard.POINT_OF_CONTACT && it.values.first() == ''
-        })
 
         metacard == metacardPlain
     }
 
     def 'test plain text metacard with provided id and xform-generated title'() {
         when:
-        def metacard = metacardFactory.generateMetacard('text/plain', 'test-id', 'filename',
-                null, path)
+        def metacard = metacardFactory.generateMetacard('text/plain', 'test-id', 'filename', path)
 
         then:
         1 * metacardPlain.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
         1 * metacardPlain.getTitle() >> { 'this is a title' }
         0 * metacardPlain.setAttribute({ it.name == Metacard.TITLE })
-        1 * metacardPlain.setAttribute({
-            it.name == Metacard.POINT_OF_CONTACT && it.values.first() == ''
-        })
-
-        metacard == metacardPlain
-    }
-
-    def 'test plain text metacard with provided id and xform-generated title and a subject'() {
-        setup:
-        def subject = Mock(Subject)
-        def principals = Mock(PrincipalCollection)
-        principals.oneByType(_) >> { null }
-        principals.getPrimaryPrincipal() >> { 'test-subject' }
-        subject.getPrincipals() >> { principals }
-
-        when:
-        def metacard = metacardFactory.generateMetacard('text/plain', 'test-id', 'filename',
-                subject, path)
-
-        then:
-        1 * metacardPlain.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
-        1 * metacardPlain.getTitle() >> { 'this is a title' }
-        0 * metacardPlain.setAttribute({ it.name == Metacard.TITLE })
-        1 * metacardPlain.setAttribute({
-            it.name == Metacard.POINT_OF_CONTACT && it.values.first() == 'test-subject'
-        })
 
         metacard == metacardPlain
     }
 
     def 'test xml metacard with provided id and xform-generated title'() {
         when:
-        def metacard = metacardFactory.generateMetacard('application/xml', 'test-id', 'filename',
-                null, path)
+        def metacard = metacardFactory.generateMetacard('application/xml', 'test-id', 'filename', path)
 
         then:
         then:
         1 * metacardXml.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
         1 * metacardXml.getTitle() >> { 'this is a title' }
         0 * metacardXml.setAttribute({ it.name == Metacard.TITLE })
-        1 * metacardXml.setAttribute({
-            it.name == Metacard.POINT_OF_CONTACT && it.values.first() == ''
-        })
 
         metacard == metacardXml
     }
 
     def 'ensure that order of operations matters for transformers'() {
         when:
-        def metacard = metacardFactory.generateMetacard('application/xml2', 'test-id', 'filename',
-                null, path)
+        def metacard = metacardFactory.generateMetacard('application/xml2', 'test-id', 'filename', path)
 
         then:
         then:
         1 * metacardXml2.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
         1 * metacardXml2.getTitle() >> { 'this is a title' }
         0 * metacardXml2.setAttribute({ it.name == Metacard.TITLE })
-        1 * metacardXml2.setAttribute({
-            it.name == Metacard.POINT_OF_CONTACT && it.values.first() == ''
-        })
 
         metacard == metacardXml2
     }

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportTest.groovy
@@ -83,7 +83,7 @@ class OperationsMetacardSupportTest extends Specification {
         def contentPaths = [:]
 
         when:
-        opsMetacard.generateMetacardAndContentItems([], null, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems([], metacardMap, contentItems, contentPaths)
 
         then:
         metacardMap.isEmpty()
@@ -101,7 +101,7 @@ class OperationsMetacardSupportTest extends Specification {
         def inputs = [item]
 
         when:
-        opsMetacard.generateMetacardAndContentItems(inputs, null, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems(inputs, metacardMap, contentItems, contentPaths)
 
         then:
         thrown(IngestException)
@@ -117,7 +117,7 @@ class OperationsMetacardSupportTest extends Specification {
         def inputs = [item]
 
         when:
-        opsMetacard.generateMetacardAndContentItems(inputs, null, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems(inputs, metacardMap, contentItems, contentPaths)
 
         then:
         thrown(IngestException)
@@ -136,7 +136,7 @@ class OperationsMetacardSupportTest extends Specification {
         def inputs = [item]
 
         when:
-        opsMetacard.generateMetacardAndContentItems(inputs, null, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems(inputs, metacardMap, contentItems, contentPaths)
 
         then:
         thrown(IngestException)
@@ -147,7 +147,6 @@ class OperationsMetacardSupportTest extends Specification {
         def metacardMap = [:]
         List<ContentItem> contentItems = []
         Map<String, Path> contentPaths = [:]
-        def subject = Mock(Subject)
         frameworkProperties.mimeTypeMapper.guessMimeType(_, _) >> { 'text/plain' }
         def item = Mock(ContentItem)
         item.getFilename() >> 'joe.txt'
@@ -157,7 +156,7 @@ class OperationsMetacardSupportTest extends Specification {
         def inputs = [item]
 
         when:
-        opsMetacard.generateMetacardAndContentItems(inputs, subject, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems(inputs, metacardMap, contentItems, contentPaths)
 
         then:
         metacardMap.size() == 1
@@ -175,7 +174,6 @@ class OperationsMetacardSupportTest extends Specification {
         def metacardMap = [:]
         List<ContentItem> contentItems = []
         Map<String, Path> contentPaths = [:]
-        def subject = Mock(Subject)
         frameworkProperties.mimeTypeMapper.guessMimeType(_, _) >> { 'text/plain' }
         def item = Mock(ContentItem)
         item.getFilename() >> 'joe.txt'
@@ -185,7 +183,7 @@ class OperationsMetacardSupportTest extends Specification {
         def inputs = [item]
 
         when:
-        opsMetacard.generateMetacardAndContentItems(inputs, subject, metacardMap, contentItems, contentPaths)
+        opsMetacard.generateMetacardAndContentItems(inputs, metacardMap, contentItems, contentPaths)
 
         then:
         1 * transformer.transform(_) >> { throw new IOException() }

--- a/catalog/security/catalog-security-plugin/pom.xml
+++ b/catalog/security/catalog-security-plugin/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>catalog-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
@@ -48,7 +52,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>platform-util</Embed-Dependency>
+                        <Embed-Dependency>catalog-core-api-impl, platform-util</Embed-Dependency>
                         <Export-Package/>
                     </instructions>
                 </configuration>
@@ -71,19 +75,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.89</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.87</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.5</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/distribution/ddf-common/src/main/resources/etc/definitions/core-attribute-injectors.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/core-attribute-injectors.json
@@ -1,0 +1,7 @@
+{
+  "inject": [
+    {
+      "attribute": "point-of-contact"
+    }
+  ]
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -126,6 +126,7 @@ import ddf.catalog.data.types.Validation;
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class TestCatalog extends AbstractIntegrationTest {
+
     private static final String METACARD_X_PATH = "/metacards/metacard[@id='%s']";
 
     private static final String SAMPLE_DATA = "sample data";
@@ -139,6 +140,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     private static KarafConsole console;
 
     private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
+    public static final String ADMIN = "admin";
 
     @Rule
     public TestName testName = new TestName();
@@ -257,7 +259,38 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .log()
                 .all()
                 .assertThat()
-                .body(hasXPath("/metacard[@id='" + id + "']"));
+                .body(hasXPath("/metacard[@id='" + id + "']"))
+                .body(hasXPath("/metacard/string[@name='point-of-contact']"),
+                        containsString("Guest@Guest"));
+
+        deleteMetacard(id);
+    }
+
+    @Test
+    public void testPointOfContactSetOnIngestWhenLoggedIn() {
+        String id = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"))
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .expect()
+                .log()
+                .all()
+                .statusCode(HttpStatus.SC_CREATED)
+                .when()
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
+
+        String url = REST_PATH.getUrl() + id;
+        LOGGER.info("Getting response to {}", url);
+        when().get(url)
+                .then()
+                .log()
+                .all()
+                .assertThat()
+                .body(hasXPath("/metacard[@id='" + id + "']"))
+                .body(hasXPath("/metacard/string[@name='point-of-contact']/value[text()='" + ADMIN
+                        + "']"));
 
         deleteMetacard(id);
     }
@@ -2287,8 +2320,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         Path tmpFile = definitionsDirPath.resolve(filename);
         tmpFile.toFile()
                 .deleteOnExit();
-        Files.copy(IOUtils.toInputStream(getFileContent(filename)),
-                tmpFile);
+        Files.copy(IOUtils.toInputStream(getFileContent(filename)), tmpFile);
         return tmpFile.toFile();
     }
 
@@ -2334,9 +2366,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .assertThat()
                     .body(hasXPath(newMetacardXpath + "/type", is(newMetacardTypeName)))
                     .body(hasXPath("count(" + newMetacardXpath
-                            + "/string[@name=\"validation-errors\"]/value)", is("2")))
-                    .body(hasXPath(newMetacardXpath
-                            + "/string[@name=\"validation-errors\"]/value[text()=\"point-of-contact is required\"]"))
+                            + "/string[@name=\"validation-errors\"]/value)", is("1")))
                     .body(hasXPath(newMetacardXpath
                             + "/string[@name=\"validation-errors\"]/value[text()=\"new-attribute-required-1 is required\"]"))
                     .body(hasXPath(
@@ -2517,7 +2547,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
                     .until(() -> getServiceManager().getServiceReferences(InjectableAttribute.class,
-                            null), hasSize(2));
+                            null), hasSize(3));
             return null;
         });
 
@@ -2541,9 +2571,13 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .assertThat()
                     .body(hasXPath(basicMetacardXpath + "/type", is(basicMetacardTypeName)))
                     .body(hasXPath(basicMetacardXpath + "/int[@name='page-count']/value", is("55")))
+                    .body(hasXPath(basicMetacardXpath + "/string[@name='point-of-contact']"),
+                            containsString("Guest@Guest"))
                     .body(not(hasXPath(basicMetacardXpath + "/double[@name='temperature']")))
                     .body(hasXPath(otherMetacardXpath + "/type", is(otherMetacardTypeName)))
                     .body(hasXPath(otherMetacardXpath + "/int[@name='page-count']/value", is("55")))
+                    .body(hasXPath(otherMetacardXpath + "/string[@name='point-of-contact']"),
+                            containsString("Guest@Guest"))
                     .body(hasXPath(otherMetacardXpath + "/double[@name='temperature']/value",
                             is("-12.541")));
         } finally {
@@ -2552,7 +2586,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             uninstallDefinitionJson(file, () -> {
                 expect("Injectable attributes to be unregistered").within(10, TimeUnit.SECONDS)
                         .until(() -> getServiceManager().getServiceReferences(InjectableAttribute.class,
-                                null), is(empty()));
+                                null), hasSize(1));
                 return null;
             });
         }
@@ -2563,7 +2597,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
                     .until(() -> getServiceManager().getServiceReferences(InjectableAttribute.class,
-                            null), hasSize(2));
+                            null), hasSize(3));
             return null;
         });
 
@@ -2591,17 +2625,20 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .body(hasXPath(basicMetacardXpath + "/type", is(basicMetacardTypeName)))
                     .body(hasXPath(basicMetacardXpath + "/int[@name='page-count']/value", is("55")))
                     .body(not(hasXPath(basicMetacardXpath + "/double[@name='temperature']")))
+                    .body(not(hasXPath(basicMetacardXpath + "/string[@name='point-of-contact']")))
                     .body(hasXPath(otherMetacardXpath + "/type", is(otherMetacardTypeName)))
                     .body(hasXPath(otherMetacardXpath + "/int[@name='page-count']/value", is("55")))
                     .body(hasXPath(otherMetacardXpath + "/double[@name='temperature']/value",
-                            is("-12.541")));
+                            is("-12.541")))
+                    .body(not(hasXPath(basicMetacardXpath + "/string[@name='point-of-contact']")));
+
         } finally {
             deleteMetacard(id);
             deleteMetacard(id2);
             uninstallDefinitionJson(file, () -> {
                 expect("Injectable attributes to be unregistered").within(10, TimeUnit.SECONDS)
                         .until(() -> getServiceManager().getServiceReferences(InjectableAttribute.class,
-                                null), is(empty()));
+                                null), hasSize(1));
                 return null;
             });
         }


### PR DESCRIPTION
#### What does this PR do?
 - Moves logic for setting point of contact from the `MetacardFactory` to the `SecurityPlugin`, so that all ingested metacards hit the logic instead of just metacards with associated products.
 - Configured attribute injector for point of contact, so that the attribute descriptor is put on all metacards and thus the attribute is persisted.
 - Updated itests.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @brendan-hofmann @jrnorth @shaundmorris 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@stustison
#### How should this be tested? (List steps with links to updated documentation)
 - Run a full build against an empty repo.
 - Ingest metacards of different types as at least two different users. Verify the `Point of Contact` attribute is set to the uploader's user name for every metacard. ("Guest" if not signed in)
#### Any background context you want to provide?
This builds the foundation for a feature that adds a security exception for all metacard point-of-contact fields so the uploader can see their product
#### What are the relevant tickets?
[DDF-2661](https://codice.atlassian.net/browse/DDF-2661)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests
