### PR TITLE
DDF-2783 Updates summary view to allow animated thumbnails

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
@@ -22,9 +22,10 @@ define([
     'component/property/property.collection.view',
     'component/loading-companion/loading-companion.view',
     'component/alert/alert',
-    'component/singletons/metacard-definitions'
+    'component/singletons/metacard-definitions',
+    'js/ResultUtils'
 ], function (Marionette, _, $, EditorView, store, PropertyCollectionView, LoadingCompanionView,
-             alertInstance, metacardDefinitions) {
+             alertInstance, metacardDefinitions, ResultUtils) {
 
     return EditorView.extend({
         className: 'is-metacard-basic',
@@ -88,23 +89,7 @@ define([
                                return attrMap;
                            }, attributeMap);
                        }, {});
-                       self.model.first().get('metacard').get('properties').set(attributeMap);
-                       store.get('workspaces').forEach(function(workspace){
-                           workspace.get('queries').forEach(function(query){
-                               if (query.get('result')) {
-                                   query.get('result').get('results').forEach(function(result){
-                                       if (result.get('metacard').get('properties').get('id') ===  self.model.first().get('metacard').get('properties').get('id')){
-                                           result.get('metacard').get('properties').set(attributeMap);
-                                       }
-                                   });
-                               }
-                           });
-                       });
-                       alertInstance.get('currentResult').get('results').forEach(function(result){
-                           if (result.get('metacard').get('properties').get('id') ===  self.model.first().get('metacard').get('properties').get('id')){
-                               result.get('metacard').get('properties').set(attributeMap);
-                           }
-                       });
+                       ResultUtils.updateResults(self.model, attributeMap);
                    }).always(function(){
                        setTimeout(function(){  //let solr flush
                           LoadingCompanionView.endLoading(self);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
@@ -22,9 +22,10 @@ define([
     'component/property/property.collection.view',
     'component/loading-companion/loading-companion.view',
     'component/alert/alert',
-    'component/singletons/metacard-definitions'
+    'component/singletons/metacard-definitions',
+    'js/ResultUtils'
 ], function (Marionette, _, $, EditorView, store, PropertyCollectionView, LoadingCompanionView,
-             alertInstance, metacardDefinitions) {
+             alertInstance, metacardDefinitions, ResultUtils) {
 
     return EditorView.extend({
         className: 'is-metacards-basic',
@@ -96,25 +97,7 @@ define([
                                 return attrMap;
                             }, attributeMap);
                         }, {});
-                        self.model.forEach(function(metacard){
-                           metacard.get('metacard').get('properties').set(attributeMap);
-                        });
-                        store.get('workspaces').forEach(function(workspace){
-                            workspace.get('queries').forEach(function(query){
-                                if (query.get('result')) {
-                                    query.get('result').get('results').forEach(function(result){
-                                        if (payload[0].ids.indexOf(result.get('metacard').get('properties').get('id')) !== -1){
-                                            result.get('metacard').get('properties').set(attributeMap);
-                                        }
-                                    });
-                                }
-                            });
-                        });
-                        alertInstance.get('currentResult').get('results').forEach(function(result){
-                            if (payload[0].ids.indexOf(result.get('metacard').get('properties').get('id')) !== -1){
-                                result.get('metacard').get('properties').set(attributeMap);
-                            }
-                        });
+                        ResultUtils.updateResults(self.model, attributeMap);
                     }).always(function(){
                         setTimeout(function(){  //let solr flush
                             LoadingCompanionView.endLoading(self);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.hbs
@@ -12,7 +12,7 @@
  **/
  --}}
 <input type="file"/>
-<canvas></canvas>
+<img></img>
 <button class="is-primary">
     <span class="fa fa-upload"></span>
 </button>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.less
@@ -2,11 +2,11 @@
   display: block;
   width: 100%;
   white-space: nowrap;
+  padding-right: 0px;
 
   position: relative;
   min-height: @minimumButtonSize;
   white-space: nowrap;
-  vertical-align: top;
   text-align: center;
   font-size: 0px;
 
@@ -21,19 +21,9 @@
     width: @minimumButtonSize;
     display: none;
     font-size: @largeFontSize;
-    vertical-align: top;
+    vertical-align: middle;
   }
   img {
-    width: 100%;
-    text-align: center;
-    line-height: @minimumButtonSize;
-    margin: 0px;
-    white-space: nowrap;
-    overflow: hidden;
-    -ms-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-  }
-  canvas {
     margin: auto;
     display: inline-block;
     min-height: @minimumButtonSize;
@@ -48,7 +38,7 @@
 }
 
 @{customElementNamespace}input.is-thumbnail.is-empty {
-  canvas {
+  img {
     display: none;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
@@ -30,7 +30,7 @@
         </div>
         {{#if metacard.properties.thumbnail}}
         <div class="detail-thumbnail details-property" data-help="thumbnail">
-                <img src="{{metacard.properties.thumbnail}}">
+                <img src="{{getImageSrc metacard.properties.thumbnail}}">
         </div>
         {{/if}}
         <div class="detail-lastModified details-property" data-help="modified">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -83,7 +83,7 @@ module.exports = Marionette.ItemView.extend({
                     }
                 }
                 if (property === 'thumbnail') {
-                    html = '<img src="' +  Common.escapeHTML(value) + '">';
+                    html = '<img src="' +  Common.getImageSrc(Common.escapeHTML(value)) + '">';
                     className = "is-thumbnail";
                 }
                 return {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/Common.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/Common.js
@@ -64,6 +64,13 @@ define([
         getMomentDate: function(date){
            return moment(date).fromNow();
         },
+        getImageSrc: function(img){
+            if (img === "" || img.substring(0, 4) === 'http') {
+                return img;
+            } else {
+                return "data:image/png;base64," + img;
+            }
+        },
         cancelRepaintForTimeframe: function(requestDetails){
             if (requestDetails) {
                 window.cancelAnimationFrame(requestDetails.requestId);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
@@ -13,8 +13,9 @@
 define([
     'underscore',
     'moment',
-    'handlebars/runtime'
-], function (_, moment, Handlebars) {
+    'handlebars/runtime',
+    'js/Common'
+], function (_, moment, Handlebars, Common) {
     'use strict';
     // The module to be exported
     var helper, helpers = {
@@ -327,6 +328,9 @@ define([
                     return encodeURIComponent(str);
                 }
                 return str;
+            },
+            getImageSrc: function(img){
+                return Common.getImageSrc(img);
             },
           json: function (obj) {
             return JSON.stringify(obj);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/ResultUtils.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/ResultUtils.js
@@ -33,5 +33,32 @@ module.exports = {
                 result.refreshData();
             }
         });
+    },
+    updateResults: function(results, attributeMap){
+        if (results.length === undefined) {
+            results = [results];
+        }
+        var ids = results.map(function(result){
+            return result.get('metacard').id;
+        });
+        results.forEach(function(metacard){
+            metacard.get('metacard').get('properties').set(attributeMap);
+        });
+        store.get('workspaces').forEach(function(workspace){
+            workspace.get('queries').forEach(function(query){
+                if (query.get('result')) {
+                    query.get('result').get('results').forEach(function(result){
+                        if (ids.indexOf(result.get('metacard').get('properties').get('id')) !== -1){
+                            result.get('metacard').get('properties').set(attributeMap);
+                        }
+                    });
+                }
+            });
+        });
+        alert.get('currentResult').get('results').forEach(function(result){
+            if (ids.indexOf(result.get('metacard').get('properties').get('id')) !== -1){
+                result.get('metacard').get('properties').set(attributeMap);
+            }
+        });
     }
 };


### PR DESCRIPTION
#### What does this PR do?
 - Removes the use of canvas from the input-thumbnail component.  Now we directly use the img tag.
 - Updates metacard edit views to use a new method in ResultUtils that allows easy updates to metacards throughout the system.
 - Adds a convenience method to Common to allow determining the correct format to be used in an img src field. Updates to various files to use this new method.  This allows us to not care whether the img string is a url or a base64 encoding.
 - Adds some error handling to the input-thumbnail component for when users select files that aren't images.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@figliold 
@andrewkfiedler
@jlcsmith 
@rzwiefel 
@djblue 

#### How should this be tested? (List steps with links to updated documentation)
Go to the summary view of a metacard.  Test out uploading new thumbnails.  Verify that things update correct.  
Test out bulk editing metacards to ensure there are no regressions there.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2783
