### PR TITLE
DDF-2331 Made thread pool and readLockInterval configurable in Content Directory Monitor

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -49,12 +49,10 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-osgi</artifactId>
-            <version>${camel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,6 +32,8 @@
         <cm:managed-component class="org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor"
                               init-method="init" destroy-method="destroy">
             <argument ref="camelContext"/>
+            <property name="numThreads" value="1"/>
+            <property name="readLockIntervalMilliseconds" value="1000"/>
             <property name="monitoredDirectoryPath" value=""/>
             <property name="attributeOverrides">
                 <list/>

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,6 +21,14 @@
             name="Directory Path" id="monitoredDirectoryPath" required="true"
             type="String" default=""/>
 
+        <AD description="Specifies the maximum number of concurrent files to be processed within a directory (maximum of 8).  If this number exceeds 8, 8 will be used in order to preserve system resources."
+            name="Maximum Concurrent Files" id="numThreads" required="true"
+            type="Integer" default="1"/>
+
+        <AD description="Specifies the time to wait (in milliseconds) before acquiring a lock on a file in the monitored directory.  This interval is used for sleeping between attempts to acquire the read lock on a file to be ingested.  The default value of 1000 milliseconds is recommended."
+            name="ReadLock Time Interval" id="readLockIntervalMilliseconds" required="true"
+            type="Integer" default="100"/>
+
         <AD description="Choose what happens to the content item after it is ingested. Delete will remove the original file after storing it in the content store. Move will store the item in the content store, and a copy under ./ingested, then remove the original file. (NOTE: this will double the amount of disk space used.) Monitor in place will index the file and serve it from its original location."
             name="Processing Mechanism" id="processingMechanism" required="false"
             type="String" default="in_place">

--- a/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
@@ -1,8 +1,8 @@
 
 === Directory Monitors
 
-====  Content Directory Monitor
-The Content Directory Monitor provides the capability to easily add content and metacards into the ${ddf-catalog} by placing a file in a directory.
+====  Content Directory Monitor (CDM)
+The Content Directory Monitor (CDM) provides the capability to easily add content and metacards into the ${ddf-catalog} by placing a file in a directory.
 
 ===== Installing the Content Directory Monitor
 
@@ -10,7 +10,7 @@ The Content Directory Monitor is installed by default with a standard installati
 
 ===== Configuring the Content Directory Monitor
 
-Configure the Content Directory Monitor from the ${admin-console}:
+Configure the CDM from the ${admin-console}:
 
 . Navigate to the *${admin-console}*.
 . Select the *${ddf-catalog}* application.
@@ -21,7 +21,7 @@ include::{adoc-include}/_tables/org.codice.ddf.catalog.content.monitor.ContentDi
 
 ===== Using the Content Directory Monitor
 
-The Content Directory Monitor processes files in a directory, and all of its sub-directories. The Content Directory Monitor offers three options:
+The CDM processes files in a directory, and all of its sub-directories. The CDM offers three options:
 
 * Delete
 * Move
@@ -47,8 +47,16 @@ Regardless of the option, the ${branding} takes each file in a monitored directo
 ** If the original file is modified, the metacard is updated to reflect the new content.
 ** If the original file is renamed, the old metacard is deleted and a new metacard is created.
 
-.Atribute Mapper
-The Content Directory Monitor supports setting metacard attributes directly when ${branding} ingests a file. Custom mappings are entered in the form:
+.Parallel Processing
+The CDM supports parallel processing of files (up to 8 files processed concurrently).  This is configured by setting the number of *Maximum Concurrent Files* in the configuration.  A maximum of 8 is imposed to protect system resources.
+
+.Read Lock
+When the CDM is set up, the directory specified is continuously scanned, and files are locked for processing based on the *ReadLock Time Interval*.  This does not apply to the *Monitor in place* processing directive.  Files will not be ingested without having a ReadLock that has observed no change in the file size.
+This is done so that files that are in transit will not be ingested prematurely.  It is recommended that the *ReadLock Time Interval* be set to a lower amount of time when the *Maximum Concurrent Files* is set above 1 so that files are
+locked in a timely manner and processed as soon as possible.  When a higher *ReadLock Time Interval* is set, the time it takes for files to be processed is increased.
+
+.Attribute Mapper
+The CDM supports setting metacard attributes directly when ${branding} ingests a file. Custom mappings are entered in the form:
 
 `*attribute-name=attribute-value*`
 
@@ -65,7 +73,7 @@ To set multi-valued attributes, use a separate override for each value. For exam
 `*topic.keyword=radiology*`
 
 .Errors
-If the directory monitor fails to read the file, an error will be logged in the ingest log. If the directory monitor is
+If the CDM fails to read the file, an error will be logged in the ingest log. If the directory monitor is
 configured to *Delete* or *Move*, the original file is also moved to the `\.errors` directory.
 
 .Other


### PR DESCRIPTION
#### What does this PR do?
This PR adds the ability to specify how many threads to use when configuring a Content Directory Monitor so files can be consumed in parallel.  It also reduces the default size of the readLockInterval to a more reasonable value. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / configure CDM with multiple threads / Observe Parallel Processing 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2331](https://codice.atlassian.net/browse/DDF-2331)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
