### PR TITLE
DDF-2750 Fixed regenerated sources activation status

### DIFF
--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -192,19 +192,21 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
      * configurations if the right conditions are met but will never delete a configuration other
      * than for switching a configuration from enabled to disabled or vice-versa
      *
-     * @param metacard    Registry metacard with new service binding info
-     * @param createEvent Flag indicating if this was a metacard create or update event
+     * @param metacard       Registry metacard with new service binding info
+     * @param activationHint Flag indicating if the created/updated configuration should be activated.
+     *                       Configuration activation is not determined solely on this field but in
+     *                       conjunction with {@see setActivateConfigurations} and {@see setPreserveActiveConfigurations}.
      * @throws IOException
      * @throws InvalidSyntaxException
      * @throws ParserException
      */
-    private synchronized void updateRegistryConfigurations(Metacard metacard, boolean createEvent)
+    private synchronized void updateRegistryConfigurations(Metacard metacard, boolean activationHint)
             throws IOException, InvalidSyntaxException, ParserException {
         if(RegistryUtility.isIdentityNode(metacard)){
             return;
         }
 
-        boolean autoActivateConfigurations = activateConfigurations && (createEvent
+        boolean autoActivateConfigurations = activateConfigurations && (activationHint
                 || !preserveActiveConfigurations);
 
         List<ServiceBindingType> bindingTypes = registryTypeHelper.getBindingTypes(
@@ -690,7 +692,7 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
                     if (deleteOldConfig) {
                         deleteRegistryConfigurations(metacard);
                     }
-                    updateRegistryConfigurations(metacard, false);
+                    updateRegistryConfigurations(metacard, deleteOldConfig);
                 } catch (InvalidSyntaxException | ParserException | IOException e) {
                     LOGGER.debug(
                             "Unable to update registry configurations. Registry source configurations won't be updated for metacard id: {}",
@@ -799,7 +801,7 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
                                 + registryId);
             }
             deleteRegistryConfigurations(metacards.get(0));
-            updateRegistryConfigurations(metacards.get(0), false);
+            updateRegistryConfigurations(metacards.get(0), true);
         } catch (IOException | ParserException | InvalidSyntaxException e) {
             throw new FederationAdminException(
                     "Error regenerating sources for registry entry " + registryId, e);


### PR DESCRIPTION
#### What does this PR do?
Fixes the activation of sources after being regenerated
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@gordocanchola @mcalcote 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and start the Registry.
On the Node Information page create a secondary local node and add a service with a valid binding
Verify there is an source for the binding on the sources tab and activate it.
In Registry -> Configuration -> Registry Source Configuration Handler check the Activate Configurations checkbox
On the Node Information page click the Regenerate Sources and select the secondary node
Refresh the sources tab and verify there is still an active source for the secondary node binding.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2750#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
