### PR TITLE
DDF-2776 Change constant for Associations.EXTERNAL from metacard.associations.external to associations.external

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Associations.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/Associations.java
@@ -37,5 +37,5 @@ public interface Associations {
     /**
      * {@link ddf.catalog.data.Attribute} name for accessing the external associations of the {@link Metacard}. <br/>
      */
-    String EXTERNAL = "metacard.associations.external";
+    String EXTERNAL = "associations.external";
 }

--- a/distribution/docs/src/main/resources/_contents/_data/associations-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/associations-attributes-table-contents.adoc
@@ -11,13 +11,13 @@
 |Constraints
 |Example Value
 
-|associations.derived
+|metacard.associations.derived
 |ID of one or more metacards derived from this metacard.
 |List of Strings
 |A valid metacard ID (conventionally, a type 4 random UUID with hyphens removed).
 |70809f17782c42b8ba15747b86b50ebf
 
-|associations.related
+|metacard.associations.related
 |ID of one or more metacards related to this metacard.
 |List of Strings
 |A valid metacard ID (conventionally, a type 4 random UUID with hyphens removed).


### PR DESCRIPTION
#### What does this PR do?
DDF-2776 Change constant for Associations.EXTERNAL from metacard.associations.external to associations.external
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Data](https://github.com/orgs/codice/teams/data)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 
#### How should this be tested? (List steps with links to updated documentation)
Verify build passes
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2776](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
