### PR TITLE
DDF-2704 Make the catalog ui the default search ui

### DIFF
--- a/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,7 +19,7 @@
         <AD
                 description="Specifies the redirect URI to use when accessing the /search URI."
                 name="Redirect URI" id="defaultUri" required="true" type="String"
-                default="/search/standard"
+                default="/search/catalog"
                 />
     </OCD>
 

--- a/catalog/ui/search-ui/search-ui-app/src/main/resources/org.codice.ddf.ui.searchui.filter.RedirectServlet.config
+++ b/catalog/ui/search-ui/search-ui-app/src/main/resources/org.codice.ddf.ui.searchui.filter.RedirectServlet.config
@@ -1,2 +1,2 @@
-defaultUri="/search/standard"
+defaultUri="/search/catalog"
 service.pid="org.codice.ddf.ui.searchui.filter.RedirectServlet"

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -122,7 +122,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
             // Start the services needed for testing.
             // We need to start the Search UI to test that it redirects properly
-            getServiceManager().startFeature(true, "security-idp", "search-ui");
+            getServiceManager().startFeature(true, "security-idp", "search-ui", "catalog-ui");
             getServiceManager().waitForAllBundles();
 
             // Get all of the metadata


### PR DESCRIPTION
#### What does this PR do?
Makes the catalog ui the default search ui when redirecting from /search
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@vinamartin @brianfelix 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler 
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and go to the https://localhost:8993/search and verify that you are redirected to the catalog ui 
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2704
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
