### PR TITLE
[2.10.x]DDF-2715: Making Point of Contact read-only

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -344,6 +344,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-pointofcontactupdate</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.admin</groupId>
             <artifactId>catalog-admin-module-sources</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -339,6 +339,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.security</groupId>
+            <artifactId>catalog-security-pointofcontact-policyplugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.admin</groupId>
             <artifactId>catalog-admin-module-sources</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -323,11 +323,12 @@
         <bundle>mvn:ddf.catalog.security/catalog-security-policyplugin/${project.version}</bundle>
     </feature>
 
-    <feature name="catalog-security-pointofcontact-policyplugin" install="auto" version="${project.version}"
-             description="DDF Point of Contact Policy Plugin">
+    <feature name="catalog-security-pointofcontact-readonly" install="auto" version="${project.version}"
+             description="DDF Point of Contact Read Only">
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">security-pdp-authz</feature>
         <bundle>mvn:ddf.catalog.security/catalog-security-pointofcontact-policyplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-pointofcontactupdate/${project.version}</bundle>
     </feature>
 
     <feature name="catalog-security-metacardattributeplugin" install="auto" version="${project.version}"

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -323,8 +323,14 @@
         <bundle>mvn:ddf.catalog.security/catalog-security-policyplugin/${project.version}</bundle>
     </feature>
 
-    <feature name="catalog-security-metacardattributeplugin" install="auto"
-             version="${project.version}"
+    <feature name="catalog-security-pointofcontact-policyplugin" install="auto" version="${project.version}"
+             description="DDF Point of Contact Policy Plugin">
+        <feature prerequisite="true">catalog-app</feature>
+        <feature prerequisite="true">security-pdp-authz</feature>
+        <bundle>mvn:ddf.catalog.security/catalog-security-pointofcontact-policyplugin/${project.version}</bundle>
+    </feature>
+
+    <feature name="catalog-security-metacardattributeplugin" install="auto" version="${project.version}"
              description="DDF Catalog Metacard Attribute Policy Plugin">
         <feature prerequisite="true">security-pdp-authz</feature>
         <bundle>

--- a/catalog/plugin/catalog-plugin-pointofcontactupdate/pom.xml
+++ b/catalog/plugin/catalog-plugin-pointofcontactupdate/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -16,36 +16,28 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>catalog-security-pom</artifactId>
-        <groupId>ddf.catalog.security</groupId>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
         <version>2.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>catalog-security-pointofcontact-policyplugin</artifactId>
-    <name>DDF :: Catalog :: Security :: Point of Contact Policy Plugin</name>
+    <artifactId>catalog-plugin-pointofcontactupdate</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Point of Contact Update</name>
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security.policy</groupId>
-            <artifactId>security-policy-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -57,7 +49,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>catalog-core-api-impl, platform-util</Embed-Dependency>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
                         <Export-Package/>
                     </instructions>
                 </configuration>
@@ -80,17 +75,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.97</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.83</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
 
                                     </limits>
@@ -102,5 +97,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/catalog/plugin/catalog-plugin-pointofcontactupdate/src/main/java/org/codice/ddf/catalog/plugin/metacard/PointOfContactUpdatePlugin.java
+++ b/catalog/plugin/catalog-plugin-pointofcontactupdate/src/main/java/org/codice/ddf/catalog/plugin/metacard/PointOfContactUpdatePlugin.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.PreAuthorizationPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+
+/**
+ * Update plugin that sets Point of Contact to the previous value if the new value is null.
+ */
+public class PointOfContactUpdatePlugin implements PreAuthorizationPlugin {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PointOfContactUpdatePlugin.class);
+
+    @Override
+    public CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public UpdateRequest processPreUpdate(UpdateRequest input,
+            Map<String, Metacard> existingMetacards) throws StopProcessingException {
+        input.getUpdates()
+                .forEach(e -> {
+                    Metacard newMetacard = e.getValue();
+                    Metacard previous = getPreviousMetacardWithId(newMetacard.getId(),
+                            existingMetacards);
+
+                    if (previous != null
+                            && newMetacard.getAttribute(Metacard.POINT_OF_CONTACT) == null
+                            && isResourceMetacard(newMetacard)) {
+                        newMetacard.setAttribute(previous.getAttribute(Metacard.POINT_OF_CONTACT));
+                    }
+                });
+
+        return input;
+    }
+
+    @Override
+    public DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public DeleteResponse processPostDelete(DeleteResponse input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public QueryResponse processPostQuery(QueryResponse input) throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public ResourceRequest processPreResource(ResourceRequest input)
+            throws StopProcessingException {
+        return input;
+    }
+
+    @Override
+    public ResourceResponse processPostResource(ResourceResponse input, Metacard metacard)
+            throws StopProcessingException {
+        return input;
+    }
+
+    private boolean isResourceMetacard(Metacard metacard) {
+        return metacard.getTags()
+                .isEmpty() || metacard.getTags()
+                .contains("resource");
+    }
+
+    private Metacard getPreviousMetacardWithId(String id, Map<String, Metacard> previousMetacards) {
+        Metacard previous;
+        try {
+            previous = previousMetacards.entrySet()
+                    .stream()
+                    .map(e -> e.getValue())
+                    .filter((x) -> x.getId()
+                            .equals(id))
+                    .findFirst()
+                    .get();
+        } catch (NoSuchElementException e) {
+            LOGGER.debug("Cannot locate metacard {} for update.", id);
+            return null;
+        }
+
+        return previous;
+    }
+}

--- a/catalog/plugin/catalog-plugin-pointofcontactupdate/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-pointofcontactupdate/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <bean id="pointOfContactUpdatePlugin" class="org.codice.ddf.catalog.plugin.metacard.PointOfContactUpdatePlugin"/>
+
+    <service ref="pointOfContactUpdatePlugin" interface="ddf.catalog.plugin.PreAuthorizationPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-pointofcontactupdate/src/test/java/org/codice/ddf/catalog/plugin/metacard/PointOfContactUpdatePluginTest.java
+++ b/catalog/plugin/catalog-plugin-pointofcontactupdate/src/test/java/org/codice/ddf/catalog/plugin/metacard/PointOfContactUpdatePluginTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+
+public class PointOfContactUpdatePluginTest {
+
+    private static final String RESOURCE_ID1 = "resource-id1";
+
+    private static final String RESOURCE_ID2 = "resource-id2";
+
+    private static final String REGISTRY_ID = "registry-id";
+
+    private static final String ADMIN_EMAIL = "admin@localhost.local";
+
+    private static final String NEW_EMAIL = "new@email.com";
+
+    private PointOfContactUpdatePlugin pointOfContactUpdatePlugin =
+            new PointOfContactUpdatePlugin();
+
+    private List<Metacard> listOfUpdatedMetacards;
+
+    private UpdateRequestImpl updateRequestInput;
+
+    private Map<String, Metacard> existingMetacards;
+
+    @Before
+    public void setup() throws Exception {
+        listOfUpdatedMetacards = getListOfUpdatedMetacards();
+        updateRequestInput = new UpdateRequestImpl(new String[] {RESOURCE_ID1, RESOURCE_ID2,
+                REGISTRY_ID}, listOfUpdatedMetacards);
+        existingMetacards = getPreviousMetacardsWithPointOfContact();
+    }
+
+    @Test
+    public void processPreUpdateOnlyModifiesResourceMetacards() throws Exception {
+        UpdateRequest updateRequestOutput = pointOfContactUpdatePlugin.processPreUpdate(
+                updateRequestInput,
+                existingMetacards);
+
+        assertThat(updateRequestOutput.getUpdates()
+                .get(0)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT)
+                .getValue(), equalTo(ADMIN_EMAIL));
+        assertThat(updateRequestOutput.getUpdates()
+                .get(1)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT)
+                .getValue(), equalTo(ADMIN_EMAIL));
+        assertThat(updateRequestOutput.getUpdates()
+                .get(2)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT), is(nullValue()));
+    }
+
+    @Test
+    public void processPreUpdateDoesNothingIfNewPOCHasAValue() throws Exception {
+        listOfUpdatedMetacards.forEach(m -> m.setAttribute(new AttributeImpl(Metacard.POINT_OF_CONTACT,
+                NEW_EMAIL)));
+
+        UpdateRequest updateRequestOutput = pointOfContactUpdatePlugin.processPreUpdate(
+                updateRequestInput,
+                existingMetacards);
+
+        assertThat(updateRequestOutput.getUpdates()
+                .get(0)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT)
+                .getValue(), equalTo(NEW_EMAIL));
+        assertThat(updateRequestOutput.getUpdates()
+                .get(1)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT)
+                .getValue(), equalTo(NEW_EMAIL));
+        assertThat(updateRequestOutput.getUpdates()
+                .get(2)
+                .getValue()
+                .getAttribute(Metacard.POINT_OF_CONTACT)
+                .getValue(), equalTo(NEW_EMAIL));
+    }
+
+    @Test
+    public void testPassthroughMethods() throws Exception {
+
+        CreateRequest createRequest = mock(CreateRequest.class);
+        DeleteRequest deleteRequest = mock(DeleteRequest.class);
+        QueryRequest queryRequest = mock(QueryRequest.class);
+        ResourceRequest resourceRequest = mock(ResourceRequest.class);
+
+        DeleteResponse deleteResponse = mock(DeleteResponse.class);
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        ResourceResponse resourceResponse = mock(ResourceResponse.class);
+
+        assertThat(pointOfContactUpdatePlugin.processPreCreate(createRequest), is(createRequest));
+        assertThat(pointOfContactUpdatePlugin.processPreDelete(deleteRequest), is(deleteRequest));
+        assertThat(pointOfContactUpdatePlugin.processPostDelete(deleteResponse),
+                is(deleteResponse));
+        assertThat(pointOfContactUpdatePlugin.processPreQuery(queryRequest), is(queryRequest));
+        assertThat(pointOfContactUpdatePlugin.processPostQuery(queryResponse), is(queryResponse));
+        assertThat(pointOfContactUpdatePlugin.processPreResource(resourceRequest),
+                is(resourceRequest));
+        assertThat(pointOfContactUpdatePlugin.processPostResource(resourceResponse,
+                mock(Metacard.class)), is(resourceResponse));
+
+        verifyZeroInteractions(createRequest,
+                deleteRequest,
+                queryRequest,
+                resourceRequest,
+                deleteResponse,
+                queryResponse,
+                resourceResponse);
+    }
+
+    private List<Metacard> getListOfUpdatedMetacards() {
+        Metacard resourceMetacard1 = getMetacardWithIdAndTag(RESOURCE_ID1, "resource");
+        Metacard resourceMetacard2 = getMetacardWithIdAndTag(RESOURCE_ID2, null);
+        Metacard registryMetacard = getMetacardWithIdAndTag(REGISTRY_ID, "registry");
+
+        return Arrays.asList(resourceMetacard1, resourceMetacard2, registryMetacard);
+    }
+
+    private Map<String, Metacard> getPreviousMetacardsWithPointOfContact() {
+        Attribute pocAttribute = new AttributeImpl(Metacard.POINT_OF_CONTACT, ADMIN_EMAIL);
+        Metacard resourceMetacard1 = getMetacardWithIdAndTag(RESOURCE_ID1, "resource");
+        resourceMetacard1.setAttribute(pocAttribute);
+        Metacard resourceMetacard2 = getMetacardWithIdAndTag(RESOURCE_ID2, null);
+        resourceMetacard2.setAttribute(pocAttribute);
+        Metacard registryMetacard = getMetacardWithIdAndTag(REGISTRY_ID, "registry");
+        registryMetacard.setAttribute(pocAttribute);
+
+        Map<String, Metacard> existingMetacards = new HashMap<String, Metacard>();
+        existingMetacards.put(RESOURCE_ID1, resourceMetacard1);
+        existingMetacards.put(RESOURCE_ID2, resourceMetacard2);
+        existingMetacards.put(REGISTRY_ID, registryMetacard);
+
+        return existingMetacards;
+    }
+
+    private Metacard getMetacardWithIdAndTag(String id, String tag) {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId(id);
+
+        if (tag != null) {
+            Set<String> tags = new HashSet<String>();
+            tags.add(tag);
+            metacard.setTags(tags);
+        }
+
+        return metacard;
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -34,5 +34,6 @@
         <module>catalog-plugin-content-uri</module>
         <module>catalog-plugin-clientinfo</module>
         <module>catalog-plugin-metacardingest-network</module>
+        <module>catalog-plugin-pointofcontactupdate</module>
     </modules>
 </project>

--- a/catalog/security/catalog-security-plugin/src/main/java/ddf/catalog/security/plugin/SecurityPlugin.java
+++ b/catalog/security/catalog-security-plugin/src/main/java/ddf/catalog/security/plugin/SecurityPlugin.java
@@ -51,8 +51,10 @@ public class SecurityPlugin implements AccessPlugin {
         if (input.getMetacards() != null && subject != null) {
             input.getMetacards()
                     .forEach(metacard -> {
-                        metacard.setAttribute(new AttributeImpl(Metacard.POINT_OF_CONTACT,
-                                SubjectUtils.getEmailAddress(subject)));
+                        if (metacard.getTags().isEmpty() || metacard.getTags().contains("resource")) {
+                            metacard.setAttribute(new AttributeImpl(Metacard.POINT_OF_CONTACT,
+                                    SubjectUtils.getEmailAddress(subject)));
+                        }
                     });
         }
 

--- a/catalog/security/catalog-security-plugin/src/test/java/ddf/catalog/security/plugin/SecurityPluginTest.java
+++ b/catalog/security/catalog-security-plugin/src/test/java/ddf/catalog/security/plugin/SecurityPluginTest.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.security.plugin;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +32,10 @@ import java.util.Set;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.util.ThreadContext;
 import org.junit.Test;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
@@ -41,17 +47,16 @@ import ddf.catalog.operation.ResourceRequest;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
+import ddf.security.SubjectUtils;
+import ddf.security.assertion.SecurityAssertion;
 
 public class SecurityPluginTest {
 
     public static final String TEST_USER = "test-user";
 
     @Test
-    public void testNominalCaseCreate() throws Exception {
-        Subject mockSubject = mock(Subject.class);
-        PrincipalCollection mockPrincipals = mock(PrincipalCollection.class);
-        when(mockPrincipals.getPrimaryPrincipal()).thenReturn(TEST_USER);
-        when(mockSubject.getPrincipals()).thenReturn(mockPrincipals);
+    public void testNominalCaseCreateWithEmail() throws Exception {
+        Subject mockSubject = setupMockSubject();
 
         ThreadContext.bind(mockSubject);
         CreateRequest request = new MockCreateRequest();
@@ -66,6 +71,25 @@ public class SecurityPluginTest {
         request.getMetacards()
                 .forEach(metacard -> assertThat(metacard.getAttribute(Metacard.POINT_OF_CONTACT)
                         .getValue(), equalTo(TEST_USER)));
+    }
+
+    @Test
+    public void testNominalCaseCreateWithoutEmail() throws Exception {
+        Subject mockSubject = mock(Subject.class);
+        ThreadContext.bind(mockSubject);
+
+        CreateRequest request = new MockCreateRequest();
+        SecurityPlugin plugin = new SecurityPlugin();
+
+        request = plugin.processPreCreate(request);
+
+        assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT),
+                equalTo(mockSubject));
+        assertThat(request.getMetacards()
+                .size(), is(2));
+        request.getMetacards()
+                .forEach(metacard -> assertThat(metacard.getAttribute(Metacard.POINT_OF_CONTACT),
+                        is(nullValue())));
     }
 
     @Test
@@ -147,6 +171,33 @@ public class SecurityPluginTest {
         SecurityPlugin plugin = new SecurityPlugin();
         request = plugin.processPreCreate(request);
         assertThat(request.getPropertyValue(SecurityConstants.SECURITY_SUBJECT), equalTo(null));
+    }
+
+    private Subject setupMockSubject() {
+        XSString mockAttributeValue = mock(XSString.class);
+        when(mockAttributeValue.getValue()).thenReturn(TEST_USER);
+
+        List<XMLObject> listOfAttributeValues = Arrays.asList(mockAttributeValue);
+
+        Attribute mockAttribute = mock(Attribute.class);
+        when(mockAttribute.getName()).thenReturn(SubjectUtils.EMAIL_ADDRESS_CLAIM_URI);
+        when(mockAttribute.getAttributeValues()).thenReturn(listOfAttributeValues);
+
+        List<Attribute> listOfAttributes = Arrays.asList(mockAttribute);
+
+        AttributeStatement mockAttributeStatement = mock(AttributeStatement.class);
+        when(mockAttributeStatement.getAttributes()).thenReturn(listOfAttributes);
+
+        List<AttributeStatement> listOfAttributeStatements = Arrays.asList(mockAttributeStatement);
+
+        Subject mockSubject = mock(Subject.class);
+        PrincipalCollection mockPrincipals = mock(PrincipalCollection.class);
+        SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+
+        when(mockSecurityAssertion.getAttributeStatements()).thenReturn(listOfAttributeStatements);
+        when(mockPrincipals.oneByType(SecurityAssertion.class)).thenReturn(mockSecurityAssertion);
+        when(mockSubject.getPrincipals()).thenReturn(mockPrincipals);
+        return mockSubject;
     }
 
     public static class MockCreateRequest implements CreateRequest {

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/pom.xml
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>catalog-security-pom</artifactId>
+        <groupId>ddf.catalog.security</groupId>
+        <version>2.10.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-security-pointofcontact-policyplugin</artifactId>
+    <name>DDF :: Catalog :: Security :: Point of Contact Policy Plugin</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.policy</groupId>
+            <artifactId>security-policy-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>catalog-core-api-impl, platform-util</Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.97</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.83</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPlugin.java
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPlugin.java
@@ -57,6 +57,11 @@ public class PointOfContactPolicyPlugin implements PolicyPlugin {
     @Override
     public PolicyResponse processPreUpdate(Metacard newMetacard,
             Map<String, Serializable> properties) throws StopProcessingException {
+        //If it's not a resource metacard, don't apply the policy.
+        if (!newMetacard.getTags().isEmpty() && !newMetacard.getTags().contains("resource")) {
+            return new PolicyResponseImpl();
+        }
+
         List<Metacard> previousStateMetacards = ((OperationTransaction) properties.get(
                 OPERATION_TRANSACTION_KEY)).getPreviousStateMetacards();
 

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPlugin.java
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPlugin.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.security.policy.metacard;
+
+import static ddf.catalog.Constants.OPERATION_TRANSACTION_KEY;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.OperationTransaction;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.plugin.PolicyPlugin;
+import ddf.catalog.plugin.PolicyResponse;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.plugin.impl.PolicyResponseImpl;
+import ddf.security.permission.Permissions;
+
+/**
+ * Security-based plugin that adds a policy if the point-of-contact field changed on preUpdate.
+ */
+public class PointOfContactPolicyPlugin implements PolicyPlugin {
+    private static final String[] PERMISSION_STRING = {"read-only=Cannot update the point-of-contact field"};
+
+    private static final Map<String, Set<String>> PERMISSION_MAP =
+            Permissions.parsePermissionsFromString(PERMISSION_STRING);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PointOfContactPolicyPlugin.class);
+
+    @Override
+    public PolicyResponse processPreCreate(Metacard input, Map<String, Serializable> properties)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPreUpdate(Metacard newMetacard,
+            Map<String, Serializable> properties) throws StopProcessingException {
+        List<Metacard> previousStateMetacards = ((OperationTransaction) properties.get(
+                OPERATION_TRANSACTION_KEY)).getPreviousStateMetacards();
+
+        Metacard previous;
+        try {
+            previous = previousStateMetacards.stream()
+                    .filter((x) -> x.getId()
+                            .equals(newMetacard.getId()))
+                    .findFirst()
+                    .get();
+        } catch (NoSuchElementException e) {
+            LOGGER.debug("Cannot locate metacard {} for update.",
+                    newMetacard.getId());
+            return new PolicyResponseImpl();
+        }
+
+        return pointOfContactChanged(newMetacard, previous) ? new PolicyResponseImpl(null,
+                PERMISSION_MAP) : new PolicyResponseImpl();
+    }
+
+    private boolean pointOfContactChanged(Metacard newMetacard, Metacard previousMetacard) {
+        Attribute newPointOfContact = newMetacard.getAttribute(Metacard.POINT_OF_CONTACT);
+        Attribute oldPointOfContact = previousMetacard.getAttribute(Metacard.POINT_OF_CONTACT);
+
+        if (newPointOfContact != null && oldPointOfContact != null) {
+            return !newPointOfContact.getValue()
+                    .equals(oldPointOfContact.getValue());
+        }
+
+        //Return true if only one of them is null
+        return newPointOfContact != oldPointOfContact;
+    }
+
+    @Override
+    public PolicyResponse processPreDelete(List<Metacard> metacards,
+            Map<String, Serializable> properties) throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPostDelete(Metacard input, Map<String, Serializable> properties)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPreQuery(Query query, Map<String, Serializable> properties)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPostQuery(Result input, Map<String, Serializable> properties)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPreResource(ResourceRequest resourceRequest)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+
+    @Override
+    public PolicyResponse processPostResource(ResourceResponse resourceResponse, Metacard metacard)
+            throws StopProcessingException {
+        return new PolicyResponseImpl();
+    }
+}

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="pointOfContactPolicyPlugin" class="org.codice.ddf.catalog.security.policy.metacard.PointOfContactPolicyPlugin"/>
+
+    <service ref="pointOfContactPolicyPlugin" interface="ddf.catalog.plugin.PolicyPlugin"/>
+</blueprint>

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPluginTest.java
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPluginTest.java
@@ -24,8 +24,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,12 +89,35 @@ public class PointOfContactPolicyPluginTest {
     }
 
     @Test
-    public void processPreUpdateReturnsPolicyWhenPointOfContactsAreDifferent()
-            throws java.lang.Exception {
+    public void processPreUpdateDoesNothingWithWorkspaceMetacard() throws java.lang.Exception {
+        Set<String> setOfTags = getSetWithGivenTag("workspace");
+
         MetacardImpl oldMetacard = getMetacardWithPointOfContact("edited-" + TEST_POINT_OF_CONTACT);
+        oldMetacard.setTags(setOfTags);
+
+        MetacardImpl newMetacard = getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT);
+        newMetacard.setTags(setOfTags);
 
         PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(
-                getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT),
+                newMetacard,
+                setupAndGetInputProperties(oldMetacard));
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreUpdateReturnsPolicyWhenPointOfContactsAreDifferent()
+            throws java.lang.Exception {
+        Set<String> setOfTags = getSetWithGivenTag("resource");
+
+        MetacardImpl oldMetacard = getMetacardWithPointOfContact("edited-" + TEST_POINT_OF_CONTACT);
+        oldMetacard.setTags(setOfTags);
+
+        MetacardImpl newMetacard = getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT);
+        newMetacard.setTags(setOfTags);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(
+                newMetacard,
                 setupAndGetInputProperties(oldMetacard));
 
         responseHasPolicy(response);
@@ -169,6 +194,12 @@ public class PointOfContactPolicyPluginTest {
                 ResourceResponse.class), new MetacardImpl());
 
         responseIsEmpty(response);
+    }
+
+    private Set<String> getSetWithGivenTag(String tag) {
+        Set<String> setOfTags = new HashSet<String>();
+        setOfTags.add(tag);
+        return setOfTags;
     }
 
     private MetacardImpl getMetacardWithPointOfContact(String pointOfContact) {

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPluginTest.java
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/src/test/java/org/codice/ddf/catalog/security/policy/metacard/PointOfContactPolicyPluginTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.security.policy.metacard;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static ddf.catalog.Constants.OPERATION_TRANSACTION_KEY;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.operation.OperationTransaction;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.impl.ResourceRequestById;
+import ddf.catalog.plugin.PolicyResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PointOfContactPolicyPluginTest {
+
+    public static final String TEST_POINT_OF_CONTACT = "test-point-of-contact";
+
+    public static final String TEST_ID = "test-id";
+
+    private PointOfContactPolicyPlugin pointOfContactPolicyPlugin =
+            new PointOfContactPolicyPlugin();
+
+    private List<Metacard> listWithMetacard = new ArrayList<Metacard>();
+
+    @Mock
+    private OperationTransaction mockOperationTransaction;
+
+    @Test
+    public void processPreCreateDoesNothing() throws java.lang.Exception {
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreCreate(new MetacardImpl(),
+                Collections.emptyMap());
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreUpdateDoesNothingWithNoPreviousMetacard() throws java.lang.Exception {
+        when(mockOperationTransaction.getPreviousStateMetacards()).thenReturn(Collections.emptyList());
+        Map<String, Serializable> inputProperties = new HashMap<String, Serializable>();
+        inputProperties.put(OPERATION_TRANSACTION_KEY, mockOperationTransaction);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(new MetacardImpl(),
+                inputProperties);
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreUpdateDoesNothingWhenPointOfContactsAreSame() throws java.lang.Exception {
+        MetacardImpl metacard = getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(metacard,
+                setupAndGetInputProperties(metacard));
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreUpdateReturnsPolicyWhenPointOfContactsAreDifferent()
+            throws java.lang.Exception {
+        MetacardImpl oldMetacard = getMetacardWithPointOfContact("edited-" + TEST_POINT_OF_CONTACT);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(
+                getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT),
+                setupAndGetInputProperties(oldMetacard));
+
+        responseHasPolicy(response);
+    }
+
+    @Test
+    public void processPreUpdateReturnsPolicyWhenOldPointOfContactIsNull()
+            throws java.lang.Exception {
+        MetacardImpl oldMetacard = getMetacardWithPointOfContact(null);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(
+                getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT),
+                setupAndGetInputProperties(oldMetacard));
+
+        responseHasPolicy(response);
+    }
+
+    @Test
+    public void processPreUpdateReturnsPolicyWhenNewPointOfContactIsNull()
+            throws java.lang.Exception {
+        MetacardImpl oldMetacard = getMetacardWithPointOfContact(TEST_POINT_OF_CONTACT);
+
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreUpdate(
+                getMetacardWithPointOfContact(null),
+                setupAndGetInputProperties(oldMetacard));
+
+        responseHasPolicy(response);
+    }
+
+    @Test
+    public void processPreDeleteDoesNothing() throws java.lang.Exception {
+        PolicyResponse response =
+                pointOfContactPolicyPlugin.processPreDelete(Collections.emptyList(),
+                        Collections.emptyMap());
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPostDeleteDoesNothing() throws java.lang.Exception {
+        PolicyResponse response = pointOfContactPolicyPlugin.processPostDelete(new MetacardImpl(),
+                Collections.emptyMap());
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreQueryDoesNothing() throws java.lang.Exception {
+        PolicyResponse response = pointOfContactPolicyPlugin.processPreQuery(mock(Query.class),
+                Collections.emptyMap());
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPostQueryDoesNothing() throws java.lang.Exception {
+        PolicyResponse response = pointOfContactPolicyPlugin.processPostQuery(new ResultImpl(),
+                Collections.emptyMap());
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPreResourceDoesNothing() throws java.lang.Exception {
+        PolicyResponse response =
+                pointOfContactPolicyPlugin.processPreResource(new ResourceRequestById(TEST_ID));
+
+        responseIsEmpty(response);
+    }
+
+    @Test
+    public void processPostResourceDoesNothing() throws java.lang.Exception {
+        PolicyResponse response = pointOfContactPolicyPlugin.processPostResource(mock(
+                ResourceResponse.class), new MetacardImpl());
+
+        responseIsEmpty(response);
+    }
+
+    private MetacardImpl getMetacardWithPointOfContact(String pointOfContact) {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setId(TEST_ID);
+        metacard.setPointOfContact(pointOfContact);
+        return metacard;
+    }
+
+    private void responseIsEmpty(PolicyResponse response) {
+        assertThat(response.itemPolicy()
+                .entrySet(), hasSize(0));
+        assertThat(response.operationPolicy()
+                .entrySet(), hasSize(0));
+    }
+
+    private Map<String, Serializable> setupAndGetInputProperties(Metacard metacard) {
+        listWithMetacard.add(metacard);
+        listWithMetacard.add(new MetacardImpl());
+        when(mockOperationTransaction.getPreviousStateMetacards()).thenReturn(listWithMetacard);
+        Map<String, Serializable> inputProperties = new HashMap<String, Serializable>();
+        inputProperties.put(OPERATION_TRANSACTION_KEY, mockOperationTransaction);
+        return inputProperties;
+    }
+
+    private void responseHasPolicy(PolicyResponse response) {
+        assertThat(response.itemPolicy()
+                .entrySet(), hasSize(1));
+        assertTrue(response.itemPolicy()
+                .get("read-only")
+                .contains("Cannot update the point-of-contact field"));
+        assertThat(response.operationPolicy()
+                .entrySet(), hasSize(0));
+    }
+}

--- a/catalog/security/pom.xml
+++ b/catalog/security/pom.xml
@@ -32,5 +32,6 @@
         <module>catalog-security-xmlattributeplugin</module>
         <module>catalog-security-metacardattributeplugin</module>
         <module>catalog-security-resourceplugin</module>
+        <module>catalog-security-pointofcontact-policyplugin</module>
     </modules>
 </project>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -118,7 +118,7 @@
             description="List of metacard attributes that are read-only. NOTE: the provided values will be evaluated as JavaScript regular expressions when matched against metacard attributes."
             type="String"
             cardinality="10000"
-            default="^checksum$,^checksum-algorithm$,^id$,^metadata$,^metacard-type$,^source-id$,^metacard\\.,^version\\.,^validation\\."
+            default="^checksum$,^checksum-algorithm$,^id$,^metadata$,^metacard-type$,^source-id$,^point-of-contact$, ^metacard\\.,^version\\.,^validation\\."
             required="false"/>
 
         <AD id="summaryShow"

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -18,6 +18,7 @@ readOnly=[
     "id",
     "metadata",
     "source-id",
+    "point-of-contact",
     "^metacard\\.",
     "^version\\.",
     "^validation\\."

--- a/distribution/test/itests/test-itests-common/src/main/resources/definitions.json
+++ b/distribution/test/itests/test-itests-common/src/main/resources/definitions.json
@@ -6,9 +6,6 @@
         "title": {
           "required": true
         },
-        "point-of-contact": {
-          "required": true
-        },
         "new-attribute-notrequired": {
           "required": false
         },

--- a/distribution/test/itests/test-itests-common/src/main/resources/json/record/SimpleGeoJsonRecord
+++ b/distribution/test/itests/test-itests-common/src/main/resources/json/record/SimpleGeoJsonRecord
@@ -6,7 +6,8 @@
         "metadata-content-type-version": "myVersion",
         "metadata-content-type": "myType",
         "metadata": "<xml>text</xml>",
-        "modified": "2012-09-01T00:09:19.368+0000"
+        "modified": "2012-09-01T00:09:19.368+0000",
+        "point-of-contact": "admin@local"
     },
     "type": "Feature",
     "geometry": {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -147,6 +147,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
 
     public static final String ADMIN = "admin";
+    public static final String ADMIN_EMAIL = "admin@localhost.local";
 
     @Rule
     public TestName testName = new TestName();
@@ -270,9 +271,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .log()
                 .all()
                 .assertThat()
-                .body(hasXPath("/metacard[@id='" + id + "']"))
-                .body(hasXPath("/metacard/string[@name='point-of-contact']"),
-                        containsString("Guest@Guest"));
+                .body(hasXPath("/metacard[@id='" + id + "']"));
 
         deleteMetacard(id);
     }
@@ -300,8 +299,41 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .all()
                 .assertThat()
                 .body(hasXPath("/metacard[@id='" + id + "']"))
-                .body(hasXPath("/metacard/string[@name='point-of-contact']/value[text()='" + ADMIN
+                .body(hasXPath("/metacard/string[@name='point-of-contact']/value[text()='" + ADMIN_EMAIL
                         + "']"));
+
+        deleteMetacard(id);
+    }
+
+    @Test
+    public void testPointOfContactIsReadOnly() throws Exception {
+        LOGGER.debug("Ingesting SimpleGeoJsonRecord");
+        String id = given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"))
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .expect()
+                .log()
+                .all()
+                .statusCode(HttpStatus.SC_CREATED)
+                .when()
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
+
+        LOGGER.debug("Updating SimpleGeoJsonRecord");
+
+        given().auth()
+                .preemptive()
+                .basic(ADMIN, ADMIN)
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"))
+                .expect()
+                .log()
+                .all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .when()
+                .put(new DynamicUrl(REST_PATH, id).getUrl());
 
         deleteMetacard(id);
     }
@@ -2049,6 +2081,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     @Test
     public void testValidationUnenforced() throws Exception {
         getServiceManager().startFeature(true, "sample-validator");
+        getServiceManager().stopFeature(true, "catalog-security-filter");
         configureEnforcedMetacardValidators(Collections.singletonList(""), getAdminConfig());
 
         String id1 = ingestXmlFromResource("/metacard1.xml");
@@ -2150,6 +2183,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             deleteMetacard(id1);
             deleteMetacard(id2);
             getServiceManager().stopFeature(true, "sample-validator");
+            getServiceManager().startFeature(true, "catalog-security-filter");
         }
     }
 
@@ -2260,7 +2294,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Test
     public void testValidationFiltering() throws Exception {
-        getServiceManager().startFeature(true, "catalog-security-filter", "sample-validator");
+        getServiceManager().startFeature(true, "sample-validator");
 
         // Update metacardMarkerPlugin config with no enforcedMetacardValidators
         configureEnforcedMetacardValidators(Arrays.asList(""), getAdminConfig());
@@ -2351,7 +2385,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         } finally {
             deleteMetacard(id1);
             deleteMetacard(id2);
-            getServiceManager().stopFeature(true, "catalog-security-filter", "sample-validator");
+            getServiceManager().stopFeature(true, "sample-validator");
             config = configAdmin.getConfiguration("ddf.security.pdp.realm.AuthzRealm", null);
             configProps = new Hashtable<>(new PdpProperties());
             config.update(configProps);
@@ -2489,6 +2523,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testMetacardDefinitionJsonFile() throws Exception {
         final String newMetacardTypeName = "new.metacard.type";
+        getServiceManager().stopFeature(true, "catalog-security-filter");
         File file = ingestDefinitionJsonWithWaitCondition("definitions.json", () -> {
             expect("Service to be available: " + MetacardType.class.getName()).within(30,
                     TimeUnit.SECONDS)
@@ -2528,6 +2563,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                                 .isPresent());
                 return null;
             });
+            getServiceManager().startFeature(true, "catalog-security-filter");
             configureShowInvalidMetacards("false", "false", getAdminConfig());
         }
     }
@@ -2720,13 +2756,9 @@ public class TestCatalog extends AbstractIntegrationTest {
                     .assertThat()
                     .body(hasXPath(basicMetacardXpath + "/type", is(basicMetacardTypeName)))
                     .body(hasXPath(basicMetacardXpath + "/int[@name='page-count']/value", is("55")))
-                    .body(hasXPath(basicMetacardXpath + "/string[@name='point-of-contact']"),
-                            containsString("Guest@Guest"))
                     .body(not(hasXPath(basicMetacardXpath + "/double[@name='temperature']")))
                     .body(hasXPath(otherMetacardXpath + "/type", is(otherMetacardTypeName)))
                     .body(hasXPath(otherMetacardXpath + "/int[@name='page-count']/value", is("55")))
-                    .body(hasXPath(otherMetacardXpath + "/string[@name='point-of-contact']"),
-                            containsString("Guest@Guest"))
                     .body(hasXPath(otherMetacardXpath + "/double[@name='temperature']/value",
                             is("-12.541")));
         } finally {
@@ -2857,6 +2889,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         String invalidCardId = null;
         String validCardId = null;
         try {
+            getServiceManager().stopFeature(true, "catalog-security-filter");
             final String newMetacardTypeName = "customtype1";
 
             ingestDefinitionJsonWithWaitCondition("customtypedefinitions.json", () -> {
@@ -2900,6 +2933,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 deleteMetacard(validCardId);
             }
 
+            getServiceManager().startFeature(true, "catalog-security-filter");
             configureShowInvalidMetacardsReset();
         }
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -46,6 +46,7 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import com.jayway.restassured.specification.ResponseSpecification;
 
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 
@@ -262,7 +263,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         assertNotNull(id);
 
         expect(asUser("random", "password").body(stringify(ImmutableMap.of(Core.METACARD_OWNER,
-                "random@localhost.local"))), 200).put(api() + "/" + id);
+                "random@localhost.local", Metacard.POINT_OF_CONTACT, (String) body.get(Metacard.POINT_OF_CONTACT)))), 200).put(api() + "/" + id);
 
         ids.add(id); // for cleanUp
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -46,7 +46,6 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import com.jayway.restassured.specification.ResponseSpecification;
 
-import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 
@@ -263,7 +262,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         assertNotNull(id);
 
         expect(asUser("random", "password").body(stringify(ImmutableMap.of(Core.METACARD_OWNER,
-                "random@localhost.local", Metacard.POINT_OF_CONTACT, (String) body.get(Metacard.POINT_OF_CONTACT)))), 200).put(api() + "/" + id);
+                "random@localhost.local"))), 200).put(api() + "/" + id);
 
         ids.add(id); // for cleanUp
     }


### PR DESCRIPTION
#### What does this PR do?
Makes the Point of Contact field read-only and fixes `point-of-contact` to be set to the email and only when it's a resource metacard.
Note: This is the first PR for this ticket. The second one will depend on this one.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @figliold @shaundmorris 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
- Build and deploy DDF
- Ingest a metacard
- Verify in the Catalog UI that the metacard's `Point of Contact` field is set to the email address of current user (i.e. admin@localhost.local if signed in as admin) and that the field is read-only.
- Go to the Catalog UI configurations in the AdminUI and remove `point-of-contact` from the list of read-only attributes. Save.
- Go back to the Catalog UI and try to edit the `Point of Contact` field on the metacard. An error message should pop up. 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2715](https://codice.atlassian.net/browse/DDF-2715)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests
