### PR TITLE
DDF-2802 fix for confluence source docs (2.10.x)

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -80,7 +80,7 @@ For *NIX, use the `CertNew.sh` script.
 
 `sh CertNew.sh <FQDN>`
 
-Alternatively, a FQDN can be provided to the script with a comma-delimited string.
+Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
 `sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
 ****
@@ -91,7 +91,7 @@ For Windows, use the `CertNew.cmd` script.
 
 `CertNew -cn <FQDN>`
 
-Alternatively, a FQDN can be provided to the script with a comma-delimited string.
+Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
 `CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
 ****

--- a/distribution/docs/src/main/resources/_contents/_sources/confluence-federated-source-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_sources/confluence-federated-source-contents.adoc
@@ -1,7 +1,7 @@
 
 ==== Federated Source for Atlassian Confluence(R)
 
-The Confluence source provides a Federated Source to retrieve pages, comments, and attachments from a Confluence REST API and turns the results into Metacards the system can use.
+The Confluence source provides a Federated Source to retrieve pages, comments, and attachments from an Atlassian Confluence(R) REST API and turns the results into Metacards the system can use.
 The Confluence source does provide a Connected Source interface but its functionality has not been verified.
 
 Confluence Source has been tested against the following versions of Confluence with REST API v2

--- a/distribution/docs/src/main/resources/_contents/_sources/federated-sources-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_sources/federated-sources-contents.adoc
@@ -1,6 +1,8 @@
 
 The following federated sources are included with a standard installation of ${branding}:
 
+<<_federated_source_for_atlassian_confluence,Atlassian Confluence(R) Federated Source>>:: Retrieves pages, comments, and attachments from an Atlassian Confluence(R) REST API.
+
 <<_csw_federated_source,CSW Federated Source>>:: Supports searching collections of descriptive information (metadata) for data, services, and related information objects.
 
 <<_csw_federation_profile_source,CSW Federation Profile Source>>:: Supports searching collections of descriptive information (metadata) for data, services, and related information objects.

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -357,6 +357,8 @@ include::{adoc-include}/_sources/federation-strategy-contents.adoc[]
 
 include::{adoc-include}/_sources/federated-sources-contents.adoc[]
 
+include::{adoc-include}/_sources/confluence-federated-source-contents.adoc[]
+
 include::{adoc-include}/_sources/csw-federated-source-contents.adoc[]
 
 include::{adoc-include}/_sources/csw-federation-profile-source-contents.adoc[]


### PR DESCRIPTION
#### What does this PR do?

updates federated sources to include confluence source docs.

#### Who is reviewing it?

@Lambeaux @vinamartin @mcalcote @jrnorth @ahoffer @clockard 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR.

@coyotesqrl
@pklinef
@shaundmorris

#### How should this be tested?

Verify confluence docs present in docs.

#### What are the relevant tickets?
[DDF-2802](https://codice.atlassian.net/browse/DDF-2802)
#### Screenshots (if appropriate)


#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
