### PR TITLE
DDF-2644 Fixes issue with datepicker dependency that was switched to npm

### DIFF
--- a/catalog/ui/catalog-ui-search/package.json
+++ b/catalog/ui/catalog-ui-search/package.json
@@ -97,9 +97,9 @@
     "terraformer": "1.0.5",
     "terraformer-wkt-parser": "1.1.0",
     "uuid": "2.0.2",
-    "eonasdan-bootstrap-datetimepicker": "4.17.45",
     "openlayers": "3.20.1",
     "plotly.js": "1.10.5",
-    "vis": "4.15.0"
+    "vis": "4.15.0",
+    "eonasdan-bootstrap-datetimepicker": "Eonasdan/bootstrap-datetimepicker#4.17.37"
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/index.html
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/index.html
@@ -29,7 +29,7 @@
     <link href="lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
     <link href="lib/jquery-ui-multiselect-widget/jquery.multiselect.css" rel="stylesheet">
     <link href="lib/cesium-drawhelper/DrawHelper.css" rel="stylesheet"/>
-    <link href="lib/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css" rel="stylesheet"/>
+    <link href="lib/eonasdan-bootstrap-datetimepicker/css/bootstrap-datetimepicker.css" rel="stylesheet"/>
     
     <link href="css/index.css" rel="stylesheet">
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/bootstrapDatepicker.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/bootstrapDatepicker.less
@@ -1,11 +1,22 @@
 .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.bootstrap-datetimepicker-widget table td.day:hover,
-.bootstrap-datetimepicker-widget table td.hour:hover,
-.bootstrap-datetimepicker-widget table td.minute:hover,
-.bootstrap-datetimepicker-widget table td.second:hover,
-.bootstrap-datetimepicker-widget table td span:hover,
+.bootstrap-datetimepicker-widget table td:not(.active).day:hover,
+.bootstrap-datetimepicker-widget table td:not(.active).hour:hover,
+.bootstrap-datetimepicker-widget table td:not(.active).minute:hover,
+.bootstrap-datetimepicker-widget table td:not(.active).second:hover,
+.bootstrap-datetimepicker-widget table td:not(.active) span:not(.active):hover,
 .bootstrap-datetimepicker-widget {
   background: @dropdown-background-color;
+}
+
+.bootstrap-datetimepicker-widget .glyphicon.glyphicon-chevron-up,
+.bootstrap-datetimepicker-widget .glyphicon.glyphicon-chevron-down,
+.bootstrap-datetimepicker-widget .glyphicon.glyphicon-calendar,
+.bootstrap-datetimepicker-widget .glyphicon.glyphicon-time {
+  color: @primary-color;
+}
+
+.bootstrap-datetimepicker-widget .active {
+  background-color: @primary-color !important;
 }
 
 .bootstrap-datetimepicker-widget.dropdown-menu {

--- a/catalog/ui/catalog-ui-search/webpack/config/base.js
+++ b/catalog/ui/catalog-ui-search/webpack/config/base.js
@@ -21,6 +21,11 @@ module.exports = {
                 from: resolve('node_modules/cesium/Build/Cesium'),
                 to: resolve('target/webapp/cesium'),
                 force: true
+            },
+            {
+                from: resolve('node_modules/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css'),
+                to: resolve('target/webapp/lib/eonasdan-bootstrap-datetimepicker/css/bootstrap-datetimepicker.css'),
+                force: true
             }
         ])
     ],

--- a/catalog/ui/catalog-ui-search/yarn.lock
+++ b/catalog/ui/catalog-ui-search/yarn.lock
@@ -2767,14 +2767,14 @@ entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-eonasdan-bootstrap-datetimepicker@4.17.45:
-  version "4.17.45"
-  resolved "https://registry.yarnpkg.com/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.45.tgz#def7e1423c9f2943a9f8bf2925c61af030079773"
+eonasdan-bootstrap-datetimepicker@Eonasdan/bootstrap-datetimepicker#4.17.37:
+  version "4.17.37"
+  resolved "https://codeload.github.com/Eonasdan/bootstrap-datetimepicker/tar.gz/fd8bd86dd78f789fb742798b7d49aba0a957af62"
   dependencies:
     bootstrap "^3.3"
-    jquery "^1.8.3 || ^2.0"
-    moment "^2.10"
-    moment-timezone "^0.4.0"
+    jquery ">=1.8.3 <2.2.0"
+    moment "~2.8"
+    moment-timezone "~0.4"
 
 errno@^0.1.1, errno@^0.1.3:
   version "0.1.4"
@@ -4887,7 +4887,7 @@ jquery-ui@1.10.4:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.10.4.tgz#a096fe5f4e0f2ab69a0585cf10455877f57506bd"
 
-jquery@1.12.4, jquery@>=1.7.1, "jquery@^1.8.3 || ^2.0":
+jquery@1.12.4, jquery@>=1.7.1, "jquery@>=1.8.3 <2.2.0":
   version "1.12.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
 
@@ -5802,15 +5802,19 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment-timezone@^0.4.0:
+moment-timezone@~0.4:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
   dependencies:
     moment ">= 2.6.0"
 
-moment@2.13.0, "moment@>= 2.6.0", moment@^2.10:
+moment@2.13.0, "moment@>= 2.6.0":
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.13.0.tgz#24162d99521e6d40f99ae6939e806d2139eaac52"
+
+moment@~2.8:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.8.4.tgz#cc174aabb19223efff5699a9467805a2789838bf"
 
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What does this PR do?
 - The datepicker was switched from being resolved through bower to being resolved through npm recently, with https://github.com/codice/ddf/commit/fc8a567a9e76f4020cbe7f2a92b1d37b3939d470
 - Unfortunately, the css has been missing since that commit.  When I added the css back in using webpack, I noticed the datepicker had some regressions.  As such, I rolled it back to the original bower version.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@pklinef 
@djblue 
@rzwiefel 
@tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Check out the Catalog UI and ensure the datepicker has the correct css.