### PR TITLE
DDF-2645 Added Associations Attributes to Tika Input Transformer fallback MetacardTypes

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,10 +28,6 @@
         <property name="fallbackPowerpointMetacardType" ref="fallbackPowerpointMetacardType"/>
     </bean>
 
-    <reference id="commonMetacardType" interface="ddf.catalog.data.MetacardType"
-               filter="(name=common)"
-               availability="mandatory"/>
-
     <reference-list id="contentExtractors"
                     interface="ddf.catalog.content.operation.ContentMetadataExtractor"
                     availability="optional">
@@ -47,7 +43,7 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
@@ -60,12 +56,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackJpegMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.jpeg"/>
@@ -74,12 +69,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackMp4MetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.mp4"/>
@@ -88,13 +82,12 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.transformer.common.tika.Mp4MetacardType"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackMpegMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.mpeg"/>
@@ -103,12 +96,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackOfficeDocMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.doc"/>
@@ -117,12 +109,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackPdfMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.pdf"/>
@@ -131,12 +122,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <bean id="fallbackPowerpointMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="fallback.powerpoint"/>
@@ -145,12 +135,11 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
             </list>
         </argument>
     </bean>
-
 
     <service ref="commonTikaMetacardType" interface="ddf.catalog.data.MetacardType">
         <service-properties>


### PR DESCRIPTION
#### What does this PR do?
This PR adds AssociationsAttributes to fallback Tika MetacardTypes so they can be seen in the Catalog UI
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @brianfelix 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest Tika Content / Verify Associations work
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2645](https://codice.atlassian.net/browse/DDF-2645)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
