### PR TITLE
DDF-2843: Add incremental builder extension to speed up PR builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,12 @@
         <jodah-failsafe.version>0.9.5</jodah-failsafe.version>
         <apache.shiro.version>1.3.2</apache.shiro.version>
         <spark.version>2.5.5</spark.version>
+
+        <!-- gitflow-incremental-builder -->
+        <!-- See https://github.com/vackosar/gitflow-incremental-builder for a list of all the options -->
+        <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
+        <gib.baseBranch>HEAD</gib.baseBranch>
+        <gib.enabled>false</gib.enabled>
     </properties>
     <!--
     NOTE: The properties ddf.scm.connection.url, snapshots.repository.url and releases.repository.url should be defined
@@ -227,6 +233,11 @@
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav-jackrabbit</artifactId>
                 <version>2.7</version>
+            </extension>
+            <extension>
+                <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
+                <artifactId>gitflow-incremental-builder</artifactId>
+                <version>3.1</version>
             </extension>
         </extensions>
         <pluginManagement>


### PR DESCRIPTION
#### What does this PR do?
Adds the `gitflow-incremental-builder` build extension to the root `pom.xml` to support local and PR incremental builds.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@oconnormi 
@LinkMJB 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
1. Run `mvn clean install` and make sure a normal build is executed.
1. Make a local change to a source file, run `mvn -Dgib.enaled=true clean install` and make sure only the module that was changed and all its dependent modules are built

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2843](https://codice.atlassian.net/browse/DDF-2843)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
