### PR TITLE
DDF-2732: Update CrlChecker to accept any valid URL for the location of the CRL

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -178,7 +178,7 @@ Enabling CRL revocation or modifying the CRL file will require a restart of ${br
 ====
 
 . Place the CRL in <${branding}.home>/etc/keystores.
-. Add the line `org.apache.ws.security.crypto.merlin.x509crl.file=etc/keystores/<CRL_FILENAME>` to the following files:
+. Add the line `org.apache.ws.security.crypto.merlin.x509crl.file=etc/keystores/<CRL_FILENAME>` to the following files (It is possible to specify a URL, or file path as the CRL location):
 .. `<${branding}.home>/etc/ws-security/server/encryption.properties`
 .. `<${branding}_HOME>/etc/ws-security/server/encryption.properties`
 .. `<${branding-lowercase}.home>/etc/ws-security/issuer/encryption.properties`
@@ -205,7 +205,7 @@ The PKIHandler implements CRL revocation, so any web context that is configured 
 With guest access, a user with a revoked certificate will be given a 401 error, but users without a certificate will be able to access the web context as the guest user.
 
 The STS CRL interceptor does not need a web context specified.
-The CRL interceptor for the STS will become active after specifying the CRL file in the `encryption.properties` file and restarting ${branding}.
+The CRL interceptor for the STS will become active after specifying the CRL file, or URL for the CRL in the `encryption.properties` file and restarting ${branding}.
 
 [NOTE]
 ====

--- a/distribution/docs/src/main/resources/_contents/securing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/securing-contents.adoc
@@ -1051,7 +1051,7 @@ Enabling CRL revocation or modifying the CRL file will require a restart of ${br
 
 ["lowerroman"]
 . Place the CRL in <${branding}.home>/etc/keystores.
-. Uncomment the following line in `<${branding}.home>/etc/ws-security/server/encryption.properties`, `<${branding}_HOME>/etc/ws-security/server/encryption.properties`, `<${branding-lowercase}.home>/etc/ws-security/issuer/encryption.properties`, `<${branding}_HOME>/etc/ws-security/server/signature.properties`, and `<${branding}_HOME>/etc/ws-security/issuer/signature.properties`  and replace the filename with the CRL file used in previous step.
+. Uncomment the following line in `<${branding}.home>/etc/ws-security/server/encryption.properties`, `<${branding}_HOME>/etc/ws-security/server/encryption.properties`, `<${branding-lowercase}.home>/etc/ws-security/issuer/encryption.properties`, `<${branding}_HOME>/etc/ws-security/server/signature.properties`, and `<${branding}_HOME>/etc/ws-security/issuer/signature.properties`  and replace the filename with the CRL file used in previous step (This can be a URL, or the file path).
 
 [source]
 ----
@@ -1077,7 +1077,7 @@ The PKIHandler implements CRL revocation, so any web context that is configured 
 With guest access, a user with a revoked cert will be given a 401 error, but users without a certificate will be able to access the web context as the guest user.
 
 The STS CRL interceptor does not need a web context specified.
-The CRL interceptor for the STS will become active after specifying the CRL file in the `encryption.properties` file and restarting ${branding}.
+The CRL interceptor for the STS will become active after specifying the CRL file, or URL of the CRL in the `encryption.properties` file and restarting ${branding}.
 
 [NOTE]
 ====


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to specify any valid URL for the location of a CRL in the CrlChecker's createCrl method.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@stustison 
@clockard
@brianfelix
@mcalcote
@vinamartin
@taz77 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Tested by specifying a URL location of a CRL in the encryption.properties file.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2732](https://codice.atlassian.net/browse/DDF-2732)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [-] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
