### PR TITLE
DDF-2766 Removes incorrect line from Landing Page docs

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.distribution.landing-page.properties-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.distribution.landing-page.properties-table-contents.adoc
@@ -68,7 +68,7 @@
 |Additional Links
 |links
 |String
-|Additional links to be displayed on the landing page. Use the format <text>,<link> (e.g. `example`, `http://www.example.com`). If no comma is present, the text and link are assumed to be the same. Empty entries are ignored.
+|Additional links to be displayed on the landing page. Use the format <text>,<link> (e.g. `example`, `http://www.example.com`). Empty entries are ignored.
 |
 |yes
 |===


### PR DESCRIPTION
#### What does this PR do?

Removes an incorrect line in the Landing Page documentation. The format is strictly enforced on the landing page so prior to this change this documentation did not reflect the actual behavior.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@spearskw @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

@ricklarsen 
[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 
#### How should this be tested? (List steps with links to updated documentation)
Follow the documentation instructions for configuring the landing page with this update, and verify that using the given format works.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2766)