### PR TITLE
DDF-2745: Fix resource-uri being overriden by null update

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
@@ -68,8 +68,6 @@ public class OverrideAttributesSupport {
                 .filter(Objects::nonNull)
                 .filter(attribute -> !attribute.getName()
                         .equals(Metacard.ID))
-                .filter(attribute -> !attribute.getName()
-                        .equals(Metacard.RESOURCE_URI))
                 .filter(attribute -> !onlyFillNull
                         || metacard.getAttribute(attribute.getName()) == null)
                 .forEach(metacard::setAttribute);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
@@ -63,7 +63,7 @@ public class OverrideAttributesSupportTest {
                 .getTitle(), is("updated"));
         assertThat(metacardMap.get("original")
                 .getResourceURI()
-                .toString(), is("content:stuff"));
+                .toString(), is("content:newstuff"));
         assertThat(metacardMap.get("original")
                 .getId(), is("original"));
         assertThat(metacardMap.get("original")
@@ -99,7 +99,7 @@ public class OverrideAttributesSupportTest {
                 .getTitle(), is("updated"));
         assertThat(metacardMap.get("original")
                 .getResourceURI()
-                .toString(), is("content:stuff"));
+                .toString(), is("content:newstuff"));
         assertThat(metacardMap.get("original")
                 .getId(), is("original"));
         assertThat(metacardMap.get("original")
@@ -128,7 +128,7 @@ public class OverrideAttributesSupportTest {
         assertThat(updatedMetacard.getMetadata(), is("updated"));
         assertThat(updatedMetacard.getTitle(), is("updated"));
         assertThat(updatedMetacard.getResourceURI()
-                .toString(), is("content:stuff"));
+                .toString(), is("content:newstuff"));
         assertThat(updatedMetacard.getId(), is("original"));
         assertThat(updatedMetacard.getMetacardType()
                 .getName(), is("ddf.metacard"));
@@ -155,7 +155,7 @@ public class OverrideAttributesSupportTest {
         assertThat(updatedMetacard.getMetadata(), is("updated"));
         assertThat(updatedMetacard.getTitle(), is("updated"));
         assertThat(updatedMetacard.getResourceURI()
-                .toString(), is("content:stuff"));
+                .toString(), is("content:newstuff"));
         assertThat(updatedMetacard.getId(), is("original"));
         assertThat(updatedMetacard.getMetacardType()
                 .getName(), is("other"));

--- a/catalog/plugin/catalog-plugin-content-uri/src/test/java/org/codice/ddf/catalog/content/plugin/uri/ContentUriAccessPluginTest.java
+++ b/catalog/plugin/catalog-plugin-content-uri/src/test/java/org/codice/ddf/catalog/content/plugin/uri/ContentUriAccessPluginTest.java
@@ -33,9 +33,11 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.plugin.StopProcessingException;
 
-public class TestContentUriAccessPlugin {
+public class ContentUriAccessPluginTest {
 
     public static final String ID_OR_URI = "ID_OR_URI";
+
+    public static final String CONTENT_URI = "content:abc123";
 
     private UpdateRequest input;
 
@@ -61,6 +63,14 @@ public class TestContentUriAccessPlugin {
     }
 
     @Test
+    public void bothUrisAreContentAndEqual() throws StopProcessingException, URISyntaxException {
+        when(updateCard.getResourceURI()).thenReturn(new URI(CONTENT_URI));
+        when(existingMetacard.getResourceURI()).thenReturn(new URI(CONTENT_URI));
+        contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
+        assertNoChanges();
+    }
+
+    @Test
     public void bothUrisNull() throws StopProcessingException {
         when(updateCard.getResourceURI()).thenReturn(null);
         when(existingMetacard.getResourceURI()).thenReturn(null);
@@ -68,26 +78,24 @@ public class TestContentUriAccessPlugin {
         assertNoChanges();
     }
 
-    @Test
+    @Test(expected = StopProcessingException.class)
     public void updateUriNull() throws StopProcessingException, URISyntaxException {
         when(updateCard.getResourceURI()).thenReturn(null);
-        when(existingMetacard.getResourceURI()).thenReturn(new URI(""));
+        when(existingMetacard.getResourceURI()).thenReturn(new URI(CONTENT_URI));
         contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
-        assertNoChanges();
     }
 
-    @Test
+    @Test(expected = StopProcessingException.class)
     public void existingUriNull() throws StopProcessingException, URISyntaxException {
-        when(updateCard.getResourceURI()).thenReturn(new URI(""));
+        when(updateCard.getResourceURI()).thenReturn(new URI(CONTENT_URI));
         when(existingMetacard.getResourceURI()).thenReturn(null);
         contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
-        assertNoChanges();
     }
 
     @Test
     public void existingUriNonContent() throws StopProcessingException, URISyntaxException {
-        when(updateCard.getResourceURI()).thenReturn(new URI(""));
-        when(existingMetacard.getResourceURI()).thenReturn(new URI(""));
+        when(updateCard.getResourceURI()).thenReturn(new URI(CONTENT_URI));
+        when(existingMetacard.getResourceURI()).thenReturn(new URI("blah:abc123"));
         contentUriAccessPlugin.processPreUpdate(input, existingMetacards);
         assertNoChanges();
     }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -715,7 +715,7 @@ public class RESTEndpoint implements RESTService {
                 if (multipartBody != null) {
                     List<Attachment> contentParts = multipartBody.getAllAttachments();
                     if (contentParts != null && contentParts.size() > 0) {
-                        createInfo = parseAttachment(contentParts.get(0));
+                        createInfo = parseAttachments(contentParts, transformerParam);
                     } else {
                         LOGGER.debug("No file contents attachment found");
                     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -2803,6 +2803,39 @@ public class TestCatalog extends AbstractIntegrationTest {
         deleteMetacard(id);
     }
 
+    @Test
+    public void testUpdateStorageCannotOverrideResourceUri()
+            throws IOException {
+        String fileName = testName.getMethodName() + ".jpg";
+        String overrideResourceUri = "content:abc123";
+        String overrideTitle = "overrideTitle";
+
+        File tmpFile = createTemporaryFile(fileName,
+                IOUtils.toInputStream(getFileContent(SAMPLE_IMAGE)));
+
+        String id = given().multiPart("parse.resource", tmpFile)
+                .multiPart(Core.TITLE, overrideTitle)
+                .multiPart(Core.RESOURCE_URI, overrideResourceUri)
+                .expect()
+                .log()
+                .headers()
+                .statusCode(HttpStatus.SC_CREATED)
+                .when()
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
+
+        given().multiPart("parse.resource", tmpFile)
+                .multiPart(Core.RESOURCE_URI, overrideResourceUri)
+                .expect()
+                .log()
+                .headers()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .when()
+                .put(REST_PATH.getUrl() + id);
+
+        deleteMetacard(id);
+    }
+
     private ValidatableResponse executeOpenSearch(String format, String... query) {
         StringBuilder buffer = new StringBuilder(OPENSEARCH_PATH.getUrl()).append("?")
                 .append("format=")


### PR DESCRIPTION
#### What does this PR do?
- Fix resource-uri being overriden by null update

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk @troymohl @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full Build.

#### Any background context you want to provide?
Existing `Metacard`'s URIs should not be able to be overridden in order to prevent resources with no references to it.

#### What are the relevant tickets?
[DDF-2745](https://codice.atlassian.net/browse/DDF-2745)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
