### PR TITLE
DDF-2762 Update workspace sharing inputs to update on change rather than keydown

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.view.js
@@ -31,13 +31,13 @@ define([
         template: '<input class="form-control" type="text"/>',
         modelEvents: { change: 'updateValue' },
         events: {
-            'keyup .form-control': 'onKeyup'
+            'change .form-control': 'onChange'
         },
         onRender: function () { this.updateValue(); },
         valueKey: function () {
             return this.options.valueKey || 'value';
         },
-        onKeyup: function (e) {
+        onChange: function (e) {
             this.model.set(this.valueKey(), e.target.value);
         },
         updateValue: function () {


### PR DESCRIPTION
#### What does this PR do?
 - Previously they updated after each keypress, which causes the cursor to move to the end of the line during typing.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@pklinef 
@rzwiefel 
@djblue 
@garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Go to the workspace sharing view.  Add an email.  Move the cursor to the center of the email and type.  Verify it doesn't move automatically to the end of the line.  Apply your change and verify the saving still works as it should.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2762