### PR TITLE
DDF-2708 Refactored Catalog UI to register WorkspaceMetacardType in the service registry

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceMetacardImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceMetacardImpl.java
@@ -15,7 +15,6 @@ package org.codice.ddf.catalog.ui.metacard.workspace;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -23,36 +22,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import ddf.catalog.data.Attribute;
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.impl.MetacardTypeImpl;
-import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Associations;
 import ddf.catalog.data.types.Core;
 
 public class WorkspaceMetacardImpl extends MetacardImpl {
 
-    private static final MetacardType TYPE;
-
-    static {
-        Set<AttributeDescriptor> descriptors = ImmutableList.of(new SecurityAttributes(),
-                new WorkspaceAttributes())
-                .stream()
-                .map(MetacardType::getAttributeDescriptors)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-
-        TYPE = new MetacardTypeImpl(WorkspaceAttributes.WORKSPACE_TAG,
-                BasicTypes.BASIC_METACARD,
-                descriptors);
-    }
+    public static final MetacardType TYPE = new WorkspaceMetacardType();
 
     public WorkspaceMetacardImpl() {
         super(TYPE);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceMetacardType.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceMetacardType.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.workspace;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.SecurityAttributes;
+
+public class WorkspaceMetacardType implements MetacardType {
+
+    private static final Set<AttributeDescriptor> ATTRIBUTE_DESCRIPTORS =
+            ImmutableSet.of(new CoreAttributes(),
+                    new SecurityAttributes(),
+                    new WorkspaceAttributes(),
+                    new AssociationsAttributes())
+                    .stream()
+                    .map(MetacardType::getAttributeDescriptors)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+
+    @Override
+    public String getName() {
+        return WorkspaceAttributes.WORKSPACE_TAG;
+    }
+
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return ATTRIBUTE_DESCRIPTORS;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor(String s) {
+        for (AttributeDescriptor attributeDescriptor : ATTRIBUTE_DESCRIPTORS) {
+            if (attributeDescriptor.getName()
+                    .equals(s)) {
+                return attributeDescriptor;
+            }
+        }
+        return null;
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,6 +17,14 @@
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
+    <bean id="workspaceMetacardType" class="org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceMetacardType" />
+
+    <service ref="workspaceMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="workspace"/>
+        </service-properties>
+    </service>
+
     <reference id="webBranding" interface="org.codice.ddf.branding.BrandingPlugin"/>
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="uiCamelContext"/>
@@ -48,10 +56,6 @@
         <property name="branding" ref="webBranding"/>
         <property name="httpProxy" ref="httpProxyService"/>
     </bean>
-
-    <service interface="ddf.catalog.data.MetacardType">
-        <bean class="org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceAttributes"/>
-    </service>
 
     <service interface="ddf.catalog.data.MetacardType">
         <bean class="org.codice.ddf.catalog.ui.metacard.workspace.QueryMetacardTypeImpl"/>


### PR DESCRIPTION
#### What does this PR do?
This PR registers the WorkspaceMetacardType in the service registry so it can be reference throughout DDF.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)
@djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Create Some Workspaces / `log:set DEBUG ddf.catalog.transformer`/`dump --cql "\"metacard-tags\" like 'workspace'"` / `catalog:ingest -t xml` / Reingest the workspace metacards and observe that the XML input transformer references the WorkspaceMetacardType.
Additionally, verify that Workspaces still have expected behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2708](https://codice.atlassian.net/browse/DDF-2708)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
