### PR TITLE
DDF-2724 Add the ability to search historical data to the query options in the Catalog UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ replace with next unreleased version
 - [DDF-2260](https://codice.atlassian.net/browse/DDF-2260) Update PDF Input Tranformer to Extract GeoPDF Metadata
 - [DDF-2180](https://codice.atlassian.net/browse/DDF-2180) Added support for FTPS on the FTP endpoint
 - [DDF-2133](https://codice.atlassian.net/browse/DDF-2133) The FTP endpoint port number is configurable.
+- [DDF-2724](https://codice.atlassian.net/browse/DDF-2724) Add the ability to search historical data to the individual query drop down menu in the Catalog UI.
 - [DDF-2094](https://codice.atlassian.net/browse/DDF-2094) Add support for decrypting encrypted passwords in all sources
 - [DDF-2036](https://codice.atlassian.net/browse/DDF-2036) Provide the option to "drape" an overview of a georeferenced image onto the display map.
 - [DDF-2508](https://codice.atlassian.net/browse/DDF-2508) Allowed for the ingest of a resource/metadata through the Catalog REST Endpoint.

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.hbs
@@ -46,3 +46,10 @@
         Search Archived
     </div>
 </div>
+<div class="query-interaction interaction-historic" data-help="Executes the search, but specifically looks for historical data.">
+    <div class="interaction-icon fa fa-history">
+    </div>
+    <div class="interaction-text">
+        Search Historical
+    </div>
+</div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
@@ -36,6 +36,7 @@ define([
             'click .interaction-delete': 'handleDelete',
             'click .interaction-duplicate': 'handleDuplicate',
             'click .interaction-deleted': 'handleDeleted',
+            'click .interaction-historic': 'handleHistoric',
             'click': 'handleClick'
         },
         ui: {
@@ -54,7 +55,9 @@ define([
             this.model.collection.remove(this.model);
         },
         handleDeleted: function(){
-            this.model.startSearch(true);
+            this.model.startSearch({
+                limitToDeleted: true
+            });
         },
         handleDuplicate: function(){
             if (this.model.collection.canAddQuery()){
@@ -64,6 +67,11 @@ define([
                 var newQuery = new this.model.constructor(copyAttributes);
                 store.setQueryByReference(newQuery);
             }
+        },
+        handleHistoric: function(){
+            this.model.startSearch({
+                limitToHistoric: true
+            });
         },
         handleClick: function(){
             this.$el.trigger('closeDropdown.'+CustomElements.getNamespace());

--- a/distribution/docs/src/main/resources/_contents/_using/using-catalog-search-ui-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_using/using-catalog-search-ui-contents.adoc
@@ -106,6 +106,7 @@ View, edit, and add searches from the *Searches* tab.
 * *Delete*: Remove this search
 * *Duplicate*: Create a copy of this search as a starting point
 * *Search Archived*: Execute the search, but specifically for archived results.
+* *Search Historical*: Execute the search, but specifically for historical results.
 
 ===== Editing a Search
 


### PR DESCRIPTION
#### What does this PR do?
Using the dropdown option menu on a single query in the catalog UI will now present an option called Search Historical which queries metacards that have been tagged as revisions.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brianfelix @vinamartin @gordocanchola @emmberk 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui) @rzwiefel 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Install the DDF Registry App and then open the Registry App tile in the Admin UI and update the local node to generate a revision in the catalog. Open the Catalog UI, enter the local workspace template and perform a default search (which should return 0 results), then use the new Search Historical query option from the dropdown. You should see the registry revision metacard. 

#### Any background context you want to provide?
This functionality could assist in finding historical data on resource metacards that are updated regularly.

#### What are the relevant tickets?
[DDF-2724](https://codice.atlassian.net/browse/DDF-2724)

#### Screenshots (if appropriate)
![screen shot 2017-01-18 at 10 21 05 am](https://cloud.githubusercontent.com/assets/11355332/22075283/abc63fe8-dd68-11e6-8dd6-d9d28268b6a7.png)

#### Checklist:
- [x] Documentation Updated
- [x] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
