### PR TITLE
DDF-2320 Updated CatalogFramework to try all InputTransformers before failing ingest

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactoryTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactoryTest.groovy
@@ -68,8 +68,10 @@ class MetacardFactoryTest extends Specification {
                 [itXml, itXml2, itBad]
             } else if (m.baseType == 'application/xml2') {
                 [itXml2, itXml, itBad]
+            } else if (m.baseType == 'application/xml3') {
+                [itBad, itXml]
             } else if (m.baseType == 'application/xml-bad') {
-                [itBad, itXml, itXml2]
+                [itBad]
             } else if (m.baseType == 'text/plain') {
                 [itPlain]
             }
@@ -84,6 +86,18 @@ class MetacardFactoryTest extends Specification {
 
         then:
         thrown(MetacardCreationException)
+    }
+
+    def 'test metacard generation with xformer failure'() {
+        when:
+        def metacard = metacardFactory.generateMetacard('application/xml3', 'test-id', 'filename', path)
+
+        then:
+        1 * metacardXml.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
+        1 * metacardXml.getTitle() >> { 'this is a title' }
+        0 * metacardXml.setAttribute({ it.name == Metacard.TITLE })
+
+        metacard == metacardXml
     }
 
     def 'test plain text metacard with no id or title'() {
@@ -117,7 +131,6 @@ class MetacardFactoryTest extends Specification {
         def metacard = metacardFactory.generateMetacard('application/xml', 'test-id', 'filename', path)
 
         then:
-        then:
         1 * metacardXml.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
         1 * metacardXml.getTitle() >> { 'this is a title' }
         0 * metacardXml.setAttribute({ it.name == Metacard.TITLE })
@@ -129,7 +142,6 @@ class MetacardFactoryTest extends Specification {
         when:
         def metacard = metacardFactory.generateMetacard('application/xml2', 'test-id', 'filename', path)
 
-        then:
         then:
         1 * metacardXml2.setAttribute({ it.name == Metacard.ID && it.values.first() == 'test-id' })
         1 * metacardXml2.getTitle() >> { 'this is a title' }


### PR DESCRIPTION
#### What does this PR do?
When multiple InputTransformers are present that all handle a given mime-type (e.g. text/xml) they should each be called until one successfully creates a metacard. Currently, if any of them throw an exception, the processing chain is stopped and the other InputTransformers are not called.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / log:set DEBUG ddf.catalog.impl / Ingest XML and observe multiple transformers are called / use PostMan to test the rest endpoint
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2320](https://codice.atlassian.net/browse/DDF-2320)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests