### PR TITLE
DDF-2804 -> 2.10.x Update hardening guide to recommend 10 minute session timeout

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
@@ -18,9 +18,9 @@ It is recommended to apply the following security mitigations to the ${branding}
 
 |JMX
 |tampering, information disclosure, and unauthorized access
-a|* Remove `-Dcom.sun.management.jmxremote` from `<${branding}_HOME>/bin/karaf`.
-* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg`
-* Uninstall the management bundle using the command line console: `uninstall management`
+a|* Remove `-Dcom.sun.management.jmxremote` from `<${branding}_HOME>/bin/karaf`. +
+* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg` +
+* Uninstall the management bundle using the command line console: `uninstall management` +
 
 |File System Access
 |tampering, information disclosure, and denial of service
@@ -28,15 +28,15 @@ a|Set OS File permissions under the `<${branding}_HOME>` directory (e.g. `/deplo
 
  If Caching is installed:
 
-* Set permissions for the installation directory `/data/product-cache` such that only the ${branding} process and users with the appropriate SCI controls and classification levels can view any stored product.
-* Caching can be turned off as well to mitigate this risk.
-** To disable caching, navigate to ${ddf-catalog}
-** Select *Standard Catalog Framework*
-** Uncheck the `Enable Product Caching` box.
-* Install ${ddf-security} to ensure only the appropriate users are accessing the products.
-** From the ${admin-console}, select *Manage Applications*.
-** Install ${ddf-security}, if applicable.
-* Cached files are written by the user running the ${branding} `process/application`.
+* Set permissions for the installation directory `/data/product-cache` such that only the ${branding} process and users with the appropriate SCI controls and classification levels can view any stored product. +
+* Caching can be turned off as well to mitigate this risk. +
+** To disable caching, navigate to ${ddf-catalog} +
+** Select *Standard Catalog Framework* +
+** Uncheck the `Enable Product Caching` box. +
+* Install ${ddf-security} to ensure only the appropriate users are accessing the products. +
+** From the ${admin-console}, select *Manage Applications*. +
+** Install ${ddf-security}, if applicable. +
+* Cached files are written by the user running the ${branding} `process/application`. +
 
 On system: ensure that not everyone can change ACLs on your object.
 
@@ -62,4 +62,13 @@ a|Update the `<${branding}_HOME>/etc/org.ops4j.pax.web.cfg` file to add the entr
 Setting this configuration may break compatibility to legacy systems that do not support two-way SSL.
 ====
 
+|Session Inactivity Timeout
+|unauthorized access
+a|Update the Session configuration to have no greater than 10 minute Session Timeout. + 
+
+ * Navigate to the *${admin-console}*. +
+ * Select the *${ddf-security}* application. +
+ * Select the *Configuration* tab. +
+ * Select `Session`. +
+ * Set `Session Timeout (in minutes)` to `10` (or less). +
 |===


### PR DESCRIPTION
2.10.x port from https://github.com/codice/ddf/pull/1690
#### What does this PR do?
Added a row to the Environment Hardening suggestions that describes how to update the Session Timeout to the recommended 10 minutes.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ricklarsen @ahoffer 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Docs](https://github.com/orgs/codice/teams/docs) @Lambeaux 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Read the changes, observe the generated table.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2804](https://codice.atlassian.net/browse/DDF-2804)

#### Screenshots (if appropriate)
![screen shot 2017-02-14 at 4 07 10 pm](https://cloud.githubusercontent.com/assets/11355332/22953742/bc213204-f2cf-11e6-8eda-ea0f5cc2b783.png)

![screen shot 2017-02-14 at 5 22 13 pm](https://cloud.githubusercontent.com/assets/11355332/22955599/2b91068c-f2da-11e6-99e6-24e176e4bad6.png)
(PDF)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
