### PR TITLE
DDF-2612 Fixed CachingFederationStrategy source id issue and added itest to verify cache works

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -14,7 +14,6 @@
 package ddf.catalog.cache.solr.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -241,7 +240,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
                     QueryRequest sourceQueryRequest = new QueryRequestImpl(modifiedQuery,
                             queryRequest.isEnterprise(),
-                            Collections.singleton(source.getId()),
+                            new HashSet<>(queryRequest.getSourceIds()),
                             new HashMap<>(queryRequest.getProperties()));
                     try {
                         for (PreFederatedQueryPlugin service : preQuery) {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -268,6 +268,10 @@ public abstract class AbstractIntegrationTest {
             HTTP_PORT,
             "/services");
 
+    public static final DynamicUrl SEARCH_ROOT = new DynamicUrl(SECURE_ROOT,
+            HTTPS_PORT,
+            "/search");
+
     public static final DynamicUrl REST_PATH = new DynamicUrl(SERVICE_ROOT, "/catalog/");
 
     public static final DynamicUrl OPENSEARCH_PATH = new DynamicUrl(REST_PATH, "query");


### PR DESCRIPTION
#### What does this PR do?
Fixes CachingFederationStrategy so metacard cache queries will have the right source ids.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining @mcalcote 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Verify itests pass
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2612)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
