### PR TITLE
DDF-2703 Update metacard model to stop searching as soon as possible

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
@@ -50,6 +50,7 @@ define([
         initialize: function(){
             this.set('currentResult', new Metacard.SearchResult());
             this.listenTo(this, 'change:currentMetacard', this.handleUpdate);
+            this.listenTo(this, 'change:currentMetacard', this.handleCurrentMetacard);
             this.listenTo(this, 'change:currentResult', this.handleResultChange);
             this.listenTo(this.get('activeSearchResults'), 'update add remove reset', this.updateActiveSearchResultsAttributes);
         },
@@ -73,6 +74,11 @@ define([
             this.clearSelectedResults();
             this.setActiveSearchResults(this.get('currentResult').get('results'));
             this.addSelectedResult(this.get('currentMetacard'));
+        },
+        handleCurrentMetacard: function(){
+            if (this.get('currentMetacard') !== undefined){
+                this.get('currentQuery').cancelCurrentSearches();
+            }
         },
         getActiveSearchResults: function(){
             return this.get('activeSearchResults');


### PR DESCRIPTION
#### What does this PR do?
 - As soon as a source returns the metacard, the query is now stopped.  This will prevent issues with connections to slow sources being left open unnecessarily.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@jlcsmith 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
This only affects the https://localhost:8993/search/catalog/#metacards/ route.  To test it, connect more than one source.  Then route to a metacard.  You should see that outstanding searches are canceled as soon as the metacard is found.  

#### Any background context you want to provide?
A limited number of connections can be opened per domain in the browser, so this is integral to making sure unnecessary connections to slow sources are left open.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2703

#### Screenshots (if appropriate)
[Cancellation](https://webmshare.com/play/NdJbg)
