### PR TITLE
DDF-2787- Updates how thumbnail action url is generated

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -32,6 +32,18 @@ define([
 
         var blacklist = [];
 
+        function generateThumbnailUrl(url){
+            var newUrl = url;
+            if(url.indexOf("?") >= 0) {
+                newUrl += '&';
+            } else {
+                newUrl += '?';
+            }
+            newUrl += '_=' +Date.now();
+            return newUrl;
+        }
+
+
         function checkTokenWithWildcard(token, filter){
             var filterRegex = new RegExp(filter.split('*').join('.*'));
             return filterRegex.test(token);
@@ -665,7 +677,7 @@ define([
                     result.metacard.color = color;
                     var thumbnailAction = _.findWhere(result.actions, {id: 'catalog.data.metacard.thumbnail'});
                     if (result.hasThumbnail && thumbnailAction) {
-                        result.metacard.properties.thumbnail = thumbnailAction.url + '&_='+Date.now();
+                        result.metacard.properties.thumbnail = generateThumbnailUrl(thumbnailAction.url);
                     } else {
                         result.metacard.properties.thumbnail = undefined;
                     }
@@ -816,7 +828,7 @@ define([
 
                         var thumbnailAction = _.findWhere(result.actions, {id: 'catalog.data.metacard.thumbnail'});
                         if (result.hasThumbnail && thumbnailAction) {
-                            result.metacard.properties.thumbnail = thumbnailAction.url + '&_='+Date.now();
+                           result.metacard.properties.thumbnail = generateThumbnailUrl(thumbnailAction.url);
                         }
                     });
 


### PR DESCRIPTION
#### What does this PR do?
Old code assumed that there would always have a preceding parameter before adding the timestamp, this PR updates to remove that assumption.
 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue @garrettfreibott 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler 
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Build catalog-ui-search

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2787)
