### PR TITLE
DDF-2720 Add null check to fix potential null dereference

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -197,6 +197,11 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.lib</groupId>
             <artifactId>common-system</artifactId>
             <version>${project.version}</version>
@@ -275,6 +280,27 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-injectattribute</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>mockito-core</artifactId>
+                    <groupId>org.mockito</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule-agent</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -465,7 +491,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine} -Djava.awt.headless=true</argLine>
+                    <argLine>${argLine} -javaagent:${powermock.agent} -Djava.awt.headless=true -noverify</argLine>
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -244,7 +244,8 @@ public class ReliableResourceDownloader implements Runnable {
                             String.format("Attempt %d of %d.",
                                     retryAttempts,
                                     downloaderConfig.getMaxRetryAttempts()),
-                            reliableResourceStatus.getBytesRead(),
+                            (null == reliableResourceStatus) ?
+                                    null : reliableResourceStatus.getBytesRead(),
                             downloadIdentifier);
                     delay();
                     reliableResourceCallable = retrieveResource(bytesRead);


### PR DESCRIPTION
According to static analysis, reliableResourceStatus in ReliableResourceDownloader could be null
when reliableResourceStatus.getBytesRead is called on line 247. Added a safeguard against this.

#### What does this PR do?
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @AzGoalie @mweser @brendan-hofmann 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@michaelmenousek 
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
Make sure full build passes.
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/2720)
#### Checklist:
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
