### PR TITLE
DDF-2742: Mark itests in TestCatalog that use the Felix File Installe…

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -2347,7 +2347,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testMetacardDefinitionJsonFile() throws Exception {
         final String newMetacardTypeName = "new.metacard.type";
         File file = ingestDefinitionJsonWithWaitCondition("definitions.json", () -> {
@@ -2413,7 +2413,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testDefaultValuesCreate() throws Exception {
         final String customMetacardTypeName = "custom";
         File file = ingestDefinitionJsonWithWaitCondition("defaults.json", () -> {
@@ -2479,7 +2479,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testDefaultValuesUpdate() throws Exception {
         final String customMetacardTypeName = "custom";
         File file = ingestDefinitionJsonWithWaitCondition("defaults.json", () -> {
@@ -2552,7 +2552,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testInjectAttributesOnCreate() throws Exception {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
@@ -2603,7 +2603,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testInjectAttributesOnUpdate() throws Exception {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
@@ -2713,7 +2713,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
-    @ConditionalIgnore(condition = SkipUnstableTest.class)
+    @ConditionalIgnore(condition = SkipUnstableTest.class)   // DDF-2743
     public void testTypeValidation() throws Exception {
         String invalidCardId = null;
         String validCardId = null;

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -85,6 +85,9 @@ import org.apache.http.HttpStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule.ConditionalIgnore;
+import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
 import org.codice.ddf.itests.common.csw.CswQueryBuilder;
@@ -144,6 +147,9 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Rule
     public TestName testName = new TestName();
+
+    @Rule
+    public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
 
     private UrlResourceReaderConfigurator urlResourceReaderConfigurator;
 
@@ -2341,6 +2347,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testMetacardDefinitionJsonFile() throws Exception {
         final String newMetacardTypeName = "new.metacard.type";
         File file = ingestDefinitionJsonWithWaitCondition("definitions.json", () -> {
@@ -2406,6 +2413,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testDefaultValuesCreate() throws Exception {
         final String customMetacardTypeName = "custom";
         File file = ingestDefinitionJsonWithWaitCondition("defaults.json", () -> {
@@ -2471,6 +2479,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testDefaultValuesUpdate() throws Exception {
         final String customMetacardTypeName = "custom";
         File file = ingestDefinitionJsonWithWaitCondition("defaults.json", () -> {
@@ -2543,6 +2552,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testInjectAttributesOnCreate() throws Exception {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
@@ -2593,6 +2603,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testInjectAttributesOnUpdate() throws Exception {
         final File file = ingestDefinitionJsonWithWaitCondition("injections.json", () -> {
             expect("Injectable attributes to be registered").within(30, TimeUnit.SECONDS)
@@ -2702,6 +2713,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnore(condition = SkipUnstableTest.class)
     public void testTypeValidation() throws Exception {
         String invalidCardId = null;
         String validCardId = null;


### PR DESCRIPTION
#### What does this PR do?
Several itests that use the Felix File Installer in TestCatalog fail intermittently on Jenkins.  This PR marks those tests unstable, so they don't continue to fail the build.

 testInjectAttributesOnCreate(ddf.test.itests.catalog.TestCatalog)
 testDefaultValuesCreate(ddf.test.itests.catalog.TestCatalog)
 testInjectAttributesOnUpdate(ddf.test.itests.catalog.TestCatalog)
 testDefaultValuesUpdate(ddf.test.itests.catalog.TestCatalog)
 testTypeValidation(ddf.test.itests.catalog.TestCatalog)
 testMetacardDefinitionJsonFile(ddf.test.itests.catalog.TestCatalog)

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Joy603 
@brjeter 
@jrnorth 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2742
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
