### PR TITLE
DDF-2711 Add exception for thumbnails to be shown in table visualization

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -24,6 +24,13 @@ define([
             this.getMetacardTypes();
             this.getDatatypeEnum();
         },
+        isHiddenTypeExceptThumbnail: function(id){
+            if (id === 'thumbnail'){
+                return false;
+            } else {
+                return this.isHiddenType(id);
+            }
+        },
         isHiddenType: function(id){
             return this.metacardTypes[id].type === 'XML' ||
             this.metacardTypes[id].type === 'BINARY' ||

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -92,7 +92,7 @@ module.exports = Marionette.ItemView.extend({
                     value: value,
                     html: html,
                     class: className,
-                    hidden: hiddenColumns.indexOf(property) >= 0 || properties.isHidden(property) || metacardDefinitions.isHiddenType(property)
+                    hidden: hiddenColumns.indexOf(property) >= 0 || properties.isHidden(property) || metacardDefinitions.isHiddenTypeExceptThumbnail(property)
                 };
             })
         };

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-rearrange.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-rearrange.view.js
@@ -49,7 +49,7 @@ module.exports = Marionette.ItemView.extend({
                 label: properties.attributeAliases[property],
                 id: property,
                 hidden: hiddenColumns.indexOf(property) >= 0,
-                notCurrentlyAvailable: (availableAttributes.indexOf(property) === -1) || (properties.isHidden(property)) || metacardDefinitions.isHiddenType(property)
+                notCurrentlyAvailable: (availableAttributes.indexOf(property) === -1) || (properties.isHidden(property)) || metacardDefinitions.isHiddenTypeExceptThumbnail(property)
             };
         });
     },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
@@ -50,7 +50,7 @@ module.exports = Marionette.ItemView.extend({
                 label: properties.attributeAliases[property],
                 id: property,
                 hidden: hiddenColumns.indexOf(property) >= 0,
-                notCurrentlyAvailable: (availableAttributes.indexOf(property) === -1) || (properties.isHidden(property)) || metacardDefinitions.isHiddenType(property)
+                notCurrentlyAvailable: (availableAttributes.indexOf(property) === -1) || (properties.isHidden(property)) || metacardDefinitions.isHiddenTypeExceptThumbnail(property)
             };
         });
     },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
@@ -99,7 +99,7 @@ module.exports = Marionette.ItemView.extend({
             return {
                 label: properties.attributeAliases[property],
                 id: property,
-                hidden: hiddenColumns.indexOf(property) >= 0 || properties.isHidden(property) || metacardDefinitions.isHiddenType(property),
+                hidden: hiddenColumns.indexOf(property) >= 0 || properties.isHidden(property) || metacardDefinitions.isHiddenTypeExceptThumbnail(property),
                 sortable: sortAttributes.indexOf(property) >= 0
             };
         });


### PR DESCRIPTION
#### What does this PR do?
 - All 'Binary' type attributes were being hidden from the table visualization, so an exception is now added for thumbnails.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@djblue 
@jlcsmith 
@andrewkfiedler

#### How should this be tested? 
Ingest data with thumbnails and use the table visualization.  Verify that the thumbnails show up in the table.  Also check the rearrange columns view and the hide / show columns view to make sure they show up there.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2711

#### Screenshots (if appropriate)
![Table View](http://i.imgur.com/HgUTmKm.png)
![Table Settings View](http://i.imgur.com/rFKGQuZ.png)