### PR TITLE
DDF-2596 releases contain dashes in the version not deploying

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationImpl.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationImpl.java
@@ -113,7 +113,7 @@ public class ApplicationImpl implements Application, Comparable<Application> {
         int numberOfParts;
 
         // DDF-2596
-        repoNameParts = repoName.split("-(?=[0-9])");
+        repoNameParts = repoName.split("-(?=[0-9])", 2);
         numberOfParts = repoNameParts.length;
         switch (numberOfParts) {
         case 1:
@@ -124,9 +124,8 @@ public class ApplicationImpl implements Application, Comparable<Application> {
             name = repoNameParts[0];
             version = repoNameParts[1];
             break;
-        case 3:
-            throw new RuntimeException(String.format("Could not tokenize repository name of '%s'",
-                    repoName));
+        default:
+            LOGGER.error("Could not tokenize repository name of '%s'", repoName);
         }
     }
 

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationImplTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationImplTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Set;
@@ -105,11 +104,15 @@ public class ApplicationImplTest {
         assertThat("Version number is wrong", application.getVersion(), equalTo("0.0.0"));
     }
 
-    @Test(expected = Exception.class)
-    public void testUnparsableApplicationName() throws IOException {
+    @Test
+    public void testComplexApplicationName() throws Exception {
+        String name = "test-dependencies-1.2.3-1a";
         Repository repo = mock(Repository.class);
-        when(repo.getName()).thenReturn("MyName-0.0.0-1.1");
-        new ApplicationImpl(repo);
+        when(repo.getName()).thenReturn(name);
+        when(repo.getFeatures()).thenReturn(new Feature[0]);
+        ApplicationImpl application = new ApplicationImpl(repo);
+        assertThat("Application name is wrong", application.getName(), equalTo("test-dependencies"));
+        assertThat("Version number is wrong", application.getVersion(), equalTo("1.2.3-1a"));
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
A recent merge caused issues when creating a release for reflex because we used a dash after the version number since it was an out of band release.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brendan-hofmann
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
@ahoffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
unit and itests
#### Any background context you want to provide?
when trying to do an out of band release with a dash in the version this issue caused application deployment to fail.
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
