### PR TITLE
DDF-2672 Added Mime Type Aliases to Tika Input Transformer service properties

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -352,19 +352,30 @@ public class TikaInputTransformer implements InputTransformer {
     }
 
     private List<String> getSupportedMimeTypes() {
-        SortedSet<MediaType> mediaTypes = MediaTypeRegistry.getDefaultRegistry()
-                .getTypes();
+        MediaTypeRegistry mediaTypeRegistry = MediaTypeRegistry.getDefaultRegistry();
+
+        Set<MediaType> mediaTypes = mediaTypeRegistry.getTypes();
+        Set<MediaType> mediaTypeAliases = new HashSet<>();
         List<String> mimeTypes = new ArrayList<>(mediaTypes.size());
 
         for (MediaType mediaType : mediaTypes) {
-            String mimeType = mediaType.getType() + "/" + mediaType.getSubtype();
-            mimeTypes.add(mimeType);
+            addMediaTypetoMimeTypes(mediaType, mimeTypes);
+            mediaTypeAliases.addAll(mediaTypeRegistry.getAliases(mediaType));
         }
+
+        for (MediaType mediaType : mediaTypeAliases) {
+            addMediaTypetoMimeTypes(mediaType, mimeTypes);
+        }
+
         mimeTypes.add("image/jp2");
-        mimeTypes.add("image/bmp");
 
         LOGGER.debug("supported mime types: {}", mimeTypes);
         return mimeTypes;
+    }
+
+    private void addMediaTypetoMimeTypes(MediaType mediaType, List<String> mimeTypes) {
+        String mimeType = mediaType.getType() + "/" + mediaType.getSubtype();
+        mimeTypes.add(mimeType);
     }
 
     private void createThumbnail(InputStream input, Metacard metacard) {


### PR DESCRIPTION
#### What does this PR do?
This PR adds the mime type aliases defined in the Default Mime Type Registry for Tika to the Tike Input transformer service properties
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @jrnorth 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / log:set DEBUG ddf.catalog.transformer.input.tika / Install / verify debug
```12:59:35,300 | DEBUG | eb2-be9ea68d2ae2 | nsformer.input.tika.TikaInputTransformer  372 | ka-input-transformer | supported mime types ``` contains text/xml alias
Complete alias list can be found here : 
http://grepcode.com/file/repo1.maven.org/maven2/org.apache.tika/tika-core/1.9/org/apache/tika/mime/tika-mimetypes.xml
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2672](https://codice.atlassian.net/browse/DDF-2672)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
