### PR TITLE
DDF-2829: Combined Doc and Documentation folders into a single folder

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -111,27 +111,27 @@
         <!-- Javadoc -->
         <fileSet>
             <directory>${setup.folder}/catalog_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/catalog_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/catalog_api_javadoc</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${setup.folder}/mime_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/mime_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/mime_api_javadoc</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${setup.folder}/content_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/content_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/content_api_javadoc</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${setup.folder}/action_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/action_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/action_api_javadoc</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${setup.folder}/security_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/security_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/security_api_javadoc</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${setup.folder}/encryption_api_javadoc</directory>
-            <outputDirectory>/docs/sdk/encryption_api_javadoc</outputDirectory>
+            <outputDirectory>/documentation/javadoc/encryption_api_javadoc</outputDirectory>
         </fileSet>
 
         <!-- Console Branding -->


### PR DESCRIPTION
#### What does this PR do?
Combined Doc and Documentation folders into a single folder
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote @vinamartin @emmberk 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@ricklarsen 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold 
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
Build the distro using a build profile that includes documentation (mvn javadoc:aggregate OR mvn release are two such examples) and ensure that all documentation and javadocs are in the documentation folder.
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2829)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
