### PR TITLE
DDF-2805 Add ability to perform queries with the 'NOT' operator to the Catalog UI

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.hbs
@@ -14,9 +14,7 @@
 <button class="filter-remove is-negative" data-help="Removes this branch.">
     <span class="fa fa-minus"></span>
 </button>
-<div class="filter-operator" data-help="If 'AND' is used,
-all the filters in the branch have to be true for this branch to be true.  If 'OR' is used, only one
-of the filters in this branch have to be true for this branch to be true.">
+<div class="filter-operator">
 
 </div>
 <div class="filter-contents">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -53,11 +53,17 @@ define([
         onBeforeShow: function(){
             this.filterOperator.show(DropdownView.createSimpleDropdown({
                 list: [{
-                    label: 'AND',
+                    label: 'All of these',
                     value: 'AND'
                 }, {
-                    label: 'OR',
+                    label: 'Any of these',
                     value: 'OR'
+                }, {
+                    label: 'Not all of these',
+                    value: 'NOT AND'
+                }, {
+                    label: 'Not any of these',
+                    value: 'NOT OR'
                 }],
                 defaultSelection: ['AND']
             }));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -357,21 +357,36 @@ define([
         }
 
         function matchesFilters(metacard, resultFilter, metacardTypes) {
+            var i;
             switch (resultFilter.type) {
                 case 'AND':
-                    for (var i = 0; i <= resultFilter.filters.length - 1; i++) {
+                    for (i = 0; i <= resultFilter.filters.length - 1; i++) {
                         if (!matchesFilter(metacard, resultFilter.filters[i], metacardTypes)) {
                             return false;
                         }
                     }
                     return true;
-                case 'OR':
-                    for (var j = 0; j <= resultFilter.filters.length - 1; j++) {
-                        if (matchesFilter(metacard, resultFilter.filters[j], metacardTypes)) {
+                case 'NOT AND':
+                    for (i = 0; i <= resultFilter.filters.length - 1; i++) {
+                        if (!matchesFilter(metacard, resultFilter.filters[i], metacardTypes)) {
                             return true;
                         }
                     }
-                    break;
+                    return false;
+                case 'OR':
+                    for (i = 0; i <= resultFilter.filters.length - 1; i++) {
+                        if (matchesFilter(metacard, resultFilter.filters[i], metacardTypes)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                case 'NOT OR':
+                    for (i = 0; i <= resultFilter.filters.length - 1; i++) {
+                        if (matchesFilter(metacard, resultFilter.filters[i], metacardTypes)) {
+                            return false;
+                        }
+                    }
+                    return true;
                 default:
                     return matchesFilter(metacard, resultFilter, metacardTypes);
             }


### PR DESCRIPTION
#### What does this PR do?
 - Adds the ability to perform queries with the 'NOT' operator to the Catalog UI.
 - This allows users to exclude results from their query.  If structured correctly a user can also query for all results that lack a particular attribute.

#### I'm looking for feedback in particular about what to name these new options.
 - Right now they're tentatively named 'NOT AND' and 'NOT OR'.  Please comment with some suggestions.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@djblue 
@rzwiefel 
@tbatie 
@jlcsmith 
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Go to the Advanced Query view and select one of the 'NOT' operators.  Verify it works as expected.
Go to the results for a query.  Add a client side filter with one of the 'NOT' operators.  Verify it works as expected.
