### PR TITLE
DDF-2699 Added filter for TikaMimeTypeResolver in the REST Endpoint blueprint

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,7 +19,7 @@
     <reference id="transformerMapper" interface="ddf.mime.MimeTypeToTransformerMapper"/>
     <reference id="catalog" interface="ddf.catalog.CatalogFramework"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
-    <reference id="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver"/>
+    <reference id="tikaMimeTypeResolver" filter="(name=tikaMimeTypeResolver)" interface="ddf.mime.MimeTypeResolver"/>
     <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>
 
     <bean id="actionFactory"

--- a/platform/mime/tika/platform-mime-tika-resolver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/mime/tika/platform-mime-tika-resolver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,6 +24,10 @@
         <property name="priority" value="-1"/>
 	</bean>
 
-	<service ref="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver"/>
+	<service ref="tikaMimeTypeResolver" interface="ddf.mime.MimeTypeResolver">
+		<service-properties>
+			<entry key="name" value="tikaMimeTypeResolver" />
+		</service-properties>
+	</service>
 
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
The blueprint reference in the REST endpoint is intended to be the TikaMimeTypeResolver, but without a filter, there is potential for this reference to be other implementations of the MimeTypeResolver interface.  This was observed in a windows environment, which caused some file extensions to not be present during REST calls.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest Data / Use REST endpoint to download various filetypes and verify their extensions.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2699](https://codice.atlassian.net/browse/DDF-2699)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
