### PR TITLE
DDF-2707 Update cesium initialization to set imageryProvider to false

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -66,6 +66,7 @@ function createMap(insertionElement) {
             //skyBox: false,
             //skyAtmosphere: false,
             baseLayerPicker: false, // Hide the base layer picker,
+            imageryProvider: false, // prevent default imagery provider
             mapMode2D: 0
         }
     });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -42,12 +42,6 @@ define(['underscore',
             // must create cesium map after containing DOM is attached.
             this.map = new Cesium.Viewer(options.element, options.cesiumOptions);
 
-            /*
-             * baseLayerPicker:false has side effect of creating default baselayer
-             * from default imageryProvider value; remove any default layer here.
-             */
-            this.map.imageryLayers.removeAll();
-
             this.collection.forEach(function (model) {
                 var type = imageryProviderTypes[model.get('type')];
                 var initObj = _.omit(model.attributes, 'type', 'label', 'index', 'modelCid');

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.controller.js
@@ -94,7 +94,8 @@ define(['application',
                             sceneModePicker: true,
                             selectionIndicator: false,
                             infoBox: false,
-                            baseLayerPicker: false // Hide the base layer picker
+                            baseLayerPicker: false, // Hide the base layer picker,
+                            imageryProvider: false // prevent default imagery provider
                         }
                     }
                 );

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -42,12 +42,6 @@ define(['underscore',
             // must create cesium map after containing DOM is attached.
             this.map = new Cesium.Viewer(options.divId, options.cesiumOptions);
 
-            /*
-             * baseLayerPicker:false has side effect of creating default baselayer
-             * from default imageryProvider value; remove any default layer here.
-             */
-            this.map.imageryLayers.removeAll();
-
             this.collection.forEach(function (model) {
                 var type = imageryProviderTypes[model.get('type')];
                 var initObj = _.omit(model.attributes, 'type', 'label', 'index', 'modelCid');


### PR DESCRIPTION
#### What does this PR do?
 - See https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Widgets/CesiumWidget/CesiumWidget.js#L317
 - If we don't set it to false, a default server is set that can't be reached in closed environments.  While we used to eventually remove the default, this will ensure the default isn't even set.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@bdeining 

@jlcsmith 
@andrewkfiedler

#### How should this be tested? (List steps with links to updated documentation)
Go to each of the search UIs.  Open the network developer tools and look for a request to https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?incl=ImageryProviders&key=0&jsonp=loadJsonp402905 when Cesium gets loaded.  If it doesn't show up, you're good.


#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2707