### PR TITLE
DDF-2706 Add configuration option to hide editing capability in the Catalog UI

### DIFF
--- a/catalog/ui/catalog-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/catalog-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -52,3 +52,4 @@ hiddenAttributes=[
     "metacard.sharing",
     "cached"
 ]
+isEditingAllowed=B"true"

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -74,6 +74,8 @@ public class ConfigurationApplication implements SparkApplication {
 
     private String terrainEndpoint;
 
+    private Boolean isEditingAllowed = false;
+
     private Boolean isSignIn = true;
 
     private Boolean isTask = false;
@@ -236,6 +238,7 @@ public class ConfigurationApplication implements SparkApplication {
         config.put("attributeAliases", attributeAliases);
         config.put("sourcePollInterval", sourcePollInterval);
         config.put("scheduleFrequencyList", scheduleFrequencyList);
+        config.put("isEditingAllowed", isEditingAllowed);
 
         return config;
     }
@@ -496,6 +499,14 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setIngest(Boolean isIngest) {
         this.isIngest = isIngest;
+    }
+
+    public Boolean getIsEditingAllowed() {
+        return this.isEditingAllowed;
+    }
+
+    public void setIsEditingAllowed(Boolean isEditingAllowed){
+        this.isEditingAllowed = isEditingAllowed;
     }
 
     public void setTypeNameMapping(String[] mappings) {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -152,6 +152,13 @@
             cardinality="10000"
             default="1800,3600,7200,14400,28800,57600,86400"
             required="true"/>
+
+        <AD id="isEditingAllowed"
+            name="Allow Editing"
+            description="Allow editing capability to be visible in the UI"
+            type="Boolean"
+            default="true"
+            required="true"/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.ui.config">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/editor.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/editor.less
@@ -48,6 +48,7 @@
   }
 }
 
+.is-editing-restricted @{customElementNamespace}editor,
 @{customElementNamespace}editor.is-revision,
 @{customElementNamespace}editor.is-deleted,
 @{customElementNamespace}editor.is-remote {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.less
@@ -209,6 +209,7 @@
   }
 }
 
+.is-editing-restricted @{customElementNamespace}metacard-associations,
 @{customElementNamespace}metacard-associations.is-deleted,
 @{customElementNamespace}metacard-associations.is-revision,
 @{customElementNamespace}metacard-associations.is-remote {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-history/metacard-history.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-history/metacard-history.less
@@ -60,6 +60,12 @@
 
 }
 
+.is-editing-restricted @{customElementNamespace}metacard-history {
+  button {
+    display: none;
+  }
+}
+
  .is-small-screen, .is-mobile-screen {
   @{customElementNamespace}metacard-history {
     overflow: auto;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.less
@@ -48,3 +48,12 @@
         }
     }
 }
+
+.is-editing-restricted @{customElementNamespace}tabs.is-metacard {
+    > .tabs-list {
+        [data-id=Overwrite],
+        [data-id=Archive] {
+            display: none !important;
+        }
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
@@ -20,8 +20,9 @@ define([
     'jquery',
     '../tabs.view',
     './tabs-metacard',
-    'js/store'
-], function (wreqr, Marionette, _, $, TabsView, MetacardTabsModel, store) {
+    'js/store',
+    'properties'
+], function (wreqr, Marionette, _, $, TabsView, MetacardTabsModel, store, properties) {
 
     return TabsView.extend({
         className: 'is-metacard',
@@ -58,6 +59,9 @@ define([
                 this.model.set('activeTab', 'Summary');
             }
             if (result.isRemote() && ['History', 'Associations', 'Quality', 'Archive', 'Overwrite'].indexOf(activeTabName) >=0){
+                this.model.set('activeTab', 'Summary');
+            }
+            if (properties.isEditingRestricted() && ['Archive', 'Overwrite'].indexOf(activeTabName) >=0){
                 this.model.set('activeTab', 'Summary');
             }
             var activeTab = this.model.getActiveView();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.less
@@ -4,6 +4,7 @@
 @{customElementNamespace}tabs.is-metacards.is-resource {
 }
 
+.is-editing-restricted @{customElementNamespace}tabs.is-metacards,
 @{customElementNamespace}tabs.is-metacards.is-mixed.is-revision,
 @{customElementNamespace}tabs.is-metacards.is-revision,
 @{customElementNamespace}tabs.is-metacards.is-mixed.is-deleted,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
@@ -19,8 +19,9 @@ define([
     'jquery',
     '../tabs.view',
     './tabs-metacards',
-    'js/store'
-], function (Marionette, _, $, TabsView, MetacardsTabsModel, store) {
+    'js/store',
+    'properties'
+], function (Marionette, _, $, TabsView, MetacardsTabsModel, store, properties) {
 
     function getTypes(results){
         var types = {};
@@ -75,6 +76,9 @@ define([
                 this.model.set('activeTab', 'Details');
             }
             if (types.indexOf('remote') >= 0 && ['Archive'].indexOf(activeTabName) >= 0){
+                this.model.set('activeTab', 'Details');
+            }
+            if (properties.isEditingRestricted() && ['Archive'].indexOf(activeTabName) >=0){
                 this.model.set('activeTab', 'Details');
             }
             var activeTab = this.model.getActiveView();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
@@ -81,13 +81,21 @@ define(function (require) {
                 throw new Error('Configuration could not be loaded: (status: ' + status + ', message: ' + errorThrown.message + ')');
             });
 
+            this.handleEditing();
+
             return props;
+        },
+        handleEditing: function(){
+            $('html').toggleClass('is-editing-restricted', this.isEditingRestricted());
         },
         isHidden: function(attribute){
           return match(this.hiddenAttributes, attribute);
         },
         isReadOnly: function(attribute){
           return match(this.readOnly, attribute);
+        },
+        isEditingRestricted: function(){
+            return !this.isEditingAllowed;
         }
     };
 


### PR DESCRIPTION
#### What does this PR do?
 - Adds an administrative option to hide editing capability in the Catalog UI from the catalog.ui.config.
 - Note that this doesn't do anything to restrict editing on the backend.
 - Default is to allow editing.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@pklinef
@rzwiefel 
@andrewkfiedler

#### How should this be tested? (List steps with links to updated documentation)
Go to the Catalog UI and verify that editing is not allowed by default.   Editing should be hidden from the Summary, Details, History, & Associations views.  The Overwrite and Archive tabs should be hidden entirely.  When selecting multiple metacards as once, only the Details tab should be available and editing should be hidden from it.

Then go to the Admin UI and proceed to the org.codice.ddf.catalog.ui.config.  Turn the config for Allow Editing to true.  Return to the Catalog UI and verify the opposite of what you verified for when editing is not allowed.

#### Any background context you want to provide?
Do note that this doesn't do anything to restrict editing on the backend.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2706