### PR TITLE
[Backport] DDF-2795 Fix attribute overrides in directory monitor causing an error if the value has a comma

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObject.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObject.java
@@ -16,22 +16,19 @@ package ddf.camel.component.catalog.content;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.camel.Message;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileMessage;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -192,25 +189,16 @@ public class ContentProducerDataAccessObject {
 
     public void processHeaders(Map<String, Object> headers, StorageRequest storageRequest,
             File ingestedFile) {
-        String attributeOverrideHeaders = (String) headers.get(Constants.ATTRIBUTE_OVERRIDES_KEY);
-        if (StringUtils.isNotEmpty(attributeOverrideHeaders)) {
+        Map<String, Serializable> attributeOverrideHeaders = new HashMap<>((Map) headers.get(
+                Constants.ATTRIBUTE_OVERRIDES_KEY));
+        if (!attributeOverrideHeaders.isEmpty()) {
             storageRequest.getProperties()
                     .put(Constants.ATTRIBUTE_OVERRIDES_KEY,
-                            createAttributeOverrideMapFromHeaders(attributeOverrideHeaders));
+                            (Serializable) attributeOverrideHeaders);
         }
         if (headers.containsKey(Constants.STORE_REFERENCE_KEY)) {
             storageRequest.getProperties()
                     .put(Constants.STORE_REFERENCE_KEY, ingestedFile.getAbsolutePath());
         }
-    }
-
-    public HashMap<String, List<String>> createAttributeOverrideMapFromHeaders(
-            String attributeOverrideHeaders) {
-        return Arrays.stream(attributeOverrideHeaders.split(","))
-                .collect(Collectors.toMap(s -> s.split("=")[0],
-                        s -> Collections.singletonList(s.split("=")[1]),
-                        (a, b) -> Stream.concat(a.stream(), b.stream())
-                                .collect(Collectors.toList()),
-                        HashMap::new));
     }
 }

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import ddf.catalog.CatalogFramework;
@@ -209,7 +210,10 @@ public class ContentProducerDataAccessObjectTest {
         String mimeType = "txt";
 
         Map<String, Object> headers = new HashedMap();
-        headers.put(Constants.ATTRIBUTE_OVERRIDES_KEY, "example=something");
+        Map<String, Serializable> attributeOverrides = new HashMap<>();
+        attributeOverrides.put("example", ImmutableList.of("something", "something1"));
+        attributeOverrides.put("example2", ImmutableList.of("something2"));
+        headers.put(Constants.ATTRIBUTE_OVERRIDES_KEY, attributeOverrides);
 
         kind = StandardWatchEventKinds.ENTRY_CREATE;
         contentProducerDataAccessObject.createContentItem(mockFileSystemPersistenceProvider,
@@ -243,17 +247,22 @@ public class ContentProducerDataAccessObjectTest {
         StorageRequest storageRequest = mock(StorageRequest.class);
         doReturn(requestProperties).when(storageRequest)
                 .getProperties();
+
         Map<String, Object> camelHeaders = new HashMap<>();
-        camelHeaders.put(Constants.ATTRIBUTE_OVERRIDES_KEY, "foo=bar,foo=baz");
+        Map<String, Serializable> attributeOverrides = new HashMap<>();
+        attributeOverrides.put("example", ImmutableList.of("something", "something1"));
+        attributeOverrides.put("example2", ImmutableList.of("something2"));
+        camelHeaders.put(Constants.ATTRIBUTE_OVERRIDES_KEY, attributeOverrides);
+
         contentProducerDataAccessObject.processHeaders(camelHeaders,
                 storageRequest,
                 Files.createTempFile("foobar", "txt")
                         .toFile());
         assertThat(requestProperties.containsKey(Constants.STORE_REFERENCE_KEY), is(false));
         assertThat(((Map<String, List<String>>) requestProperties.get(Constants.ATTRIBUTE_OVERRIDES_KEY)).get(
-                "foo"), is(Arrays.asList("bar", "baz")));
+                "example"), is(Arrays.asList("something", "something1")));
         requestProperties.clear();
-        camelHeaders.put(Constants.ATTRIBUTE_OVERRIDES_KEY, "");
+        camelHeaders.put(Constants.ATTRIBUTE_OVERRIDES_KEY, ImmutableMap.of());
         camelHeaders.put(Constants.STORE_REFERENCE_KEY, "true");
         contentProducerDataAccessObject.processHeaders(camelHeaders,
                 storageRequest,

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,7 +25,7 @@
             name="Maximum Concurrent Files" id="numThreads" required="true"
             type="Integer" default="1"/>
 
-        <AD description="Specifies the time to wait (in milliseconds) before acquiring a lock on a file in the monitored directory.  This interval is used for sleeping between attempts to acquire the read lock on a file to be ingested.  The default value of 1000 milliseconds is recommended."
+        <AD description="Specifies the time to wait (in milliseconds) before acquiring a lock on a file in the monitored directory.  This interval is used for sleeping between attempts to acquire the read lock on a file to be ingested.  The default value of 100 milliseconds is recommended. If the value provided is less than 100, the default value will be used."
             name="ReadLock Time Interval" id="readLockIntervalMilliseconds" required="true"
             type="Integer" default="100"/>
 

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import ddf.catalog.Constants;
-
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 
@@ -53,8 +51,8 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
 
     private static final String DUMMY_DATA = "Dummy data in a text file. ";
 
-    private static final List<String> ATTRIBUTE_OVERRIDES = Arrays.asList("test1=someParameter1",
-            "test2=someParameter2");
+    private static final String[] ATTRIBUTE_OVERRIDES =
+            new String[] {"test1=someParameter1", "test1=someParameter0", "test2=(some,parameter,with,commas)"};
 
     private static final int MAX_SECONDS_FOR_FILE_COPY = 5;
 
@@ -184,9 +182,9 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
                 1000);
         RouteDefinition routeDefinition = camelContext.getRouteDefinitions()
                 .get(0);
-        assertThat(routeDefinition.toString(), containsString(
-                "SetHeader[" + Constants.ATTRIBUTE_OVERRIDES_KEY
-                        + ", simple{Simple: test1=someParameter1,test2=someParameter2}"));
+        assertThat(routeDefinition.toString(),
+                containsString("SetHeader[" + Constants.ATTRIBUTE_OVERRIDES_KEY
+                        + ", {{test2=[(some,parameter,with,commas)], test1=[someParameter1, someParameter0]}}"));
     }
 
     @Test
@@ -312,12 +310,12 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
     }
 
     private void submitConfigOptions(ContentDirectoryMonitor monitor, String monitoredDirectory,
-            String processingMechanism, List<String> attributeOverrides, int numThreads,
+            String processingMechanism, String[] attributeOverrides, int numThreads,
             int readLockIntervalMilliseconds) throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put("monitoredDirectoryPath", monitoredDirectory);
         properties.put("processingMechanism", processingMechanism);
-        properties.put("attributeOverrides", attributeOverrides.toArray());
+        properties.put("attributeOverrides", attributeOverrides);
         properties.put("numThreads", numThreads);
         properties.put("readLockIntervalMilliseconds", readLockIntervalMilliseconds);
         monitor.updateCallback(properties);


### PR DESCRIPTION
#### What does this PR do?
Pass in map of attribute overrides to routeDefinition instead of comma-separated string to ensure attributes with commas do not cause an error

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@ryeats 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith  

#### How should this be tested? (List steps with links to updated documentation)
* Monitor a directory
* Set an attribute override of `location=Polygon((10 10, 10 20, 20 20, 20 10, 10 10 ))`
* Check that the override works for files placed in the directory (`catalog:inspect metacard`)

#### What are the relevant tickets?
[DDF-2795](https://codice.atlassian.net/browse/DDF-2795)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
