### PR TITLE
DDF-2719 Upgrade Dependency - XStream Bundle 1.4.3 to 1.4.9

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -35,7 +35,7 @@
         <logkit.version>1.0.1</logkit.version>
         <cdi-api.version>1.2</cdi-api.version>
         <el-api.version>2.2</el-api.version>
-        <xstream.bundle.version>1.4.3_1</xstream.bundle.version>
+        <xstream.bundle.version>1.4.9_1</xstream.bundle.version>
         <jts.version>1.12</jts.version>
         <xalan.version>2.7.2</xalan.version>
         <xerces.version>2.11.0</xerces.version>
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.3</version>
+                <version>1.4.9</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/catalog/spatial/pom.xml
+++ b/catalog/spatial/pom.xml
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.4</version>
+                <version>1.4.9</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.4</version>
+                <version>1.4.9</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.jaxb2_commons</groupId>


### PR DESCRIPTION
#### What does this PR do?
Upgrades the XStream dependency to version 1.4.9 due to security vulnerabilities.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@mcalcote 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Full clean build, all itests should pass.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2719](https://codice.atlassian.net/browse/DDF-2719)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
