### PR TITLE
DDF-2423 Updated TestCatalog cache itest to reduce flakiness

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -83,6 +83,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
+import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
@@ -135,6 +136,10 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     private static final String DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS = "data/products";
 
+    private static KarafConsole console;
+
+    private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
+
     @Rule
     public TestName testName = new TestName();
 
@@ -149,6 +154,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
+            console = new KarafConsole(getServiceManager().getBundleContext(), features, sessionFactory);
         } catch (Exception e) {
             LOGGER.error("Failed in @BeforeExam: ", e);
             fail("Failed in @BeforeExam: " + e.getMessage());
@@ -863,6 +869,9 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Test
     public void testCachedContentLengthHeader() throws IOException {
+
+        console.runCommand(CLEAR_CACHE);
+
         String fileName = "testCachedContentLengthHeader" + ".jpg";
         File tmpFile = createTemporaryFile(fileName,
                 IOUtils.toInputStream(getFileContent(SAMPLE_IMAGE)));
@@ -887,7 +896,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .headers();
 
         //Get again to hit the cache
-        get(url).then()
+        get(url + "&mode=cache").then()
                 .log()
                 .headers()
                 .assertThat()


### PR DESCRIPTION
#### What does this PR do?
Changes the testCachedContentLengthHeader itest in TestCatalog to clear the catalog's cache before the test is run and also ensure the cache is queried. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @clockard @gordocanchola @tbatie 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Run TestCatalog#testCachedContentLengthHeader

#### Any background context you want to provide?
This test has been reported as flaky a few times in the past. With these changes hopefully the test will fail more accurately. 

#### What are the relevant tickets?
[DDF-2423](https://codice.atlassian.net/browse/DDF-2423)

#### Screenshots (if appropriate)
![screen shot 2017-01-06 at 10 14 41 am](https://cloud.githubusercontent.com/assets/11355332/21726204/fa65aa7c-d3f8-11e6-9bff-4dd60576d504.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
