### PR TITLE
DDF-2774: client.bat script does not give access to the DDF console

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
@@ -77,7 +77,7 @@ setx JAVA_HOME "<PATH_TO_JAVA><JAVA_VERSION>" /m
 setx PATH "%PATH%;%JAVA_HOME%\bin" /m
 ----
 +
-. Restart Terminal(shell) or Command Prompt.
+. Restart Terminal (shell) or Command Prompt.
 
 * Verify that the `JAVA_HOME` was set correctly.
 ====
@@ -200,9 +200,9 @@ unzip ${branding-lowercase}-${project.version}.zip
 DO NOT use the windows zip utility bundled with windows to unzip {branding}.
 Unzipping {branding} using the windows zip utility will cause unexpected behavior and errors in {branding}!
 
-.Use Java to Unzip in Windows(Replace `<JAVA_VERSION>` with Current Version)
+.Use Java to Unzip in Windows
 ----
-"<PATH_TO_JAVA>\jdk\<JAVA_VERSION>\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
+"%JAVA_HOME%\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
 ----
 
 The unzipping process may take time to complete.

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -31,7 +31,7 @@ Alternatively, to run ${branding} as a background service, run the `start` scrip
 
 [NOTE]
 ====
-If console access is needed while running as a service, run the `client` script:
+If console access is needed while running as a service, run the `client` script on the host where the ${branding} is running:
 
 .*NIX
 ----
@@ -42,6 +42,8 @@ If console access is needed while running as a service, run the `client` script:
 ----
 <${branding}_HOME>/bin/client.bat -h localhost
 ----
+
+If running the `client` script form a different host, use the `-h` option followed by the name or IP of the host where ${branding} is running.
 ====
 
 ==== Stopping ${branding}

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -40,7 +40,7 @@ If console access is needed while running as a service, run the `client` script:
 
 .Windows
 ----
-<${branding}_HOME>/bin/client.bat
+<${branding}_HOME>/bin/client.bat -h localhost
 ----
 ====
 


### PR DESCRIPTION
#### What does this PR do?
Updates the documentation to show that the `-h localhost` option must be used on Windows when running `client.bat`.
Also addressed a few other minor issues in the installation documentation related to Windows.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Joy603 
@brjeter 
@ricklarsen 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
Build the documentation and make sure information is accurate.

#### What are the relevant tickets?
[DDF-2774](https://codice.atlassian.net/browse/DDF-2774)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
