### PR TITLE
DDF-2512 Added AGM support to OpenLayers

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -25,6 +25,7 @@ define(['underscore',
         BM: ol.source.BingMaps,
         WMS: ol.source.TileWMS,
         MQ: ol.source.MapQuest,
+        AGM: ol.source.XYZ,
         SI: ol.source.ImageStatic
     };
 
@@ -112,7 +113,12 @@ define(['underscore',
                 if (initObj.parameters) {
                     _.extend(initObj, initObj.parameters);
                 }
+            } else if (typeStr === 'AGM'){
+                if (initObj.url && initObj.url.indexOf('/tile/{z}/{y}/{x}') === -1) {
+                    initObj.url = initObj.url + '/tile/{z}/{y}/{x}';
+                }
             }
+
             return new layerType({
                 visible: model.get('show'),
                 preload: Infinity,


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for AGM in OpenLayers.  Configuring an ArcGis provider now works in 2D and 3D maps without having to change the configuration in the Admin UI.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure / Verify EPSG:4326 / Verify EPSG:3857 on Cesium & OpenLayers
`[{"type": "AGM","url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/" }]`
#### Any background context you want to provide?
http://resources.arcgis.com/en/help/rest/apiref/wmtstile.html
#### What are the relevant tickets?
[DDF-2512](https://codice.atlassian.net/browse/DDF-2512)
#### Screenshots (if appropriate)
![screen shot 2017-03-03 at 11 01 28 am](https://cloud.githubusercontent.com/assets/6551038/23562699/ccd4d77a-0000-11e7-9677-1b2facb29683.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
