### PR TITLE
DDF-2360 Corrected instructions for DDF heap setting in windows service wrapper

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -153,8 +153,9 @@ wrapper.java.additional.21=-XX:+UnlockDiagnosticVMOptions
 wrapper.java.additional.22=-XX:+UnsyncloadClass
 wrapper.java.additional.23=-Dderby.system.home=%KARAF_HOME%/data/derby
 
-#Update the following:
-wrapper.java.maxmemory=4096
+# Set the JVM max heap space as desired
+wrapper.java.additional.24=-Xmx4g
+
 ----
 +
 . Set the `<${branding}_HOME>` property.


### PR DESCRIPTION
#### What does this PR do?
Karaf has a hard-coded limit for the "wrapper.java.maxmemory" property of 4G.  
Updated the docs to use the java max heap space argument

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
