### PR TITLE
DDF-2697 Fix mark/reset IOException

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -292,7 +292,8 @@
                             hazelcast;scope=runtime|compile,
                             notifications,
                             platform-util,
-                            versioning-common
+                            versioning-common,
+                            tika-core
                         </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.cache.impl,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.detect.DefaultProbDetector;
 import org.apache.tika.detect.Detector;
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.codice.ddf.platform.util.InputValidation;
@@ -187,7 +188,8 @@ public class OperationsMetacardSupport {
         return fileName;
     }
 
-    private String guessMimeType(String mimeTypeRaw, String fileName, Path tmpContentPath)
+    // package-private for unit testing
+    String guessMimeType(String mimeTypeRaw, String fileName, Path tmpContentPath)
             throws IOException {
         if (ContentItem.DEFAULT_MIME_TYPE.equals(mimeTypeRaw)) {
             try (InputStream inputStreamMessageCopy = com.google.common.io.Files.asByteSource(
@@ -204,9 +206,7 @@ public class OperationsMetacardSupport {
             }
             if (ContentItem.DEFAULT_MIME_TYPE.equals(mimeTypeRaw)) {
                 Detector detector = new DefaultProbDetector();
-                try (InputStream inputStreamMessageCopy = com.google.common.io.Files.asByteSource(
-                        tmpContentPath.toFile())
-                        .openStream()) {
+                try (InputStream inputStreamMessageCopy = TikaInputStream.get(tmpContentPath)) {
                     MediaType mediaType = detector.detect(inputStreamMessageCopy, new Metadata());
                     mimeTypeRaw = mediaType.toString();
                 } catch (IOException e) {

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportTest.groovy
@@ -20,9 +20,9 @@ import ddf.catalog.source.IngestException
 import ddf.catalog.transform.InputTransformer
 import ddf.mime.MimeTypeMapper
 import ddf.mime.MimeTypeToTransformerMapper
-import ddf.security.Subject
 import spock.lang.Specification
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 class OperationsMetacardSupportTest extends Specification {
@@ -232,5 +232,16 @@ class OperationsMetacardSupportTest extends Specification {
         then:
         1 * registry.getDefaultValue('testtype', 'att4') >> { Optional.ofNullable('default4') }
         1 * metacard.setAttribute(_)
+    }
+
+    def 'test multiple detector fall through'() {
+        mimeTypeMapper.guessMimeType(_, _) >> null
+        def tempFile = Files.createTempFile("test", "bin")
+        Files.write(tempFile.toAbsolutePath(), "test file content".getBytes())
+        when:
+        def mimeType = opsMetacard.guessMimeType(ContentItem.DEFAULT_MIME_TYPE, tempFile.getFileName().toString(), tempFile.toAbsolutePath())
+        then:
+        !ContentItem.DEFAULT_MIME_TYPE.equals(mimeType)
+        "text/plain".equals(mimeType)
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Resolve an issue with mimetype resolution in tika's probabilistic detector.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@AzGoalie 
@ahoffer 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Verify that a text file with a `.bin` extension gets a mimetype of `text/plain` instead of the default.
#### Any background context you want to provide?
This issue was failing silently because we caught the IOException and logged it at `DEBUG`.
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2697)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
