### PR TITLE
DDF-2617: Configuring solr to log to separate log file to reduce noise in main log.

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -78,7 +78,7 @@
 
         <RollingFile name="solr" append="true"
                      fileName="${sys:karaf.data}/log/solr.log"
-                     filePattern="${sys:karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+                     filePattern="${sys:karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
             <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>
@@ -106,9 +106,14 @@
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
+        <Logger name="org.apache.lucene" level="info" additivity="false">
+            <AppenderRef ref="solr"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
         <!-- CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console. -->
         <Logger name="org.apache.cxf" level="warn"/>
-        <Logger name="org.apache.lucene" level="warn"/>
         <Logger name="lux.solr" level="warn"/>
         <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
         <Logger name="org.apache.aries.spifly" level="warn"/>

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -75,6 +75,16 @@
                 <AppenderRef ref="securityBackup"/>
             </Failovers>
         </Failover>
+
+        <RollingFile name="solr" append="true"
+                     fileName="${sys:karaf.data}/log/solr.log"
+                     filePattern="${sys:karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
     </Appenders>
 
     <Loggers>
@@ -90,10 +100,15 @@
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
+        <Logger name="org.apache.solr" level="info" additivity="false">
+            <AppenderRef ref="solr"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
         <!-- CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console. -->
         <Logger name="org.apache.cxf" level="warn"/>
         <Logger name="org.apache.lucene" level="warn"/>
-        <Logger name="org.apache.solr" level="warn"/>
         <Logger name="lux.solr" level="warn"/>
         <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
         <Logger name="org.apache.aries.spifly" level="warn"/>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -42,6 +42,8 @@ log4j.additivity.ingestLogger=false
 # Solr Logger
 log4j.logger.org.apache.solr = INFO, solr, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
 log4j.additivity.org.apache.solr = false
+log4j.logger.org.apache.lucene = INFO, solr, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.lucene = false
 
 # Syslog appender
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
@@ -104,7 +106,6 @@ log4j.appender.sift.appender.append=true
 
 # CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console.
 log4j.logger.org.apache.cxf = WARN
-log4j.logger.org.apache.lucene = WARN
 log4j.logger.lux.solr = WARN
 log4j.logger.org.ops4j.pax.web.jsp = WARN
 log4j.logger.org.apache.aries.spifly = WARN

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -39,6 +39,10 @@ log4j.additivity.securityLogger=false
 log4j.logger.ingestLogger = INFO, ingestError, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
 log4j.additivity.ingestLogger=false
 
+# Solr Logger
+log4j.logger.org.apache.solr = INFO, solr, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.solr = false
+
 # Syslog appender
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
 log4j.appender.syslog.layout=org.apache.log4j.PatternLayout
@@ -79,6 +83,15 @@ log4j.appender.security.append=true
 log4j.appender.security.maxFileSize=20MB
 log4j.appender.security.maxBackupIndex=10
 
+# Solr File appender
+log4j.appender.solr=org.apache.log4j.RollingFileAppender
+log4j.appender.solr.layout=org.apache.log4j.PatternLayout
+log4j.appender.solr.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.solr.file=${karaf.data}/log/solr.log
+log4j.appender.solr.append=true
+log4j.appender.solr.maxFileSize=20MB
+log4j.appender.solr.maxBackupIndex=10
+
 # Sift appender
 log4j.appender.sift=org.apache.log4j.sift.MDCSiftingAppender
 log4j.appender.sift.key=bundle.name
@@ -92,7 +105,6 @@ log4j.appender.sift.appender.append=true
 # CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console.
 log4j.logger.org.apache.cxf = WARN
 log4j.logger.org.apache.lucene = WARN
-log4j.logger.org.apache.solr = WARN
 log4j.logger.lux.solr = WARN
 log4j.logger.org.ops4j.pax.web.jsp = WARN
 log4j.logger.org.apache.aries.spifly = WARN

--- a/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
@@ -314,6 +314,9 @@ During ${branding} installation, the major directories and files shown in the ta
 |`data/log/security.log`
 |Log file that records user interactions with the system for auditing purposes.
 
+|`data/log/solr.log`
+|Log file for any info coming from Standalone Solr Server.
+
 |`deploy`
 |Hot-deploy directory – KARs and bundles added to this directory will be hot-deployed (Empty upon ${branding} installation)
 

--- a/distribution/docs/src/main/resources/_contents/extending-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/extending-contents.adoc
@@ -310,7 +310,7 @@ Apache Karaf is a FOSS product that includes an OSGi framework and adds extra fu
 
 ${admin-console}:: Useful for configuring applications, installing/uninstalling features, and viewing services such as metrics.
 ${command-console}:: Provides command line administration of the OSGi container. All functionality in the ${command-console} can also be performed via this command line console.
-Logging:: Provides centralized logging to `data/log/${branding-lowercase}.log`. Security logging is provided at `data/log/security.log`. Ingest error logging can be viewed in `data/log/ingest_error.log`.
+Logging:: Provides centralized logging to `data/log/${branding-lowercase}.log`. Security logging is provided at `data/log/security.log`. Ingest error logging can be viewed in `data/log/ingest_error.log`. Solr logging can be viewed in `data/log/solr.log`.
 Provisioning:: Of libraries or applications.
 Security:: Provides a security framework based on Java Authentication and Authorization Service (JAAS).
 Deployer:: Provides hot deployment of new bundles by dropping them into the `<INSTALL_DIR>/deploy` directory.

--- a/distribution/docs/src/main/resources/_contents/installing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/installing-contents.adoc
@@ -316,6 +316,9 @@ During ${branding} installation, the major directories and files shown in the ta
 |`data/log/security.log`
 |Log file that records user interactions with the system for auditing purposes.
 
+|`data/log/solr.log`
+|Log file for any info coming from Standalone Solr Server.
+
 |`deploy`
 |Hot-deploy directory – KARs and bundles added to this directory will be hot-deployed (Empty upon ${branding} installation)
 


### PR DESCRIPTION
#### What does this PR do?
Configures all logs from `org.apache.solr` to go to a separate log file instead of in the main log. This is to reduce noise in the main log, but still have solr logs for debugging.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @figliold @ricklarsen 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
- Build and run (including stepping through setup).
- Restart DDF. This will produce some solr errors when trying to create the Solr cores (see below for example). `log:tail` and verify there are no such errors in the console. Check `{karaf.home}/data/log/solr.log` and verify the solr logs are there including the errors.

```ERROR | qtp255340046-91  | org.apache.solr.common.SolrException      148 | lr-server-standalone | org.apache.solr.common.SolrException: Error CREATEing SolrCore 'metacard_cache': Could not create a new core in /opt/ddf/data/solr/metacard_cacheas another core is already defined there```
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2617](https://codice.atlassian.net/browse/DDF-2617)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
