### PR TITLE
DDF-2819 Add maven-version-validation-plugin to root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <reports.repository.url/>
         <project.scm.id>github</project.scm.id>
         <!-- Must MANUALLY update this if the ddf/support project's version changes -->
-        <ddf.support.version>2.3.6</ddf.support.version>
+        <ddf.support.version>2.3.7-SNAPSHOT</ddf.support.version>
         <!-- Do NOT set karaf.data or karaf.base -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -114,7 +114,8 @@
         <cxf.version.range>[3.0,4.0)</cxf.version.range>
         <spring.version.range>[4.1,5)</spring.version.range>
         <servicemix.bundles.freemarker.version>2.3.23_1</servicemix.bundles.freemarker.version>
-        <servicemix.bundles.commons-httpclient.version>3.1_7</servicemix.bundles.commons-httpclient.version>
+        <servicemix.bundles.commons-httpclient.version>3.1_7
+        </servicemix.bundles.commons-httpclient.version>
         <commons-codec.version>1.10</commons-codec.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jackson2.version>2.8.3</jackson2.version>
@@ -594,6 +595,25 @@
                     </plugins>
                 </pluginManagement>
                 <plugins>
+                    <plugin>
+                        <groupId>ddf.support</groupId>
+                        <artifactId>version-validation-plugin</artifactId>
+                        <version>${ddf.support.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check-package-json</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <whitelistedValues>
+                                <param>-beta</param>
+                                <param>#</param>
+                            </whitelistedValues>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
#### What does this PR do?
Enables a ddf-support maven plugin which scans the project at build for any package.json files which incorrectly use version ranges for dependencies.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @AzGoalie @vinamartin 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Will need to pull in ddf-support PR as well (https://github.com/codice/ddf-support/pull/38) for the actual plugin, and then run `mvn verify` in DDF. Successful if verify errors out with a MojoException due to incorrect version range symbols. 

#### Any background context you want to provide?
Version ranges expose the codebase to potential vulnerabilities, unlike sticking to exact, known versions of dependencies. 

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2819)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
