### PR TITLE
DDF-2769 Validation problems not shown in Search UI "Quality" tab

### DIFF
--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronReport.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronReport.java
@@ -68,10 +68,9 @@ public interface SchematronReport {
     public String getReportAsText() throws TransformerException;
 
     /**
-     * If the Schematron report is uninitialized or, if initialized, the report
-     * has no failed assertions for errors and no failed reports for errors.
+     * If the Schematron report is uninitialized
      *
-     * @return True is there are not errors OR the report is uninitialized.
+     * @return True is the report is uninitialized.
      */
     boolean isEmpty();
 }

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronReport.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronReport.java
@@ -27,9 +27,7 @@ public interface SchematronReport {
      * the suppressWarnings argument is true, then Schematron warnings are also included in the
      * document's validity assessment.
      *
-     * @param suppressWarnings
-     *            do not include Schematron warnings in determining validity
-     *
+     * @param suppressWarnings do not include Schematron warnings in determining validity
      * @return true if no assert or report error messages found in SVRL report, false otherwise
      */
     public boolean isValid(boolean suppressWarnings);
@@ -69,4 +67,11 @@ public interface SchematronReport {
      */
     public String getReportAsText() throws TransformerException;
 
+    /**
+     * If the Schematron report is uninitialized or, if initialized, the report
+     * has no failed assertions for errors and no failed reports for errors.
+     *
+     * @return True is there are not errors OR the report is uninitialized.
+     */
+    boolean isEmpty();
 }

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -274,11 +274,6 @@ public class SchematronValidationService
         }
     }
 
-    public SchematronReport getSchematronReport() {
-        ;
-        return schematronReport;
-    }
-
     @Override
     public void validate(Metacard metacard) throws ValidationException {
 
@@ -342,6 +337,11 @@ public class SchematronValidationService
 
     private SchematronReport generateReport(String metadata, Templates validator)
             throws SchematronValidationException {
+
+        if (StringUtils.isEmpty(metadata)) {
+            return new SvrlReport();
+        }
+
         XMLReader xmlReader = null;
         try {
             XMLReader xmlParser = XMLReaderFactory.createXMLReader();

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -45,6 +45,7 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.services.common.Describable;
 import org.codice.ddf.platform.util.XMLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,6 @@ import org.xml.sax.helpers.XMLReaderFactory;
 import com.google.common.collect.ImmutableSet;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.util.Describable;
 import ddf.catalog.validation.MetacardValidator;
 import ddf.catalog.validation.ReportingMetacardValidator;
 import ddf.catalog.validation.ValidationException;
@@ -390,7 +390,8 @@ public class SchematronValidationService
         } catch (ValidationException e) {
             LOGGER.warn("Exception validating metacard ID {}\n{}",
                     metacard.getId(),
-                    e.getLocalizedMessage());
+                    e.getLocalizedMessage(),
+                    e);
         }
 
         return Optional.ofNullable(report);

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SchematronValidationService.java
@@ -315,8 +315,8 @@ public class SchematronValidationService
         MetacardValidationReportImpl report = new MetacardValidationReportImpl();
         Set<String> attributes = ImmutableSet.of("metadata");
         String metadata = metacard.getMetadata();
-        boolean canBeValidated = StringUtils.isNotEmpty(metadata) && namespace != null
-                && namespace.equals(XMLUtils.getRootNamespace(metadata));
+        boolean canBeValidated = StringUtils.isNotEmpty(metadata) || namespace == null
+                || namespace.equals(XMLUtils.getRootNamespace(metadata));
         if (canBeValidated) {
             try {
                 for (Future<Templates> validator : validators) {

--- a/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SvrlReport.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/java/ddf/services/schematron/SvrlReport.java
@@ -40,13 +40,16 @@ import org.w3c.dom.NodeList;
  * validation.
  *
  * @author rodgersh
- *
  */
 public class SvrlReport implements SchematronReport {
-    /** SVRL report tag for assertion that failed during Schematron validation */
+    /**
+     * SVRL report tag for assertion that failed during Schematron validation
+     */
     private static final String ASSERT_FAIL_TAG = "svrl:failed-assert";
 
-    /** SVRL report tag for report that failed during Schematron validation */
+    /**
+     * SVRL report tag for report that failed during Schematron validation
+     */
     private static final String REPORT_FAIL_TAG = "svrl:failed-report";
 
     /**
@@ -57,7 +60,7 @@ public class SvrlReport implements SchematronReport {
 
     /**
      * Value for svrl:failed-assert tag's flag attribute for warnings.
-     *
+     * <p>
      * Example: <svrl:failed-assert test="if(invalid) then 1 else not($hasInvalids)" flag="warning">
      * ... </svrl:failed-assert>
      */
@@ -65,7 +68,7 @@ public class SvrlReport implements SchematronReport {
 
     /**
      * Value for svrl:failed-assert tag's flag attribute for errors
-     *
+     * <p>
      * Example: <svrl:failed-assert test="if(invalid) then 1 else not($hasInvalids)" flag="error">
      * ... </svrl:failed-assert>
      */
@@ -73,28 +76,27 @@ public class SvrlReport implements SchematronReport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SvrlReport.class);
 
-    /** Schematron report in DOM format */
+    /**
+     * Schematron report in DOM format
+     */
     private DOMResult report;
 
-    /** The root element of the report's DOM tree. */
+    /**
+     * The root element of the report's DOM tree.
+     */
     private Element root = null;
 
     /**
-     * Private default constructor to prevent instantiating SvrlReport without required DOMResult
-     * argument.
-     */
-    private SvrlReport() {
-
-    }
-
-    /**
-     * @param result
-     *            DOM-formatted results from Schematron validation
+     * @param result DOM-formatted results from Schematron validation
      */
     public SvrlReport(DOMResult result) {
         this.report = result;
         this.root = (Element) report.getNode()
                 .getFirstChild();
+    }
+
+    public SvrlReport() {
+
     }
 
     /**
@@ -103,9 +105,7 @@ public class SvrlReport implements SchematronReport {
      * the suppressWarnings argument is true, then Schematron warnings are also included in the
      * document's validity assessment.
      *
-     * @param suppressWarnings
-     *            do not include Schematron warnings in determining validity
-     *
+     * @param suppressWarnings do not include Schematron warnings in determining validity
      * @return true if no assert or report error messages found in SVRL report, false otherwise
      */
     @Override
@@ -143,11 +143,14 @@ public class SvrlReport implements SchematronReport {
      * Retrieve only the specified type of assertion messages (warnings or errors) from the SVRL
      * report.
      *
-     * @parameter type the type of assert message to search for in SVRL report, "warning" or "error"
      * @return list of XML Nodes for all assert nodes of specified type
+     * @parameter type the type of assert message to search for in SVRL report, "warning" or "error"
      */
     public List<Node> getAllAssertMessages(String type) {
-        List<Node> assertions = new ArrayList<Node>();
+        List<Node> assertions = new ArrayList<>();
+        if (isEmpty()) {
+            return assertions;
+        }
 
         NodeList assertFailures = getAllAssertMessages();
         for (int i = 0; i < assertFailures.getLength(); i++) {
@@ -177,8 +180,8 @@ public class SvrlReport implements SchematronReport {
      * Retrieve only the specified type of report messages (warnings or errors) from the SVRL
      * report.
      *
-     * @parameter type the type of report message to search for in SVRL report, "warning" or "error"
      * @return list of XML Nodes for all report nodes
+     * @parameter type the type of report message to search for in SVRL report, "warning" or "error"
      */
     public List<Node> getAllReportMessages(String type) {
         List<Node> reports = new ArrayList<Node>();
@@ -204,7 +207,11 @@ public class SvrlReport implements SchematronReport {
      */
     @Override
     public List<String> getErrors() {
-        List<String> errors = new ArrayList<String>();
+        List<String> errors = new ArrayList<>();
+
+        if (isEmpty()) {
+            return errors;
+        }
 
         List<Node> errorAssertions = getAllAssertMessages(ERROR_FLAG_ATTR_TEXT);
         for (Node error : errorAssertions) {
@@ -228,20 +235,26 @@ public class SvrlReport implements SchematronReport {
      */
     @Override
     public List<String> getWarnings() {
-        List<String> warnings = new ArrayList<String>();
+        List<String> warnings = new ArrayList<>();
+
+        if (isEmpty()) {
+            return warnings;
+        }
 
         List<Node> warningAssertions = getAllAssertMessages(WARNING_FLAG_ATTR_TEXT);
         for (Node warning : warningAssertions) {
-            LOGGER.debug("warning(from assertions) = {}", warning.getFirstChild()
-                    .getTextContent());
+            LOGGER.debug("warning(from assertions) = {}",
+                    warning.getFirstChild()
+                            .getTextContent());
             warnings.add(warning.getFirstChild()
                     .getTextContent());
         }
 
         List<Node> warningReports = getAllReportMessages(WARNING_FLAG_ATTR_TEXT);
         for (Node warning : warningReports) {
-            LOGGER.debug("warning(from reports) = {}", warning.getFirstChild()
-                    .getTextContent());
+            LOGGER.debug("warning(from reports) = {}",
+                    warning.getFirstChild()
+                            .getTextContent());
             warnings.add(warning.getFirstChild()
                     .getTextContent());
         }
@@ -269,6 +282,11 @@ public class SvrlReport implements SchematronReport {
         out.close();
 
         return sw.toString();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return root == null;
     }
 
 };

--- a/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,8 +17,11 @@
 
     <cm:managed-service-factory
             id="ddf.services.schematron.SchematronValidationService"
-            factory-pid="ddf.services.schematron.SchematronValidationService"
-            interface="ddf.catalog.validation.MetacardValidator">
+            factory-pid="ddf.services.schematron.SchematronValidationService">
+        <interfaces>
+            <value>ddf.catalog.validation.MetacardValidator</value>
+            <value>ddf.catalog.validation.ReportingMetacardValidator</value>
+        </interfaces>
         <service-properties>
             <cm:cm-properties persistent-id="ddf.services.schematron.SchematronValidationService"/>
         </service-properties>


### PR DESCRIPTION
The validation  errors and warnings do not show on the "Quality" tab of the catalog search UI because the schema and schematron validators do not implement the ReportingMetacardValidator interface.
#### What does this PR do?
Implements the ReportingMetacardValidator in several classes and updates their service definitions.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@emanns95 
@AzGoalie 
@mweser 
#### Select at least one member from relevant component team(s) from below (at least one 
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Ingest files with schema or schematron warnings.
Retrieve them as metacards in the catalog search UI.
Navigate to the "Quality" tab on the results page.
The expected result is that the warnings are displayed in the tab.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2769
#### Screenshots (if appropriate)
