### PR TITLE
DDF-2692 Update revert action to refresh result data differently

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-actions/metacard-actions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-actions/metacard-actions.view.js
@@ -30,9 +30,6 @@ define([
         className: 'is-list',
         template: template,
         tagName: CustomElements.register('metacard-actions'),
-        modelEvents: {
-            'all': 'render'
-        },
         regions: {
             mapActions: '.map-actions'
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-archive/metacard-archive.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-archive/metacard-archive.view.js
@@ -32,9 +32,6 @@ define([
         },
         template: template,
         tagName: CustomElements.register('metacard-archive'),
-        modelEvents: {
-            'all': 'render'
-        },
         events: {
             'click button.archive': 'handleArchive',
             'click button.restore': 'handleRestore'

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-quality/metacard-quality.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-quality/metacard-quality.view.js
@@ -32,9 +32,6 @@ define([
         },
         template: template,
         tagName: CustomElements.register('metacard-quality'),
-        modelEvents: {
-            'all': 'render'
-        },
         events: {},
         ui: {},
         selectionInterface: store,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
@@ -37,11 +37,12 @@ define([
             this.determineAvailableContent();
             TabsView.prototype.initialize.call(this);
             var debounceDetermineContent = _.debounce(this.handleMetacardChange, 200);
+            var throttleDetermineContent = _.throttle(this.handleMetacardChange, 200);
             this.listenTo(this.selectionInterface.getSelectedResults(), 'update',debounceDetermineContent);
             this.listenTo(this.selectionInterface.getSelectedResults(), 'add', debounceDetermineContent);
             this.listenTo(this.selectionInterface.getSelectedResults(), 'remove', debounceDetermineContent);
             this.listenTo(this.selectionInterface.getSelectedResults(), 'reset', debounceDetermineContent);
-            this.listenTo(this.selectionInterface.getSelectedResults(), 'refreshdata', debounceDetermineContent);
+            this.listenTo(this.selectionInterface.getSelectedResults(), 'refreshdata', throttleDetermineContent);
         },
         handleMetacardChange: function(){
             this.determineAvailableContent();


### PR DESCRIPTION
 - Previously the revert action was using a response from the endpoint.  However, this response could not be used directly as special parsing is done for results in the result collection.  Specifically, the thumbnail gets converted to a URI.
 - Now the metacard is immediately tagged as a revision, pending refresh from the cql endpoint.  If the refresh takes too long, the user is pushed back to the default view with a warning instructing them that they'll receive write control again once the data returns (if it makes sense based on the returned data).
 - Updated single metacard inspector view to throttle rather than debounce refreshes to current metacard data.  This makes for a more consistent experience if the refresh happens to come back a ms or so too late and the warning pops up.  If we didn't do this, they'd see the warning but wouldn't be affected by anything (they'd stay on the history view instead of being kicked back to the default view).  This should minimize confusion in those edge scenarios.
 - Updated a few views to no longer rerender on all model updates, as this can cause issues if the view happens to be destroyed.

@djblue 
@rzwiefel 
[UI](https://github.com/orgs/codice/teams/ui)
@pklinef
@andrewkfiedler 

#### How should this be tested? (List steps with links to updated documentation)
Upload an item with a thumbnail.  Then search for the item, or expand it.  Give it some history by editing an attribute.  Now go to the history view and revert to the previous version. 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2692

#### Screenshots (if appropriate)
Before: https://gfycat.com/DazzlingEuphoricBandicoot
After: https://gfycat.com/CompetentInfamousCockerspaniel
After (high latency): https://gfycat.com/CanineTameBluefish
