### PR TITLE
DDF-2690 Remove race condition in initial workspace fetch

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -125,8 +125,8 @@ define([
             url: '/search/catalog/internal/workspaces',
             useAjaxSync: true,
             initialize: function(){
-                this.fetch();
-                this.listenTo(user, 'change', this.fetch);
+                this.handleUserChange();
+                this.listenTo(user, 'change', this.handleUserChange);
                 var collection = this;
                 collection.on('add',function(workspace){
                     workspace.on('change:lastModifiedDate',function(){
@@ -137,6 +137,9 @@ define([
                     collection.save();
                 });
                 this.listenTo(this, 'add', this.tagGuestWorkspace);
+            },
+            handleUserChange: function(){
+                this.fetch({remove: false});
             },
             tagGuestWorkspace: function (model) {
                 if (this.isGuestUser() && model.isNew()) {


### PR DESCRIPTION
 - It's possible for the initial fetch of workspaces from the cloud to take so long that a user can create a new cloud workspace in the meantime, then the fetch comes back missing that workspace and the workspace gets obliterated while you’re in it.
While the chance is very slim, we should defend against it by making the fetch non-destructive.

[UI](https://github.com/orgs/codice/teams/ui)
@jlcsmith
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
This one is hard to test (since it's a race condition).  I had to manually force it to happen by updating the code.
You can do the same by going to this area of the code: https://github.com/codice/ddf/blob/master/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js#L128

Then changing the line `this.fetch()` to
```
this.createWorkspace('Hey look a race condition');
setTimeout(function(){
   this.fetch();
}, 10000);
```
and also updating the parse function of the same model to:
```
   parse: function(){
       return [];
   }
```

To see the suggested change in action, change the above fetch to be `this.fetch({remove: false})`.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2690

#### Screenshots (if appropriate)
Before: https://gfycat.com/WigglyFinishedHanumanmonkey
After: https://gfycat.com/ExcitableFarflungCrustacean