### PR TITLE
DDF-2687 Update vendored DrawHelper to not remove overlapping points

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
@@ -933,12 +933,8 @@ var DrawHelper = (function() {
                     if (cartesian) {
                         _self.stopDrawing();
                         if(typeof options.callback == 'function') {
-                            // remove overlapping ones
-                            var index = positions.length - 1;
-                            // TODO - calculate some epsilon based on the zoom level
-                            var epsilon = Cesium.Math.EPSILON3;
-                            for(; index > 0 && positions[index].equalsEpsilon(positions[index - 1], epsilon); index--) {}
-                            options.callback(positions.splice(0, index + 1));
+                            //https://github.com/leforthomas/cesium-drawhelper/issues/13
+                            options.callback(positions);
                         }
                     }
                 }

--- a/catalog/ui/search-ui/standard/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
@@ -933,12 +933,8 @@ var DrawHelper = (function() {
                     if (cartesian) {
                         _self.stopDrawing();
                         if(typeof options.callback == 'function') {
-                            // remove overlapping ones
-                            var index = positions.length - 1;
-                            // TODO - calculate some epsilon based on the zoom level
-                            var epsilon = Cesium.Math.EPSILON3;
-                            for(; index > 0 && positions[index].equalsEpsilon(positions[index - 1], epsilon); index--) {}
-                            options.callback(positions.splice(0, index + 1));
+                            //https://github.com/leforthomas/cesium-drawhelper/issues/13
+                            options.callback(positions);
                         }
                     }
                 }


### PR DESCRIPTION
 - See leforthomas/cesium-drawhelper#13 for details.
 - At lower zooms, points were being erroneously removed from drawings.

#### What does this PR do?
  Updates the vendored version of DrawHelper to pull in a fix for lower zoom drawings.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@jlcsmith 
@kcwire 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
Zoom to street level somewhere and draw a line or a polygon. 

#### Any background context you want to provide?
This applies the fix to both the standard and the catalog ui.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2687

#### Screenshots (if appropriate)
Before: https://gfycat.com/SereneSelfassuredBoto
After: https://gfycat.com/ElectricLittleHummingbird
