### PR TITLE
DDF-2684 added documentation for neutral taxonomy

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-categories-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-categories-contents.adoc
@@ -1,0 +1,14 @@
+
+==== Attribute Categories
+
+* <<_core_attributes_table,Core Attributes>>
+* <<_metacard_attributes_table,Metacard Attributes>>
+* <<_history_attributes_table,History Attributes>>
+* <<_associations_attributes_table,Associations Attributes>>
+* <<_datetime_attributes_table,DateTime Attributes>>
+* <<_contact_attributes_table,Contact Attributes>>
+* <<_location_attributes_table,Location Attributes>>
+* <<_media_attributes_table,Media Attributes>>
+* <<_security_attributes_table,Security Attributes>>
+* <<_topic_attributes_table,Topic Attributes>>
+* <<_validation_attributes_table,Validation Attributes>>

--- a/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-intro-contents.adoc
@@ -1,0 +1,2 @@
+
+To facilitate data sharing while maximizing the usefulness of metadata, the attributes on resources are normalized into a common taxonomy that maps to attributes in the desired output format.

--- a/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-tables-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-tables-contents.adoc
@@ -1,0 +1,17 @@
+
+.[[_core_attributes_table]]Core Attributes
+[cols="1,2,1,1,1" options="header"]
+|===
+|Term
+|Definition
+|Datatype
+|Constraints
+|Example Value
+
+|
+|
+|
+|
+|
+
+|===

--- a/distribution/docs/src/main/resources/draft-documentation.adoc
+++ b/distribution/docs/src/main/resources/draft-documentation.adoc
@@ -204,6 +204,14 @@ include::{adoc-include}/_validation/validation-intro-contents.adoc[]
 
 include::{adoc-include}/_validation/schematron-intro-contents.adoc[]
 
+=== Neutral Taxonomy
+
+include::{adoc-include}/_data/neutral-taxonomy-intro-contents.adoc[]
+
+include::{adoc-include}/_data/neutral-taxonomy-categories-contents.adoc[]
+
+include::{adoc-include}/_data/neutral-taxonomy-tables-contents.adoc[]
+
 == Endpoints
 
 include::{adoc-include}/_endpoints/endpoints-intro-contents.adoc[]


### PR DESCRIPTION
#### What does this PR do?

adds template/outline for documenting neutral taxonomy. 
#### Who is reviewing it)?

@brendan-hofmann @emanns95 @Lambeaux @mcalcote @vinamartin @jrnorth 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Docs](https://github.com/orgs/codice/teams/docs)
[IO](https://github.com/orgs/codice/teams/IO)
[Data](https://github.com/orgs/codice/teams/data)

#### Choose 2 committers to review/merge the PR.
@jlcsmith
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

verify outline, build docs successfully

#### What are the relevant tickets?
[DDF-2684](https://codice.atlassian.net/browse/DDF-2684)
[DDF-2682](https://codice.atlassian.net/browse/DDF-2682)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
