### PR TITLE
DDF-2752 Removed terracotta-toolkit-runtime-ee dependency in catalog-ui-search

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -178,11 +178,6 @@
             <version>2.2.3</version>
         </dependency>
         <dependency>
-            <groupId>org.terracotta</groupId>
-            <artifactId>terracotta-toolkit-runtime-ee</artifactId>
-            <version>4.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>c3p0</groupId>
             <artifactId>c3p0</artifactId>
             <version>0.9.1.1</version>
@@ -263,7 +258,6 @@
                             quartz,
                             quartz-jobs,
                             c3p0,
-                            terracotta-toolkit-runtime-ee,
                             ddf-security-common
                         </Embed-Dependency>
                         <Web-ContextPath>/search/catalog</Web-ContextPath>
@@ -285,7 +279,6 @@
                             !org.jboss.*,
                             !javax.ejb.*,
                             !com.tc.*,
-                            !com.terracottatech.*,
                             !org.terracotta.*,
                             !org.apache.commons.cli.*,
                             !org.hibernate.*,


### PR DESCRIPTION
#### What does this PR do?
This PR removes the dependency on `terracotta-toolkit-runtime-ee` in `catalog-ui-search` that is causing the OWASP build to fail.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@taz77 @clockard @vinamartin 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Confirm full build succeeds.
#### Any background context you want to provide?
The EHCache dependency was removed in https://github.com/codice/ddf/pull/1588.
#### What are the relevant tickets?
[DDF-2752](https://codice.atlassian.net/browse/DDF-2752)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
