### PR TITLE
DDF-2799 Add support for empty string queries to Catalog UI

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -135,7 +135,7 @@ define([
                     filters: this.filterContents.currentView.children.map(function(childView){
                         return childView.getFilters();
                     }).filter(function(filter){
-                       return filter && filter.value !== "";
+                       return filter;
                     })
                 }
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -181,7 +181,7 @@ define([
         },
         deleteInvalidFilters: function(){
             var currentValue = this.filterInput.currentView.getCurrentValue()[0];
-            if (currentValue === "" || currentValue === null){
+            if (currentValue === null){
                 this.delete();
             }
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -277,7 +277,7 @@ define([
                 }
 
                 if (valuesToCheck.length === 0) {
-                    return false;
+                    return filter.value === "";  // aligns with how querying works on the server
                 }
 
                 valuesToCheck = flattenMultivalueProperties(valuesToCheck);
@@ -697,17 +697,8 @@ define([
             generateFilteredVersion: function(filter){
                 var filteredCollection = new this.constructor();
                 filteredCollection.set(this.updateFilteredVersion(filter));
-                filteredCollection.listenToOriginalCollection(this, filter);
                 filteredCollection.amountFiltered = this.amountFiltered;
                 return filteredCollection;
-            },
-            listenToOriginalCollection: function(originalCollection, filter){
-                var debouncedUpdate = _.debounce(function(){
-                    this.reset(originalCollection.updateFilteredVersion(filter));
-                }.bind(this), 200);
-                this.listenTo(originalCollection, 'add', debouncedUpdate);
-                this.listenTo(originalCollection, 'remove',debouncedUpdate);
-                this.listenTo(originalCollection, 'update', debouncedUpdate);
             },
             updateFilteredVersion: function(filter){
                 this.amountFiltered = 0;


### PR DESCRIPTION
#### What does this PR do?
 - https://codice.atlassian.net/browse/DDF-2791 (https://github.com/codice/ddf/pull/1672) adds support for empty string queries on the server, so this adds support on the client.
 - Removes guards against empty string in filter.view and filter-builder.view.
 - This only adds support for empty string fields.
 - Updates how client side filtering is done on empty fields to match how the server side querying currently works.  As of now, searching for an empty string on a particular field will return all the null and blank valued results for that field.  On a side note, searching for wildcard (*) filters out all null and blank valued results (both client and server side).
 - Removes some unnecessary cruft from Metacard.  There's no need to listen to the unfiltered collection anymore (it already gets recomputed each time the original changes, partially due to side effects from the paginator), so this is wasted computation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@bdeining 
@rzwiefel 
@jlcsmith
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Go to the Catalog UI.  Go to the advanced page and attempt to query for blanks on any string field.  

Note that I did not add support to the basic page, since that is anyText and it's assumed you typically want a wildcard search if you leave it blank.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2799
