### PR TITLE
DDF-2740 (2.10.1 back port) Update SaxEventHandlers to return attribute descriptors

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-api/src/main/java/org/codice/ddf/transformer/xml/streaming/SaxEventHandler.java
+++ b/catalog/transformer/catalog-transformer-streaming-api/src/main/java/org/codice/ddf/transformer/xml/streaming/SaxEventHandler.java
@@ -14,16 +14,22 @@
 package org.codice.ddf.transformer.xml.streaming;
 
 import java.util.List;
+import java.util.Set;
 
 import org.xml.sax.ContentHandler;
 
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 
 /**
  * Interface used to handle sax events fired from {@link org.codice.ddf.transformer.xml.streaming.lib.SaxEventHandlerDelegate} and {@link org.codice.ddf.transformer.xml.streaming.lib.XMLInputTransformer}.
  * At the end of parsing, it will have a list of {@link Attribute}s that can be used to populate a metacard.
  * A specific implementation can be used to handle specific XML elements and metacards. @see ddf.catalog.transformer.generic.xml.impl.XMLSaxEventHandlerImpl
  * {@inheritDoc}
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
  */
 public interface SaxEventHandler extends ContentHandler {
 
@@ -32,4 +38,10 @@ public interface SaxEventHandler extends ContentHandler {
      */
     List<Attribute> getAttributes();
 
+    /**
+     * Get all the possible attribute types that can be returned by this factory's handler
+     *
+     * @return a set of attribute descriptors that can be returned by this handler
+     */
+    Set<AttributeDescriptor> getSupportedAttributeDescriptors();
 }

--- a/catalog/transformer/catalog-transformer-streaming-api/src/main/java/org/codice/ddf/transformer/xml/streaming/SaxEventHandlerFactory.java
+++ b/catalog/transformer/catalog-transformer-streaming-api/src/main/java/org/codice/ddf/transformer/xml/streaming/SaxEventHandlerFactory.java
@@ -13,14 +13,15 @@
  */
 package org.codice.ddf.transformer.xml.streaming;
 
-import java.util.Set;
-
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.util.Describable;
 
 /**
  * A factory for {@link SaxEventHandler}
  * {@inheritDoc}
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
  */
 public interface SaxEventHandlerFactory extends Describable {
 
@@ -30,12 +31,5 @@ public interface SaxEventHandlerFactory extends Describable {
      * @return a new handler to handle SAX events
      */
     SaxEventHandler getNewSaxEventHandler();
-
-    /**
-     * Get all the possible attribute types that can be returned by this factory's handler
-     *
-     * @return a set of attribute descriptors that can be returned by this handler
-     */
-    Set<AttributeDescriptor> getSupportedAttributeDescriptors();
 
 }

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/GmlHandlerFactory.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/GmlHandlerFactory.java
@@ -13,9 +13,6 @@
  */
 package org.codice.ddf.transformer.xml.streaming.impl;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.codice.ddf.transformer.xml.streaming.Gml3ToWkt;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
@@ -23,12 +20,6 @@ import org.xml.sax.ErrorHandler;
 
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.gml2.GMLHandler;
-
-import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.AttributeDescriptorImpl;
-import ddf.catalog.data.impl.BasicTypes;
-import ddf.catalog.data.types.Validation;
 
 public class GmlHandlerFactory implements SaxEventHandlerFactory {
 
@@ -43,41 +34,12 @@ public class GmlHandlerFactory implements SaxEventHandlerFactory {
 
     private static final String ORGANIZATION = "Codice";
 
-    private static Set<AttributeDescriptor> attributeDescriptors = new HashSet<>();
-
-    static {
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.GEOGRAPHY,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.GEO_TYPE));
-
-        attributeDescriptors.add(new AttributeDescriptorImpl(Validation.VALIDATION_WARNINGS,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                true /* multivalued */,
-                BasicTypes.STRING_TYPE));
-        attributeDescriptors.add(new AttributeDescriptorImpl(Validation.VALIDATION_ERRORS,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                true /* multivalued */,
-                BasicTypes.STRING_TYPE));
-    }
-
     private Gml3ToWkt gml3ToWkt;
 
     @Override
     public SaxEventHandler getNewSaxEventHandler() {
         return new GmlHandler(new GMLHandler(new GeometryFactory(), (ErrorHandler) null),
                 this.gml3ToWkt);
-    }
-
-    @Override
-    public Set<AttributeDescriptor> getSupportedAttributeDescriptors() {
-        return attributeDescriptors;
     }
 
     @Override

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/XmlSaxEventHandlerFactoryImpl.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/XmlSaxEventHandlerFactoryImpl.java
@@ -13,17 +13,10 @@
  */
 package org.codice.ddf.transformer.xml.streaming.impl;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
-
-import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.AttributeDescriptorImpl;
-import ddf.catalog.data.impl.BasicTypes;
 
 /**
  * {@inheritDoc}
@@ -41,42 +34,7 @@ public class XmlSaxEventHandlerFactoryImpl implements SaxEventHandlerFactory {
 
     private static final String ORGANIZATION = "Codice";
 
-    private static Set<AttributeDescriptor> attributeDescriptors = new HashSet<>();
-
     private Map<String, String> xmlToMetacardMapping;
-
-    static {
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.ID,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.TITLE,
-                true /* indexed */,
-                true /* stored */,
-                true /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.POINT_OF_CONTACT,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.METADATA,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.XML_TYPE));
-        attributeDescriptors.add(new AttributeDescriptorImpl(Metacard.DESCRIPTION,
-                true /* indexed */,
-                true /* stored */,
-                false /* tokenized */,
-                false /* multivalued */,
-                BasicTypes.STRING_TYPE));
-    }
 
     @Override
     public SaxEventHandler getNewSaxEventHandler() {
@@ -85,11 +43,6 @@ public class XmlSaxEventHandlerFactoryImpl implements SaxEventHandlerFactory {
         } else {
             return new XmlSaxEventHandlerImpl();
         }
-    }
-
-    @Override
-    public Set<AttributeDescriptor> getSupportedAttributeDescriptors() {
-        return attributeDescriptors;
     }
 
     @Override

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/XmlSaxEventHandlerImpl.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/main/java/org/codice/ddf/transformer/xml/streaming/impl/XmlSaxEventHandlerImpl.java
@@ -15,15 +15,21 @@ package org.codice.ddf.transformer.xml.streaming.impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.codice.ddf.transformer.xml.streaming.AbstractSaxEventHandler;
+import org.codice.ddf.transformer.xml.streaming.lib.SaxEventHandlerUtils;
 import org.xml.sax.Attributes;
 
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
 
 /**
  * A sax event handler used to parse urn:catalog:metacard {@link Metacard}s. By default, handles all elements defined in the {@link XmlSaxEventHandlerImpl#xmlToMetacard}
@@ -31,6 +37,8 @@ import ddf.catalog.data.impl.AttributeImpl;
  * {@inheritDoc}
  */
 public class XmlSaxEventHandlerImpl extends AbstractSaxEventHandler {
+
+    private static Set<AttributeDescriptor> attributeDescriptors = new HashSet<>();
 
     /*
      * A list of Attributes that is populated during parsing and then returned by getAttributes
@@ -52,9 +60,27 @@ public class XmlSaxEventHandlerImpl extends AbstractSaxEventHandler {
      */
     private Map<String, String> xmlToMetacard;
 
+    private SaxEventHandlerUtils saxEventHandlerUtils = new SaxEventHandlerUtils();
+
+    static {
+        CoreAttributes coreAttributes = new CoreAttributes();
+        attributeDescriptors.add(coreAttributes.getAttributeDescriptor(Metacard.ID));
+        attributeDescriptors.add(coreAttributes.getAttributeDescriptor(Metacard.TITLE));
+        attributeDescriptors.add(coreAttributes.getAttributeDescriptor(Metacard.METADATA));
+        attributeDescriptors.add(coreAttributes.getAttributeDescriptor(Metacard.DESCRIPTION));
+        attributeDescriptors.add(new ContactAttributes().getAttributeDescriptor(Metacard.POINT_OF_CONTACT));
+    }
+
     @Override
     public List<Attribute> getAttributes() {
-        return attributes;
+        return saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                getSupportedAttributeDescriptors(),
+                attributes);
+    }
+
+    @Override
+    public Set<AttributeDescriptor> getSupportedAttributeDescriptors() {
+        return attributeDescriptors;
     }
 
     protected XmlSaxEventHandlerImpl() {

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/TestXmlInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/TestXmlInputTransformer.java
@@ -48,7 +48,6 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.gml2.GMLHandler;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.validation.ValidationException;
@@ -77,18 +76,18 @@ public class TestXmlInputTransformer {
 
         inputStream = new FileInputStream("src/test/resources/metacard2.xml");
         saxEventHandlerFactory = new XmlSaxEventHandlerFactoryImpl();
-        assertThat(saxEventHandlerFactory.getSupportedAttributeDescriptors()
-                .size(), is(greaterThan(0)));
-        assertThat(new GmlHandlerFactory().getSupportedAttributeDescriptors()
-                .size(), is(greaterThan(0)));
         saxEventHandler = saxEventHandlerFactory.getNewSaxEventHandler();
+        assertThat(saxEventHandler.getSupportedAttributeDescriptors()
+                .size(), is(greaterThan(0)));
 
         GMLHandler gh = new GMLHandler(new GeometryFactory(), (ErrorHandler) null);
         gmlHandler = new GmlHandler(gh, gml3ToWkt);
+        assertThat(gmlHandler.getSupportedAttributeDescriptors()
+                .size(), is(greaterThan(0)));
         saxEventHandlerDelegate = new SaxEventHandlerDelegate(Arrays.asList(saxEventHandler,
-                gmlHandler)).setMetacardType(BasicTypes.BASIC_METACARD);
+                gmlHandler));
 
-        Metacard metacard = saxEventHandlerDelegate.read(inputStream);
+        Metacard metacard = saxEventHandlerDelegate.read(inputStream).getMetacard(null);
         assertThat(metacard.getAttribute(Metacard.TITLE)
                 .getValues()
                 .size(), is(1));
@@ -144,7 +143,9 @@ public class TestXmlInputTransformer {
         saxEventHandlerDelegate = new SaxEventHandlerDelegate(Collections.singletonList(
                 saxEventHandler));
         inputStream = new FileInputStream("src/test/resources/metacard2.xml");
-        Metacard metacard = saxEventHandlerDelegate.read(inputStream);
+
+        saxEventHandlerDelegate.read(inputStream);
+        Metacard metacard = saxEventHandlerDelegate.getMetacard(null);
         assertThat(metacard.getAttribute(Metacard.TITLE)
                 .getValues()
                 .size(), is(1));
@@ -194,7 +195,7 @@ public class TestXmlInputTransformer {
                 .endElement(anyString(), anyString(), anyString());
         gmlHandler = new GmlHandler(gh, gml3ToWkt);
         saxEventHandlerDelegate = new SaxEventHandlerDelegate(Arrays.asList(saxEventHandler,
-                gmlHandler)).setMetacardType(BasicTypes.BASIC_METACARD);
+                gmlHandler));
 
         saxEventHandlerDelegate.read(inputStream);
 

--- a/catalog/transformer/catalog-transformer-streaming-lib/pom.xml
+++ b/catalog/transformer/catalog-transformer-streaming-lib/pom.xml
@@ -44,6 +44,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerUtils.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerUtils.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class SaxEventHandlerUtils {
+
+    /**
+     * This method iterates through the attribute list provided and combines the values of common attributes. The Attribute Descriptors are used to determine if the Attribute is permitted to have multiple values.
+     *
+     * @param descriptors A set of attribute descriptors. Used to determine if the attribute can have multiple values. If empty or null, a validation warning will be added to the attributes and the attribute will default to not allow multiple values.
+     * @param attributes  The list of attributes to combine.
+     * @return The list of attributes with multiple attribute values combined to a list on a single attribute. Returns null or an empty list if the attribute list provided was null or empty.
+     */
+    public List<Attribute> getCombinedMultiValuedAttributes(Set<AttributeDescriptor> descriptors,
+            List<Attribute> attributes) {
+        if (CollectionUtils.isEmpty(attributes)) {
+            return attributes;
+        }
+
+        Map<String, Boolean> multiValuedMap = getMultiValuedNameMap(descriptors);
+
+        List<String> validationWarnings = new ArrayList<>();
+        Map<String, Attribute> attributeMap = new HashMap<>();
+        for (Attribute attribute : attributes) {
+            String attributeName = attribute.getName();
+            Attribute addedAttribute = attributeMap.putIfAbsent(attributeName, attribute);
+
+            if (addedAttribute != null) {
+                Boolean addValue = multiValuedMap.get(attributeName);
+                if (addValue == null) {
+                    validationWarnings.add(String.format(
+                            "No attribute descriptor was found for attribute: '%s'. Handling the attribute as non-multi-valued.",
+                            attributeName));
+                    addValue = false;
+                }
+
+                if (addValue) {
+                    attributeMap.get(attributeName)
+                            .getValues()
+                            .addAll(attribute.getValues());
+                } else {
+                    validationWarnings.add(String.format(
+                            "Multiple values found for a non-multi-valued attribute. Attribute: '%s', Existing value: '%s', New value: '%s'. Existing value will be kept, new value will be ignored.",
+                            attributeName,
+                            attributeMap.get(attributeName)
+                                    .getValue(),
+                            attribute.getValue()));
+                }
+            }
+        }
+
+        if (!validationWarnings.isEmpty()) {
+            Attribute validationAttribute =
+                    attributeMap.get(ValidationAttributes.VALIDATION_WARNINGS);
+            if (validationAttribute != null) {
+                attributeMap.get(ValidationAttributes.VALIDATION_WARNINGS)
+                        .getValues()
+                        .addAll(validationWarnings);
+            } else {
+                attributeMap.put(ValidationAttributes.VALIDATION_WARNINGS,
+                        new AttributeImpl(ValidationAttributes.VALIDATION_WARNINGS,
+                                (Serializable) validationWarnings));
+            }
+        }
+
+        return attributeMap.values()
+                .stream()
+                .collect(Collectors.toList());
+    }
+
+    public Map<String, Boolean> getMultiValuedNameMap(Set<AttributeDescriptor> descriptors) {
+        Map<String, Boolean> multiValuedMap = new HashMap<>();
+
+        if (CollectionUtils.isNotEmpty(descriptors)) {
+            for (AttributeDescriptor descriptor : descriptors) {
+                if (descriptor != null) {
+                    multiValuedMap.put(descriptor.getName(), descriptor.isMultiValued());
+                }
+            }
+        }
+
+        return multiValuedMap;
+    }
+}

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/XmlInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/XmlInputTransformer.java
@@ -19,10 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
@@ -30,11 +27,8 @@ import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.util.Describable;
@@ -80,7 +74,7 @@ public class XmlInputTransformer implements InputTransformer, Describable {
      *
      * @return a new SaxEventHandlerDelegate
      */
-    private SaxEventHandlerDelegate create() {
+    SaxEventHandlerDelegate create() {
 
         /*
          * Gets new instances of each SaxEventHandler denoted in saxEventHandlerConfiguration
@@ -93,7 +87,7 @@ public class XmlInputTransformer implements InputTransformer, Describable {
          * Pass all the new handlers to configure and create a new SaxEventHandlerDelegate and sets
          * the metacardType
          */
-        return new SaxEventHandlerDelegate(filteredSaxEventHandlers).setMetacardType(getMetacardType());
+        return new SaxEventHandlerDelegate(filteredSaxEventHandlers);
 
     }
 
@@ -130,7 +124,7 @@ public class XmlInputTransformer implements InputTransformer, Describable {
         /*
          * Read the input stream into the metacard - where all the magic happens
          */
-            Metacard metacard = delegate.read(teeInputStream);
+            Metacard metacard = delegate.read(teeInputStream).getMetacard(id);
 
         /*
          * Read the metadata from the split input stream and set it on the Metacard.METADATA attribute.
@@ -238,28 +232,6 @@ public class XmlInputTransformer implements InputTransformer, Describable {
 
     public void setOrganization(String organization) {
         this.organization = organization;
-    }
-
-    /**
-     * Defines and returns a {@link DynamicMetacardType} based on component Sax Event Handler Factories
-     * and what attributes they populate
-     *
-     * @return a DynamicMetacardType that describes the type of metacard that is created in this transformer
-     */
-
-    public MetacardType getMetacardType() {
-        Set<AttributeDescriptor> attributeDescriptors =
-                new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
-
-        if (saxEventHandlerConfiguration != null && saxEventHandlerFactories != null) {
-            attributeDescriptors.addAll(saxEventHandlerFactories.stream()
-                    .filter(p -> saxEventHandlerConfiguration.contains(p.getId()))
-                    .map(SaxEventHandlerFactory::getSupportedAttributeDescriptors)
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toSet()));
-        }
-
-        return new DynamicMetacardType(attributeDescriptors, id);
     }
 
 }

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerUtilsTest.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerUtilsTest.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.xml.streaming.lib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class SaxEventHandlerUtilsTest {
+
+    private static Set<AttributeDescriptor> descriptors = new HashSet<>();
+
+    private SaxEventHandlerUtils saxEventHandlerUtils = new SaxEventHandlerUtils();
+
+    private CoreAttributes coreAttributes = new CoreAttributes();
+
+    @BeforeClass
+    public static void setup() {
+        CoreAttributes coreAttributes = new CoreAttributes();
+        descriptors.add(coreAttributes.getAttributeDescriptor(CoreAttributes.ID));
+        descriptors.add(coreAttributes.getAttributeDescriptor(CoreAttributes.LANGUAGE));
+    }
+
+    @Test
+    public void testValidSingleValue() {
+        List<Attribute> attributes = getTestAttributes();
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                descriptors,
+                attributes);
+
+        assertThat(combinedAttributes.size(), is(2));
+        assertIdAttribute(combinedAttributes);
+        assertLanguageAttribute(combinedAttributes, 1);
+    }
+
+    @Test
+    public void testValidMultiValue() {
+        List<Attribute> attributes = getTestAttributes();
+        attributes.add(new AttributeImpl(CoreAttributes.LANGUAGE, "Dothraki"));
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                descriptors,
+                attributes);
+
+        assertThat(combinedAttributes.size(), is(2));
+        assertIdAttribute(combinedAttributes);
+        assertLanguageAttribute(combinedAttributes, 2);
+    }
+
+    @Test
+    public void testInvalidMultiValue() {
+        List<Attribute> attributes = getTestAttributes();
+        attributes.add(new AttributeImpl(CoreAttributes.ID, "anotherId"));
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                descriptors,
+                attributes);
+
+        assertThat(combinedAttributes.size(), is(3));
+        Attribute validationWarningAttr = getAttributeByName(combinedAttributes,
+                ValidationAttributes.VALIDATION_WARNINGS);
+        assertThat(validationWarningAttr, notNullValue());
+        assertIdAttribute(combinedAttributes);
+        assertLanguageAttribute(combinedAttributes, 1);
+    }
+
+    @Test
+    public void testNullAttributes() {
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                descriptors,
+                null);
+
+        assertThat(combinedAttributes, nullValue());
+    }
+
+    @Test
+    public void testNullAttributeDescriptors() {
+        List<Attribute> attributes = getTestAttributes();
+        attributes.add(new AttributeImpl(CoreAttributes.LANGUAGE, "Dothraki"));
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                null,
+                attributes);
+
+        assertThat(combinedAttributes.size(), is(3));
+        Attribute validationWarningAttr = getAttributeByName(combinedAttributes,
+                ValidationAttributes.VALIDATION_WARNINGS);
+        assertThat(validationWarningAttr, notNullValue());
+        assertAttributeContainsString(validationWarningAttr,
+                "No attribute descriptor was found for attribute");
+        assertAttributeContainsString(validationWarningAttr,
+                "Multiple values found for a non-multi-valued attribute.");
+        assertIdAttribute(combinedAttributes);
+        assertLanguageAttribute(combinedAttributes, 1);
+    }
+
+    @Test
+    public void testEmptyAttributes() {
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                descriptors,
+                Collections.emptyList());
+
+        assertThat(combinedAttributes, notNullValue());
+        assertThat(combinedAttributes, is(empty()));
+    }
+
+    @Test
+    public void testEmptyAttributeDescriptors() {
+        List<Attribute> attributes = getTestAttributes();
+        attributes.add(new AttributeImpl(CoreAttributes.LANGUAGE, "Dothraki"));
+        List<Attribute> combinedAttributes = saxEventHandlerUtils.getCombinedMultiValuedAttributes(
+                Collections.emptySet(),
+                attributes);
+
+        assertThat(combinedAttributes.size(), is(3));
+        Attribute validationWarningAttr = getAttributeByName(combinedAttributes,
+                ValidationAttributes.VALIDATION_WARNINGS);
+        assertThat(validationWarningAttr, notNullValue());
+        assertAttributeContainsString(validationWarningAttr,
+                "No attribute descriptor was found for attribute");
+        assertAttributeContainsString(validationWarningAttr,
+                "Multiple values found for a non-multi-valued attribute.");
+        assertIdAttribute(combinedAttributes);
+        assertLanguageAttribute(combinedAttributes, 1);
+    }
+
+    @Test
+    public void testGetMultiValuedNameMap() {
+        Map<String, Boolean> multiValuedMap =
+                saxEventHandlerUtils.getMultiValuedNameMap(descriptors);
+        assertThat(multiValuedMap.get(CoreAttributes.ID),
+                is(equalTo(coreAttributes.getAttributeDescriptor(CoreAttributes.ID)
+                        .isMultiValued())));
+        assertThat(multiValuedMap.get(CoreAttributes.LANGUAGE),
+                is(equalTo(coreAttributes.getAttributeDescriptor(CoreAttributes.LANGUAGE)
+                        .isMultiValued())));
+    }
+
+    @Test
+    public void testGetMultiValuedNameMapWithNullDescriptor() {
+        Set<AttributeDescriptor> modifiedDescriptors = new HashSet<>(descriptors);
+        modifiedDescriptors.add(null);
+
+        Map<String, Boolean> multiValuedMap =
+                saxEventHandlerUtils.getMultiValuedNameMap(descriptors);
+        assertThat(multiValuedMap.get(CoreAttributes.ID),
+                is(equalTo(coreAttributes.getAttributeDescriptor(CoreAttributes.ID)
+                        .isMultiValued())));
+        assertThat(multiValuedMap.get(CoreAttributes.LANGUAGE),
+                is(equalTo(coreAttributes.getAttributeDescriptor(CoreAttributes.LANGUAGE)
+                        .isMultiValued())));
+
+        assertThat(multiValuedMap.size(), is(equalTo(2)));
+    }
+
+    @Test
+    public void testGetMultiValuedNameMapWithNullOrEmptyDescriptors() {
+        Map<String, Boolean> emptyMap = saxEventHandlerUtils.getMultiValuedNameMap(null);
+        assertThat(emptyMap.size(), is(equalTo(0)));
+
+        emptyMap = saxEventHandlerUtils.getMultiValuedNameMap(Collections.emptySet());
+        assertThat(emptyMap.size(), is(equalTo(0)));
+    }
+
+    private List<Attribute> getTestAttributes() {
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(new AttributeImpl(CoreAttributes.ID, "id"));
+        attributes.add(new AttributeImpl(CoreAttributes.LANGUAGE, "English"));
+
+        return attributes;
+    }
+
+    private Attribute getAttributeByName(List<Attribute> attributes, String name) {
+        return attributes.stream()
+                .filter(attribute -> attribute.getName()
+                        .equals(name))
+                .findFirst()
+                .orElseGet(null);
+    }
+
+    private void assertLanguageAttribute(List<Attribute> attributes, int size) {
+        Attribute languageAttr = getAttributeByName(attributes, CoreAttributes.LANGUAGE);
+        assertThat(languageAttr, notNullValue());
+        assertThat(languageAttr.getValues()
+                .size(), is(size));
+    }
+
+    private void assertIdAttribute(List<Attribute> attributes) {
+        Attribute idAttr = getAttributeByName(attributes, CoreAttributes.ID);
+        assertThat(idAttr, notNullValue());
+        assertThat(idAttr.getValues()
+                .size(), is(1));
+    }
+
+    private void assertAttributeContainsString(Attribute attribute, String findThisString) {
+        List<Serializable> values = attribute.getValues();
+        assertThat(values, is(not(empty())));
+
+        long count = values.stream()
+                .filter(serializable -> serializable instanceof String)
+                .map(String.class::cast)
+                .filter(string -> string.contains(findThisString))
+                .count();
+        assertThat(count, is(greaterThan(0L)));
+    }
+
+}

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/TestGenericXmlLib.java
@@ -60,7 +60,6 @@ public class TestGenericXmlLib {
         xmlInputTransformer.setSaxEventHandlerConfiguration(Collections.singletonList("test"));
         xmlInputTransformer.setSaxEventHandlerFactories(Collections.singletonList(
                 saxEventHandlerFactory));
-        assertThat(xmlInputTransformer.getMetacardType(), notNullValue());
         Metacard metacard = null;
         try {
             metacard = xmlInputTransformer.transform(inputStream, "test");
@@ -118,10 +117,15 @@ public class TestGenericXmlLib {
         when(saxEventHandlerFactory.getId()).thenReturn("test");
         SaxEventHandler handler = getNewHandler();
         when(saxEventHandlerFactory.getNewSaxEventHandler()).thenReturn(handler);
+
         XmlInputTransformer xmlInputTransformer = new XmlInputTransformer();
         xmlInputTransformer.setSaxEventHandlerFactories(Collections.singletonList(
                 saxEventHandlerFactory));
-        MetacardType metacardType = xmlInputTransformer.getMetacardType();
+
+        xmlInputTransformer.setSaxEventHandlerConfiguration(Collections.singletonList("test"));
+
+        SaxEventHandlerDelegate delegate = xmlInputTransformer.create();
+        MetacardType metacardType = delegate.getMetacardType(xmlInputTransformer.getId());
         assertThat(metacardType.getAttributeDescriptors(),
                 is(BasicTypes.BASIC_METACARD.getAttributeDescriptors()));
     }
@@ -130,8 +134,10 @@ public class TestGenericXmlLib {
     public void testNoFactoriesTransform() {
         XmlInputTransformer xmlInputTransformer = new XmlInputTransformer();
         xmlInputTransformer.setSaxEventHandlerConfiguration(Collections.singletonList("test"));
-        xmlInputTransformer.setSaxEventHandlerFactories(null);
-        MetacardType metacardType = xmlInputTransformer.getMetacardType();
+        xmlInputTransformer.setSaxEventHandlerFactories(Collections.emptyList());
+
+        SaxEventHandlerDelegate delegate = xmlInputTransformer.create();
+        MetacardType metacardType = delegate.getMetacardType(xmlInputTransformer.getId());
         assertThat(metacardType.getAttributeDescriptors(),
                 is(BasicTypes.BASIC_METACARD.getAttributeDescriptors()));
     }
@@ -151,7 +157,7 @@ public class TestGenericXmlLib {
                 return inputTransformerErrorHandler;
             }
         };
-        Metacard metacard = saxEventHandlerDelegate.read(inputStream);
+        Metacard metacard = saxEventHandlerDelegate.read(inputStream).getMetacard(null);
         assertThat(metacard.getAttribute(Validation.VALIDATION_ERRORS)
                 .getValue(), is("mock-errors-and-warnings"));
 
@@ -170,7 +176,6 @@ public class TestGenericXmlLib {
         xmlInputTransformer.setSaxEventHandlerConfiguration(Collections.singletonList("test"));
         xmlInputTransformer.setSaxEventHandlerFactories(Collections.singletonList(
                 saxEventHandlerFactory));
-        assertThat(xmlInputTransformer.getMetacardType(), notNullValue());
         Metacard metacard = null;
         try {
             metacard = xmlInputTransformer.transform(inputStream, "test");


### PR DESCRIPTION
#### What does this PR do?
This ticket is the back port of the following functionality.
This ticket moves the getSupportedAttributeDescriptors methods from the SaxEventHandlerFactories to the SaxEventHandlers. This move is needed in the case where handler data determines the attribute descriptors.
This ticket also changes the SaxEventHandlerDelegate to no longer put duplicate attributes on a metacard blindly. It now checks the AttributeDescriptor's multivalued flag to see if having multiple values is permitted. If multivalued is false it just keeps the first value, ignoring any following ones.
This PR also splits the delegates read method into read and getMetacard methods.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2740
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
