### PR TITLE
DDF-2644 Added subscriptions persistence store type to commands

### DIFF
--- a/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
+++ b/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
@@ -36,7 +36,7 @@ public abstract class AbstractStoreCommand extends OsgiCommandSupport {
     protected PrintStream console = System.out;
 
     @Option(name = "Persistence Type", aliases = {"-t",
-            "--type"}, required = true, description = "Type of entry in the persistence store to perform the current operation on.\nOptions: attributes, preferences, metacard, saved_query, notification, activity, or workspace", multiValued = false)
+            "--type"}, required = true, description = "Type of entry in the persistence store to perform the current operation on.\nOptions: attributes, preferences, metacard, saved_query, notification, activity, subscriptions or workspace", multiValued = false)
     protected String type;
 
     @Option(name = "CQL", aliases = {"-c",

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
@@ -28,6 +28,8 @@ public interface PersistentStore {
     public static final String WORKSPACE_TYPE = "workspace";
     public static final String PREFERENCES_TYPE = "preferences";
     public static final String USER_ATTRIBUTE_TYPE = "attributes";
+    public static final String SUBSCRIPTION_TYPE = "subscriptions";
+
 
     public static final Set<String> PERSISTENCE_TYPES = new HashSet<String>(Arrays.asList(
             METACARD_TYPE,
@@ -36,7 +38,8 @@ public interface PersistentStore {
             ACTIVITY_TYPE,
             WORKSPACE_TYPE,
             PREFERENCES_TYPE,
-            USER_ATTRIBUTE_TYPE));
+            USER_ATTRIBUTE_TYPE,
+            SUBSCRIPTION_TYPE));
 
     /**
      * Adds item of specified type with the specified properties.


### PR DESCRIPTION
#### What does this PR do?
Added subscriptions persistence store type to persistence store commands.  The subscriptions store was introduced with Catalog UI for email notifications on a workspace.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining @rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
1) Create one or more email notification subscriptions by subscribing to workspaces.
2) Verify persistence store commands:
store:list -t subscriptions
store:delete -t subscriptions

#### Any background context you want to provide?

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2644)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
