### PR TITLE
DDF-2755 Fixed workspace transformer merge bug

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceTransformer.java
@@ -174,7 +174,7 @@ public class WorkspaceTransformer {
                 .filter(Objects::nonNull)
                 .map(this::remapJsonEntry)
                 .filter(e -> e.getKey() != null && e.getValue() != null)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (left, right) -> left));
     }
 
     public List<Map<String, Object>> transform(List<Metacard> metacards) {


### PR DESCRIPTION
#### What does this PR do?
Causes workspace transformer to merge duplicate keys instead of throwing an exception. While our current and future system should try not to have duplicate keys, it was allowed in some legacy configurations so must be supported to deal with them. 
 - Now when encountering duplicate attribute descriptors, the workspace transformer will not throw an exception

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
anyone
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
ingest a duplicate attribute descriptor. log in to ui. attempt to create workspace and ensure it doesn't fail.
Example Attribute descriptor that duplicates a builtin descriptor that can be put into `etc/definitions`
```json
{
  "inject": [
    {
      "attribute": "effective"
    }
  ],
  "attributeTypes": {
    "effective": {
      "type": "DATE_TYPE",
      "display": "Date Published",
      "stored": true,
      "indexed": true,
      "tokenized": false,
      "multivalued": true
    }
  }
}
```

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2755
