### PR TITLE
DDF-2765 CSW and WFS forceSpatialFilter should default to NO_FILTER instead of null

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -66,7 +66,7 @@
                 </bean>
             </property>
             <property name="isCqlForced" value="false"/>
-            <property name="forceSpatialFilter" value=""/>
+            <property name="forceSpatialFilter" value="NO_FILTER"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
             <property name="securityManager" ref="securityManager"/>
@@ -154,7 +154,7 @@
                 </bean>
             </property>
             <property name="isCqlForced" value="false"/>
-            <property name="forceSpatialFilter" value=""/>
+            <property name="forceSpatialFilter" value="NO_FILTER"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
             <property name="securityManager" ref="securityManager"/>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,7 +48,7 @@
             </property>
             <property name="featureConverterFactoryList" ref="converterList"/>
             <property name="pollInterval" value="5"/>
-            <property name="forceSpatialFilter" value=""/>
+            <property name="forceSpatialFilter" value="NO_FILTER"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
             <argument ref="encryptionService"/>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -54,7 +54,7 @@
             </property>
             <property name="featureConverterFactoryList" ref="converterList"/>
             <property name="pollInterval" value="5"/>
-            <property name="forceSpatialFilter" value=""/>
+            <property name="forceSpatialFilter" value="NO_FILTER"/>
             <property name="metacardToFeatureMapper" ref="metacardToFeatureMappers"/>
             <property name="coordinateOrder" value="LAT_LON"/>
             <property name="disableSorting" value="false"/>


### PR DESCRIPTION
#### What does this PR do?
Sets the default value of the forceSpatialFilter property of a CSW source instead of leaving it null.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @bdeining @djblue 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[IO](https://github.com/orgs/codice/teams/IO)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
This default value prevents the successful creation of CSW sources that do not specifically assign this value and do not use the Admin Console source creator (Where it's populated via the metatype).
#### What are the relevant tickets?
[DDF-2765](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
