### PR TITLE
DDF-2794 Adjusted RegistryPolicyPlugin to set user defined security attributes on the item policy

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/resources/csw-rim-node.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/csw-rim-node.xml
@@ -103,7 +103,7 @@
             <!--Optional: String representing the security level of this instance-->
             <rim:Slot name="securityLevel" slotType="xs:string">
                 <rim:ValueList>
-                    <rim:Value>role=guest</rim:Value>
+                    <rim:Value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</rim:Value>
                 </rim:ValueList>
             </rim:Slot>
 

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/permission/Permissions.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/permission/Permissions.java
@@ -14,17 +14,19 @@
 package ddf.security.permission;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 
 public class Permissions {
+
+    private static final Pattern PATTERN = Pattern.compile(",");
 
     private Permissions() {
 
@@ -47,10 +49,10 @@ public class Permissions {
                     String[] parts = perm.split("=");
                     if (parts.length == 2) {
                         String attributeName = parts[0];
-                        String attributeValue = parts[1];
-                        String[] attributeValues = attributeValue.split(",");
-                        permissions.put(attributeName,
-                                new HashSet<>(Arrays.asList(attributeValues)));
+                        Set<String> attributeValues = PATTERN.splitAsStream(parts[1])
+                                .map(String::trim)
+                                .collect(Collectors.toSet());
+                        permissions.put(attributeName, attributeValues);
                     }
                 }
             }


### PR DESCRIPTION
#### What does this PR do?
This change adds additional user defined security attributes from the Security Attributes field on the node information modal to the item policy that is generated in the RegistryPolicyPlugin. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @emmberk @vinamartin @brianfelix @gordocanchola 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security) @adimka 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Set up a DDF Registry with the Security Attributes set on the General Information tab of the local node, then try to connect to it with a second DDF without the same security attributes. The registry node should not get pulled (though the connection should return a response).

#### Any background context you want to provide?
Further considerations will have to be made for any other elements of a local node that can have Security Attributes assigned. 

#### What are the relevant tickets?
[DDF-2794](https://codice.atlassian.net/browse/DDF-2794)

#### Screenshots (if appropriate)
![screen shot 2017-02-13 at 1 35 09 pm](https://cloud.githubusercontent.com/assets/11355332/22902124/452de784-f1f1-11e6-801b-82c8e9b7b0b5.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
