### PR TITLE
DDF-2830 Updates the local repository list Karaf searches to support hot deployment

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -36,9 +36,7 @@
 #   * 3. if not found looks for ${maven.home}/conf/settings.xml
 #   * 4. if not found looks for ${M2_HOME}/conf/settings.xml
 #
-# This value is intentionally pointed to a non-existent directory to prevent Karaf
-# from finding one by its fallback rules.
-org.ops4j.pax.url.mvn.settings=thisdirectorydoesnotexist/settings.xml
+#org.ops4j.pax.url.mvn.settings=
 
 #
 # Path to the local Maven repository which is used to avoid downloading
@@ -47,9 +45,7 @@ org.ops4j.pax.url.mvn.settings=thisdirectorydoesnotexist/settings.xml
 # above, or defaulted to:
 #     System.getProperty( "user.home" ) + "/.m2/repository"
 #
-# This value is intentionally pointed to a non-existent directory to prevent Karaf
-# from finding one by its fallback rules.
-org.ops4j.pax.url.mvn.localRepository=thisdirectorydoesnotexist
+#org.ops4j.pax.url.mvn.localRepository=
 
 #
 # Default this to false. It's just weird to use undocumented repos


### PR DESCRIPTION
#### What does this PR do?
Fixes KAR hot deployment.

This change also backs out the kludge put in in #1721 to prevent the local maven repository from being searched.

_Please note that when hot deploying, a WARN message similar to the following will now appear in the log:_
```
07:57:26,274 | WARN  | pool-2-thread-1  | n.internal.config.MavenConfigurationImpl  177 | ging.pax-logging-api | Settings file [thisdirectorydoesnotexist/settings.xml] cannot be used and will be skipped (malformed url or file does not exist)
```

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison

#### How should this be tested? (List steps with links to updated documentation)
On a production box, or one where your local `.m2` directory has been removed, attempt to hot deploy a KAR. It should succeed (assuming it is a correctly constructed KAR).

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2830](https://codice.atlassian.net/browse/DDF-2830)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
