### PR TITLE
DDF-2728 Remove EHCache dependency from catalog ui

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -183,19 +183,9 @@
             <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-terracotta</artifactId>
-            <version>2.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>c3p0</groupId>
             <artifactId>c3p0</artifactId>
             <version>0.9.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-            <version>2.10.2.2.21</version>
         </dependency>
         <dependency>
             <groupId>ddf.persistence.core</groupId>
@@ -274,8 +264,6 @@
                             quartz-jobs,
                             c3p0,
                             terracotta-toolkit-runtime-ee,
-                            ehcache-terracotta,
-                            ehcache,
                             ddf-security-common
                         </Embed-Dependency>
                         <Web-ContextPath>/search/catalog</Web-ContextPath>


### PR DESCRIPTION
#### What does this PR do?

Remove an unused dependency committed via https://github.com/codice/ddf-ui/pull/7

Description of the PR is nightly email notifications of queries in workspaces.

The manifests of builds show this library as not being used.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@clockard 
@brianfelix 
@mcalcote
@vinamartin 
@cruzj6


#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

Attempt a full build. All tests should pass. The compiled DDF should be unziped and executed. Confirm that workspaces are working in the new search UI.


#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2728](https://codice.atlassian.net/browse/DDF-2728)

#### Screenshots (if appropriate)
N/A
#### Checklist:
- [x] Documentation Updated
- [x] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
