### PR TITLE
DDF-2671: Added visibility of each sources active url and warnings for local addresses

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -67,6 +67,8 @@ define([
 
                 if (this.model && this.model.has('currentConfiguration')) {
                     data.currentConfiguration = this.model.get('currentConfiguration').toJSON();
+                    data.currentUrl = this.model.get('currentUrl');
+                    data.isLoopbackUrl = this.model.get('isLoopbackUrl');
                 } else {
                     data.currentConfiguration = undefined;
                 }

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceList.handlebars
@@ -16,6 +16,7 @@
     <thead>
         <th class="name">Name</th>
         <th class="active-binding">Active Binding</th>
+        <th>Binding URL</th>
         <th class="status">Status</th>
         <th><a href="#" class="addSourceLink fa fa-plus"></a></th>
         <th><a href="#" class="removeSourceLink fa fa-trash-o"></a></th>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceRow.handlebars
@@ -41,7 +41,15 @@
         </b>
     </div>
 </td>
-<td colspan="4">
+<td>
+  <div>
+      {{#if isLoopbackUrl}}
+      <i class="fa fa-exclamation-triangle" style="color:red" title="This source is configured to point at the local system. This is not a supported federation method and may cause unexpected behavior"></i>
+      {{/if}}
+      {{currentUrl}}
+  </div>
+</td>
+<td cols"4">
     {{#if currentConfiguration}}
         {{#if loading}}
             <span class='label label-info'>Loading</span>


### PR DESCRIPTION
#### What does this PR do?

* Adds a column to the sources list to display the currently active URL
* Adds a warning when the currently active URL is pointing at `localhost` or `org.codice.ddf.system.hostname`

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@figliold 
@brjeter 
@Lambeaux 
@bantillo 
@Joy603 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

@codice/ui 
@andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@lessarderic
@pklinef

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?

[DDF-2671](https://codice.atlassian.net/browse/DDF-2671)

#### Screenshots (if appropriate)

![sources_loopback_warning](https://cloud.githubusercontent.com/assets/3409759/21654521/d23b2002-d283-11e6-998c-ad625334ac17.png)
![sources_loopback_warnings](https://cloud.githubusercontent.com/assets/3409759/21654522/d23b888a-d283-11e6-871d-32b9929204de.png)
![sources_loopback_warning_tooltip](https://cloud.githubusercontent.com/assets/3409759/21654523/d23eb244-d283-11e6-9624-4b2169fd835b.png)

#### Checklist:
- [ ] Change Log Updated
