### PR TITLE
DDF-2807: Cleans up maven profiles & adds quickbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ The distribution will be available under "distribution/ddf/target" directory.
 To build DDF using the [parallel builds feature of maven](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3), Run the following command:
 
 ```
-mvn install -T 8 -P\!documentation
+mvn install -T 8 -DskipDocs=true
 ```
 
 Which tells maven to use 8 threads when building DDF. You can manually adjust the thread count to suit your machine, or use a relative thread count to the number of cores present on your machine by running the following command:
 
 ```
-mvn install -T 1.5C -P\!documentation
+mvn install -T 1.5C -DskipDocs=true
 ```
 
 Which will use 6 threads if your machine has 4 cores.

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -539,22 +539,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>integration-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <includes>
-                                <include>**/*IntegrationTest.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
@@ -96,6 +96,29 @@
                         </goals>
                         <configuration>
                             <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>

--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -433,7 +433,10 @@
         <profile>
             <id>documentation</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>skipDocs</name>
+                    <value>!true</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -117,7 +117,10 @@
         <profile>
             <id>documentation</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>skipDocs</name>
+                    <value>!true</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -54,7 +54,10 @@
         <profile>
             <id>documentation</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>skipDocs</name>
+                    <value>!true</value>
+                </property>
             </activation>
                 <properties>
                     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,27 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.4.201502262128</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.8.1</version>
+                    <configuration>
+                        <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>3.2.0</version>
@@ -251,107 +272,6 @@
                         <maxmem>512M</maxmem>
                         <fork>${compiler.fork}</fork>
                         <encoding>${project.build.sourceEncoding}</encoding>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.4</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>ddf.support</groupId>
-                            <artifactId>support-pmd</artifactId>
-                            <version>${ddf.support.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <rulesets>
-                            <ruleset>
-                                basic.xml
-                            </ruleset>
-                            <ruleset>
-                                empty.xml
-                            </ruleset>
-                            <ruleset>
-                                sunsecure.xml
-                            </ruleset>
-                            <ruleset>
-                                unnecessary.xml
-                            </ruleset>
-                        </rulesets>
-                        <failOnViolation>
-                            false
-                        </failOnViolation>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>
-                                    check
-                                </goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>ddf.support</groupId>
-                            <artifactId>support-checkstyle</artifactId>
-                            <version>${ddf.support.version}</version>
-                            <optional>true</optional>
-                        </dependency>
-                    </dependencies>
-                    <executions>
-                        <execution>
-                            <id>checkstyle-check</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <!-- This configures the plugin for mvn install -->
-                                <configLocation>checkstyle-enforced.xml</configLocation>
-                                <headerLocation>lpgl-header-check.txt</headerLocation>
-                                <sourceDirectory>${basedir}</sourceDirectory>
-                                <includes>src/**/*.java</includes>
-                                <consoleOutput>true</consoleOutput>
-                                <failsOnError>true</failsOnError>
-                                <linkXRef>false</linkXRef>
-                                <aggregate>true</aggregate>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>checkstyle-check-xml</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <!-- This configures the plugin for mvn install -->
-                                <configLocation>checkstyle-enforced-xml.xml</configLocation>
-                                <headerLocation>lpgl-header-check-xml.txt</headerLocation>
-                                <sourceDirectory>${basedir}</sourceDirectory>
-                                <includes>src/**/*.xml, pom.xml</includes>
-                                <consoleOutput>true</consoleOutput>
-                                <failsOnError>true</failsOnError>
-                                <linkXRef>false</linkXRef>
-                                <aggregate>true</aggregate>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <!-- This configures the plugin for mvn checkstyle:checkstyle  -->
-                        <configLocation>checkstyle-enforced.xml</configLocation>
-                        <headerLocation>lpgl-header-check.txt</headerLocation>
-                        <sourceDirectory>${basedir}</sourceDirectory>
-                        <includes>src/**/*.java</includes>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                        <linkXRef>false</linkXRef>
-                        <aggregate>true</aggregate>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -414,14 +334,6 @@
                     <version>2.3.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.8.1</version>
-                    <configuration>
-                        <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>2.5.1</version>
@@ -464,67 +376,6 @@
                         </additionalparam>
                         <outputDirectory>${project.build.directory}</outputDirectory>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.4.201502262128</version>
-                    <executions>
-                        <execution>
-                            <id>default-prepare-agent</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>default-report</id>
-                            <phase>prepare-package</phase>
-                            <configuration>
-                                <outputDirectory>
-                                    ${project.build.directory}/site/${project.report.output.directory}/jacoco/
-                                </outputDirectory>
-                            </configuration>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>default-check</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <haltOnFailure>true</haltOnFailure>
-                                <rules>
-                                    <rule>
-                                        <element>BUNDLE</element>
-                                        <!--
-                                        When overriding the limits in child pom files make sure
-                                        to override all four limits. Limits that are excluded
-                                        will be set to 0 not 0.75
-                                        -->
-                                        <limits>
-                                            <limit>
-                                                <counter>INSTRUCTION</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                            <limit>
-                                                <counter>BRANCH</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                            <limit>
-                                                <counter>COMPLEXITY</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                        </limits>
-                                    </rule>
-                                </rules>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
@@ -577,34 +428,10 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <!--  We don't want to inherit this *change* to the plugin configuration. -->
-                <!--  Sub modules will still inherit the plugin and the configuration from pluginManagment -->
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <!-- Match the execution defined in the pluginManagment and override it-->
-                        <!-- Prev check here. -->
-                        <id>checkstyle-check</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>checkstyle-check-xml</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
@@ -614,32 +441,234 @@
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs.version}</version>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>High</threshold>
-                    <xmlOutput>true</xmlOutput>
-                    <xmlOutputDirectory>${project.build.directory}/findbugs</xmlOutputDirectory>
-                </configuration>
-            </plugin>
         </plugins>
     </reporting>
     <profiles>
         <profile>
-            <id>pmd</id>
+            <id>staticAnalysis</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>skipStatic</name>
+                    <value>!true</value>
+                </property>
             </activation>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-checkstyle-plugin</artifactId>
+                            <version>2.17</version>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>ddf.support</groupId>
+                                    <artifactId>support-checkstyle</artifactId>
+                                    <version>${ddf.support.version}</version>
+                                    <optional>true</optional>
+                                </dependency>
+                            </dependencies>
+                            <executions>
+                                <execution>
+                                    <id>checkstyle-check</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <!-- This configures the plugin for mvn install -->
+                                        <configLocation>checkstyle-enforced.xml</configLocation>
+                                        <headerLocation>lpgl-header-check.txt</headerLocation>
+                                        <sourceDirectory>${basedir}</sourceDirectory>
+                                        <includes>src/**/*.java</includes>
+                                        <consoleOutput>true</consoleOutput>
+                                        <failsOnError>true</failsOnError>
+                                        <linkXRef>false</linkXRef>
+                                        <aggregate>true</aggregate>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>checkstyle-check-xml</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <!-- This configures the plugin for mvn install -->
+                                        <configLocation>checkstyle-enforced-xml.xml</configLocation>
+                                        <headerLocation>lpgl-header-check-xml.txt</headerLocation>
+                                        <sourceDirectory>${basedir}</sourceDirectory>
+                                        <includes>src/**/*.xml, pom.xml</includes>
+                                        <consoleOutput>true</consoleOutput>
+                                        <failsOnError>true</failsOnError>
+                                        <linkXRef>false</linkXRef>
+                                        <aggregate>true</aggregate>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <!-- This configures the plugin for mvn checkstyle:checkstyle  -->
+                                <configLocation>checkstyle-enforced.xml</configLocation>
+                                <headerLocation>lpgl-header-check.txt</headerLocation>
+                                <sourceDirectory>${basedir}</sourceDirectory>
+                                <includes>src/**/*.java</includes>
+                                <consoleOutput>true</consoleOutput>
+                                <failsOnError>true</failsOnError>
+                                <linkXRef>false</linkXRef>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-prepare-agent</id>
+                                    <goals>
+                                        <goal>prepare-agent</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>default-report</id>
+                                    <phase>prepare-package</phase>
+                                    <configuration>
+                                        <outputDirectory>
+                                            ${project.build.directory}/site/${project.report.output.directory}/jacoco/
+                                        </outputDirectory>
+                                    </configuration>
+                                    <goals>
+                                        <goal>report</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>default-check</id>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <haltOnFailure>true</haltOnFailure>
+                                        <rules>
+                                            <rule>
+                                                <element>BUNDLE</element>
+                                                <!--
+                                                When overriding the limits in child pom files make sure
+                                                to override all four limits. Limits that are excluded
+                                                will be set to 0 not 0.75
+                                                -->
+                                                <limits>
+                                                    <limit>
+                                                        <counter>INSTRUCTION</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                    <limit>
+                                                        <counter>BRANCH</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                    <limit>
+                                                        <counter>COMPLEXITY</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                </limits>
+                                            </rule>
+                                        </rules>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-pmd-plugin</artifactId>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <!--  We don't want to inherit this *change* to the plugin configuration. -->
+                        <!--  Sub modules will still inherit the plugin and the configuration from pluginManagment -->
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <!-- Match the execution defined in the pluginManagment and override it-->
+                                <!-- Prev check here. -->
+                                <id>checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>checkstyle-check-xml</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-findbugs</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>ddf.support</groupId>
+                                            <artifactId>support-findbugs</artifactId>
+                                            <version>${ddf.support.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>
+                                                ${project.build.directory}/target/classes/
+                                            </outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <excludes>META-INF</excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <version>${findbugs.version}</version>
+                        <configuration>
+                            <excludeFilterFile>
+                                ${project.build.directory}/target/classes/findbugs-exclude.xml
+                            </excludeFilterFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>generate-findbugs</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>2.17</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <version>${findbugs.version}</version>
+                        <configuration>
+                            <effort>Max</effort>
+                            <threshold>High</threshold>
+                            <xmlOutput>true</xmlOutput>
+                            <xmlOutputDirectory>${project.build.directory}/findbugs
+                            </xmlOutputDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
         <profile>
             <id>release</id>
@@ -789,76 +818,6 @@
                 </plugins>
             </reporting>
         </profile>
-        <profile>
-            <id>findbugs</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-findbugs</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>ddf.support</groupId>
-                                            <artifactId>support-findbugs</artifactId>
-                                            <version>${ddf.support.version}</version>
-                                            <type>jar</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>
-                                                ${project.build.directory}/target/classes/
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <excludes>META-INF</excludes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>${findbugs.version}</version>
-                        <configuration>
-                            <excludeFilterFile>
-                                ${project.build.directory}/target/classes/findbugs-exclude.xml
-                            </excludeFilterFile>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>generate-findbugs</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.gmavenplus</groupId>
-                        <artifactId>gmavenplus-plugin</artifactId>
-                        <version>1.4</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>compile</goal>
-                                    <goal>testCompile</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
     <!--
       Dependencies listed here will always be used in all sub poms.
@@ -936,4 +895,3 @@
         <module>distribution</module>
     </modules>
 </project>
-


### PR DESCRIPTION
#### What does this PR do?
**Description of the changes for each file in order:**
_README.md_
Updates build instructions in the README to reflect the changes below. 

_catalog-core-standardframework/pom.xml_
Removes unused integration test profile

_spatial-geocoding-geocoder/pom.xml_
Updates this pom to have `<rules` which was breaking 

_search-ui/standard/pom.xml, distribution/ddf/pom.xml, distribution/docs/pom.xml_
Changes the documentation profile to be activated when the property “skipDocs” is false or not provided. (Reference an example here: http://maven.apache.org/guides/introduction/introduction-to-profiles.html). This was done to prevent issues with profile activation that were happening. 
From the Maven website, emphasis mine:
_[A profile using `<activeByDefault>`] will automatically be active for all builds unless another profile **in the same POM** is activated using one of the previously described methods. All profiles that are active by default are **automatically deactivated** when a profile in the POM is activated on the command line or through its activation config._

By changing it to property based activation, the profile will still run by default without being deactivated by other profiles and can also be skipped with `-DskipDocs=true` when running a build. 

_pom.xml_
Removes pmd plugin. 
Formatting changes.
Adds quick build, the current quick build disables findbugs, tests, jacoco, and skips test scope, I am not certain if that last bit is necessary. Documentation cannot easily be added to this profile because of the property based activation.
If there is anything missing from this profile, please provide feedback.
For findbugs, I have again added property based activation just in case.   
**Update:**
Created a profile to contain all of our static analysis tools. 
This profile runs by default when `skipTools` is not defined. Running with `-DskipTools=true` will deactivate the profile, thus deactivating all the static analysis tools. Use this with caution, the following tools will not be run: Checkstyle, Jacoco, Findbugs. 
As a result, I removed the Findbugs profile after moving it into the static analysis tool profile.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@oconnormi @AzGoalie @brendan-hofmann @Lambeaux @tbatie 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Run using `-Prelease` and verify the documentation is in the distribution
Run using `-Pquickbuild` and verify the build is quicker than a full build
Run using `-DskipDocs=true` and verify the docs are skipped

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2807)