### PR TITLE
DDF-2779 Remove extra points from line / polygon drawings in Cesium

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/lib/cesium-drawhelper/DrawHelper.js
@@ -934,7 +934,8 @@ var DrawHelper = (function() {
                         _self.stopDrawing();
                         if(typeof options.callback == 'function') {
                             //https://github.com/leforthomas/cesium-drawhelper/issues/13
-                            options.callback(positions);
+                            //need to remove last 2 positions since those are from finishing the drawing
+                            options.callback(positions.slice(0, positions.length - 2));
                         }
                     }
                 }


### PR DESCRIPTION
#### What does this PR do?
 - https://github.com/codice/ddf/pull/1534 made a change to DrawHelper which allowed drawings at higher zooms to work.  However, DrawHelper was relying on this to remove the extra points that occur when finishing a drawing.  As a result, we need to remove the final two points on all polygon / line drawings.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 
@garrettfreibott 
@andrewkfiedler
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Create line and polygon drawings in Cesium and verify that they contain only the number of points you that were drawn.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2779
