### PR TITLE
DDF-2781 Update app to start only after initial user fetch

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
@@ -16,22 +16,31 @@ require([
     'application',
     'properties',
     'store',
+    'component/singletons/user-instance',
     'js/MediaQueries',
     'js/Theming',
     'js/SystemUsage'
-], function($, app, properties, store) {
+], function($, app, properties, store, user) {
+
+    var workspaces = store.get('workspaces');
+
+    function attemptToStart() {
+        if (workspaces.fetched && user.fetched){
+            app.App.start({});
+        } else if (!user.fetched){
+            user.once('sync', function() {
+                attemptToStart();
+            });
+        } else {
+            workspaces.once('sync', function() {
+                attemptToStart();
+            });
+        }
+    }
 
     //$(window).trigger('resize');
     $(window.document).ready(function() {
         window.document.title = properties.branding + ' ' + properties.product;
     });
-    // Actually start up the application.  Entire app depends on workspaces, so don't allow anything until they're fetched.
-    var workspaces = store.get('workspaces');
-    if (workspaces.fetched) {
-        app.App.start({});
-    } else {
-        workspaces.once('sync', function() {
-            app.App.start({});
-        });
-    }
+    attemptToStart();
 });


### PR DESCRIPTION
#### What does this PR do?
 - Starting before then could cause issues with routing to notifications, or inconsistencies in the display username.
 - We were already waiting for the initial workspace fetch, so this adds on to that.  Now we wait for both the initial workspace and the initial user fetch before starting.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 
@rzwiefel 
@pklinef 
@andrewkfiedler

#### How should this be tested? (List steps with links to updated documentation)
Cause a notification (such as by uploading).  Make sure your settings have persistent notifications. Go to it. Refresh. Test with network latency to see the improvement from the old way.

Another way is to add setTimeouts into the code around the initial fetches to see the app wait for them to complete.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2781
