### PR TITLE
DDF-2832 Update upload validation check to include metacard validation in addition to attribute validation

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/upload-item/upload-item.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/upload-item/upload-item.less
@@ -204,3 +204,11 @@
         transform: scale(1) translateX(100%);
     }
 }
+
+@{customElementNamespace}upload-item.has-validation-issues.checking-validation {
+
+    .success-issues {
+        opacity: @minimumOpacity;
+        transform: scale(1) translateX(0%);
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Upload.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Upload.js
@@ -12,6 +12,7 @@
 /*global require, setTimeout*/
 var Backbone = require('backbone');
 var $ = require('jquery');
+require('js/jquery.whenAll');
 
 function fileMatches(file, model) {
     return file === model.get('file');
@@ -22,10 +23,20 @@ function checkValidation(model) {
         model.set('validating', true);
         //wait for solr
         setTimeout(function() {
-            $.get('/search/catalog/internal/metacard/' + model.get('id') + '/attribute/validation').then(function(response) {
+            $.whenAll.apply(this, [
+                $.get('/search/catalog/internal/metacard/' + model.get('id') + '/attribute/validation').then(function(response) {
+                    model.set({
+                        issues: model.get('issues') || response.length > 0
+                    });
+                }),
+                $.get('/search/catalog/internal/metacard/' + model.get('id') + '/validation').then(function(response) {
+                    model.set({
+                        issues: model.get('issues') || response.length > 0
+                    });
+                })
+            ]).always(function() {
                 model.set({
-                    validating: false,
-                    issues: response.length > 0
+                    validating: false
                 });
             });
         }, 2000);


### PR DESCRIPTION
#### What does this PR do?
 - Previously the check only included attribute validation.  Now it will look for both metacard and attribute validation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@jlcsmith 
@troymohl 
@andrewkfiedler 

#### How should this be tested? (List steps with links to updated documentation)
Add a metacard validator and an attribute validator.  Verify that with one, the other, or both violated that they get flagged on the upload view.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2832