### PR TITLE
DDF-2467: Fixes catalog:removeall command when using Solr Cloud

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -512,7 +512,7 @@ public class DeleteOperations {
         QueryImpl queryImpl =
                 new QueryImpl(queryOperations.getFilterWithAdditionalFilters(idFilters),
                         1,  /* start index */
-                        0,  /* page size */
+                        deleteRequest.getAttributeValues().size(),  /* page size */
                         null,
                         false, /* total result count */
                         0   /* timeout */);


### PR DESCRIPTION
#### What does this PR do? 
Fixes catalog:removeall command when using Solr Cloud.  Previously the catalog:removeall command resulted in "Could not find all metacards specified in request" error on the command line when DDF was configured to use Solr Cloud.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brjeter 
@oconnormi 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Manual tests: 
1) Configure DDF to use Solr Cloud in system.properties (this will require setup zookeeper and solr cloud)
2) Ingest
3) Run catalog:removeall 
4) Verify all metacards removed from catalog

#### Any background context you want to provide?

#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-2467

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
