### PR TITLE
DDF-2739 Remove default bluemarble WMS tile server

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -26,7 +26,7 @@
             name="Imagery Providers"
             description='List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), GE (GoogleEarth). Example: {"type": "WMS", "url": "http://example.com", "layers": ["layer1", "layer2"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha": 0.5}'
             type="String"
-            default='[{ "type": "WMS"\, "url": "http://geoint.nrlssc.navy.mil/nrltileserver/wms"\, "layers": ["bluemarble"]\, "alpha": 1 }\, { "type": "OSM"\, "url": "http://a.tile.openstreetmap.org"\, "fileExtension": "png"\, "alpha": 0.3 }]'
+            default=''
             required="false"/>
 
         <AD id="terrainProvider"

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -1,7 +1,7 @@
 service.pid="org.codice.ddf.catalog.ui.config"
 resultCount=I"250"
 
-imageryProviders="[{\ \"type\":\ \"WMS\",\ \"url\":\ \"http://geoint.nrlssc.navy.mil/nrltileserver/wms\",\ \"layers\":\ [\"bluemarble\"],\ \"alpha\":\ 1\ },\ {\ \"type\":\ \"OSM\",\ \"url\":\ \"http://a.tile.openstreetmap.org\",\ \"fileExtension\":\ \"png\",\ \"alpha\":\ 0.3\ }]"
+imageryProviders=""
 terrainProvider="{\ \"type\":\ \"CT\",\ \"url\":\ \"http://assets.agi.com/stk-terrain/tilesets/world/tiles\"\ }"
 
 projection="EPSG:3857"

--- a/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
+++ b/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,8 @@ import org.codice.ddf.branding.BrandingRegistry;
 import org.codice.proxy.http.HttpProxyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.impl.BinaryContentImpl;
@@ -162,7 +165,7 @@ public class ConfigurationStore {
         config.put("resultCount", resultCount);
         config.put("typeNameMapping", typeNameMapping);
         config.put("terrainProvider", proxiedTerrainProvider);
-        config.put("imageryProviders", proxiedImageryProviders);
+        config.put("imageryProviders", getProxiedImageryProviders());
         config.put("gazetteer", isGazetteer);
         config.put("showIngest", isIngest);
         config.put("projection", projection);
@@ -214,7 +217,16 @@ public class ConfigurationStore {
     }
 
     public List<Map<String, Object>> getProxiedImageryProviders() {
-        return proxiedImageryProviders;
+        if (proxiedImageryProviders.isEmpty()) {
+            return Collections.singletonList(ImmutableMap.of(
+                    "type", "SI",
+                    "url", "/search/standard/images/natural_earth_50m.png",
+                    "parameters", ImmutableMap.of(
+                            "imageSize", Arrays.asList(10800, 5400)),
+                    "alpha", 1));
+        } else {
+            return proxiedImageryProviders;
+        }
     }
 
     public List<String> getImageryProviders() {

--- a/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -41,7 +41,7 @@
         <property name="branding" ref="brandingRegistry"/>
         <property name="httpProxy" ref="httpProxyService"/>
         <property name="imageryProviders"
-                  value='{"type" "WMS" "url" "http://geoint.nrlssc.navy.mil/nrltileserver/wms" "layers" ["bluemarble"]  "alpha" 1},{"type" "OSM" "url" "http://a.tile.openstreetmap.org" "fileExtension" "png" "alpha" 0.3 }'/>
+                  value=''/>
         <property name="terrainProvider"
                   value='{"type" "CT" "url" "http://assets.agi.com/stk-terrain/tilesets/world/tiles"}'/>
     </bean>

--- a/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
         <AD name="Imagery Providers" id="imageryProviders"
             required="false" type="String" cardinality="10000"
             description='List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), GE (GoogleEarth). Example: {"type" "WMS" "url" "http://example.com" "layers" ["layer1" "layer2"] "parameters" {"FORMAT" "image/png" "VERSION" "1.1.1"} "alpha" 0.5}'
-            default='{"type" "WMS" "url" "http://geoint.nrlssc.navy.mil/nrltileserver/wms" "layers" ["bluemarble"]  "alpha" 1},{"type" "OSM" "url" "http://a.tile.openstreetmap.org" "fileExtension" "png" "alpha" 0.3 }'
+            default=''
         />
 
         <AD name="Terrain Provider" id="terrainProvider"

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -20,7 +20,7 @@
 |imageryProviders
 |String
 |List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), GE (GoogleEarth). Example: {"type": "WMS", "url": "http://example.com", "layers": ["layer1", "layer2"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha": 0.5}
-|[{ "type": "WMS"\, "url": "http://geoint.nrlssc.navy.mil/nrltileserver/wms"\, "layers": ["bluemarble"]\, "alpha": 1 }\, { "type": "OSM"\, "url": "http://a.tile.openstreetmap.org"\, "fileExtension": "png"\, "alpha": 0.3 }]
+|
 |false
 
 |Terrain Provider


### PR DESCRIPTION
#### What does this PR do?
Removes the bluemarble tile layer and have the cesium globe rely on the default Natural Earth image.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @gordocanchola @vinamartin @brianfelix @emmberk @taz77 @cruzj6 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui) @garrettfreibott 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@pklinef 
 
#### How should this be tested? (List steps with links to updated documentation)
Install a default DDF, then load the Search UIs and confirm the static Natural Earth image is visible on the cesium globe. 

#### Any background context you want to provide?

The Standard and Catalog UIs had a default bluemarble WMS tile server configured that was unreliable and lead to no globe appearing at all. This tile server was removed, but not replaced since additional considerations would have to be made regarding proper attribution and usage of alternatives. Natural Earth maps are in the public domain, require no permission and no attribution. http://www.naturalearthdata.com/about/terms-of-use/

#### What are the relevant tickets?
[2739](https://codice.atlassian.net/browse/2739)

#### Screenshots (if appropriate)
![screen shot 2017-02-02 at 6 21 55 am](https://cloud.githubusercontent.com/assets/11355332/22551394/e2cf8a76-e911-11e6-92dd-a75409d8907a.png)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
