### PR TITLE
DDF-2645 Exposed Tika fallback metacard types as services

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -90,6 +90,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.transformer.common.tika.Mp4MetacardType"/>
             </list>
         </argument>
     </bean>
@@ -151,14 +152,55 @@
     </bean>
 
 
-    <service ref="commonMetacardType" interface="ddf.catalog.data.MetacardType">
+    <service ref="commonTikaMetacardType" interface="ddf.catalog.data.MetacardType">
         <service-properties>
-            <entry key="name" value="tika"/>
+            <entry key="name" value="fallback.common"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackExcelMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.excel"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackJpegMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.jpeg"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackMp4MetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.mp4"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackMpegMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.mpeg"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackOfficeDocMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.doc"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackPdfMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.pdf"/>
+        </service-properties>
+    </service>
+
+    <service ref="fallbackPowerpointMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="fallback.powerpoint"/>
         </service-properties>
     </service>
 
     <!-- Register the Transformers -->
     <service auto-export="interfaces" ref="tikaTransformer"/>
-
 
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
The Tika MetacardType beans were created, but not exposed. This change exposes those MetacardType beans as services.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brianfelix @gordocanchola @emmberk 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data) @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and use the tika transformer to ingest an Mp4 file. Then use Solr to confirm the Audio_Sample_Rate attribute is set.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2645](https://codice.atlassian.net/browse/DDF-2645)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests