### PR TITLE
DDF-2696 Change default email notification reply address

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -255,7 +255,7 @@
         <argument
                 value="The workspace '%[attribute=title]' contains up to %[hitCount] results. Log in to see results https://localhost:8993/search/catalog/#workspaces/%[attribute=id]."/>
         <argument value="Workspace '%[attribute=title]' notification"/>
-        <argument value="donotreply@test.com"/>
+        <argument value="donotreply@example.com"/>
         <argument value="localhost"/>
         <argument>
             <bean class="org.codice.ddf.catalog.ui.query.monitor.impl.ListMetacardFormatter">

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.email.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.email.xml
@@ -33,7 +33,7 @@
 
         <AD description="Set the 'from' email address."
             name="From Address" id="fromEmail" required="true" type="String"
-            default="donotreply@test.com"/>
+            default="donotreply@example.com"/>
 
     </OCD>
 


### PR DESCRIPTION
#### What does this PR do?

Change default email notification reply address to donotreply@example.com

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining 
@rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

@andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build & install. Navigate to the admin screen for Email Notifications and confirm that the default reply address is donotreply@example.com.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2696](https://codice.atlassian.net/browse/DDF-2696)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
