### PR TITLE
DDF-2731: Move property logic to platform-util where it can be reused

### DIFF
--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -84,6 +84,11 @@
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -94,6 +99,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
+                            platform-util,
                             type-parser,
                             org.apache.felix.utils,
                             common-system,
@@ -124,17 +130,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.86</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/GuestClaimsHandlerExt.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/ui/admin/api/GuestClaimsHandlerExt.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
-import org.codice.ddf.ui.admin.api.util.PropertiesFileReader;
+import org.codice.ddf.platform.util.properties.PropertiesFileReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/platform/admin/core/admin-core-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,7 +20,8 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <bean id="propertiesFileSupport" class="org.codice.ddf.ui.admin.api.util.PropertiesFileReader"/>
+    <bean id="propertiesFileSupport"
+          class="org.codice.ddf.platform.util.properties.PropertiesFileReader"/>
 
     <bean id="guestClaimsHandlerExt" class="org.codice.ddf.ui.admin.api.GuestClaimsHandlerExt"
           init-method="init">

--- a/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/GuestClaimsHandlerExtTest.java
+++ b/platform/admin/core/admin-core-api/src/test/java/org/codice/ddf/ui/admin/api/GuestClaimsHandlerExtTest.java
@@ -33,7 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
-import org.codice.ddf.ui.admin.api.util.PropertiesFileReader;
+import org.codice.ddf.platform.util.properties.PropertiesFileReader;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -748,6 +748,7 @@
 
     <feature name="platform-scheduler" install="manual" version="${project.version}"
              description="Schedules tasks">
+        <feature prerequisite="true">commons</feature>
         <feature prerequisite="true">security-core-api</feature>
         <bundle>mvn:ddf.platform/platform-scheduler/${project.version}</bundle>
     </feature>
@@ -948,7 +949,9 @@
     </feature>
 
     <feature name="platform-filter-delegate" install="manual" version="${project.version}">
+        <feature prerequisite="true">commons</feature>
         <feature prerequisite="true" version="${project.version}">kernel</feature>
+        <feature prerequisite="true" version="${spring.version}_1">spring</feature>
         <feature prerequisite="true">pax-http-jetty</feature>
         <feature prerequisite="true">pax-jetty</feature>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
@@ -972,11 +975,9 @@
         <feature prerequisite="true">branding-api</feature>
         <feature prerequisite="true">wrap</feature>
         <feature prerequisite="true">camel-http</feature>
+        <feature prerequisite="true">commons</feature>
         <bundle dependency="true">mvn:ch.qos.cal10n/cal10n-api/0.7.4</bundle>
         <bundle dependency="true">mvn:org.slf4j/slf4j-ext/${org.slf4j.version}</bundle>
-        <bundle dependency="true">mvn:commons-io/commons-io/${commons-io.version}</bundle>
-        <bundle dependency="true">mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
-        <bundle dependency="true">mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
         <bundle dependency="true">mvn:org.ops4j.base/ops4j-base-lang/${org.ops4j-base-lang}</bundle>
         <bundle dependency="true">mvn:org.ops4j.pax.swissbox/pax-swissbox-lifecycle/${org.ops4j.pax.swissbox.version}</bundle>
         <bundle dependency="true">mvn:org.ops4j.pax.swissbox/pax-swissbox-optional-jcl/${org.ops4j.pax.swissbox.version}</bundle>
@@ -986,6 +987,12 @@
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/${javax.inject.bundle.version}</bundle>
         <bundle dependency="true">mvn:javax.validation/validation-api/${validation.version}</bundle>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+    </feature>
+
+    <feature name="commons" version="${project.version}" install="manual" hidden="true">
+        <bundle dependency="true">mvn:commons-io/commons-io/${commons-io.version}</bundle>
+        <bundle dependency="true">mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
+        <bundle dependency="true">mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
     </feature>
 
     <feature name="platform-filter-response" install="manual" version="${project.version}"
@@ -1033,6 +1040,8 @@
 
     <feature name="platform-paxweb-jettyconfig" install="manual" version="${project.version}"
              description="Custom Session Manager">
+        <feature prerequisite="true" version="${spring.version}_1">spring</feature>
+        <feature prerequisite="true">commons</feature>
         <feature>pax-jetty</feature>
         <bundle dependency="true">wrap:mvn:net.jodah/failsafe/${jodah-failsafe.version}</bundle>
         <bundle>mvn:ddf.platform/platform-paxweb-jettyconfig/${project.version}</bundle>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -134,6 +134,11 @@
             <artifactId>common-system</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -173,6 +178,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
+                            platform-util,
                             httpclient;scope=!test,
                             httpcore,
                             google-http-client,

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/PropertiesLoader.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/PropertiesLoader.java
@@ -13,178 +13,49 @@
  */
 package ddf.security;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.text.StrSubstitutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.support.PropertiesLoaderUtils;
 
 /**
  * Utility class that attempts several different methods for loading in properties files from the
  * classpath or file system.
+ *
+ * @deprecated Use {@link org.codice.ddf.platform.util.properties.PropertiesLoader} instead.
  */
+@Deprecated
 public final class PropertiesLoader {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesLoader.class);
-
     private PropertiesLoader() {
         // static only!
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Convert properties to a Map.
+     *
+     * @see org.codice.ddf.platform.util.properties.PropertiesLoader#toMap(Properties)
+     */
     public static <K, V> Map<K, V> toMap(Properties properties) {
-        if (properties != null) {
-            final Set<Map.Entry<Object, Object>> entries = properties.entrySet();
-            Map<K, V> map = new HashMap<K, V>(entries.size() * 2);
-            for (Map.Entry<Object, Object> entry : entries) {
-                map.put((K) entry.getKey(), (V) entry.getValue());
-            }
-
-            return map;
-        }
-        return new HashMap<K, V>();
+        return org.codice.ddf.platform.util.properties.PropertiesLoader.getInstance()
+                .toMap(properties);
     }
 
     /**
      * Load properties from a file with no classloader specified.
      *
-     * @param propertiesFile
-     * @return Properties
+     * @see org.codice.ddf.platform.util.properties.PropertiesLoader#loadProperties(String)
      */
     public static Properties loadProperties(String propertiesFile) {
-        return loadProperties(propertiesFile, null);
+        return org.codice.ddf.platform.util.properties.PropertiesLoader.getInstance()
+                .loadProperties(propertiesFile, null);
     }
 
     /**
      * Will attempt to load properties from a file using the given classloader. If that fails,
      * several other methods will be tried until the properties file is located.
      *
-     * @param propertiesFile
-     * @param classLoader
-     * @return Properties
+     * @see org.codice.ddf.platform.util.properties.PropertiesLoader#loadProperties(String, ClassLoader)
      */
     public static Properties loadProperties(String propertiesFile, ClassLoader classLoader) {
-        boolean error = false;
-        Properties properties = new Properties();
-        if (propertiesFile != null) {
-            try {
-                LOGGER.debug(
-                        "Attempting to load properties from {} with Spring PropertiesLoaderUtils.",
-                        propertiesFile);
-                properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile);
-            } catch (IOException e) {
-                error = true;
-                LOGGER.debug("Unable to load properties using default Spring properties loader.",
-                        e);
-            }
-            if (error || properties.isEmpty()) {
-                if (classLoader != null) {
-                    try {
-                        LOGGER.debug(
-                                "Attempting to load properties from {} with Spring PropertiesLoaderUtils with class loader.",
-                                propertiesFile);
-                        properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile,
-                                classLoader);
-                        error = false;
-                    } catch (IOException e) {
-                        error = true;
-                        LOGGER.debug(
-                                "Unable to load properties using default Spring properties loader.",
-                                e);
-                    }
-                } else {
-                    try {
-                        LOGGER.debug(
-                                "Attempting to load properties from {} with Spring PropertiesLoaderUtils with class loader.",
-                                propertiesFile);
-                        properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile,
-                                PropertiesLoader.class.getClassLoader());
-                        error = false;
-                    } catch (IOException e) {
-                        error = true;
-                        LOGGER.debug(
-                                "Unable to load properties using default Spring properties loader.",
-                                e);
-                    }
-                }
-            }
-
-            if (error || properties.isEmpty()) {
-                LOGGER.debug("Attempting to load properties from file system: {}", propertiesFile);
-                File propFile = new File(propertiesFile);
-                // If properties file has fully-qualified absolute path (which
-                // the blueprint file specifies) then can load it directly.
-                if (propFile.isAbsolute()) {
-                    LOGGER.debug("propertiesFile {} is absolute", propertiesFile);
-                    propFile = new File(propertiesFile);
-                } else {
-                    String karafHome = System.getProperty("karaf.home");
-                    if (karafHome != null && !karafHome.isEmpty()) {
-                        propFile = new File(karafHome, propertiesFile);
-                    } else {
-                        karafHome = System.getProperty("ddf.home");
-                        if (karafHome != null && !karafHome.isEmpty()) {
-                            propFile = new File(karafHome, propertiesFile);
-                        } else {
-                            propFile = new File(propertiesFile);
-                        }
-                    }
-                }
-                properties = new Properties();
-
-                try (InputStreamReader reader = new InputStreamReader(new FileInputStream(propFile),
-                        StandardCharsets.UTF_8)) {
-                    properties.load(reader);
-                } catch (FileNotFoundException e) {
-                    error = true;
-                    LOGGER.debug("Could not find properties file: {}",
-                            propFile.getAbsolutePath(),
-                            e);
-                } catch (IOException e) {
-                    error = true;
-                    LOGGER.debug("Error reading properties file: {}",
-                            propFile.getAbsolutePath(),
-                            e);
-                }
-            }
-            if (error || properties.isEmpty()) {
-                LOGGER.debug("Attempting to load properties as a resource: {}", propertiesFile);
-                InputStream ins = PropertiesLoader.class.getResourceAsStream(propertiesFile);
-                if (ins != null) {
-                    try {
-                        properties.load(ins);
-                        ins.close();
-                    } catch (IOException e) {
-                        LOGGER.debug("Unable to load properties: {}", propertiesFile, e);
-                    } finally {
-                        IOUtils.closeQuietly(ins);
-                    }
-                }
-            }
-
-            //replace any ${prop} with system properties
-            Properties filtered = new Properties();
-            for (Map.Entry<?, ?> entry : properties.entrySet()) {
-                filtered.put(StrSubstitutor.replaceSystemProperties(entry.getKey()),
-                        StrSubstitutor.replaceSystemProperties(entry.getValue()));
-            }
-            properties = filtered;
-
-        } else {
-            LOGGER.debug("Properties file must not be null.");
-        }
-
-        return properties;
+        return org.codice.ddf.platform.util.properties.PropertiesLoader.getInstance()
+                .loadProperties(propertiesFile, classLoader);
     }
 }

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -58,6 +58,18 @@
             <artifactId>failsafe</artifactId>
             <version>${jodah-failsafe.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/properties/PropertiesFileReader.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/properties/PropertiesFileReader.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.ui.admin.api.util;
+package org.codice.ddf.platform.util.properties;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -23,8 +23,6 @@ import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import ddf.security.PropertiesLoader;
 
 /**
  * Useful for scanning a directory for properties files and aggregating the data into maps and lists.
@@ -91,9 +89,9 @@ public class PropertiesFileReader {
     private Map<String, String> loadPropertiesFile(File propertiesFile) {
         Map<String, String> propertyMap = new HashMap<>();
         if (propertiesFile != null && propertiesFile.exists()) {
-            Properties properties =
-                    PropertiesLoader.loadProperties(propertiesFile.getAbsolutePath());
-            propertyMap = PropertiesLoader.toMap(properties);
+            PropertiesLoader loader = PropertiesLoader.getInstance();
+            Properties properties = loader.loadProperties(propertiesFile.getAbsolutePath());
+            propertyMap = loader.toMap(properties);
         }
         return propertyMap;
     }

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/properties/PropertiesLoader.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/properties/PropertiesLoader.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util.properties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+/**
+ * Utility class that attempts several different methods for loading in properties files from the
+ * classpath or file system. The strategies are attempted in the following order:
+ * <ol>
+ * <li>Spring (default class loader) uses utilities found in Spring-Core to load properties.</li>
+ * <li>Spring (given class loader) does the same as above, but with respect to the given class loader.</li>
+ * <li>Direct file system loading; useful when the properties have a fully-qualified absolute path.
+ * Relative paths are also valid, and loading attempts path resolution using (in order):
+ * <ol>
+ * <li>The relative path prepended with the {@code karaf.home} property</li>
+ * <li>The relative path prepended with the {@code ddf.home} property</li>
+ * <li>The relative path itself, without any modification</li>
+ * </ol>
+ * </li>
+ * <li>Resource loading using Java's built in resource system</li>
+ * </ol>
+ * Note that the first successful strategy is the one whose results are non-empty, and no further strategies
+ * will be attempted thereafter. Property placeholders are always substituted after the loading has finished.
+ * <p>
+ * If all strategies fail, then the returned Properties object will be empty.
+ */
+public final class PropertiesLoader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesLoader.class);
+
+    private static final PropertiesLoader INSTANCE = new PropertiesLoader();
+
+    private PropertiesLoader() {
+
+    }
+
+    public static PropertiesLoader getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Converts an instance of Properties to an instance of a Map, which is the preferred API for
+     * working with key-value collections.
+     *
+     * @param properties the properties object whose elements should be in the resultant map
+     * @param <K>        the object type of the key in the returned map
+     * @param <V>        the object type of the value in the returned map
+     * @return a new map with all elements of the given properties, or empty if the properties were null
+     */
+    @SuppressWarnings("unchecked")
+    public <K, V> Map<K, V> toMap(Properties properties) {
+        if (properties != null) {
+            final Set<Map.Entry<Object, Object>> entries = properties.entrySet();
+            Map<K, V> map = new HashMap<K, V>(entries.size() * 2);
+            for (Map.Entry<Object, Object> entry : entries) {
+                map.put((K) entry.getKey(), (V) entry.getValue());
+            }
+
+            return map;
+        }
+        return new HashMap<K, V>();
+    }
+
+    /**
+     * Load properties from a file with no classloader specified.
+     *
+     * @param propertiesFile the resource name or the file path of the properties file
+     * @return Properties deserialized from the specified file, or empty if the load failed
+     */
+    public Properties loadProperties(String propertiesFile) {
+        return loadProperties(propertiesFile, null);
+    }
+
+    /**
+     * Will attempt to load properties from a file using the given classloader. If that fails,
+     * several other methods will be tried until the properties file is located.
+     *
+     * @param propertiesFile the resource name or the file path of the properties file
+     * @param classLoader    the class loader with access to the properties file
+     * @return Properties deserialized from the specified file, or empty if the load failed
+     */
+    public Properties loadProperties(String propertiesFile, ClassLoader classLoader) {
+        boolean error = false;
+        Properties properties = new Properties();
+        if (propertiesFile != null) {
+            try {
+                LOGGER.debug(
+                        "Attempting to load properties from {} with Spring PropertiesLoaderUtils.",
+                        propertiesFile);
+                properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile);
+            } catch (IOException e) {
+                error = true;
+                LOGGER.debug("Unable to load properties using default Spring properties loader.",
+                        e);
+            }
+            if (error || properties.isEmpty()) {
+                if (classLoader != null) {
+                    try {
+                        LOGGER.debug(
+                                "Attempting to load properties from {} with Spring PropertiesLoaderUtils with class loader.",
+                                propertiesFile);
+                        properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile,
+                                classLoader);
+                        error = false;
+                    } catch (IOException e) {
+                        error = true;
+                        LOGGER.debug(
+                                "Unable to load properties using default Spring properties loader.",
+                                e);
+                    }
+                } else {
+                    try {
+                        LOGGER.debug(
+                                "Attempting to load properties from {} with Spring PropertiesLoaderUtils with class loader.",
+                                propertiesFile);
+                        properties = PropertiesLoaderUtils.loadAllProperties(propertiesFile,
+                                PropertiesLoader.class.getClassLoader());
+                        error = false;
+                    } catch (IOException e) {
+                        error = true;
+                        LOGGER.debug(
+                                "Unable to load properties using default Spring properties loader.",
+                                e);
+                    }
+                }
+            }
+
+            if (error || properties.isEmpty()) {
+                LOGGER.debug("Attempting to load properties from file system: {}", propertiesFile);
+                File propFile = new File(propertiesFile);
+                // If properties file has fully-qualified absolute path (which
+                // the blueprint file specifies) then can load it directly.
+                if (propFile.isAbsolute()) {
+                    LOGGER.debug("propertiesFile {} is absolute", propertiesFile);
+                    propFile = new File(propertiesFile);
+                } else {
+                    String rootDirectory = System.getProperty("karaf.home");
+                    if (rootDirectory != null && !rootDirectory.isEmpty()) {
+                        propFile = new File(rootDirectory, propertiesFile);
+                    } else {
+                        rootDirectory = System.getProperty("ddf.home");
+                        if (rootDirectory != null && !rootDirectory.isEmpty()) {
+                            propFile = new File(rootDirectory, propertiesFile);
+                        } else {
+                            propFile = new File(propertiesFile);
+                        }
+                    }
+                }
+                properties = new Properties();
+
+                try (InputStreamReader reader = new InputStreamReader(new FileInputStream(propFile),
+                        StandardCharsets.UTF_8)) {
+                    properties.load(reader);
+                } catch (FileNotFoundException e) {
+                    error = true;
+                    LOGGER.debug("Could not find properties file: {}",
+                            propFile.getAbsolutePath(),
+                            e);
+                } catch (IOException e) {
+                    error = true;
+                    LOGGER.debug("Error reading properties file: {}",
+                            propFile.getAbsolutePath(),
+                            e);
+                }
+            }
+            if (error || properties.isEmpty()) {
+                LOGGER.debug("Attempting to load properties as a resource: {}", propertiesFile);
+                InputStream ins = PropertiesLoader.class.getResourceAsStream(propertiesFile);
+                if (ins != null) {
+                    try {
+                        properties.load(ins);
+                        ins.close();
+                    } catch (IOException e) {
+                        LOGGER.debug("Unable to load properties: {}", propertiesFile, e);
+                    } finally {
+                        IOUtils.closeQuietly(ins);
+                    }
+                }
+            }
+
+            //replace any ${prop} with system properties
+            Properties filtered = new Properties();
+            for (Map.Entry<?, ?> entry : properties.entrySet()) {
+                filtered.put(StrSubstitutor.replaceSystemProperties(entry.getKey()),
+                        StrSubstitutor.replaceSystemProperties(entry.getValue()));
+            }
+            properties = filtered;
+
+        } else {
+            LOGGER.debug("Properties file must not be null.");
+        }
+
+        return properties;
+    }
+}

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/properties/PropertiesFileReaderTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/properties/PropertiesFileReaderTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util.properties;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class PropertiesFileReaderTest {
+    @ClassRule
+    public static TemporaryFolder testFolder = new TemporaryFolder();
+
+    private static final Path NONEXISTENT_PATH = Paths.get("this", "path");
+
+    private static final int VALUES_PER_FILE = 4;
+
+    private static String propertiesTestDirectoryPath;
+
+    private static String propertiesTestEmptyDirectoryPath;
+
+    private static String propertiesTestSingleFilePath;
+
+    private PropertiesFileReader reader = new PropertiesFileReader();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        File propertiesEmptyDirectory = testFolder.newFolder("empty");
+        File propertiesTestDirectory = testFolder.newFolder("properties");
+
+        propertiesTestEmptyDirectoryPath = propertiesEmptyDirectory.getPath();
+        propertiesTestDirectoryPath = propertiesTestDirectory.getPath();
+        propertiesTestSingleFilePath = Paths.get(propertiesTestDirectoryPath, "test1.properties")
+                .toString();
+
+        File propsFile1 = new File(propertiesTestDirectory, "test1.properties");
+        File propsFile2 = new File(propertiesTestDirectory, "test2.properties");
+        File propsFile3 = new File(propertiesTestDirectory, "test3.properties");
+
+        File randomFile = new File(propertiesTestDirectory, "random.cfg");
+        assert randomFile.createNewFile();
+
+        generateAndSaveProperties(propsFile1, "test1value", VALUES_PER_FILE);
+        generateAndSaveProperties(propsFile2, "test2value", VALUES_PER_FILE);
+        generateAndSaveProperties(propsFile3, "test3value", VALUES_PER_FILE);
+
+    }
+
+    @Test
+    public void testLoadDirectoryNullPath() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory(null);
+        assertEmpty(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadFileNullPath() throws Exception {
+        Map<String, String> resultsOneFile = reader.loadSinglePropertiesFile(null);
+        assertEmpty(resultsOneFile);
+    }
+
+    @Test
+    public void testLoadDirectoryEmptyStringForPath() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory("");
+        assertEmpty(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadFileEmptyStringForPath() throws Exception {
+        Map<String, String> resultsOneFile = reader.loadSinglePropertiesFile("");
+        assertEmpty(resultsOneFile);
+    }
+
+    @Test
+    public void testLoadDirectoryNonExistentPath() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory(
+                NONEXISTENT_PATH.toString());
+        assertEmpty(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadFileNonExistentPath() throws Exception {
+        Map<String, String> resultsOneFile =
+                reader.loadSinglePropertiesFile(NONEXISTENT_PATH.toString());
+        assertEmpty(resultsOneFile);
+    }
+
+    @Test
+    public void testLoadPropertiesFilesInDirectory() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory(
+                propertiesTestDirectoryPath);
+        validateAllProps(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadPropertiesFilesInEmptyDirectory() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory(
+                propertiesTestEmptyDirectoryPath);
+        assertEmpty(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadPropertiesFileInDirectoryGivenFileNotDirectory() throws Exception {
+        List<Map<String, String>> resultsDirectory = reader.loadPropertiesFilesInDirectory(
+                propertiesTestSingleFilePath);
+        assertEmpty(resultsDirectory);
+    }
+
+    @Test
+    public void testLoadSinglePropertiesFile() throws Exception {
+        Map<String, String> resultsOneFile = reader.loadSinglePropertiesFile(
+                propertiesTestSingleFilePath);
+        validateSinglePropertiesFile(resultsOneFile, 1);
+    }
+
+    @Test
+    public void testLoadSinglePropertiesFileGivenDirectoryNotFile() throws Exception {
+        Map<String, String> resultsOneFile = reader.loadSinglePropertiesFile(
+                propertiesTestDirectoryPath);
+        assertEmpty(resultsOneFile);
+    }
+
+    private static void generateAndSaveProperties(File destination, String valuePrefix,
+            int quantity) throws IOException {
+        Properties properties = new Properties();
+        for (int i = 1; i <= quantity; i++) {
+            properties.put(format("%s%d", "key", i), format("%s%d", valuePrefix, i));
+        }
+        properties.store(new FileWriter(destination), "For testing purposes");
+    }
+
+    private static void assertEmpty(Map<String, String> map) {
+        assertThat("File targeted for property loading should NOT have produced results",
+                map.entrySet(),
+                hasSize(0));
+    }
+
+    private static void assertEmpty(List<Map<String, String>> list) {
+        assertThat("Directory targeted for property loading should NOT have produced results",
+                list,
+                hasSize(0));
+    }
+
+    private static void validateAllProps(List<Map<String, String>> propCollection) {
+        propCollection.forEach(props -> validateSinglePropertiesFile(props,
+                resolvePropFileNumber(props)));
+    }
+
+    private static int resolvePropFileNumber(Map<String, String> props) {
+        return Character.getNumericValue(props.get("key1")
+                .toCharArray()[4]);
+    }
+
+    private static void validateSinglePropertiesFile(Map<String, String> props, int testNumber) {
+        assertThat(props.get("key1"), is(format("test%dvalue1", testNumber)));
+        assertThat(props.get("key2"), is(format("test%dvalue2", testNumber)));
+        assertThat(props.get("key3"), is(format("test%dvalue3", testNumber)));
+        assertThat(props.get("key4"), is(format("test%dvalue4", testNumber)));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Addresses minor technical debt from previous sprint. 

#### Who is reviewing it?
@oconnormi 
@brjeter 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR.
@lessarderic 
@figliold 

#### How should this be tested?
This technical debt has no specific testing steps. 

#### Any background context you want to provide?
Yes. Similar functionality to `PropertiesFileReader` already exists in `security-core-api` within the `PropertiesLoader` class. Since `admin-core-api` already depends on `security-core-api` it made sense to just move the property manipulation logic there. 

#### What are the relevant tickets?
[DDF-2731](https://codice.atlassian.net/browse/DDF-2731)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
