### PR TITLE
DDF-2842 Fixed coordinate order for CSW Federated Sources

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-common/pom.xml
@@ -67,6 +67,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>geospatial</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/BoundingBoxReader.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/BoundingBoxReader.java
@@ -14,16 +14,24 @@
 package org.codice.ddf.spatial.ogc.csw.catalog.common;
 
 import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.libs.geo.GeoFormatException;
+import org.codice.ddf.libs.geo.util.GeospatialUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
 
 /**
  * Parses OWS Bounding Box geometry XML and converts it to WKT.
- *
+ * <p>
  * Bounding Box XML is of the form:
- *
+ * <p>
  * <pre>
  *  {@code
  *  <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
@@ -34,20 +42,32 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * </pre>
  *
  * @author rodgersh
- *
  */
 public class BoundingBoxReader {
     private static final transient Logger LOGGER = LoggerFactory.getLogger(BoundingBoxReader.class);
 
     private static final String SPACE = " ";
 
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+    private static final ThreadLocal<WKTWriter> WKT_WRITER_THREAD_LOCAL =
+            new ThreadLocal<WKTWriter>() {
+                @Override
+                protected WKTWriter initialValue() {
+                    return new WKTWriter();
+                }
+            };
+
     private HierarchicalStreamReader reader;
 
     private CswAxisOrder cswAxisOrder;
 
+    private WKTReader wktReader;
+
     public BoundingBoxReader(HierarchicalStreamReader reader, CswAxisOrder cswAxisOrder) {
         this.reader = reader;
         this.cswAxisOrder = cswAxisOrder;
+        wktReader = new WKTReader(GEOMETRY_FACTORY);
     }
 
     public String getWkt() throws CswException {
@@ -62,11 +82,10 @@ public class BoundingBoxReader {
         }
 
         String crs = reader.getAttribute("crs");
-        // TODO: CRS value determines order of bounding box values, i.e.,
-        // WGS-84 specifies lon,lat order
-        // EPSG:4326 specifies lat,lon order
-        // For now we assume lat,lon order
-        LOGGER.debug("crs = {}", crs);
+        // For now, default an empty CRS to EPSG:4326
+        crs = StringUtils.isEmpty(crs) ? "urn:ogc:def:crs:EPSG:6.11:4326" : crs;
+
+        LOGGER.debug("crs = {}, coordinate order = {}", crs, this.cswAxisOrder);
 
         // Move down to the first child node of <BoundingBox>, which should
         // be the <LowerCorner> tag
@@ -77,7 +96,7 @@ public class BoundingBoxReader {
         if (reader.getNodeName()
                 .contains("LowerCorner")) {
             String value = reader.getValue();
-            lowerCornerPosition = getCoordinates(value, this.cswAxisOrder);
+            lowerCornerPosition = getCoordinates(value);
         }
 
         // Move back up to the <BoundingBox> parent tag
@@ -92,12 +111,11 @@ public class BoundingBoxReader {
         if (reader.getNodeName()
                 .contains("UpperCorner")) {
             String value = reader.getValue();
-            upperCornerPosition = getCoordinates(value, this.cswAxisOrder);
+            upperCornerPosition = getCoordinates(value);
         }
 
         // If both corner positions parsed, then compute other 2 corner
-        // positions of the
-        // bounding box and create the WKT for the bounding box.
+        // positions of the bounding box and create the WKT for the bounding box.
         if (lowerCornerPosition != null && lowerCornerPosition.length == 2
                 && upperCornerPosition != null && upperCornerPosition.length == 2) {
 
@@ -111,17 +129,19 @@ public class BoundingBoxReader {
                     "BoundingBoxReader.getWkt(): could not find either LowerCorner or UpperCorner tags.");
         }
 
-        // Move position back up to the parent <BoundingBox> tag, where we
-        // started
+        // Move position back up to the parent <BoundingBox> tag, where we started
         reader.moveUp();
 
-        LOGGER.debug("Returning WKT in LON/LAT coord order: {}.", wkt);
+        if (!isEPSG4326(crs) || (cswAxisOrder.equals(CswAxisOrder.LAT_LON) && isEPSG4326(crs))) {
+            wkt = convertToEPSG4326(wkt, crs);
+        }
+        LOGGER.debug("Returning WKT {}.", wkt);
         return wkt;
     }
 
     /**
      * We want to create WKT in LON/LAT order.
-     *
+     * <p>
      * Points for bounding box will be computed starting with the lower corner, and proceeding in a
      * clockwise rotation. So lower corner point would be point 1, upper corner point would be point
      * 3, and points 2 and 4 would be computed.
@@ -130,9 +150,9 @@ public class BoundingBoxReader {
         LOGGER.debug("Creating WKT in LON/LAT coordinate order.");
         if (upperCornerPosition[0].equals(lowerCornerPosition[0]) && upperCornerPosition[1].equals(
                 lowerCornerPosition[1])) {
-            return "POINT(" + lowerCornerPosition[0] + SPACE + lowerCornerPosition[1] + ")";
+            return "POINT (" + lowerCornerPosition[0] + SPACE + lowerCornerPosition[1] + ")";
         }
-        return "POLYGON((" + lowerCornerPosition[0] + SPACE + lowerCornerPosition[1] + ", "
+        return "POLYGON ((" + lowerCornerPosition[0] + SPACE + lowerCornerPosition[1] + ", "
                 + upperCornerPosition[0] + SPACE + lowerCornerPosition[1] + ", "
                 + upperCornerPosition[0] + SPACE + upperCornerPosition[1] + ", "
                 + lowerCornerPosition[0] + SPACE + upperCornerPosition[1] + ", "
@@ -140,30 +160,49 @@ public class BoundingBoxReader {
     }
 
     /**
-     * @param coords
-     *            The latitude and longitude coordinates (in no particular order).
-     * @param axisOrder
-     *            The order that the axes are represented.
-     * @return The coordinates in LON/LAT order.
+     * @param coords The latitude and longitude coordinates (in no particular order).
+     * @return The coordinates in an array
      */
-    private String[] getCoordinates(String coords, CswAxisOrder axisOrder) {
+    private String[] getCoordinates(String coords) {
+        return coords.split(SPACE);
+    }
 
-        switch (axisOrder) {
-        case LAT_LON: {
-            /**
-             * We want to create WKT in LON/LAT order. Since the response has the coords in LAT/LON
-             * order, we need to reverse them.
-             */
-            return StringUtils.reverseDelimited(coords, SPACE.charAt(0))
-                    .split(SPACE);
+    private String convertToEPSG4326(String wkt, String crs) throws CswException {
+        try {
+            Geometry geometry = wktReader.read(wkt);
+            Geometry convertedGeometry = GeospatialUtil.transformToEPSG4326LonLatFormat(geometry,
+                    crs);
+
+            if (convertedGeometry != null && withinEPSG4326Bounds(convertedGeometry)) {
+                return WKT_WRITER_THREAD_LOCAL.get()
+                        .write(convertedGeometry);
+            } else {
+                throw new GeoFormatException();
+            }
+        } catch (ParseException | GeoFormatException e) {
+            LOGGER.debug("Unable to convert {} from {} to EPSG:4326", wkt, crs, e);
+            throw new CswException(String.format("Unable to convert %s from %s to EPSG:4326",
+                    wkt,
+                    crs));
         }
-        default: {
-            /**
-             * We want to create WKT in LON/LAT order. Since this is the order of the coords in the
-             * response, we use them as-is.
-             */
-            return coords.split(SPACE);
+    }
+
+    private boolean isEPSG4326(String crs) {
+        return (crs.contains("4326") || crs.contains("CRS84"));
+    }
+
+    private boolean withinEPSG4326Bounds(Geometry geometry) {
+        Coordinate[] coordinates = geometry.getCoordinates();
+        for (Coordinate coordinate : coordinates) {
+            // Longitude
+            if (coordinate.x <= -180 || coordinate.x >= 180) {
+                return false;
+            }
+            // Latitude
+            if (coordinate.y <= -90 || coordinate.y >= 90) {
+                return false;
+            }
         }
-        }
+        return true;
     }
 }

--- a/catalog/spatial/csw/spatial-csw-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/TestBoundingBoxReader.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/TestBoundingBoxReader.java
@@ -41,12 +41,15 @@ public class TestBoundingBoxReader {
             LoggerFactory.getLogger(TestBoundingBoxReader.class);
 
     private static final String POLYGON_CONTROL_WKT_IN_LON_LAT =
-            "POLYGON((65.6272038662182 33.305863417212,"
-                    + " 65.7733371981862 33.305863417212, 65.7733371981862 33.6653407061501,"
-                    + " 65.6272038662182 33.6653407061501, 65.6272038662182 33.305863417212))";
+            "POLYGON ((65.6272038662182 33.305863417212, 65.6272038662182 33.6653407061501, 65.7733371981862 33.6653407061501, 65.7733371981862 33.305863417212, 65.6272038662182 33.305863417212))";
+
+    private static final String NON_JTS_FORMATTED_POLYGON_CONTROL_WKT_IN_LON_LAT =
+            "POLYGON ((65.6272038662182 33.305863417212, 65.7733371981862 33.305863417212, 65.7733371981862 33.6653407061501, 65.6272038662182 33.6653407061501, 65.6272038662182 33.305863417212))";
+
+    private static final String POLYGON_UTM_LON_LAT = "POLYGON ((29.999988636853967 9.999983148395557, 30.49995986771138 10.004117795867893, 30.499959660281664 10.00414490359446, 29.999988388080407 10.000010244696764, 29.999988636853967 9.999983148395557))";
 
     private static final String POINT_CONTROL_WKT_IN_LON_LAT =
-            "POINT(65.6272038662182 33.305863417212)";
+            "POINT (65.6272038662182 33.305863417212)";
 
     /**
      * Verify that if given a BoundingBox with coords in LON/LAT that the resulting WKT is in
@@ -67,7 +70,7 @@ public class TestBoundingBoxReader {
         LOGGER.debug("WKT: {}", wktInLonLat);
 
         // Verify
-        assertThat(wktInLonLat, is(POLYGON_CONTROL_WKT_IN_LON_LAT));
+        assertThat(wktInLonLat, is(NON_JTS_FORMATTED_POLYGON_CONTROL_WKT_IN_LON_LAT));
     }
 
     /**
@@ -176,4 +179,82 @@ public class TestBoundingBoxReader {
         boundingBoxReader.getWkt();
     }
 
+    @Test
+    public void testJTSConverterEPSG4326LatLon() throws Exception {
+        // Setup
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse("src/test/resources/BoundingBoxInLatLonEPSG4326.xml");
+        HierarchicalStreamReader hReader = new DomReader(doc);
+        BoundingBoxReader boundingBoxReader = new BoundingBoxReader(hReader, CswAxisOrder.LAT_LON);
+
+        // Perform Test
+        String wktInLonLat = boundingBoxReader.getWkt();
+        LOGGER.debug("WKT: {}", wktInLonLat);
+
+        // Verify
+        assertThat(wktInLonLat, is(POLYGON_CONTROL_WKT_IN_LON_LAT));
+    }
+
+    @Test
+    public void testJTSConverterEPSG4326LonLat() throws Exception {
+        // Setup
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse("src/test/resources/BoundingBoxInLonLatEPSG4326.xml");
+        HierarchicalStreamReader hReader = new DomReader(doc);
+        BoundingBoxReader boundingBoxReader = new BoundingBoxReader(hReader, CswAxisOrder.LON_LAT);
+
+        // Perform Test
+        String wktInLonLat = boundingBoxReader.getWkt();
+        LOGGER.debug("WKT: {}", wktInLonLat);
+
+        // Verify
+        assertThat(wktInLonLat, is(NON_JTS_FORMATTED_POLYGON_CONTROL_WKT_IN_LON_LAT));
+    }
+
+    @Test
+    public void testJTSConverterEPSG32636() throws Exception {
+        // Setup
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse("src/test/resources/BoundingBoxEPSG32636.xml");
+        HierarchicalStreamReader hReader = new DomReader(doc);
+        BoundingBoxReader boundingBoxReader = new BoundingBoxReader(hReader, CswAxisOrder.LAT_LON);
+
+        // Perform Test
+        String wktInLonLat = boundingBoxReader.getWkt();
+        LOGGER.debug("WKT: {}", wktInLonLat);
+
+        // Verify
+        assertThat(wktInLonLat, is(POLYGON_UTM_LON_LAT));
+    }
+
+    @Test(expected = CswException.class)
+    public void testJTSConverterBadCrs() throws Exception {
+        // Setup
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse("src/test/resources/BoundingBoxBadCrs.xml");
+        HierarchicalStreamReader hReader = new DomReader(doc);
+        BoundingBoxReader boundingBoxReader = new BoundingBoxReader(hReader, CswAxisOrder.LAT_LON);
+        boundingBoxReader.getWkt();
+    }
+
+    @Test(expected = CswException.class)
+    public void testJTSConverterBadLat() throws Exception {
+        // Setup
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse("src/test/resources/BoundingBoxBadCoordinates.xml");
+        HierarchicalStreamReader hReader = new DomReader(doc);
+        BoundingBoxReader boundingBoxReader = new BoundingBoxReader(hReader, CswAxisOrder.LAT_LON);
+
+        // Perform Test
+        String wktInLonLat = boundingBoxReader.getWkt();
+        LOGGER.debug("WKT: {}", wktInLonLat);
+
+        // Verify
+        assertThat(wktInLonLat, is(NON_JTS_FORMATTED_POLYGON_CONTROL_WKT_IN_LON_LAT));
+    }
 }

--- a/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxBadCoordinates.xml
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxBadCoordinates.xml
@@ -1,0 +1,17 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<BoundingBox crs="">
+    <LowerCorner>-92.6272038662182 33.305863417212</LowerCorner>
+    <UpperCorner>92.7733371981862 33.6653407061501</UpperCorner>
+</BoundingBox>

--- a/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxBadCrs.xml
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxBadCrs.xml
@@ -1,0 +1,17 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<BoundingBox crs="EPSG:Bad">
+    <LowerCorner>171070 1106907</LowerCorner>
+    <UpperCorner>225928 1106910</UpperCorner>
+</BoundingBox>

--- a/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxEPSG32636.xml
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxEPSG32636.xml
@@ -1,0 +1,17 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<BoundingBox crs="EPSG:32636">
+    <LowerCorner>171070 1106907</LowerCorner>
+    <UpperCorner>225928 1106910</UpperCorner>
+</BoundingBox>

--- a/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxInLatLonEPSG4326.xml
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxInLatLonEPSG4326.xml
@@ -1,0 +1,17 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+    <LowerCorner>33.305863417212 65.6272038662182</LowerCorner>
+    <UpperCorner>33.6653407061501 65.7733371981862</UpperCorner>
+</BoundingBox>

--- a/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxInLonLatEPSG4326.xml
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/resources/BoundingBoxInLonLatEPSG4326.xml
@@ -1,0 +1,17 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+    <LowerCorner>65.6272038662182 33.305863417212</LowerCorner>
+    <UpperCorner>65.7733371981862 33.6653407061501</UpperCorner>
+</BoundingBox>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TestTransactionMessageBodyReader.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TestTransactionMessageBodyReader.java
@@ -422,7 +422,7 @@ public class TestTransactionMessageBodyReader {
         assertThat(metacard.getModifiedDate(), is(date));
 
         assertThat(metacard.getLocation(), is(
-                "POLYGON((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
+                "POLYGON ((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
 
         assertThat(request.getService(), is(CswConstants.CSW));
         assertThat(request.getVersion(), is(CswConstants.VERSION_2_0_2));
@@ -472,7 +472,7 @@ public class TestTransactionMessageBodyReader {
 
         Serializable newLocationValue = recordProperties.get("location");
         assertThat(newLocationValue, notNullValue());
-        assertThat(newLocationValue, is("POLYGON((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
+        assertThat(newLocationValue, is("POLYGON ((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
 
         Serializable newFormatValue = recordProperties.get("media.format");
         // No <Value> was specified in the request.
@@ -524,7 +524,7 @@ public class TestTransactionMessageBodyReader {
         assertThat(metacard.getModifiedDate(), is(date));
 
         assertThat(metacard.getLocation(), is(
-                "POLYGON((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
+                "POLYGON ((1.0 2.0, 3.0 2.0, 3.0 4.0, 1.0 4.0, 1.0 2.0))"));
 
         assertThat(firstUpdateAction.getHandle(), is("handle1"));
         assertThat(firstUpdateAction.getTypeName(), is(CswConstants.CSW_RECORD));

--- a/catalog/spatial/csw/spatial-csw-source/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source/pom.xml
@@ -160,6 +160,11 @@
             <artifactId>security-core-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>geospatial</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -198,6 +203,7 @@
                             platform-util-unavailableurls,
                             jaxb2-basics-runtime,
                             commons-lang3,
+                            geospatial,
                             security-core-impl
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/catalog/spatial/csw/spatial-csw-transformer/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/pom.xml
@@ -110,6 +110,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>geospatial</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-attributeregistry</artifactId>
             <version>${project.version}</version>
@@ -137,6 +142,7 @@
                             spatial-ogc-common,
                             catalog-core-api-impl,
                             platform-util,
+                            geospatial,
                             commons-lang3
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProvider.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProvider.java
@@ -74,8 +74,8 @@ public class CswTransformProvider implements Converter {
      * @param o       - metacard to transform.
      * @param writer  - writes the XML.
      * @param context - the marshalling context. Should contain a map entry for {@link
-     *                org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants.TRANSFORMER_LOOKUP_KEY}
-     *                {@link org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants.TRANSFORMER_LOOKUP_VALUE}
+     *                org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants#TRANSFORMER_LOOKUP_KEY}
+     *                {@link org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants#TRANSFORMER_LOOKUP_VALUE}
      *                to identify which transformer to use. Also contains properties for any
      *                arguments to provide the transformer.
      */
@@ -87,7 +87,7 @@ public class CswTransformProvider implements Converter {
         Metacard metacard = (Metacard) o;
         String keyArg = (String) context.get(CswConstants.TRANSFORMER_LOOKUP_KEY);
         String valArg = (String) context.get(CswConstants.TRANSFORMER_LOOKUP_VALUE);
-        MetacardTransformer transformer = null;
+        MetacardTransformer transformer;
 
         if (StringUtils.isNotBlank(keyArg) && StringUtils.isNotBlank(valArg)) {
             transformer = metacardTransformerManager.getTransformerByProperty(keyArg, valArg);
@@ -102,7 +102,7 @@ public class CswTransformProvider implements Converter {
                     valArg));
         }
 
-        BinaryContent content = null;
+        BinaryContent content;
         try {
             content = transformer.transform(metacard, getArguments(context));
         } catch (CatalogTransformerException e) {
@@ -150,11 +150,11 @@ public class CswTransformProvider implements Converter {
     public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
         String keyArg = (String) context.get(CswConstants.TRANSFORMER_LOOKUP_KEY);
         String valArg = (String) context.get(CswConstants.TRANSFORMER_LOOKUP_VALUE);
-        InputTransformer transformer = null;
+        InputTransformer transformer;
         if (StringUtils.isNotBlank(keyArg) && StringUtils.isNotBlank(valArg)) {
             transformer = inputTransformerManager.getTransformerByProperty(keyArg, valArg);
         } else {
-            transformer = inputTransformerManager.<InputTransformer>getTransformerBySchema(
+            transformer = inputTransformerManager.getTransformerBySchema(
                     CswConstants.CSW_OUTPUT_SCHEMA);
         }
 
@@ -164,7 +164,12 @@ public class CswTransformProvider implements Converter {
                     valArg));
         }
 
-        Metacard metacard = null;
+        /* The CswRecordConverter uses unmarshal, which requires the context */
+        if (transformer instanceof CswRecordConverter) {
+            return ((CswRecordConverter) transformer).unmarshal(reader, context);
+        }
+
+        Metacard metacard;
         try (InputStream is = readXml(reader, context)) {
             InputStream inputStream = is;
             if (LOGGER.isDebugEnabled()) {
@@ -183,7 +188,6 @@ public class CswTransformProvider implements Converter {
 
     private InputStream readXml(HierarchicalStreamReader reader, UnmarshallingContext context)
             throws IOException {
-        InputStream is = null;
 
         Map<String, String> namespaces = null;
         Object namespaceObj = context.get(CswConstants.NAMESPACE_DECLARATIONS);

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestCswUnmarshallHelper.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestCswUnmarshallHelper.java
@@ -110,7 +110,7 @@ public class TestCswUnmarshallHelper {
 
         matcherMap.put(AttributeType.AttributeFormat.BINARY, notNullValue());
         matcherMap.put(AttributeType.AttributeFormat.GEOMETRY, is(
-                "POLYGON((44.792 -6.171, 51.126 -6.171, 51.126 -2.228, 44.792 -2.228, 44.792 -6.171))"));
+                "POLYGON ((44.792 -6.171, 44.792 -2.228, 51.126 -2.228, 51.126 -6.171, 44.792 -6.171))"));
 
         AttributeType.AttributeFormat[] attributeFormats = AttributeType.AttributeFormat.values();
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGetRecordsResponseConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGetRecordsResponseConverter.java
@@ -198,7 +198,7 @@ public class TestGetRecordsResponseConverter {
         expectedValues.put(Media.FORMAT, "Shapefile");
         expectedValues.put(Metacard.CONTENT_TYPE, "dataset");
         expectedValues.put(Core.LOCATION,
-                "POLYGON((5.121 52.139, 4.468 52.139, 4.468 52.517, 5.121 52.517, 5.121 52.139))");
+                "POLYGON ((5.121 52.139, 4.468 52.139, 4.468 52.517, 5.121 52.517, 5.121 52.139))");
         assertMetacard(mc, expectedValues);
 
         expectedValues.clear();
@@ -221,7 +221,7 @@ public class TestGetRecordsResponseConverter {
         expectedValues.put(Media.FORMAT, "Shapefile 2");
         expectedValues.put(Metacard.CONTENT_TYPE, "dataset 2");
         expectedValues.put(Core.LOCATION,
-                "POLYGON((6.121 53.139, 5.468 53.139, 5.468 53.517, 6.121 53.517, 6.121 53.139))");
+                "POLYGON ((6.121 53.139, 5.468 53.139, 5.468 53.517, 6.121 53.517, 6.121 53.139))");
         assertMetacard(mc, expectedValues);
 
         expectedValues.clear();

--- a/catalog/spatial/registry/registry-api-impl/pom.xml
+++ b/catalog/spatial/registry/registry-api-impl/pom.xml
@@ -189,6 +189,11 @@
             <artifactId>security-core-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>geospatial</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -233,6 +238,7 @@
                             platform-util-unavailableurls,
                             jaxb2-basics-runtime,
                             commons-lang3,
+                            geospatial,
                             security-core-impl
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/catalog/spatial/registry/registry-schema-bindings/pom.xml
+++ b/catalog/spatial/registry/registry-schema-bindings/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>spatial-csw-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>geospatial</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -171,7 +176,8 @@
                             jaxb2-basics-runtime,
                             registry-common,
                             catalog-core-api-impl;scope=!test,
-                            commons-lang3
+                            commons-lang3,
+                            geospatial
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue with passing context information (coordinateOrder) to the CswRecordConverter and adds a unit test to prevent regression.  Additionally it adds more robust support for CRS conversions when parsing CSW responses.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install/ Configure various CSW sources ( some with LAT / LON vs LON / LAT) and verify results.
#### Any background context you want to provide?
This PR relies on this PR for GeospatialUtils : https://github.com/codice/ddf/pull/1712
#### What are the relevant tickets?
[DDF-2842](https://codice.atlassian.net/browse/DDF-2842)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
