### PR TITLE
DDF-2722 Fixes update id ordering bug

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -109,8 +109,7 @@ public class MetacardApplication implements SparkApplication {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetacardApplication.class);
 
-    private static final String UPDATE_ERROR_MESSAGE =
-            "Item is either restricted or not found.";
+    private static final String UPDATE_ERROR_MESSAGE = "Item is either restricted or not found.";
 
     private static final Set<Action> CONTENT_ACTIONS = ImmutableSet.of(Action.VERSIONED_CONTENT,
             Action.DELETED_CONTENT);
@@ -624,8 +623,10 @@ public class MetacardApplication implements SparkApplication {
                 .stream()
                 .map(Result::getMetacard)
                 .collect(Collectors.toList());
-        return catalogFramework.update(new UpdateRequestImpl(changedIds.toArray(new String[0]),
-                changedMetacards));
+        return catalogFramework.update(new UpdateRequestImpl(changedMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList())
+                .toArray(new String[0]), changedMetacards));
     }
 
     private boolean isChangeTypeDate(AttributeChange attributeChange, Metacard result) {


### PR DESCRIPTION
 #### What does this PR do?
- the catalog framework update request that takes an array of ids and list of metacards must have both sets in the correct respective order

this ensures the ids are in that correct order.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
anyone
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[IO](https://github.com/orgs/codice/teams/IO)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
ensure multi-select and edit does not throw an exception

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2722

