### PR TITLE
DDF-2325 Set the country code plugin to auto install

### DIFF
--- a/catalog/spatial/spatial-app/src/main/resources/features.xml
+++ b/catalog/spatial/spatial-app/src/main/resources/features.xml
@@ -87,6 +87,7 @@
         <feature prerequisite="true">spatial-app</feature>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-geocoder/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-websearch/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-plugin/${project.version}</bundle>
     </feature>
 
     <feature name="offline-gazetteer" install="manual" version="${project.version}"
@@ -99,11 +100,6 @@
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-geocoder/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-localsearch/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-admin-module/${project.version}</bundle>
-    </feature>
-
-    <feature name="spatial-geocoding-plugin" install="manual" version="${project.version}"
-             description="Plugin that uses GeoCoder to fetch country codes for geolocated metacards">
-        <feature prerequisite="true">spatial-app</feature>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-plugin/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
#### What does this PR do?
This PR sets the `spatial-geocoding-plugin` to install automatically with the `spatial-app` so that geolocated metacard* will have the `location.country-code` attribute set.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @brianfelix @peterhuffer 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)

1. Confirm that the `spatial-geocoding-plugin` is installed automatically as part of the `spatial-app`.
2. Ingest a geolocated metacard*, and confirm that the `location.country-code` attribute is set correctly on the metacard.

#### Any background context you want to provide?
Adding the country code to metacards was already implemented by https://github.com/codice/ddf/pull/1171. This purpose of this PR is to set this capability to auto-install.

*Note: Metacards must implement a  `MetacardType` that has the 
[`Location#COUNTRY_CODE` descriptor](https://github.com/codice/ddf/blob/76975e51a8093358329ff828afbb7ae82a1adba7/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/LocationAttributes.java#L44-L44) in order for the `location.country-code` attribute to be set by the `spatial-geocoding-plugin`. (See `GeoCoderPlugin#hasCountryCode`.)
#### What are the relevant tickets?
[DDF-2325](https://codice.atlassian.net/browse/DDF-2325)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
