### PR TITLE
[2.9.x]DDF-2661: Backport to fix point of contact for creating metacards.

### DIFF
--- a/catalog/security/catalog-security-plugin/pom.xml
+++ b/catalog/security/catalog-security-plugin/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>catalog-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
@@ -48,7 +52,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>platform-util</Embed-Dependency>
+                        <Embed-Dependency>catalog-core-api-impl, platform-util</Embed-Dependency>
                         <Export-Package />
                     </instructions>
                 </configuration>
@@ -71,22 +75,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.5</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.89</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/security/catalog-security-plugin/src/test/java/ddf/catalog/security/plugin/SecurityPluginTest.java
+++ b/catalog/security/catalog-security-plugin/src/test/java/ddf/catalog/security/plugin/SecurityPluginTest.java
@@ -14,8 +14,10 @@
 package ddf.catalog.security.plugin;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,10 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.util.ThreadContext;
 import org.junit.Test;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.Query;
@@ -40,77 +45,97 @@ import ddf.security.Subject;
 
 public class SecurityPluginTest {
 
+    private static final String TEST_USER = "test-user";
+
     @Test
     public void testNominalCaseCreate() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        PrincipalCollection mockPrincipals = mock(PrincipalCollection.class);
+        when(mockPrincipals.getPrimaryPrincipal()).thenReturn(TEST_USER);
+        when(mockSubject.getPrincipals()).thenReturn(mockPrincipals);
+
+        ThreadContext.bind(mockSubject);
         CreateRequest request = new MockCreateRequest();
         SecurityPlugin plugin = new SecurityPlugin();
+
         request = plugin.processPreCreate(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
+        assertThat(request.getMetacards()
+                .size(), is(2));
+        request.getMetacards()
+                .forEach(metacard -> assertThat(metacard.getAttribute(Metacard.POINT_OF_CONTACT)
+                        .getValue(), equalTo(TEST_USER)));
     }
 
     @Test
     public void testNominalCaseUpdate() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
         UpdateRequest request = new MockUpdateRequest();
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreUpdate(request, new HashMap<>());
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
     public void testNominalCaseDelete() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
         DeleteRequest request = new MockDeleteRequest();
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreDelete(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
     public void testNominalCaseQuery() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
         QueryRequest request = new MockQueryRequest();
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreQuery(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
     public void testNominalCaseResource() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
         ResourceRequest request = new MockResourceRequest();
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreResource(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
     public void testSubjectExists() throws Exception {
-        Subject subject = mock(Subject.class);
+        Subject mockSubject = mock(Subject.class);
         CreateRequest request = new MockCreateRequest();
         request.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, subject);
+                .put(SecurityConstants.SECURITY_SUBJECT, mockSubject);
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreCreate(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
     public void testBadSubjectCase() throws Exception {
-        Subject subject = mock(Subject.class);
-        ThreadContext.bind(subject);
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
         CreateRequest request = new MockCreateRequest();
         request.getProperties()
                 .put(SecurityConstants.SECURITY_SUBJECT, new HashMap<>());
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreCreate(request);
-        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(subject));
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
     }
 
     @Test
@@ -127,9 +152,17 @@ public class SecurityPluginTest {
     public static class MockCreateRequest implements CreateRequest {
         private Map<String, Serializable> props = new HashMap<>();
 
+        private List<Metacard> metacards;
+
         @Override
         public List<Metacard> getMetacards() {
-            return null;
+            if (metacards == null) {
+                metacards = new ArrayList<>();
+                metacards.add(new MetacardImpl());
+                metacards.add(new MetacardImpl(new MetacardTypeImpl("test-type", null)));
+            }
+
+            return metacards;
         }
 
         @Override


### PR DESCRIPTION
#### What does this PR do?
- Moves logic for setting point of contact from the `CatalogFrameworkImpl` to the `SecurityPlugin`, so that all ingested metacards hit the logic instead of just metacards with associated products.
 - Updated itests.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @brendan-hofmann @jrnorth @shaundmorris 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@stustison
#### How should this be tested? (List steps with links to updated documentation)
 - Run a full build against an empty repo.
 - Ingest metacards of different types as at least two different users. Verify the `Point of Contact` attribute is set to the uploader's user name for every metacard. ("Guest" if not signed in)
#### Any background context you want to provide?
This builds the foundation for a feature that adds a security exception for all metacard point-of-contact fields so the uploader can see their product
#### What are the relevant tickets?
[DDF-2661](https://codice.atlassian.net/browse/DDF-2661)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests
