### PR TITLE
DDF-2780 Update to latest Cesium

### DIFF
--- a/catalog/ui/catalog-ui-search/package.json
+++ b/catalog/ui/catalog-ui-search/package.json
@@ -79,7 +79,7 @@
     "backbone.modelbinder": "1.1.0",
     "backbone.paginator": "2.0.5",
     "bootstrap": "3.2.0",
-    "cesium": "1.26.0",
+    "cesium": "1.30.0",
     "density-clustering": "1.3.0",
     "dropzone": "4.3.0",
     "geo-convex-hull": "1.2.0",

--- a/catalog/ui/catalog-ui-search/yarn.lock
+++ b/catalog/ui/catalog-ui-search/yarn.lock
@@ -1590,11 +1590,11 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-cesium@1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.26.0.tgz#2d47c33b5e5b772f6a67ab8b72d6106f89669b12"
+cesium@1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.30.0.tgz#f261ccc28c78339abbb77ec3cd32354c193fa4ec"
   dependencies:
-    requirejs "2.3.2"
+    requirejs "^2.3.2"
 
 chai-as-promised@4.3.0:
   version "4.3.0"
@@ -7524,7 +7524,7 @@ request@~2.51.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-requirejs@2.3.2:
+requirejs@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.2.tgz#0eaa870d4c7db3b15dd1322e6b65b0388fc4b2c6"
 


### PR DESCRIPTION
#### What does this PR do?
 - Update Cesium from 1.26.0 to 1.30.0 to fix issue seen in https://github.com/AnalyticalGraphicsInc/cesium/issues/4563

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@garrettfreibott 
@tbatie 
@figliold
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Verify map still works as expected.  It's possible new regressions were introduced, however I didn't notice any.  

#### Any background context you want to provide?
https://github.com/AnalyticalGraphicsInc/cesium/issues/4563

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2780
