### PR TITLE
DDF-2806 Add Jetty dependency to Catalog UI Search pom.xml

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>filter-proxy</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
#### What does this PR do?
Add Jetty dependency to Catalog UI Search pom.xml

This removes an exception in the log relating to GzipFilters being deprecated.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @brendan-hofmann @emanns95 @spearskw 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@shaundmorris
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Simple build to verify UI is loaded correctly in admin UI.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2806)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
