### PR TITLE
DDF-2057 Replace use of .includes function in handlebars with .indexOf for IE compatibility

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/HandlebarsHelpers.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/HandlebarsHelpers.js
@@ -26,7 +26,7 @@ define([
                 }
             },
             containsCsw: function(value, options) {
-                if (value.includes("CSW")) {
+                if (value.indexOf("CSW") >= 0) {
                     return options.fn(this);
                 } else {
                     return options.inverse(this);


### PR DESCRIPTION
#### What does this PR do?
Replaces the use of the .includes() javascript function in the Remote Registry modal. This function is not supported by Internet Explorer and would cause the modal not to open.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @brianfelix @vinamartin @gordocanchola @emmberk @cruzj6 @taz77 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui) @garrettfreibott 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Boot DDF and install the Registry, then navigate to the Remote Registries tab in the Registry App. Click the `+` button to Add a remote Registry. The modal should open and the browser console should be free of .include( errors.

#### Any background context you want to provide?
This change is specifically for IE10, but should be confirmed in Chrome & FF.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility

#### What are the relevant tickets?
[2057](https://codice.atlassian.net/browse/2057)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
