### PR TITLE
DDF-2778 Added support for WMTS EPSG:4326 in Cesium

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -15,8 +15,9 @@
 define(['underscore',
     'marionette',
     'cesium',
-    'js/controllers/common.layerCollection.controller'
-], function (_, Marionette, Cesium, CommonLayerController) {
+    'js/controllers/common.layerCollection.controller',
+    'properties'
+], function (_, Marionette, Cesium, CommonLayerController, properties) {
     "use strict";
 
     var imageryProviderTypes = {
@@ -45,6 +46,12 @@ define(['underscore',
             this.collection.forEach(function (model) {
                 var type = imageryProviderTypes[model.get('type')];
                 var initObj = _.omit(model.attributes, 'type', 'label', 'index', 'modelCid');
+
+                /* Set the tiling scheme for WMTS imagery providers that are EPSG:4326 */
+                if(model.get('type') === "WMT" && properties.projection === "EPSG:4326") {
+                    initObj.tilingScheme = new Cesium.GeographicTilingScheme();
+                }
+
                 var provider = new type(initObj);
                 var layer = this.map.imageryLayers.addImageryProvider(provider);
                 this.layerForCid[model.id] = layer;

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -15,8 +15,9 @@
 define(['underscore',
     'marionette',
     'cesium',
-    'js/controllers/common.layerCollection.controller'
-], function (_, Marionette, Cesium, CommonLayerController) {
+    'js/controllers/common.layerCollection.controller',
+    'properties'
+], function (_, Marionette, Cesium, CommonLayerController, properties) {
     "use strict";
 
     var imageryProviderTypes = {
@@ -45,6 +46,12 @@ define(['underscore',
             this.collection.forEach(function (model) {
                 var type = imageryProviderTypes[model.get('type')];
                 var initObj = _.omit(model.attributes, 'type', 'label', 'index', 'modelCid');
+
+                /* Set the tiling scheme for WMTS imagery providers that are EPSG:4326 */
+                if(model.get('type') === "WMT" && properties.projection === "EPSG:4326") {
+                    initObj.tilingScheme = new Cesium.GeographicTilingScheme();
+                }
+
                 var provider = new type(initObj);
                 var layer = this.map.imageryLayers.addImageryProvider(provider);
                 this.layerForCid[model.cid] = layer;


### PR DESCRIPTION
#### What does this PR do?
This PR sets the TilingScheme appropriately for EPSG:4326 WMTS projections
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)
@djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure Catalog UI Imagery Provider with a WMTS layer that is in EPSG:4326 / Verify layer is positioned properly.

http://suite.opengeo.org/geoserver/gwc/service/wmts
`[{"type": "WMT","url": "http://suite.opengeo.org/geoserver/gwc/service/wmts", "layer" : "opengeo:countries", "style" : "", "format" : "image/jpeg", "tileMatrixSetID": "EPSG:4326", "tileMatrixLabels" : ['EPSG:4326:0', 'EPSG:4326:1', 'EPSG:4326:2', 'EPSG:4326:3', 'EPSG:4326:4', 'EPSG:4326:5', 'EPSG:4326:6', 'EPSG:4326:7', 'EPSG:4326:8', 'EPSG:4326:9', 'EPSG:4326:10', 'EPSG:4326:11', 'EPSG:4326:12', 'EPSG:4326:13', 'EPSG:4326:14', 'EPSG:4326:15', 'EPSG:4326:16', 'EPSG:4326:17', 'EPSG:4326:18', 'EPSG:4326:19', 'EPSG:4326:20', 'EPSG:4326:21']}]`

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2778](https://codice.atlassian.net/browse/DDF-2778)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
