### PR TITLE
DDF-2759: Feature configuration files are not always being processed

### DIFF
--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationFilesPoller.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationFilesPoller.java
@@ -72,10 +72,22 @@ public class ConfigurationFilesPoller implements Runnable {
         this.fileExtension = fileExtension;
     }
 
-    public void init() {
+    public void init() throws IOException {
         LOGGER.debug("Starting {}...",
                 this.getClass()
                         .getName());
+
+        try {
+            LOGGER.debug("Registering path [{}] with Watch Service.",
+                    configurationDirectoryPath.toString());
+            configurationDirectoryPath.register(watchService, ENTRY_CREATE);
+        } catch (IOException e) {
+            LOGGER.error("Unable to register path [{}] with Watch Service",
+                    configurationDirectoryPath.toString(),
+                    e);
+            throw e;
+        }
+
         executorService.execute(this);
     }
 
@@ -87,17 +99,6 @@ public class ConfigurationFilesPoller implements Runnable {
     @Override
     public void run() {
         try {
-            try {
-                LOGGER.debug("Registering path [{}] with Watch Service.",
-                        configurationDirectoryPath.toString());
-                configurationDirectoryPath.register(watchService, ENTRY_CREATE);
-            } catch (IOException e) {
-                LOGGER.info("Unable to register path [{}] with Watch Service",
-                        configurationDirectoryPath.toString(),
-                        e);
-                return;
-            }
-
             WatchKey key;
 
             while (!Thread.currentThread()


### PR DESCRIPTION
Moved the WatchService directory registration in the `ConfigurationFilesPoller` `init()` method to ensure that no file creation and/or modification events are missed.

#### What does this PR do?
Fixes a race condition in the ConfigurationFilesPoller class that could cause some configuration files to not be read in at system startup.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brjeter 
@oconnormi 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Full builds including all integration tests.

#### What are the relevant tickets?
[DDF-2759](https://codice.atlassian.net/browse/DDF-2759)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
