### PR TITLE
DDF-2831 Made retry intervals for Catalog Sources configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ replace with next unreleased version
 - List of features added
 
 	- [JIRA View of All New Features](https://codice.atlassian.net/issues/?jql=project%3DDDF%20AND%20issuetype%20in%20%28%22new%20feature%22%2C%20improvement%2C%20story%2C%20task%29%20AND%20fixVersion%20%3D%20VERSION_NUMBER%20ORDER%20BY%20priority)
+	- [Configurable retry intervals for unavailable Catalog Sources](https://codice.atlassian.net/browse/DDF-2831)
 
 ### API CHANGES
 

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -143,6 +143,16 @@ org.codice.ddf.platform.requireAuditEncoding=false
 
 # Sets the default port number for the catalog-ftp feature FTP endpoint
 org.codice.ddf.catalog.ftp.port=8021
+#
+# Maximum Endpoint Contact Interval
+#
+# Max seconds between attempts to contact the endpoint of a source
+org.codice.ddf.platform.util.http.maxRetryInterval=300
+#
+# Initial Endpoint Contact Interval
+#
+# Initial seconds between attempts to contact the endpoint of a source
+org.codice.ddf.platform.util.http.initialRetryInterval=10
 
 
 #

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
@@ -224,6 +224,29 @@ TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 |org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
 |Yes
 
+
+6+^h|Catalog Source Retry Interval
+
+|Initial Endpoint Contact Interval
+|org.codice.ddf.platform.util.http.initialRetryInterval
+|Integer
+|If a Catalog Source is unavailable, try to connect to it after the initial interval has elapsed.
+After every retry, the interval doubles, up to a given maximum interval.
+The interval is measured in seconds.
+|10
+|Yes
+
+|Maximum Endpoint Contact Interval
+|Maximum seconds between attempts to establish contact with unavailable Catalog Source.
+|Integer
+|Do not wait longer than the maximum interval to attempt to establish a connection with an
+unavailable Catalog Source. Smaller values result in more current information about the status
+ of Catalog Sources, but cause more network traffic.
+The interval is measured in seconds.
+|300
+|Yes
+
+
 6+^h|File Upload Settings
 
 |File extensions flagged as potentially dangerous to the host system or external clients

--- a/platform/util/platform-util-unavailableurls/pom.xml
+++ b/platform/util/platform-util-unavailableurls/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.platform.util</groupId>
@@ -23,6 +25,12 @@
     <name>DDF :: Platform :: Util :: Unavailable Urls</name>
     <packaging>jar</packaging>
     <dependencies>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.16.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/platform/util/platform-util-unavailableurls/src/main/java/org/codice/ddf/platform/util/http/UnavailableUrls.java
+++ b/platform/util/platform-util-unavailableurls/src/main/java/org/codice/ddf/platform/util/http/UnavailableUrls.java
@@ -76,6 +76,23 @@ public class UnavailableUrls {
     }
 
     /**
+     * @return The maximum number of seconds to wait before pinging an unavailable URL
+     */
+    public int getMaxRetryInterval() {
+        String property = System.getProperty(MAX_TIMEOUT_SECONDS_PROPERTY, "300");
+        return Integer.parseInt(property);
+    }
+
+    /**
+     * @return The number of seconds to between the first and seconds attempts to
+     * contact the unavailable URL.
+     */
+    public int getInitialRetryInterval() {
+        String property = System.getProperty(INITIAL_TIMEOUT_SECONDS_PROPERTY, "10");
+        return Integer.parseInt(property);
+    }
+
+    /**
      * Add a URL to the set of unavailable URL's.
      * NOTE: the URL will automatically be removed when it can be reached.
      *
@@ -88,7 +105,7 @@ public class UnavailableUrls {
     /**
      * Does the set contain a specified URL.
      *
-     * @param url
+     * @param url of the endpoint to ping
      * @return the truth
      */
     public boolean contains(String url) {

--- a/platform/util/platform-util-unavailableurls/src/test/java/org/codice/ddf/platform/util/http/UnavailableUrlsTest.java
+++ b/platform/util/platform-util-unavailableurls/src/test/java/org/codice/ddf/platform/util/http/UnavailableUrlsTest.java
@@ -53,8 +53,6 @@ public class UnavailableUrlsTest {
     @Before
     public void setUp() throws Exception {
         scheduler = Mockito.mock(ScheduledExecutorService.class);
-        //        System.setProperty(MAX_TIMEOUT_SECONDS_PROPERTY, MAX_TIMEOUT_SECONDS);
-        //        System.setProperty(INITIAL_TIMEOUT_SECONDS_PROPERTY, INITIAL_TIMEOUT_SECONDS);
     }
 
     private UnavailableUrls initSet(int pingResponse) {
@@ -195,6 +193,22 @@ public class UnavailableUrlsTest {
                 not(hasItemInArray(greaterThan(getMaxTimoutSeconds()))));
     }
 
+    @Test
+    public void testUnsetSysProperties() {
+        System.getProperties()
+                .remove(INITIAL_TIMEOUT_SECONDS_PROPERTY);
+        System.getProperties()
+                .remove(MAX_TIMEOUT_SECONDS_PROPERTY);
+        UnavailableUrls unavailableUrls = new UnavailableUrls();
+        assertThat("Failed to find a max retry interval",
+                unavailableUrls.getMaxRetryInterval(),
+                greaterThan(0));
+        assertThat("Failed to find a initial retry interval",
+                unavailableUrls.getInitialRetryInterval(),
+                greaterThan(0));
+
+    }
+
     private Long getMaxTimoutSeconds() {
         return Long.parseLong(MAX_TIMEOUT_SECONDS);
     }
@@ -206,7 +220,7 @@ public class UnavailableUrlsTest {
 
         public final TimeUnit unit;
 
-        public SchedulerCapture(Runnable r, Long to, TimeUnit tu) {
+        SchedulerCapture(Runnable r, Long to, TimeUnit tu) {
             this.runnable = r;
             this.timeout = to;
             this.unit = tu;

--- a/platform/util/platform-util-unavailableurls/src/test/java/org/codice/ddf/platform/util/http/UnavailableUrlsTest.java
+++ b/platform/util/platform-util-unavailableurls/src/test/java/org/codice/ddf/platform/util/http/UnavailableUrlsTest.java
@@ -13,7 +13,12 @@
  */
 package org.codice.ddf.platform.util.http;
 
+import static org.codice.ddf.platform.util.http.UnavailableUrls.INITIAL_TIMEOUT_SECONDS_PROPERTY;
+import static org.codice.ddf.platform.util.http.UnavailableUrls.MAX_TIMEOUT_SECONDS_PROPERTY;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 import java.net.HttpURLConnection;
@@ -21,17 +26,35 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class UnavailableUrlsTest {
+
+    private static final String MAX_TIMEOUT_SECONDS = "300";
+
+    private static final String INITIAL_TIMEOUT_SECONDS = "10";
+
+    @Rule
+    public final ProvideSystemProperty initialTimeout = new ProvideSystemProperty(
+            INITIAL_TIMEOUT_SECONDS_PROPERTY,
+            INITIAL_TIMEOUT_SECONDS);
+
+    @Rule
+    public final ProvideSystemProperty maxTimout = new ProvideSystemProperty(
+            MAX_TIMEOUT_SECONDS_PROPERTY,
+            MAX_TIMEOUT_SECONDS);
 
     private ScheduledExecutorService scheduler;
 
     @Before
     public void setUp() throws Exception {
         scheduler = Mockito.mock(ScheduledExecutorService.class);
+        //        System.setProperty(MAX_TIMEOUT_SECONDS_PROPERTY, MAX_TIMEOUT_SECONDS);
+        //        System.setProperty(INITIAL_TIMEOUT_SECONDS_PROPERTY, INITIAL_TIMEOUT_SECONDS);
     }
 
     private UnavailableUrls initSet(int pingResponse) {
@@ -59,20 +82,6 @@ public class UnavailableUrlsTest {
         UnavailableUrls set = initSet(200);
         set.add("hello");
         assertThat(set.contains("hello"), is(true));
-    }
-
-    private class SchedulerCapture {
-        public final Runnable runnable;
-
-        public final long timeout;
-
-        public final TimeUnit unit;
-
-        public SchedulerCapture(Runnable r, long to, TimeUnit tu) {
-            this.runnable = r;
-            this.timeout = to;
-            this.unit = tu;
-        }
     }
 
     // capture the call to the scheduler and return the parameters
@@ -121,13 +130,13 @@ public class UnavailableUrlsTest {
      * @param list - list of two or more positive integers
      * @return true if sequence is exponential, false otherwise
      */
-    private boolean isExponentialBackoff(long[] list) {
+    private boolean isExponentialBackoff(Long[] list) {
         if (list.length < 2) {
             return false;
         }
 
         double base = list[1] / (double) list[0];
-        long max = list[list.length - 1];
+        Long max = list[list.length - 1];
 
         if (!(base > 1)) {
             return false;
@@ -135,7 +144,7 @@ public class UnavailableUrlsTest {
 
         for (int i = 1; i < list.length - 1; i++) {
             double changeOfBase = Math.log(list[i]) / Math.log(base);
-            if (changeOfBase < i && list[i] != max) {
+            if (changeOfBase < i && !list[i].equals(max)) {
                 return false;
             }
         }
@@ -145,19 +154,19 @@ public class UnavailableUrlsTest {
 
     @Test
     public void testIsExponentialBackoff() {
-        assertThat(isExponentialBackoff(new long[] {1, 1, 1, 1, 1}), is(false)); // constant
-        assertThat(isExponentialBackoff(new long[] {1, 2, 3, 4, 5, 6}), is(false)); // linear
-        assertThat(isExponentialBackoff(new long[] {1, 4, 9, 16, 25}), is(false)); // quadratic
-        assertThat(isExponentialBackoff(new long[] {1, 8, 27, 64, 125}), is(false)); // cubic
-        assertThat(isExponentialBackoff(new long[] {1, 2, 4, 8, 16, 32}),
+        assertThat(isExponentialBackoff(new Long[] {1L, 1L, 1L, 1L, 1L}), is(false)); // constant
+        assertThat(isExponentialBackoff(new Long[] {1L, 2L, 3L, 4L, 5L, 6L}), is(false)); // linear
+        assertThat(isExponentialBackoff(new Long[] {1L, 4L, 9L, 16L, 25L}), is(false)); // quadratic
+        assertThat(isExponentialBackoff(new Long[] {1L, 8L, 27L, 64L, 125L}), is(false)); // cubic
+        assertThat(isExponentialBackoff(new Long[] {1L, 2L, 4L, 8L, 16L, 32L}),
                 is(true));  // exponential 2^n
-        assertThat(isExponentialBackoff(new long[] {4, 8, 16, 32, 64, 128, 256}),
+        assertThat(isExponentialBackoff(new Long[] {4L, 8L, 16L, 32L, 64L, 128L, 256L}),
                 is(true));  // exponential 2^n
-        assertThat(isExponentialBackoff(new long[] {1, 3, 9, 81, 243, 729}),
+        assertThat(isExponentialBackoff(new Long[] {1L, 3L, 9L, 81L, 243L, 729L}),
                 is(true));  // exponential 3^n
-        assertThat(isExponentialBackoff(new long[] {3, 9, 81, 243, 729, 2187}),
+        assertThat(isExponentialBackoff(new Long[] {3L, 9L, 81L, 243L, 729L, 2187L}),
                 is(true));  // exponential 3^n
-        assertThat(isExponentialBackoff(new long[] {1, 2, 6, 24, 120, 720, 5040}),
+        assertThat(isExponentialBackoff(new Long[] {1L, 2L, 6L, 24L, 120L, 720L, 5040L}),
                 is(true));  // factorial
     }
 
@@ -167,7 +176,7 @@ public class UnavailableUrlsTest {
         // Number of times to retry ping, should be big enough to reach max
         // timeout and plateau.
         int retries = 25;
-        long backoffs[] = new long[retries];
+        Long backoffs[] = new Long[retries];
 
         SchedulerCapture sc;
         UnavailableUrls set = initSet(404);
@@ -181,6 +190,26 @@ public class UnavailableUrlsTest {
         }
 
         assertThat(isExponentialBackoff(backoffs), is(true));
+        assertThat("List should not contain a value greater than the maximum cutoff value",
+                backoffs,
+                not(hasItemInArray(greaterThan(getMaxTimoutSeconds()))));
     }
 
+    private Long getMaxTimoutSeconds() {
+        return Long.parseLong(MAX_TIMEOUT_SECONDS);
+    }
+
+    private class SchedulerCapture {
+        public final Runnable runnable;
+
+        public final long timeout;
+
+        public final TimeUnit unit;
+
+        public SchedulerCapture(Runnable r, Long to, TimeUnit tu) {
+            this.runnable = r;
+            this.timeout = to;
+            this.unit = tu;
+        }
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
 Change retry interval for unavailable endpoints
      The max retry interval can now be set in system properties and defaults to 300 seconds.
      The initial retry interval can be set in system properties and defaults to 10 seconds.
      The exponential behavior is noW doubling the interval instead of growing it by a factor of 10.
      The unit test includes a check to make sure no interval is longer than the max.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@stustison @brendan-hofmann @codymacdonald
#### Select at least one member from relevant component team(s) from below (at least one @stustison 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Run unit and integration tests.
#### Any background context you want to provide?

If a source is created and the endpoint is not available, DDF will periodically try to establish a connection. The problem is the retry period. The interval between retries grows exponentially, up to 420 minutes (7 hours).  Here is a table

||Retry #||Actual Timeout||
|1| 10 seconds|
|2| 2 minutes 45 seconds|
|3| 16m|
|4| 2 hours 45 minutes|
|5 |7 hours|

The system will re-try almost instantly (10 seconds), then retry after about 2 minutes, then 16 minutes, then again around 3 hours. After that, it retries the connection only every 7 hours. For example, if the endpoint for the source becomes available 20 minutes after the source is created, you will have to wait about 2 hours and 45 minutes for the endpoint to become available. 

The class that implements the re-try behavior is `UnavailableUrls`. It has two constant values, `INITIAL_TIMEOUT_SECONDS` and `MAX_TIMEOUT_SECONDS`. The most important one is `MAX_TIMEOUT_SECONDS`, because the exponential growth quickly reaches this value. Include  new system properties and let administrators change the values.

It is possible that this behavior is also responsible for the failures on Windows. If an itest is set to timeout at 10 minutes, but the endpoint is not responding 2 minutes and 45 seconds after the source is active, the test will always fail.

#### What are the relevant tickets?
[DDF-2831](https://codice.atlassian.net/browse/DDF-2831)
#### Screenshots (if appropriate)
N/A
#### Checklist:
- [x] Documentation Updated
- [x] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Run OWASP
