### PR TITLE
DDF-2701 Updated incorrect help message for "Hide from Future Searches"

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.hbs
@@ -29,7 +29,7 @@ result from your bookmarks.">
 </div>
 <div class="metacard-interaction interaction-hide" data-help="Adds to a list
 of results that will be hidden from future searches.  To clear this list,
-go to the toolbar, click Edit, and then click reset blacklist.">
+click the Settings icon, select Hidden, then choose to unhide the record.">
     <div class="interaction-icon fa fa-eye-slash">
     </div>
     <div class="interaction-text">


### PR DESCRIPTION
#### What does this PR do?
The help description for the "Hide from Future Searches" is currently displayed as "Adds to a list of results that will be hidden from future searches. To clear this list, go to the toolbar, click Edit, and then click reset blacklist." 

The Edit menu was removed, and the way to reset the blacklist is now achieved by clicking the Settings (gear/cog icon on the top right) and choose "Hidden". The blacklisted results can then be individually or globally unhidden from this area.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@ricklarsen 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
- Build and install DDF.
- Open the Catalog UI.
- Ingest and perform a search. View the results.
- Choose one of the results, click the menu so that the `Hide from Future Searches` option is displayed.
- Click the Help (?) button and choose the `Hide from Future Searches` option. 
- Verify the Help description is accurate.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2701

#### Screenshots (if appropriate)
![screen shot 2017-01-10 at 4 23 27 pm](https://cloud.githubusercontent.com/assets/16792154/21829043/29c74d92-d751-11e6-8b03-a340fb7b2208.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
