### PR TITLE
DDF-2817 A configurable servlet filter now attaches Content Security Policy, X-XSS-Protection and X-Frame-Options headers to responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ replace with next unreleased version
 - This version will require data to be reindexed.
 
 ### NEW FEATURES
+- [DDF-2817](https://codice.atlassian.net/browse/DDF-2817) A configurable servlet filter now attaches Content Security Policy, X-XSS-Protection and X-Frame-Options headers to responses
 - [DDF-2729](https://codice.atlassian.net/browse/DDF-2729) Added ability for administrators to disable the use of the cache when using the Catalog UI
 - [DDF-2535](https://codice.atlassian.net/browse/DDF-2535) Added Confluence Federated Source
 - [DDF-2639](https://codice.atlassian.net/browse/DDF-2639) Catalog security plugin to protect resource URIs

--- a/distribution/docs/src/main/resources/_contents/_security-contents/managing-security-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_security-contents/managing-security-contents.adoc
@@ -49,6 +49,7 @@ include::{adoc-include}/_tables/conf-ddf.security.sts.wss.configuration-table-co
 include::{adoc-include}/_tables/conf-ddf.security.pdp.realm.AuthzRealm-table-contents.adoc[]
 include::{adoc-include}/_tables/conf-org.codice.ddf.security.filter.login.Session-table-contents.adoc[]
 include::{adoc-include}/_tables/conf-org.codice.ddf.security.policy.context.impl.PolicyManager-table-contents.adoc[]
+include::{adoc-include}/_tables/conf-org.codice.ddf.security.response.filter.ResponseHeaderConfig-table-contents.adoc[]
 
 |===
 

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.security.response.filter.ResponseHeaderConfig-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.security.response.filter.ResponseHeaderConfig-table-contents.adoc
@@ -1,0 +1,3 @@
+|HTTP Response Security
+|org.codice.ddf.security.response.filter.ResponseHeaderConfig
+|Instructions for the client browser detailing which location and/or which type of resources may be loaded.

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.security.response.filter.ResponseHeaderConfig.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.security.response.filter.ResponseHeaderConfig.adoc
@@ -1,0 +1,34 @@
+.[[org.codice.ddf.security.response.filter.ResponseHeaderConfig]]HTTP Response Security Configuration
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Content Security Policy
+|xContentSecurityPolicy
+|String
+|Instructions for the client browser detailing which location and/or which type of resources may be loaded.
+|default-src 'none'; connect-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'
+|true
+
+
+|X-Frame-Options
+|xFrameOptions
+|String
+|The X-Frame-Options HTTP response header can be used to indicate whether or not a browser may render a page in a frame, iframe or object.
+|SAMEORIGIN
+|true
+
+|X-XSS-Protection
+|xXssProtection
+|String
+|The HTTP X-XSS-Protection response header is a feature that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks.
+|1; mode=block
+|true
+
+|===

--- a/platform/security/filter/pom.xml
+++ b/platform/security/filter/pom.xml
@@ -37,5 +37,6 @@
         <module>security-filter-web-sso</module>
         <module>security-filter-login</module>
         <module>security-filter-authorization</module>
+        <module>security-filter-response</module>
     </modules>
 </project>

--- a/platform/security/filter/security-filter-response/pom.xml
+++ b/platform/security/filter/security-filter-response/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>filter</artifactId>
+        <groupId>ddf.security.filter</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>security-filter-response</artifactId>
+    <name>DDF :: Security :: Filter :: Response</name>
+    <description>Adds http response servlet filters.</description>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <!--The ResponseSecurityFilter consists of several setters and a doFilter method that sets several strings and performs no logic-->
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/filter/security-filter-response/src/main/java/org/codice/ddf/security/response/filter/ResponseSecurityFilter.java
+++ b/platform/security/filter/security-filter-response/src/main/java/org/codice/ddf/security/response/filter/ResponseSecurityFilter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.response.filter;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Servlet filter that adds security information to the http response header.
+ */
+public class ResponseSecurityFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResponseSecurityFilter.class);
+
+    public static final String X_XSS_PROTECTION = "X-XSS-Protection";
+
+    public static final String X_FRAME_OPTIONS = "X-Frame-Options";
+
+    public static final String X_CONTENT_SECURITY_POLICY = "X-Content-Security-Policy";
+
+    public static final String DEFAULT_XSS_PROTECTION_VALUE = "1; mode=block";
+
+    public static final String DEFAULT_X_FRAME_OPTIONS_VALUE = "SAMEORIGIN";
+
+    public static final String DEFAULT_CONTENT_SECURITY_POLICY =
+            "default-src 'none'; connect-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'";
+
+    private String xXssProtection = DEFAULT_XSS_PROTECTION_VALUE;
+
+    private String xFrameOptions = DEFAULT_X_FRAME_OPTIONS_VALUE;
+
+    private String xContentSecurityPolicy = DEFAULT_CONTENT_SECURITY_POLICY;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOGGER.debug("Initializing Response Security Filter.");
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain filterChain) throws IOException, ServletException {
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        response.setHeader(X_CONTENT_SECURITY_POLICY, xContentSecurityPolicy);
+        response.setHeader(X_XSS_PROTECTION, xXssProtection);
+        response.setHeader(X_FRAME_OPTIONS, xFrameOptions);
+
+        filterChain.doFilter(servletRequest, response);
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.debug("Destroying Response Security Filter.");
+    }
+
+    public void setXXssProtection(String xXssProtection) {
+        this.xXssProtection = xXssProtection;
+    }
+
+    public void setXContentSecurityPolicy(String xContentSecurityPolicy) {
+        this.xContentSecurityPolicy = xContentSecurityPolicy;
+    }
+
+    public void setXFrameOptions(String xFrameOptions) {
+        this.xFrameOptions = xFrameOptions;
+    }
+}

--- a/platform/security/filter/security-filter-response/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-response/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="filter" class="org.codice.ddf.security.response.filter.ResponseSecurityFilter">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.security.response.filter.ResponseHeaderConfig"
+                update-strategy="container-managed"/>
+    </bean>
+
+    <service ref="filter"
+             interface="javax.servlet.Filter" ranking="1">
+        <service-properties>
+            <entry key="filter-name" value="response-filter"/>
+            <entry key="urlPatterns" value="/*"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/security/filter/security-filter-response/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/filter/security-filter-response/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="HTTP Response Security" id="org.codice.ddf.security.response.filter.ResponseHeaderConfig">
+        <AD description="Instructions for the client browser detailing which location and/or which type of resources may be loaded."
+            name="Content Security Policy" id="xContentSecurityPolicy" required="true" type="String"
+            default="default-src 'none'; connect-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'"/>
+        <AD description="The X-Frame-Options HTTP response header can be used to indicate whether or not a browser may render a page in a frame, iframe or object."
+            name="X-Frame-Options" id="xFrameOptions" required="true" type="String"
+            default="SAMEORIGIN"/>
+        <AD description="The HTTP X-XSS-Protection response header is a feature that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks."
+            name="X-XSS-Protection" id="xXssProtection" required="true" type="String"
+            default="1; mode=block"/>
+    </OCD>
+
+    <Designate pid="org.codice.ddf.security.response.filter.ResponseHeaderConfig">
+        <Object ocdref="org.codice.ddf.security.response.filter.ResponseHeaderConfig"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/platform/security/security-services-app/pom.xml
+++ b/platform/security/security-services-app/pom.xml
@@ -251,6 +251,11 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.filter</groupId>
+            <artifactId>security-filter-response</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.filter</groupId>
             <artifactId>security-filter-authorization</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -181,6 +181,11 @@
         <bundle>mvn:ddf.security.filter/security-filter-web-sso/${project.version}</bundle>
     </feature>
 
+    <feature name="security-filter-response" install="manual" version="${project.version}"
+             description="Response Filter for outgoing HTTP messages.">
+        <bundle>mvn:ddf.security.filter/security-filter-response/${project.version}</bundle>
+    </feature>
+
     <feature name="security-policy-context" install="manual" version="${project.version}"
              description="Web Context policy manager">
         <bundle>mvn:ddf.security.policy/security-policy-api/${project.version}</bundle>
@@ -273,6 +278,7 @@
         <feature>security-guest</feature>
         <feature>security-certificate</feature>
         <feature>security-migratable</feature>
+        <feature>security-filter-response</feature>
     </feature>
 
     <feature name="security-web-sso-defaults" install="manual" version="${project.version}"


### PR DESCRIPTION
Forward port of https://github.com/codice/ddf/pull/1717
#### What does this PR do?
A configurable servlet filter was added that attaches content security policy, x frame options and xss protection headers to responses.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @emmberk @vinamartin @brianfelix @ricklarsen 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security) @bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and load into the Admin UI. Using the developer tools built into the browser, inspect the response headers as the pages load. Confirm the new response headers are present (CSP, XSS, XFrame)

Navigate to the Security App, Configuration Tab and update the HTTP Response Security config values. Load the Catalog UI and check the response headers as the page loads.

#### Any background context you want to provide?
https://www.owasp.org/index.php/Content_Security_Policy
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

#### What are the relevant tickets?
[DDF-2817](https://codice.atlassian.net/browse/DDF-2817)
#### Screenshots (if appropriate)
![screen shot 2017-02-22 at 1 23 04 pm](https://cloud.githubusercontent.com/assets/11355332/23230667/178b2bee-f902-11e6-94ee-e9c06d775a3f.png)

#### Checklist:
- [x] Documentation Updated
- [x] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
