### PR TITLE
DDF-2792 Update client side sorting to handle null / blank values more consistently

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/sort-item/sort-item.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/sort-item/sort-item.view.js
@@ -44,7 +44,7 @@ define([
             var sortAttributes = metacardDefinitions.sortedMetacardTypes.filter(function(type){
                 return !properties.isHidden(type.id);
             }).filter(function(type){
-                return !metacardDefinitions.isHiddenType(type.id);
+                return !metacardDefinitions.isHiddenTypeExceptThumbnail(type.id);
             }).filter(function(type) {
                 return blacklist.indexOf(type.id) === -1;
             }).map(function(metacardType) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
@@ -23,7 +23,6 @@ var Common = require('js/Common');
 var user = require('component/singletons/user-instance');
 var properties = require('properties');
 var metacardDefinitions = require('component/singletons/metacard-definitions');
-var blacklist = ['metacard-type', 'source-id', 'cached', 'metacard-tags', 'anyText'];
 
 module.exports = Marionette.ItemView.extend({
     template: template,
@@ -76,9 +75,7 @@ module.exports = Marionette.ItemView.extend({
     },
     serializeData: function() {
         var sortAttributes = _.filter(metacardDefinitions.sortedMetacardTypes, function(type) {
-            return type.type === 'STRING' || type.type === 'DATE';
-        }).filter(function(type) {
-            return blacklist.indexOf(type.id) === -1;
+            return !metacardDefinitions.isHiddenTypeExceptThumbnail(type.id);
         }).map(function(type) {
             return type.id;
         });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -377,16 +377,37 @@ define([
             }
         }
 
-        function checkSortValue(a, b, sorting){
+        function parseMultiValue(value){
+            if (value && value.constructor === Array){
+                return value[0];
+            }
+            return value;
+        }
+
+        function isEmpty(value){
+            return value === undefined || value === null;
+        }
+
+        function parseValue(value, attribute){
+            var attributeDefinition = metacardDefinitions.metacardTypes[attribute];
+            if (!attributeDefinition) {
+                return value.toString().toLowerCase();
+            }
+            switch(attributeDefinition.type){
+                case 'DATE':
+                case 'BOOLEAN':
+                    return value;
+                case 'STRING':
+                    return value.toString().toLowerCase();
+                default:
+                    return parseFloat(value);
+            }
+        }
+
+        function compareValues(aVal, bVal, sorting) {
             var sortOrder = sorting.direction === 'descending' ? -1 : 1;
-            var aVal = a.get('metacard>properties>' + sorting.attribute);
-            var bVal = b.get('metacard>properties>' + sorting.attribute);
-            if (aVal && aVal.constructor === Array){
-                aVal = aVal[0];
-            }
-            if (bVal && bVal.constructor === Array){
-                bVal = bVal[0];
-            }
+            aVal = parseValue(aVal, sorting.attribute);
+            bVal = parseValue(bVal, sorting.attribute);
             if (aVal < bVal) {
                 return sortOrder * -1;
             }
@@ -394,6 +415,18 @@ define([
                 return sortOrder;
             }
             return 0;
+        }
+
+        function checkSortValue(a, b, sorting){
+            var aVal = parseMultiValue(a.get('metacard>properties>' + sorting.attribute));
+            var bVal = parseMultiValue(b.get('metacard>properties>' + sorting.attribute));
+            if (isEmpty(aVal)){
+                return 1;
+            }
+            if (isEmpty(bVal)){
+                return -1;
+            }
+            return compareValues(aVal, bVal, sorting);
         }
 
         var MetaCard = {};


### PR DESCRIPTION
#### What does this PR do?
 - Updates sorting to always push null or undefined values to the end of a sort (regardless of ascending or descending).
 - Blanks are handled as they should by the particular datatype.  Hence, for a String type ascending puts them at the top, and descending at the bottom.
 - Updated string comparisons to be case insensitive to better fit user expectations.
 - Fixed issues where certain attributes were sortable from the normal sort view, but not from the table view.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@jlcsmith 
@bdeining 
@rzwiefel 

#### How should this be tested? (List steps with links to updated documentation)
Ingest some varied data.  Start testing various sorts.  Confirm that attributes with null or undefined values are always pushed to the end of a sort (regardless of ascending or descending).  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2792