### PR TITLE
DDF-2763 Updates standing searches to retry when query status is unsuccessful

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/QueryPolling.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/QueryPolling.js
@@ -131,7 +131,7 @@ define([
 
     checkForFailures = function(responses, originalQuery, timeRange) {
         _.forEach(responses, function(response) {
-            if (response[1] === "error") {
+            if (response[1] === "error" || !response[0].status.successful) {
                 var srcId = JSON.parse(response[0].options.data).src;
                 addFailure(srcId, originalQuery, timeRange);
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -614,7 +614,8 @@ define([
                         method: "POST",
                         processData: false,
                         timeout: properties.timeout,
-                        success: function(model, resp, options) {
+                        success: function(model, response, options) {
+                            response.options = options;
                             if (options.resort === true){
                                 model.get('results').fullCollection.sort();
                             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Sources.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Sources.js
@@ -61,7 +61,9 @@ define([
         initialize: function () {
           this._types = new Types();
             poller.get(this, {
-                delay: properties.sourcePollInterval
+                delay: properties.sourcePollInterval,
+                delayed: properties.sourcePollInterval,
+                continueOnError: true
             }).start();
             this.determineLocalCatalog();
             this.fetch({async: false});


### PR DESCRIPTION
 - Previously they only retried when the network request failed.  Now they will retry if the request succeeded, but the query status says unsuccessful.
 - Also updates the Sources polling to continueOnError rather than stop.
 - Updates Source polling to not begin immediately, since we fetch immediately.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 
@rzwiefel 
@jlcsmith 
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Add a standing search.  Cause it to fail but still return a 200.  Ensure that when queries can once again run successfully, a retry is made for the failed time range.

#### Any background context you want to provide?
Previously the retries were only made when network requests outright failed.  Now they will happen if the status of a query is unsuccessful as well.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2763
