### PR TITLE
DDF-2759: Feature configuration files are not always being processed

### DIFF
--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationFilesPollerTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationFilesPollerTest.java
@@ -14,6 +14,7 @@
 
 package org.codice.ddf.configuration.admin;
 
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -21,6 +22,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
@@ -32,7 +35,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -52,6 +58,32 @@ public class ConfigurationFilesPollerTest {
 
     @Mock
     private ChangeListener mockChangeListener;
+
+    @Mock
+    private Path configFilePath;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private Path directoryPath;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private Path nonConfigFilePath;
+
+    @Before
+    public void setup() {
+        File configFile = mock(File.class);
+
+        when(configFilePath.toFile()).thenReturn(configFile);
+        when(configFile.isDirectory()).thenReturn(false);
+        when(configFilePath.getFileName()).thenReturn(configFilePath);
+        when(configFilePath.endsWith(FILE_EXT)).thenReturn(true);
+
+        when(directoryPath.toFile()
+                .isDirectory()).thenReturn(true);
+
+        when(nonConfigFilePath.toFile()
+                .isDirectory()).thenReturn(true);
+        when(nonConfigFilePath.endsWith(FILE_EXT)).thenReturn(false);
+    }
 
     /**
      * Verify that poller gets started by the ExecutorService.
@@ -95,7 +127,8 @@ public class ConfigurationFilesPollerTest {
         List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
         WatchKey mockWatchKey = getMockWatchKey(watchEvents);
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = mock(Path.class);
+        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
+                mock(Path.class));
         when(mockConfigurationDirectory.register(mockWatchService,
                 StandardWatchEventKinds.ENTRY_CREATE)).thenThrow(new IOException());
         ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
@@ -113,6 +146,44 @@ public class ConfigurationFilesPollerTest {
             verify(mockWatchService, never()).take();
             throw e;
         }
+    }
+
+    @Test
+    public void testResgiterFilesAlreadyExist() throws Exception {
+        // Setup
+        Path mockPath = getMockPath(PID, FILE_EXT);
+        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
+                StandardWatchEventKinds.ENTRY_CREATE);
+        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
+        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
+        WatchService mockWatchService = getMockWatchService(mockWatchKey);
+        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
+                mock(Path.class));
+
+        Stream<Path> existingFiles = mock(Stream.class);
+        when(existingFiles.filter(any(Predicate.class))).thenReturn(Stream.of(configFilePath,
+                directoryPath,
+                nonConfigFilePath));
+        when(mockConfigurationDirectory.resolve(configFilePath)).thenReturn(configFilePath);
+
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                mockConfigurationDirectory,
+                FILE_EXT,
+                mockWatchService,
+                mockExecutorService) {
+            @Override
+            Stream<Path> getExistingFiles() throws IOException {
+                return existingFiles;
+            }
+        };
+
+        // Perform Test
+        configurationFilesPoller.register(mockChangeListener);
+
+        // Verify
+        verify(mockChangeListener).notify(configFilePath);
+        verify(mockChangeListener, never()).notify(directoryPath);
+        verify(mockChangeListener, never()).notify(nonConfigFilePath);
     }
 
     /**
@@ -154,11 +225,9 @@ public class ConfigurationFilesPollerTest {
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
                 mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
+        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
                 mockWatchService,
-                mockExecutorService);
+                mockConfigurationDirectory);
         configurationFilesPoller.register(mockChangeListener);
 
         // Perform Test
@@ -182,11 +251,9 @@ public class ConfigurationFilesPollerTest {
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
                 mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
+        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
                 mockWatchService,
-                mockExecutorService);
+                mockConfigurationDirectory);
         configurationFilesPoller.register(mockChangeListener);
 
         // Perform Test
@@ -210,11 +277,10 @@ public class ConfigurationFilesPollerTest {
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
                 mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
+
+        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
                 mockWatchService,
-                mockExecutorService);
+                mockConfigurationDirectory);
         configurationFilesPoller.register(mockChangeListener);
 
         // Perform Test
@@ -238,11 +304,9 @@ public class ConfigurationFilesPollerTest {
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path resolvedPath = mock(Path.class);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath, resolvedPath);
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
+        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
                 mockWatchService,
-                mockExecutorService);
+                mockConfigurationDirectory);
         configurationFilesPoller.register(mockChangeListener);
 
         // Perform Test
@@ -267,11 +331,11 @@ public class ConfigurationFilesPollerTest {
         WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
                 mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
+
+        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
                 mockWatchService,
-                mockExecutorService);
+                mockConfigurationDirectory);
+
         configurationFilesPoller.register(mockChangeListener);
 
         // Perform Test
@@ -364,6 +428,22 @@ public class ConfigurationFilesPollerTest {
         verify(mockExecutorService, times(2)).awaitTermination(10, TimeUnit.SECONDS);
     }
 
+    private ConfigurationFilesPoller createConfigurationFilesPoller(
+            final WatchService mockWatchService, final Path mockConfigurationDirectory) {
+        Stream<Path> existingFiles = mock(Stream.class);
+        when(existingFiles.filter(any(Predicate.class))).thenReturn(existingFiles);
+
+        return new ConfigurationFilesPoller(mockConfigurationDirectory,
+                FILE_EXT,
+                mockWatchService,
+                mockExecutorService) {
+            @Override
+            Stream<Path> getExistingFiles() throws IOException {
+                return existingFiles;
+            }
+        };
+    }
+
     private Path getMockPath(String baseFileName, String extension) {
         Path mockPath = mock(Path.class);
         when(mockPath.toString()).thenReturn(baseFileName + extension);
@@ -373,6 +453,9 @@ public class ConfigurationFilesPollerTest {
     private Path getMockConfigurationDirectoryPath(Path mockPath, Path mockResolvedPath) {
         Path mockConfigurationDirectory = mock(Path.class);
         when(mockConfigurationDirectory.resolve(mockPath)).thenReturn(mockResolvedPath);
+        File mockFile = mock(File.class);
+        when(mockConfigurationDirectory.toFile()).thenReturn(mockFile);
+        when(mockFile.list(any(FilenameFilter.class))).thenReturn(new String[0]);
         return mockConfigurationDirectory;
     }
 


### PR DESCRIPTION
Added code to notify listener of existing configuration files.

#### What does this PR do?
Makes sure existing configuration files in the watched directory are processed.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@figliold 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Run all integration tests.

#### Any background context you want to provide?
This is a follow on to https://github.com/codice/ddf/pull/1616.

#### What are the relevant tickets?
[DDF-2759](https://codice.atlassian.net/browse/DDF-2759)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
