### PR TITLE
DDF-2791 Added support for queries with empty values in SolrFilterDelegate

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -226,6 +226,13 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     @Override
     public SolrQuery propertyIsLike(String propertyName, String pattern, boolean isCaseSensitive) {
         verifyInputData(propertyName, pattern);
+        String mappedPropertyName = getMappedPropertyName(propertyName,
+                AttributeFormat.STRING,
+                false);
+
+        if (pattern.isEmpty()) {
+            return new SolrQuery("-" + mappedPropertyName + ":[\"\" TO *]");
+        }
 
         String searchPhrase = escapeSpecialCharacters(pattern);
         if (searchPhrase.contains(SOLR_WILDCARD_CHAR) || searchPhrase.contains(
@@ -241,10 +248,6 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
 
             return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, isCaseSensitive));
         } else {
-
-            String mappedPropertyName = getMappedPropertyName(propertyName,
-                    AttributeFormat.STRING,
-                    false);
             if (isCaseSensitive) {
                 mappedPropertyName = resolver.getCaseSensitiveField(mappedPropertyName);
             }
@@ -261,6 +264,13 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
                     "Case insensitive exact searches are not supported.");
         }
         verifyInputData(propertyName, literal);
+        String mappedPropertyName = getMappedPropertyName(propertyName,
+                AttributeFormat.STRING,
+                true);
+
+        if (literal.isEmpty()) {
+            return new SolrQuery("-" + mappedPropertyName + ":[\"\" TO *]");
+        }
 
         String searchPhrase = QUOTE + escapeSpecialCharacters(literal) + QUOTE;
 
@@ -268,9 +278,6 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
                 SOLR_SINGLE_WILDCARD_CHAR) || Metacard.ANY_TEXT.equals(propertyName)) {
             return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, true));
         } else {
-            String mappedPropertyName = getMappedPropertyName(propertyName,
-                    AttributeFormat.STRING,
-                    true);
             return new SolrQuery(mappedPropertyName + ":" + searchPhrase);
         }
     }
@@ -894,7 +901,7 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
         if (propertyName == null || propertyName.isEmpty()) {
             throw new UnsupportedOperationException("PropertyName is required for search.");
         }
-        if (pattern == null || pattern.isEmpty()) {
+        if (pattern == null) {
             throw new UnsupportedOperationException("Literal value is required for search.");
         }
     }

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -125,7 +125,7 @@ public class SolrFilterDelegateTest {
     /*
       DDF-314: COmmented out until the ANY_TEXT functionality is added back
       in - then these tests can be activated.
-      
+
     @Test
     public void testPropertyIsEqualTo_AnyText_CaseSensitive() {
         String expectedQuery = "any_text:\"mySearchPhrase\"";
@@ -174,6 +174,30 @@ public class SolrFilterDelegateTest {
     }
     END OMIT per DDF-314*/
 
+
+    @Test
+    public void testPropertyIsEqualToEmpty() {
+        stub(mockResolver.getField("title", AttributeFormat.STRING, true)).toReturn("title_txt");
+
+        String searchPhrase = "";
+        String expectedQuery = "-title_txt:[\"\" TO *]";
+        boolean isCaseSensitive = true;
+
+        SolrQuery isEqualTo = toTest.propertyIsEqualTo("title", searchPhrase, isCaseSensitive);
+
+        assertThat(isEqualTo.getQuery(), is(expectedQuery));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPropertyIsEqualToNull() {
+        stub(mockResolver.getField("title", AttributeFormat.STRING, true)).toReturn("title_txt");
+
+        String searchPhrase = null;
+        boolean isCaseSensitive = true;
+
+        toTest.propertyIsEqualTo("title", searchPhrase, isCaseSensitive);
+    }
+
     @Test
     public void testPropertyIsLikeWildcard() {
         stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt")
@@ -190,6 +214,31 @@ public class SolrFilterDelegateTest {
 
         assertThat(isLikeQuery.getQuery(), is(expectedQuery));
 
+    }
+
+    @Test
+    public void testPropertyIsLikeEmpty() {
+        stub(mockResolver.getField("title", AttributeFormat.STRING, false)).toReturn("title_txt");
+
+        String searchPhrase = "";
+        String expectedQuery = "-title_txt:[\"\" TO *]";
+        boolean isCaseSensitive = false;
+
+        SolrQuery isLikeQuery = toTest.propertyIsLike("title",
+                searchPhrase,
+                isCaseSensitive);
+
+        assertThat(isLikeQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPropertyIsNull() {
+        stub(mockResolver.getField("title", AttributeFormat.STRING, false)).toReturn("title_txt");
+
+        String searchPhrase = null;
+        boolean isCaseSensitive = false;
+
+        toTest.propertyIsLike("title", searchPhrase, isCaseSensitive);
     }
 
     @Test

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -382,8 +382,8 @@ public class SolrProviderTest extends SolrProviderTestCase {
         assertEquals(MockMetacard.DEFAULT_TYPE, createdMetacard.getContentTypeName());
         assertEquals(MockMetacard.DEFAULT_VERSION, createdMetacard.getContentTypeVersion());
         assertNotNull(createdMetacard.getMetadata());
-        assertThat(createdMetacard.getMetadata(),
-                containsString("<title>Flagstaff Chamber of Commerce</title>"));
+        assertThat(createdMetacard.getMetadata(), containsString(
+                "<title>Flagstaff Chamber of Commerce</title>"));
         assertThat(createdMetacard.getMetadata()
                 .isEmpty(), is(not(true)));
         assertThat(createdMetacard.getCreatedDate(), is(oneDayAgo));
@@ -422,8 +422,8 @@ public class SolrProviderTest extends SolrProviderTestCase {
         assertEquals(MockMetacard.DEFAULT_TYPE, mResult.getContentTypeName());
         assertEquals(MockMetacard.DEFAULT_VERSION, mResult.getContentTypeVersion());
         assertNotNull(mResult.getMetadata());
-        assertThat(mResult.getMetadata(),
-                containsString("<title>Flagstaff Chamber of Commerce</title>"));
+        assertThat(mResult.getMetadata(), containsString(
+                "<title>Flagstaff Chamber of Commerce</title>"));
         assertThat(mResult.getMetadata()
                 .isEmpty(), is(not(true)));
         assertThat(mResult.getCreatedDate(), is(oneDayAgo));
@@ -3222,6 +3222,21 @@ public class SolrProviderTest extends SolrProviderTestCase {
                         .like()
                         .text("gary"));
 
+
+        /* EMPTY ATTRIBUTE */
+
+        queryAndVerifyCount(3,
+                filterBuilder.attribute(Metacard.DESCRIPTION)
+                        .is()
+                        .equalTo()
+                        .text(""));
+
+        queryAndVerifyCount(0,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .equalTo()
+                        .text(""));
+
     }
 
     @Test
@@ -3234,6 +3249,7 @@ public class SolrProviderTest extends SolrProviderTestCase {
 
         MockMetacard metacard1 = new MockMetacard(Library.getFlagstaffRecord());
         metacard1.setTitle("Mary");
+
         Date exactEffectiveDate = new DateTime().minusMinutes(1)
                 .toDate();
         metacard1.setEffectiveDate(exactEffectiveDate);
@@ -3289,6 +3305,20 @@ public class SolrProviderTest extends SolrProviderTestCase {
                         .is()
                         .equalTo()
                         .date(exactEffectiveDate));
+
+        /* EMPTY ATTRIBUTE */
+
+        queryAndVerifyCount(3,
+                filterBuilder.attribute(Metacard.DESCRIPTION)
+                        .is()
+                        .equalTo()
+                        .text(""));
+
+        queryAndVerifyCount(0,
+                filterBuilder.attribute(Metacard.TITLE)
+                        .is()
+                        .equalTo()
+                        .text(""));
 
     }
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds support to match empty strings (search for metacards with an empty attribute)
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @jrnorth 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest Data / Verify queries
Note : There is no frontend support; so the query may have to be done through cURL or Postman
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2791](https://codice.atlassian.net/browse/DDF-2791)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
