### PR TITLE
DDF-2718: Removed external referencing stylesheets from documentation

### DIFF
--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -302,6 +302,10 @@
                                     <sourceDirectory>src/main/doc</sourceDirectory>
                                     <outputDirectory>target/webapp</outputDirectory>
                                     <backend>html</backend>
+                                    <attributes>
+                                        <webfonts>false</webfonts>
+                                        <iconfont-remote>false</iconfont-remote>
+                                    </attributes>
                                 </configuration>
                             </execution>
                             <execution>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -213,6 +213,10 @@
                                         <outputDirectory>${project.build.directory}/docs/html
                                         </outputDirectory>
                                         <imagesDir>${project.build.directory}/doc-contents/images</imagesDir>
+                                        <attributes>
+                                            <webfonts>false</webfonts>
+                                            <iconfont-remote>false</iconfont-remote>
+                                        </attributes>
                                     </configuration>
                                 </execution>
                                 <execution>


### PR DESCRIPTION
#### What does this PR do?
Removes external referencing stylesheets from the html documentation.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ricklarsen @brendan-hofmann @djblue 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Docs](https://github.com/orgs/codice/teams/docs) @ahoffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Quickbuild and install, open documentation from the admin ui and standard search ui. Verify in the source code that there are no external referencing stylesheets.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
