### PR TITLE
DDF-2775 Update to ensure actions displayed in the catalog/search ui are appropriate for the metacards tag.

### DIFF
--- a/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
+++ b/catalog/core/catalog-core-actions/src/main/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProvider.java
@@ -111,7 +111,8 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
      * {@inheritDoc}
      */
     public <T> boolean canHandle(T subject) {
-        return (subject instanceof Metacard) && (canHandleMetacard((Metacard) subject));
+        return (subject instanceof Metacard) && isResourceMetacard((Metacard) subject)
+                && canHandleMetacard((Metacard) subject);
     }
 
     /**
@@ -183,5 +184,11 @@ public abstract class AbstractMetacardActionProvider implements ActionProvider {
         }
 
         return SystemInfo.getSiteName();
+    }
+
+    private boolean isResourceMetacard(Metacard metacard) {
+        return metacard.getTags() == null || metacard.getTags()
+                .isEmpty() || metacard.getTags()
+                .contains(Metacard.DEFAULT_TAG);
     }
 }

--- a/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
+++ b/catalog/core/catalog-core-actions/src/test/java/org/codice/ddf/catalog/actions/AbstractMetacardActionProviderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
@@ -69,6 +70,7 @@ public class AbstractMetacardActionProviderTest {
     public void setup() {
         when(metacard.getId()).thenReturn(METACARD_ID);
         when(metacard.getSourceId()).thenReturn(SOURCE_ID);
+        when(metacard.getTags()).thenReturn(Collections.singleton(Metacard.DEFAULT_TAG));
     }
 
     private class MetacardActionProvider extends AbstractMetacardActionProvider {
@@ -136,6 +138,15 @@ public class AbstractMetacardActionProviderTest {
 
         assertThat(actionProvider.canHandle(metacard), is(true));
         verify(actionProvider).canHandleMetacard(metacard);
+    }
+
+    @Test
+    public void canHandleMetacardWithoutResourceTag() {
+        MetacardActionProvider actionProvider = createMetacardActionProvider();
+        when(metacard.getTags()).thenReturn(Collections.singleton("my-tag"));
+
+        assertThat(actionProvider.canHandle(metacard), is(false));
+        verify(actionProvider, never()).canHandleMetacard(metacard);
     }
 
     @Test

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestMetacardTransformerActionProvider.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Collections;
 
 import org.apache.commons.lang.CharEncoding;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -60,6 +61,7 @@ public class TestMetacardTransformerActionProvider extends AbstractActionProvide
 
         when(metacard.getId()).thenReturn(METACARD_ID);
         when(metacard.getSourceId()).thenReturn(REMOTE_SOURCE_ID);
+        when(metacard.getTags()).thenReturn(Collections.singleton(Metacard.DEFAULT_TAG));
 
         actionUrl = getUrl(METACARD_ID);
 

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/action/TestViewMetacardActionProvider.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Collections;
 
 import org.apache.commons.lang.CharEncoding;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -58,6 +59,7 @@ public class TestViewMetacardActionProvider extends AbstractActionProviderTest {
 
         when(metacard.getId()).thenReturn(METACARD_ID);
         when(metacard.getSourceId()).thenReturn(REMOTE_SOURCE_ID);
+        when(metacard.getTags()).thenReturn(Collections.singleton(Metacard.DEFAULT_TAG));
 
         actionUrl = getUrl(METACARD_ID);
 

--- a/catalog/spatial/registry/registry-ebrim-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-ebrim-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,6 +43,7 @@
             <entry key="id" value="rim:RegistryPackage"/>
             <entry key="mime-type" value="text/xml"/>
             <entry key="schema" value="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"/>
+            <entry key="generateActionProvider" value="false"/>
         </service-properties>
         <bean class="org.codice.ddf.registry.transformer.RegistryTransformer">
             <property name="parser" ref="xmlParser"/>


### PR DESCRIPTION
#### What does this PR do?
Adds service property to the RegistryTransformer service so it doesn't get displayed as an action for normal metacards. Updated the AbstractMetacardActionProvider so it will only return true for canHandle if the metacard is a resource metacard. Non resource metacards would fail if these actions were attempted.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @gordocanchola 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Install DDF, include the Registry in the  install.
In the Admin UI Standard Search UI->Catalog UI Search remove 'metacard-tags' from the Hidden Fields. 
Go to the Catalog UI and upload a file. 
Perform a search and go to the actions tab of that result and verify that Export as rim:RegistryPackage is not present.
Update your search by going to the advanced tab and adding another clause of metacard-tags contains registry.
Rerun the search. You should only get back one registry metacard. Verify that it only has one action and it works.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2775](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
