### PR TITLE
DDF-2808 Added integration test for ogc:Not filters

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/resources/TestSpatial/csw/request/query/CswCompoundNot.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/TestSpatial/csw/request/query/CswCompoundNot.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<GetRecords xmlns="http://www.opengis.net/cat/csw/2.0.2"
+            xmlns:ogc="http://www.opengis.net/ogc"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            service="CSW"
+            version="2.0.2"
+            maxRecords="10"
+            startPosition="1"
+            resultType="results"
+            outputFormat="application/xml"
+            outputSchema="http://www.opengis.net/cat/csw/2.0.2"
+            xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 ../../../csw/2.0.2/CSW-discovery.xsd">
+    <Query typeNames="Record">
+        <ElementSetName>full</ElementSetName>
+        <Constraint version="1.1.0">
+            <ogc:Filter>
+                <ogc:And>
+                    <ogc:PropertyIsEqualTo matchCase="true">
+                        <ogc:PropertyName>AnyText</ogc:PropertyName>
+                        <ogc:Literal>7c8da3209c994668b76102309b8f4769</ogc:Literal>
+                    </ogc:PropertyIsEqualTo>
+                    <ogc:Not>
+                        <ogc:PropertyIsLike escapeChar="\" singleChar="?" wildCard="*">
+                            <ogc:PropertyName>dc:title</ogc:PropertyName>
+                            <ogc:Literal>Aliquam *</ogc:Literal>
+                        </ogc:PropertyIsLike>
+                    </ogc:Not>
+                </ogc:And>
+            </ogc:Filter>
+        </Constraint>
+    </Query>
+</GetRecords>

--- a/distribution/test/itests/test-itests-common/src/main/resources/TestSpatial/csw/request/query/CswCompoundNotBeforeDateAndLikeText.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/TestSpatial/csw/request/query/CswCompoundNotBeforeDateAndLikeText.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<GetRecords xmlns="http://www.opengis.net/cat/csw/2.0.2"
+            xmlns:ogc="http://www.opengis.net/ogc"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            service="CSW"
+            version="2.0.2"
+            maxRecords="10"
+            startPosition="1"
+            resultType="results"
+            outputFormat="application/xml"
+            outputSchema="http://www.opengis.net/cat/csw/2.0.2"
+            xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 ../../../csw/2.0.2/CSW-discovery.xsd">
+    <Query typeNames="Record">
+        <ElementSetName>full</ElementSetName>
+        <Constraint version="1.1.0">
+            <ogc:Filter>
+                <ogc:Not>
+                    <ogc:And>
+                        <ogc:PropertyIsLessThan>
+                            <ogc:PropertyName>created</ogc:PropertyName>
+                            <ogc:Literal>2012-12-26T10:10:19.000-07:00</ogc:Literal>
+                        </ogc:PropertyIsLessThan>
+                        <ogc:PropertyIsLike wildCard="*" singleChar="#" escapeChar="!">
+                            <ogc:PropertyName>AnyText</ogc:PropertyName>
+                            <ogc:Literal>PlainXml</ogc:Literal>
+                        </ogc:PropertyIsLike>
+                    </ogc:And>
+                </ogc:Not>
+            </ogc:Filter>
+        </Constraint>
+    </Query>
+</GetRecords>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
@@ -59,8 +59,6 @@ public class TestSpatial extends AbstractIntegrationTest {
 
     private static final String CSW_QUERY_RESOURCES = CSW_RESOURCE_ROOT + "csw/request/query/";
 
-    private static final DynamicUrl CSW_ENDPOINT_URL = new DynamicUrl(SERVICE_ROOT, "/csw");
-
     private static final String CSW_METACARD = "CswRecord.xml";
 
     private static final String GEOJSON_NEAR_METACARD = "GeoJson near";
@@ -78,41 +76,41 @@ public class TestSpatial extends AbstractIntegrationTest {
     private static Map<String, String> metacardIds = new HashMap<>();
 
     private final ImmutableMap<String, ExpectedResultPair[]> cswExpectedResults =
-            ImmutableMap.<String, ExpectedResultPair[]>builder().put("CswAfterDateQuery",
-                    new ExpectedResultPair[] {
-                            new ExpectedResultPair(ResultType.TITLE, GEOJSON_NEAR_METACARD)})
-                    .put("CswBeforeDateQuery",
-                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
-                                    PLAINXML_FAR_METACARD)})
+            ImmutableMap.<String, ExpectedResultPair[]>builder()
+                    .put("CswAfterDateQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
+                                    GEOJSON_NEAR_METACARD)})
+                    .put("CswBeforeDateQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                            ResultType.TITLE,
+                            PLAINXML_FAR_METACARD)})
                     .put("CswContainingWktLineStringQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, GEOJSON_FAR_METACARD)})
+                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                                    GEOJSON_FAR_METACARD)})
                     .put("CswContainingWktPolygonQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_FAR_METACARD)})
-                    .put("CswDuringDatesQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, GEOJSON_FAR_METACARD)})
-                    .put("CswEqualToTextQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
+                    .put("CswDuringDatesQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
+                                    GEOJSON_FAR_METACARD)})
+                    .put("CswEqualToTextQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
+                                    CSW_METACARD)})
                     .put("CswIntersectingWktLineStringQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_NEAR_METACARD)})
                     .put("CswIntersectingWktPolygonQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     GEOJSON_NEAR_METACARD)})
-                    .put("CswLikeTextQuery",
-                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                    .put("CswLikeTextQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
                                     GEOJSON_NEAR_METACARD)})
                     .put("CswNearestToWktLineStringQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_NEAR_METACARD)})
                     .put("CswNearestToWktPolygonQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, GEOJSON_NEAR_METACARD),
-                                    new ExpectedResultPair(ResultType.TITLE,
-                                            PLAINXML_NEAR_METACARD)})
+                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                                    GEOJSON_NEAR_METACARD), new ExpectedResultPair(ResultType.TITLE,
+                                    PLAINXML_NEAR_METACARD)})
                     .put("CswOverLappingDatesQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     GEOJSON_NEAR_METACARD)})
@@ -134,6 +132,9 @@ public class TestSpatial extends AbstractIntegrationTest {
                     .put("CswCompoundBeforeDateAndLikeText",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_FAR_METACARD)})
+                    .put("CswCompoundNotBeforeDateAndLikeText",
+                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                                    CSW_METACARD)})
                     .put("CswLogicalOperatorContextualNotQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_NEAR_METACARD)})
@@ -145,11 +146,14 @@ public class TestSpatial extends AbstractIntegrationTest {
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_FAR_METACARD)})
                     .put("CswXPathExpressionQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
-                    .put("CswFuzzyTextQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
+                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                                    CSW_METACARD)})
+                    .put("CswFuzzyTextQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
+                                    CSW_METACARD)})
+                    .put("CswCompoundNot", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.COUNT,
+                                    "0")})
                     .build();
 
     @BeforeExam
@@ -300,6 +304,13 @@ public class TestSpatial extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testCswCompoundNotBeforeDateAndLikeText()
+            throws XPathException, ParserConfigurationException, SAXException, IOException {
+
+        performQueryAndValidateExpectedResults("CswCompoundNotBeforeDateAndLikeText");
+    }
+
+    @Test
     public void testCswCompoundLikeTextAndIntersectingWktLineString()
             throws XPathException, ParserConfigurationException, SAXException, IOException {
 
@@ -332,6 +343,13 @@ public class TestSpatial extends AbstractIntegrationTest {
             throws XPathException, ParserConfigurationException, SAXException, IOException {
 
         performQueryAndValidateExpectedResults("CswXPathExpressionQuery");
+    }
+
+    @Test
+    public void testCswCompoundNot()
+            throws XPathException, ParserConfigurationException, SAXException, IOException {
+
+        performQueryAndValidateExpectedResults("CswCompoundNot");
     }
 
     @Test
@@ -379,8 +397,7 @@ public class TestSpatial extends AbstractIntegrationTest {
             if (!queryResourcePath.endsWith("/")) {
                 String queryName = queryResourcePath.substring(
                         queryResourcePath.lastIndexOf("/") + 1);
-                savedQueries.put(removeFileExtension(queryName),
-                        getFileContent(queryResourcePath));
+                savedQueries.put(removeFileExtension(queryName), getFileContent(queryResourcePath));
             }
         }
         return savedQueries;
@@ -423,8 +440,9 @@ public class TestSpatial extends AbstractIntegrationTest {
     private void hasExpectedResults(String queryResult, ExpectedResultPair[] expectedValues)
             throws XPathException, ParserConfigurationException, SAXException, IOException {
         if (expectedValues[0].type == ResultType.COUNT) {
-            assertTrue("The responses contained a different count",
-                    hasExpectedResultCount(queryResult, expectedValues[0]));
+            assertTrue("The responses contained a different count", hasExpectedResultCount(
+                    queryResult,
+                    expectedValues[0]));
         } else if (expectedValues[0].type == ResultType.TITLE) {
             //assertion done within the method
             hasExpectedMetacardsReturned(queryResult, expectedValues);


### PR DESCRIPTION
#### What does this PR do?
This PR adds 2 integration tests for ogc:NOT filters in TestSpatial to prevent any regressions.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@troymohl @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Build DDF
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2808](https://codice.atlassian.net/browse/DDF-2808)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
