### PR TITLE
DDF-2782: Moved the location of Karaf's lock file

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -237,6 +237,11 @@ org.apache.servicemix.specs.debug = false
 org.apache.servicemix.specs.timeout = 0
 
 #
+# Directory location that Karaf will store its lock file in
+#
+karaf.lock.dir = ${karaf.instances}
+
+#
 # Settings for the OSGi 4.3 Weaving
 # By default, we will not weave any classes. Change this setting to include classes
 # that you application needs to have woven.


### PR DESCRIPTION
#### What does this PR do?
Moved Karaf's lock file from home directory to home/instances so that a user without write permissions in the home directory (such as on a hardened system) can run ddf.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @clockard @gordocanchola @vinamartin
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@stustison 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2782)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
