### PR TITLE
(2.10.x) DDF-2786 Fix issue with header and footer during zoom

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/left/slideout.left.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/left/slideout.left.less
@@ -24,3 +24,24 @@
         transform: translateX(0%);
     }
 }
+
+body.has-header @{customElementNamespace}slideout.is-left {
+    > .slideout-content {
+        top: 1.5rem;
+        height: ~'calc(100% - 1.5rem)';
+    }
+}
+
+body.has-footer @{customElementNamespace}slideout.is-left {
+    > .slideout-content {
+        top: 0%;
+        height: ~'calc(100% - 1.5rem)';
+    }
+}
+
+body.has-header.has-footer @{customElementNamespace}slideout.is-left {
+    > .slideout-content {
+        top: 1.5rem;
+        height: ~'calc(100% - 3rem)';
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/right/slideout.right.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/right/slideout.right.less
@@ -20,3 +20,24 @@
         transform: translateX(-100%);
     }
 }
+
+body.has-header @{customElementNamespace}slideout.is-right {
+    > .slideout-content {
+        top: 1.5rem;
+        height: ~'calc(100% - 1.5rem)';
+    }
+}
+
+body.has-footer @{customElementNamespace}slideout.is-right {
+    > .slideout-content {
+        top: 0%;
+        height: ~'calc(100% - 1.5rem)';
+    }
+}
+
+body.has-header.has-footer @{customElementNamespace}slideout.is-right {
+    > .slideout-content {
+        top: 1.5rem;
+        height: ~'calc(100% - 3rem)';
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/slideout.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/slideout.less
@@ -45,3 +45,24 @@
        transform: translateX(-100%);
     }
 }
+
+body.has-header @{customElementNamespace}slideout {
+    > .slideout-content {
+        top: ~'calc(2*@{minimumLineSize} + 1.5rem)';
+        height: ~'calc(100% - 2*@{minimumLineSize} - 1.5rem)';
+    }
+}
+
+body.has-footer @{customElementNamespace}slideout {
+    > .slideout-content {
+        top: ~'calc(2*@{minimumLineSize})';
+        height: ~'calc(100% - 2*@{minimumLineSize} - 1.5rem)';
+    }
+}
+
+body.has-header.has-footer @{customElementNamespace}slideout {
+    > .slideout-content {
+        top: ~'calc(2*@{minimumLineSize} + 1.5rem)';
+        height: ~'calc(100% - 2*@{minimumLineSize} - 3rem)';
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.less
@@ -66,14 +66,14 @@
 
   .home-templates-expanded {
     background: @background-color;
-    position: fixed;
+    position: absolute;
     top: 0px;
     left: 0px;
     width: 100%;
     height: 2*@minimumLineSize;
     opacity: 0;
     transition: opacity @coreTransitionTime ease-in-out;
-    transform: translateY(-100%);
+    transform: translateY(-200%);
     white-space: nowrap;
     line-height: 2*@minimumLineSize;
   }
@@ -121,20 +121,13 @@
   }
 }
 
-.has-header @{customElementNamespace}workspaces-templates.is-expanded {
-  top: 80px;
-  .home-templates-expanded {
-    top: 20px;
-  }
-}
-
 .has-footer @{customElementNamespace}workspaces-templates.is-expanded,
 .has-header @{customElementNamespace}workspaces-templates.is-expanded {
-  height: ~'calc(100vh - 2*@{minimumLineSize} - 20px)';
+  height: ~'calc(100vh - 2*@{minimumLineSize} - 1.5rem)';
 }
 
 .has-header.has-footer @{customElementNamespace}workspaces-templates.is-expanded {
-  height: ~'calc(100vh - 2*@{minimumLineSize} - 40px)';
+  height: ~'calc(100vh - 2*@{minimumLineSize} - 3rem)';
 }
 
  .is-small-screen, .is-mobile-screen {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/application.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/application.js
@@ -52,10 +52,12 @@ define([
     //setup the header
     Application.App.addInitializer(function () {
         Application.App.headerRegion.show(new Marionette.ItemView({
+            tagName: 'header',
             template: header,
-            className: 'header-layout',
             model: Application.AppModel
-        }));
+        }), {
+            replaceElement: true
+        });
         if (Application.AppModel.get('ui').header && Application.AppModel.get('ui').header !== ""){
             $('body').addClass('has-header');
         }
@@ -63,10 +65,12 @@ define([
     //setup the footer
     Application.App.addInitializer(function () {
         Application.App.footerRegion.show(new Marionette.ItemView({
+            tagName: 'footer',
             template: footer,
-            className: 'footer-layout',
             model: Application.AppModel
-        }));
+        }), {
+            replaceElement: true
+        });
         if (Application.AppModel.get('ui').footer &&Application.AppModel.get('ui').footer !== ""){
             $('body').addClass('has-footer');
         }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/content.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/content.less
@@ -1,10 +1,10 @@
 body.has-header #content,
 body.has-footer #content {
-  height: ~'calc(100% - 20px)';
+  height: ~'calc(100% - 1.5rem)';
 }
 
 body.has-header.has-footer #content {
-  height: ~'calc(100% - 40px)';
+  height: ~'calc(100% - 3rem)';
 }
 
 #content {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/headerAndFooter.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/headerAndFooter.less
@@ -1,0 +1,13 @@
+header,
+footer {
+    line-height: 1.5rem;
+    max-height: 1.5rem;
+    text-align: center;
+
+    div {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        padding: 0px @minimumSpacing;
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/init.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/init.less
@@ -6,6 +6,7 @@
 @import "divider";
 @import "disabled";
 @import "gradient";
+@import "headerAndFooter";
 @import "headers";
 @import "iframe";
 @import "labels";

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/loading.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/loading.less
@@ -1,15 +1,21 @@
-.has-header,
+.has-header {
+  #loading {
+    height: ~'calc(100% - 1.5rem)';
+    top: 1.5rem;
+  }
+}
+
 .has-footer {
   #loading {
-    height: ~'calc(100% - 20px)';
-    top: 20px;
+    height: ~'calc(100% - 1.5rem)';
+    top: 0px;
   }
 }
 
 .has-header.has-footer {
   #loading {
-    height: ~'calc(100% - 40px)';
-    top: 20px;
+    height: ~'calc(100% - 3rem)';
+    top: 1.5rem;
   }
 }
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/templates/footer.layout.handlebars
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/templates/footer.layout.handlebars
@@ -11,10 +11,6 @@
  *
  **/
  --}}
-<div class="footer-container">
-    <div class="banner-container">
-        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
-            {{ui.footer}}
-        </div>
-    </div>
+<div style="color: {{ui.color}}; background-color: {{ui.background}}" title="{{ui.footer}}">
+    {{ui.footer}}
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/templates/header.layout.handlebars
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/templates/header.layout.handlebars
@@ -11,10 +11,6 @@
  *
  **/
  --}}
-<div class="header-container">
-    <div class="banner-container">
-        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
-            {{ui.header}}
-        </div>
-    </div>
+<div style="color: {{ui.color}}; background-color: {{ui.background}}" title="{{ui.header}}">
+    {{ui.header}}
 </div>


### PR DESCRIPTION
#### What does this PR do?
 - Previously, the header and footer didn't take into account the current user's zoom.  Now they do.  Various updates to css to take this into account.
 - Simplified the header and footer templates.  Updated their regions to use replace element to simplify things further.  Added a tooltip in case the text is cut off.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@garrettfreibott 
@Lambeaux 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Add a header using the Platform config.  Verify it shows up in the Catalog UI, and that it resizes correctly during zoom changes.  Also open each of the slideouts and verify they adjust accordingly with the header.  Verify that you can scroll all the way to the bottom of the templates when they are expanded.
Add a footer and reverify.
Remove the header and reverify.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2786