### PR TITLE
DDF-2745: Fix itest request timing issue.

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -2962,14 +2962,19 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .post(REST_PATH.getUrl())
                 .getHeader("id");
 
-        given().multiPart("parse.resource", tmpFile)
-                .multiPart(Core.RESOURCE_URI, overrideResourceUri)
-                .expect()
-                .log()
-                .headers()
-                .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .when()
-                .put(REST_PATH.getUrl() + id);
+        expect("Sending bad HTTP PUT request with overridden resource-uri").within(1,
+                TimeUnit.MINUTES)
+                .until(() -> {
+                    Response response = given().multiPart("parse.resource", tmpFile)
+                            .multiPart(Core.RESOURCE_URI, overrideResourceUri)
+                            .expect()
+                            .log()
+                            .headers()
+                            .when()
+                            .put(REST_PATH.getUrl() + id);
+
+                    return response.getStatusCode() == HttpStatus.SC_BAD_REQUEST;
+                });
 
         deleteMetacard(id);
     }


### PR DESCRIPTION
#### What does this PR do?
- Fixes a flaky test that attempted to update a Metacard immediately after ingesting it, which caused it to fail sometimes.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk @mweser

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Run `TestCatalog` integration tests.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2745](https://codice.atlassian.net/browse/DDF-2745)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
