### PR TITLE
DDF-2847 Adds unsaved workspace indicators to the UI

### DIFF
--- a/catalog/ui/catalog-ui-search/package.json
+++ b/catalog/ui/catalog-ui-search/package.json
@@ -87,6 +87,7 @@
     "jquery": "1.12.4",
     "jquery-ui": "1.10.4",
     "lodash": "2.4.1",
+    "lodash.get": "4.4.2",
     "moment": "2.13.0",
     "openlayers": "3.20.1",
     "plotly.js": "1.10.5",

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -38,6 +38,7 @@
 @import 'tabs/metacard/tabs-metacard.less';
 @import 'tabs/metacards/tabs-metacards.less';
 @import 'workspace-item/workspace-item';
+@import 'workspace-details/workspace-details';
 @import 'content/content';
 @import 'workspace-explore/workspace-explore';
 @import 'workspace-saved/workspace-saved';
@@ -154,3 +155,5 @@
 @import 'user-blacklist/user-blacklist';
 @import 'blacklist-item/blacklist-item';
 @import 'system-usage/system-usage';
+@import 'save/save';
+@import 'unsaved-indicator/unsaved-indicator';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content-title/content-title.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content-title/content-title.hbs
@@ -11,5 +11,7 @@
  *
  **/
  --}}
-<input placeholder="Workspace Title" value="{{currentWorkspace.title}}">
-<div class="title-display">{{currentWorkspace.title}}</div>
+<input placeholder="Workspace Title" value="{{bind selector="> input" event="change:currentWorkspace" key=(path 'currentWorkspace' 'title')}}" data-help="This is the title of the workspace you are currently in.
+If you have permission, you can click here to start editing the title.">
+<pre class="title-display">{{bind selector="> .title-display" event="change:currentWorkspace" key=(path 'currentWorkspace' 'title')}}</pre>
+<div class="title-saved"></div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content-title/content-title.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content-title/content-title.less
@@ -4,27 +4,45 @@
 
   .title-display {
     display: inline-block;
-    padding: 4px 10px 5px 10px;
-    height: ~'calc(100% - 2px)';
-    transition: padding @coreTransitionTime linear;
+    padding: 0px 18px 0px 10px;
+    height: ~'calc(100% - 4px)';
+    transition: padding @coreTransitionTime ease-out;
     transition-delay: @coreTransitionTime;
     visibility: hidden;
+    font-size: @largeFontSize;
+    line-height: inherit;
+    border: none;
+    font-family: inherit;
+    margin: 0px;
+    overflow: hidden;
   }
   
-  .title-display:empty::after {
+  .title-display:empty::before {
     content: 'Workspace Title';
   }
 
-  input {
+  .title-saved {
+    line-height: ~'calc(2*@{minimumLineSize} - 6px)';
+    color: @warning-color;
     position: absolute;
-    left: 0px;
-    top: 0px;
-    display: inline-block;
-    vertical-align: top;
-    height: ~'calc(100% - 2px)';
+    padding-right: 0px;
+    height: ~'calc(100% - 6px)';
+    right: 0px;
+    top: 3px;
+    background: @navigation-background-color;
+    transform: scale(1);
+    opacity: 1;
+    transition: padding @coreTransitionTime ease-out @coreTransitionTime, transform @coreTransitionTime ease-out, opacity @coreTransitionTime ease-out;
   }
 
   input {
+    padding-top: 3px;
+    position: absolute;
+    left: 1px;
+    top: 2px;
+    display: inline-block;
+    vertical-align: top;
+    height: ~'calc(100% - 4px)';
     min-width: 1px;
     background: @navigation-background-color;
     border: none;
@@ -33,6 +51,9 @@
     text-overflow: ellipsis;
     width: 100%;
     cursor: pointer;
+    transition: padding @coreTransitionTime ease-out;
+    transition-delay: @coreTransitionTime;
+    padding-right: 15px;
   }
   
   input:focus {
@@ -41,10 +62,17 @@
     outline-style: solid;
     outline-width: 1px;
     outline-color: grey;
+    padding-right: 25px;
+    transition-delay: 0s;
   }
 
   input:focus + .title-display {
-    padding: 4px 25px 5px 25px;
+    padding: 0px 30px 0px 25px;
+    transition-delay: 0s;
+  }
+
+  input:focus + .title-display + .title-saved {
+    padding-right: 5px;
     transition-delay: 0s;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.view.js
@@ -26,15 +26,20 @@ define([
              DropdownHintView, Hint) {
 
     var zeroScale = "matrix(0, 0, 0, 0, 0, 0)";
+    var zeroOpacity = "0";
 
-    // specifically to account for IE Edge Bug, see http://codepen.io/andrewkfiedler/pen/apBbxq
-    function isZeroScale(element){
+    // zeroScale to specifically to account for IE Edge Bug, see http://codepen.io/andrewkfiedler/pen/apBbxq
+    // zeroOpacity to account for how browsers work
+    function isEffectivelyHidden(element){
         if (element === document){
             return false;
-        } else if (window.getComputedStyle(element).transform === zeroScale){
-            return true;
         } else {
-            return isZeroScale(element.parentNode);
+            var computedStyle = window.getComputedStyle(element);
+            if (computedStyle.transform === zeroScale || computedStyle.opacity === zeroOpacity){
+                return true;
+            } else {
+                return isEffectivelyHidden(element.parentNode);
+            }
         }
     }
 
@@ -188,7 +193,7 @@ define([
             this.$el.addClass('is-shown');
             var $elementsWithHints = $('[data-help]');
             _.each($elementsWithHints, function (element) {
-                if (isZeroScale(element)){
+                if (isEffectivelyHidden(element)){
                     return;
                 }
                 var boundingRect = element.getBoundingClientRect();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.hbs
@@ -11,5 +11,7 @@
  *
  **/
  --}}
-<button class="fa fa-bars" data-help="Click here to bring up the navigator.">
+<button data-help="Click here to bring up the navigator.">
+    <span class="fa fa-bars"></span>
+    <div class="navigation-indicator"></div>
 </button>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.less
@@ -1,10 +1,18 @@
 @{customElementNamespace}navigation-left {
     .customElement;
     position: relative;
+    overflow: hidden;
+    cursor: pointer;
 
     button {
         text-align: center;
         width: @minimumButtonSize;
         height: 100%;
+    }
+
+    button > .navigation-indicator {
+        position: absolute;
+        right: 0px;
+        top: -.3125rem;
     }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation-left/navigation-left.view.js
@@ -18,15 +18,33 @@ var CustomElements = require('CustomElements');
 var template = require('./navigation-left.hbs');
 var SlideoutLeftViewInstance = require('component/singletons/slideout.left.view-instance.js');
 var NavigatorView = require('component/navigator/navigator.view');
+var store = require('js/store');
+var UnsavedIndicatorView = require('component/unsaved-indicator/workspaces/workspaces-unsaved-indicator.view');
 
-module.exports = Marionette.ItemView.extend({
+module.exports = Marionette.LayoutView.extend({
     template: template,
     tagName: CustomElements.register('navigation-left'),
+    regions: {
+        unsavedIndicator: '.navigation-indicator'
+    },
     events: {
         'click': 'toggleNavigator'
+    },
+    initialize: function(){
+        this.listenTo(store.get('workspaces'), 'change:saved update add remove', this.handleSaved);
+        this.handleSaved();
+    },
+    onBeforeShow: function(){
+        this.unsavedIndicator.show(new UnsavedIndicatorView());
     },
     toggleNavigator: function(){
         SlideoutLeftViewInstance.updateContent(new NavigatorView());
         SlideoutLeftViewInstance.open();
+    },
+    handleSaved: function(){
+        var hasUnsaved = store.get('workspaces').find(function(workspace){
+            return !workspace.isSaved();
+        });
+        this.$el.toggleClass('is-saved', !hasUnsaved);
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation/navigation.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation/navigation.hbs
@@ -11,7 +11,7 @@
  *
  **/
  --}}
-<div class="navigation-left">
+<div class="navigation-left is-button">
 </div>
 <div class="navigation-middle">
     <!-- Meant to be used on multiple pages, but the other elements are static -->

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.hbs
@@ -18,8 +18,10 @@
 <div class="is-divider"></div>
 <div class="navigation-links">
     <button class="navigation-choice is-neutral choice-workspaces is-button">
-        <span class="fa fa-book"></span><span>Workspaces</span>
+        <span class="fa fa-book"></span><span>Workspaces</span><div class="workspaces-indicator"></div>
     </button>
+    <div class="workspaces-save">
+    </div>
     <button class="navigation-choice is-neutral choice-upload is-button">
         <span class="fa fa-upload"></span><span>Upload</span>
     </button>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.less
@@ -11,11 +11,44 @@
         word-wrap: normal;
         overflow: hidden;
         text-overflow: ellipsis;
+        position: relative;
     }
 
     .navigation-links {
-        .fa {
+        position: relative;
+        .navigation-choice .fa {
             padding-right: @minimumSpacing;
         }
     }
+
+    .choice-workspaces .workspaces-indicator {
+        padding-left: @minimumSpacing;
+        display: inline-block;
+    }
+
+    .workspaces-save {
+        position: absolute;
+        right:0px;
+        top: 0px;
+        height: auto;
+        overflow: hidden;
+        max-width: 100%;
+        .is-large-font();
+        line-height: @minimumButtonSize;
+    }
+
+    .workspaces-save > @{customElementNamespace}save {
+        padding: @largeSpacing;
+    }
+}
+
+@{customElementNamespace}navigator.is-saved {
+
+    .workspaces-save {
+        opacity: 1;
+        transition: max-width 0s linear 10*@coreTransitionTime;
+        overflow: hidden;
+        max-width: 0%;
+    }
+
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.hbs
@@ -11,10 +11,4 @@
  *
  **/
  --}}
-<div class="choice-details">
-</div>
-<div class="choice-save">
-</div>
-<div class="choice-actions is-button" title="Shows a list of actions to take on the workspace" 
-    data-help="Shows a list of actions to take on the workspace.">
-</div>
+<span class="fa fa-floppy-o"></span><span class="fa fa-check"></span>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.less
@@ -1,0 +1,44 @@
+@{customElementNamespace}save {
+    .customElement;
+    display: inline-block;
+    cursor: pointer;
+
+    .fa-floppy-o {
+        transition: opacity 2*@coreTransitionTime ease-out 0*@coreTransitionTime, 
+        transform 2*@coreTransitionTime ease-out 0*@coreTransitionTime;
+    }
+
+    span.fa-check {
+        margin: auto;
+        position: absolute;
+        line-height: inherit;
+        left: 0px;
+        text-align: center;
+        width: 100%;
+        transform: scale(2);
+        opacity: 0;
+        color: @positive-color;
+    }
+}
+
+@{customElementNamespace}save.is-saved {
+    opacity: 1;
+    overflow: hidden;
+
+    .fa-floppy-o {
+        opacity: 0;
+        transform: scale(2);
+        transition-delay: 0s;
+    }
+
+    .fa-check {
+        visibility: visible;
+        transition: transform 2*@coreTransitionTime ease-out @coreTransitionTime, 
+        opacity 2*@coreTransitionTime ease-out @coreTransitionTime,
+        color 2*@coreTransitionTime ease-out 8*@coreTransitionTime;
+        color: transparent;
+        transform: scale(1);
+        opacity: 1;
+    }
+
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/save/save.view.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var Marionette = require('marionette');
+var template = require('./save.hbs');
+var CustomElements = require('js/CustomElements');
+require('behaviors/button.behavior');
+
+// Base View, meant to be extended for whatever needs a save button
+module.exports = Marionette.ItemView.extend({
+    template: template,
+    tagName: CustomElements.register('save'),
+    className: 'is-button',
+    events: {
+        'click': 'triggerSave'
+    },
+    behaviors: {
+        button: {}
+    },
+    initialize: function() {
+        // overwrite with listeners
+    },
+    onBeforeShow: function() {
+        this.handleSaved();
+    },
+    isSaved: function() {
+        // overwrite with save check
+    },
+    triggerSave: function() {
+        // overwrite with save action
+    },
+    handleSaved: function() {
+        this.$el.toggleClass('is-saved', this.isSaved());
+        this.$el.attr('tabindex', this.isSaved() ? -1 : 0);
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/save/workspace/workspace-save.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/save/workspace/workspace-save.view.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var SaveView = require('../save.view');
+
+module.exports = SaveView.extend({
+    attributes: {
+        'data-help': 'Saves the workspace.',
+        title: 'Saves the workspace.'
+    },
+    initialize: function() {
+        this.listenTo(this.model, 'change', this.handleSaved);
+    },
+    isSaved: function() {
+        return this.model.isSaved();
+    },
+    triggerSave: function() {
+        this.model.save();
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/save/workspaces/workspaces-save.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/save/workspaces/workspaces-save.view.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var store = require('js/store');
+var SaveView = require('../save.view');
+
+module.exports = SaveView.extend({
+    attributes: {
+        'data-help': 'Saves all workspaces.',
+        title: 'Saves all workspaces.'
+    },
+    setDefaultModel: function() {
+        this.model = store;
+    },
+    initialize: function(options) {
+        if (options.model === undefined) {
+            this.setDefaultModel();
+        }
+        this.listenTo(this.model.get('workspaces'), 'change:saved update add remove', this.handleSaved);
+    },
+    isSaved: function() {
+        return !this.model.get('workspaces').find(function(workspace) {
+            return !workspace.isSaved();
+        });
+    },
+    triggerSave: function() {
+        this.model.get('workspaces').saveAll();
+    },
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.hbs
@@ -11,10 +11,4 @@
  *
  **/
  --}}
-<div class="choice-details">
-</div>
-<div class="choice-save">
-</div>
-<div class="choice-actions is-button" title="Shows a list of actions to take on the workspace" 
-    data-help="Shows a list of actions to take on the workspace.">
-</div>
+<span>*</span>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.less
@@ -1,0 +1,13 @@
+@{customElementNamespace}unsaved-indicator {
+    display: inline-block;
+    line-height: inherit;
+    color: @warning-color;
+    transform: scale(1);
+    opacity: 1;
+    transition: transform @coreTransitionTime ease-out, opacity @coreTransitionTime ease-out;
+}
+
+@{customElementNamespace}unsaved-indicator.is-saved {
+    transform: scale(2);
+    opacity: 0;
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/unsaved-indicator.view.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var Marionette = require('marionette');
+var template = require('./unsaved-indicator.hbs');
+var CustomElements = require('js/CustomElements');
+
+// Base View, meant to be extended for whatever needs an unsaved indicator
+module.exports = Marionette.ItemView.extend({
+    template: template,
+    tagName: CustomElements.register('unsaved-indicator'),
+    initialize: function() {
+        // overwrite with listeners
+    },
+    onBeforeShow: function() {
+        this.handleSaved();
+    },
+    isSaved: function() {
+        // overwrite with save check
+    },
+    handleSaved: function() {
+        this.$el.toggleClass('is-saved', this.isSaved());
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/workspace/workspace-unsaved-indicator.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/workspace/workspace-unsaved-indicator.view.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var SaveView = require('../unsaved-indicator.view');
+
+module.exports = SaveView.extend({
+    attributes: {
+        'data-help': 'Indicates the workspace is unsaved.',
+        title: 'Indicates the workspace is unsaved.'
+    },
+    initialize: function() {
+        this.listenTo(this.model, 'change', this.handleSaved);
+    },
+    isSaved: function() {
+        return this.model.isSaved();
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/workspaces/workspaces-unsaved-indicator.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/unsaved-indicator/workspaces/workspaces-unsaved-indicator.view.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+
+var store = require('js/store');
+var SaveView = require('../unsaved-indicator.view');
+
+module.exports = SaveView.extend({
+    attributes: {
+        'data-help': 'Indicates a workspace is unsaved.',
+        title: 'Indicates a workspace is unsaved.'
+    },
+    setDefaultModel: function() {
+        this.model = store;
+    },
+    initialize: function(options) {
+        if (options.model === undefined) {
+            this.setDefaultModel();
+        }
+        this.listenTo(this.model.get('workspaces'), 'change:saved update add remove', this.handleSaved);
+    },
+    isSaved: function() {
+        return !this.model.get('workspaces').find(function(workspace) {
+            return !workspace.isSaved();
+        });
+    },
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
@@ -11,10 +11,10 @@
  *
  **/
  --}}
-<div class="choice-details">
+<div class="choice-title" data-help="The title of the workspace.">
+    <span class="title-text" title="{{title}}">{{bind selector="> .choice-title > .title-text" event="change:title" key=(path "title") updateTitle=true}}</span>
+    <div class="title-indicator"></div>
 </div>
-<div class="choice-save">
-</div>
-<div class="choice-actions is-button" title="Shows a list of actions to take on the workspace" 
-    data-help="Shows a list of actions to take on the workspace.">
+<div class="choice-date" title="{{niceDate}}" data-help="The date the workspace was last modified">
+    {{bind selector="> .choice-date" event="change:modified" key=(path "niceDate") updateTitle=true}}
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.less
@@ -1,0 +1,48 @@
+@{customElementNamespace}workspace-details {
+    .customElement;
+
+    .choice-title,
+    .choice-date {
+        max-width: 100%;
+        height: @minimumLineSize;
+        line-height: @minimumLineSize;
+        padding: 0px 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .choice-title {
+        >.title-text {
+        white-space: pre;
+        .is-bold();
+        display: inline-block;
+        max-width:~'calc(100% - @{minimumFontSize})';
+        overflow: hidden;
+        text-overflow: ellipsis;
+        }
+        >.title-indicator {
+            display: inline-block;
+            vertical-align: top;
+        }
+    }
+}
+
+@{customElementNamespace}workspace-details.as-list {
+    white-space: nowrap;
+    vertical-align: top;
+    height: @minimumButtonSize;
+    transition: width @coreTransitionTime linear;
+
+    .choice-title, 
+    .choice-date {
+        width: 50%;
+        height: @minimumButtonSize;
+        line-height: @minimumButtonSize;
+        display: inline-block;
+        padding: 0px 20px;
+    }
+    .choice-date {
+        text-align: center;
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.view.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+    'wreqr',
+    'marionette',
+    'underscore',
+    'jquery',
+    './workspace-details.hbs',
+    'js/CustomElements',
+    'moment',
+    'component/singletons/user-instance',
+    'component/unsaved-indicator/workspace/workspace-unsaved-indicator.view'
+], function (wreqr, Marionette, _, $, template, CustomElements, moment, user, UnsavedIndicatorView) {
+
+    return Marionette.LayoutView.extend({
+        template: template,
+        tagName: CustomElements.register('workspace-details'),
+        regions: {
+            unsavedIndicator: '.title-indicator',
+        },
+        initialize: function(options){
+            this.listenTo(user.get('user').get('preferences'), 'change:homeDisplay', this.handleDisplayPref);
+        },
+        onRender: function(){
+            this.handleDisplayPref();
+        },
+        onBeforeShow: function(){
+            this.unsavedIndicator.show(new UnsavedIndicatorView({
+                model: this.model
+            }));
+        },
+        handleDisplayPref: function(){
+            this.$el.toggleClass('as-list', user.get('user').get('preferences').get('homeDisplay') === 'List');
+        },
+        serializeData: function() {
+            var workspacesJSON = this.model.toJSON();
+            workspacesJSON.niceDate = moment(workspacesJSON.modified).fromNow();
+            return workspacesJSON;
+        },
+    });
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-item/workspace-item.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-item/workspace-item.less
@@ -1,141 +1,86 @@
-@{customElementNamespace}workspace-item.as-grid {
+@{customElementNamespace}workspace-item {
   .customElement;
+  overflow: hidden;
   display: inline-block;
-  width: auto;
+  width: 18rem;
+  height: 2*@minimumLineSize;
   color: @text-color;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.07);
+  cursor: pointer;
+  .inlineBlockDisplay(div);
   margin-bottom: 10px;
   margin-right: 20px;
-
-  .choice.as-grid {
-    display: inline-block;
-    vertical-align: middle;
-  }
-  .choice.as-list {
-    display: none;
-  }
-
-  .choice {
-    position: relative;
-    display: inline-block;
-    width: 19rem;
-    box-shadow: 0 1px 0 rgba(0,0,0,0.07);
-    cursor: pointer;
-  }
-
-  .choice-preview {
-    line-height: 15.5625rem;
-    height: 16.8125rem;
-    text-align: center;
-    width: 100%;
-    background: @lighten-inherited-background-color;
-    font-size: @largeFontSize;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .choice-preview > img {
-    width: 100%;
-  }
-
-  .choice-preview-icon {
-    line-height: 16.8125rem;
-  }
-
-  .choice-footer {
-    white-space: nowrap;
-    text-align: center;
-    height: 2*@minimumLineSize;
-  }
-
-  .choice-details,
-  .choice-actions {
-    display: inline-block;
-    height: 100%;
-    vertical-align: top;
-  }
+  position: relative;
 
   .choice-details {
-    width: ~'calc(100% - @{minimumButtonSize})';
-    text-align: left;
+    width: 100%;
+    padding-right: 2*@minimumButtonSize;
   }
 
-  .choice-details > div:not(:first-of-type) {
+  @{customElementNamespace}workspace-details > .choice-date {
     opacity: @minimumOpacity;
   }
 
-  .choice-actions {
+  .choice-details,
+  .choice-actions,
+  .choice-save {
+    display: inline-block;
+    vertical-align: top;
+    position: relative;
+    height: 100%;
+    .is-small-font();
+  }
+
+  .choice-actions,
+  .choice-save {
     width: @minimumButtonSize;
     text-align: center;
+    height: 100%;
     line-height: 2*@minimumLineSize;
-  }
-
-  .choice-title,
-  .choice-date {
-    line-height: @minimumLineSize;
     overflow: hidden;
-    text-overflow: ellipsis;
-    padding-left: 10px;
   }
 
-  .choice-title {
-    .is-bold();
+  .choice-actions {
+    position: absolute;
+    right: 0px;
+  }
+
+  .choice-save {
+    position: absolute;
+    right: @minimumButtonSize;
+    transition: transform @coreTransitionTime linear;
+    transform: scale(1);
+    max-width: 100%;
   }
 }
 
 @{customElementNamespace}workspace-item.as-list {
   display: block;
-  margin-bottom: 10px;
+  width: 100%;
+  text-align: left;
+  height: @minimumButtonSize;
+  line-height: @minimumButtonSize;
+  white-space: nowrap;
 
-  .choice.as-grid {
-    display: none;
-  }
-
-  .choice.as-list {
-    display: block;
-    width: 100%;
-    text-align: left;
-  }
-
-  .choice {
-    height: @minimumButtonSize;
+  .choice-actions,
+  .choice-save {
     line-height: @minimumButtonSize;
-    white-space: nowrap;
-    box-shadow: 0 1px 0 rgba(0,0,0,0.07);
-    cursor: pointer;
   }
+}
 
-  .choice-details,
-  .choice-actions {
-    display: inline-block;
+
+@{customElementNamespace}workspace-item.is-saved {
+
+  .choice-save {
+      opacity: 1;
+      transition: max-width 0s ease-out 10*@coreTransitionTime;
+      overflow: hidden;
+      max-width: 0%;
   }
 
   .choice-details {
-    width: ~'calc(100% - @{minimumButtonSize})';
-    white-space: nowrap;
-    vertical-align: top;
-    height: @minimumButtonSize;
+    transition: padding @coreTransitionTime ease-out 10*@coreTransitionTime;
+    padding-right: @minimumButtonSize;  //IE Edge doesn't support calc transitions
   }
 
-  .choice-actions {
-    width: @minimumButtonSize;
-    cursor: pointer;
-    text-align: center;
-  }
-
-  .choice-title,
-  .choice-date {
-    padding: 0px 20px;
-    display: inline-block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .choice-title {
-    width: 50%;
-  }
-
-  .choice-date {
-    width: 50%;
-    text-align: center;
-  }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.hbs
@@ -11,9 +11,10 @@
  *
  **/
  --}}
-<div class="content-title" data-help="This is the title of the workspace you are currently in.
-If you have permission, you can click here to start editing the title.">
+<div class="content-title">
 </div>
-<div class="content-interactions">
+<div class="content-save">
+</div>
+<div class="content-interactions is-button">
     
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.less
@@ -5,23 +5,53 @@
   height: 2*@minimumLineSize;
   white-space: nowrap;
 
+  .inlineBlockDisplay(div, @largeFontSize) !important;
+
   > .content-title {
     height: 100%;
-    overflow: hidden;
     text-overflow: ellipsis;
     width: auto;
-    max-width: ~'calc(100% - @{minimumButtonSize})';
+    transition: padding 1*@coreTransitionTime ease-out;
+    padding-right: 2*@minimumButtonSize;
+    max-width: 100%;
   }
 
-  > .content-interactions {
+  > .content-interactions,
+  > .content-save {
+    transform: translateX(-200%);
+    transition: width 2*@coreTransitionTime ease-out, 
+        margin 2*@coreTransitionTime ease-out,
+        transform 1*@coreTransitionTime ease-out;
     width: @minimumButtonSize;
     height: 100%;
     text-align: center;
   }
 
-  > div {
-    display: inline-block;
-    vertical-align: top;
+  > .content-save {
+    margin-left: 10px;
+    position: relative;
+    overflow: hidden;
+    width: @minimumButtonSize;
+  }
+}
+
+@{customElementNamespace}workspace-menu.is-saved {
+
+  .content-save {
+      opacity: 1;
+      transition-delay: 10*@coreTransitionTime;
+      overflow: hidden;
+      width: 0%;
+      margin-left: 0px;
   }
 
+  .content-interactions {
+    transition-delay: 10*@coreTransitionTime;
+    transform: translateX(-100%);
+  }
+
+  .content-title {
+    transition-delay: 10*@coreTransitionTime;
+    padding-right: @minimumButtonSize;
+  }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-menu/workspace-menu.view.js
@@ -23,8 +23,9 @@ define([
     'component/dropdown/dropdown',
     'component/dropdown/workspace-interactions/dropdown.workspace-interactions.view',
     'js/store',
+    'component/save/workspace/workspace-save.view'
 ], function (Marionette, _, $, template, CustomElements, TitleView, DropdownModel, 
-    WorkspaceInteractionsView, store) {
+    WorkspaceInteractionsView, store, SaveView) {
 
     return Marionette.LayoutView.extend({
         setDefaultModel: function(){
@@ -34,6 +35,7 @@ define([
         tagName: CustomElements.register('workspace-menu'),
         regions: {
             title: '.content-title',
+            workspaceSave: '.content-save',
             workspaceInteractions: '.content-interactions'
         },
         initialize: function (options) {
@@ -41,11 +43,21 @@ define([
                 this.setDefaultModel();
             }
             this.listenTo(this.model, 'change:currentWorkspace', this.updateWorkspaceInteractions);
-            this.listenTo(this.model, 'change:currentWorkspace', this.handleWorkspaceChange);
+            this.listenTo(this.model, 'change:currentWorkspace', this.updateWorkspaceSave);
+            this.listenTo(this.model, 'change:currentWorkspace', this.handleSaved);
         },
         onBeforeShow: function(){
             this.title.show(new TitleView());
+            this.updateWorkspaceSave();
             this.updateWorkspaceInteractions();
+            this.handleSaved();
+        },
+        updateWorkspaceSave: function(workspace){
+             if (workspace && workspace.changed.currentWorkspace) {
+                this.workspaceSave.show(new SaveView({
+                    model: this.model.get('currentWorkspace')
+                }));
+            }
         },
         updateWorkspaceInteractions: function(workspace) {
             if (workspace && workspace.changed.currentWorkspace) {
@@ -54,6 +66,10 @@ define([
                     modelForComponent: this.model.get('currentWorkspace')
                 }));
             }
+        },
+        handleSaved: function(){
+            var currentWorkspace = this.model.get('currentWorkspace');
+            this.$el.toggleClass('is-saved', currentWorkspace ? currentWorkspace.isSaved() : false);
         }
     });
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.hbs
@@ -19,3 +19,7 @@
     <div class="home-items">
     </div>
 </div>
+<button class="home-save is-positive">
+    <span class="fa fa-floppy-o"></span>
+    <span>Save all</span>
+</button>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.less
@@ -3,20 +3,52 @@
   background: @card-background-color;
 
   .home-content {
-    height: ~'calc(100% - 2*@{minimumLineSize})';
+    display: inline-block;
+    width: 100%;
+    max-height: ~'calc(100% - 2*@{minimumLineSize} - 10px)';
     overflow: auto;
   }
 
   .home-items {
-    padding-bottom: 20px;
+    transition: padding @coreTransitionTime ease-out @coreTransitionTime;
+    padding-bottom: @minimumButtonSize;
   }
 
+  .home-save {
+    width: 100%;
+    opacity: 1;
+    transform: scale(1) translateY(-100%);
+    opacity: 1;
+    position: relative;
+    top: 0%;
+    left: 0%;
+    transition: transform @coreTransitionTime ease-out, 
+        opacity @coreTransitionTime ease-out,
+        left 0s ease-out @coreTransitionTime;
+  }
+
+}
+
+@{customElementNamespace}workspaces.is-saved {
+  .home-items  {
+    padding-bottom: 0px;
+  }
+
+  .home-save {
+    transform: scale(2) translateY(-100%);
+    left: -200%;
+    opacity: 0;
+  }
 }
 
 @{customElementNamespace}workspaces.has-templates-expanded {
 
   .home-content {
     overflow: hidden;
+  }
+
+  .home-save {
+    transform: translateY(100%);
   }
 
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces/workspaces.view.js
@@ -23,8 +23,10 @@ define([
     'component/router/router',
     'component/navigation/workspaces/navigation.workspaces.view',
     'component/workspaces-templates/workspaces-templates.view',
-    'component/workspaces-items/workspaces-items.view'
-], function (wreqr, Marionette, _, $, template, CustomElements, router, WorkspacesMenuView, WorkspacesTemplatesView, WorkspacesItemsView) {
+    'component/workspaces-items/workspaces-items.view',
+    'js/store'
+], function (wreqr, Marionette, _, $, template, CustomElements, router, WorkspacesMenuView, 
+    WorkspacesTemplatesView, WorkspacesItemsView, store) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -32,6 +34,7 @@ define([
         modelEvents: {
         },
         events: {
+            'click > .home-save': 'handleSave'
         },
         childEvents: {
             'homeTemplates:expand' : 'handleTemplatesExpand',
@@ -46,6 +49,8 @@ define([
         },
         initialize: function(){
             this.listenTo(router, 'change', this.handleRoute);
+            this.listenTo(store.get('workspaces'), 'change:saved update add remove', this.handleSaved);
+            this.handleSaved();
             this.handleRoute();
         },
         handleRoute: function(){
@@ -66,6 +71,16 @@ define([
         },
         handleTemplatesClose: function(){
             this.$el.removeClass('has-templates-expanded');
+        },
+        handleSaved: function(){
+            var hasUnsaved = store.get('workspaces').find(function(workspace){
+                return !workspace.isSaved();
+            });
+            this.$el.toggleClass('is-saved', !hasUnsaved);
+            this.$el.find('> .home-save').attr('tabindex', !hasUnsaved ? -1 : null);
+        },
+        handleSave: function(){
+            store.get('workspaces').saveAll();
         }
     });
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -86,7 +86,8 @@ require([
         cloneRef._cloneOf = this.id || this.cid;
         return cloneRef;
     };
-    Marionette.Renderer.render = function(template, data) {
+    Marionette.Renderer.render = function(template, data, view) {
+        data._view = view;
         if (typeof template === 'function') {
             return template(data);
         } else {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
@@ -28,7 +28,7 @@ define([
             window.onbeforeunload = function () {
                 var unsaved = this.get('workspaces').chain()
                     .map(function (workspace) {
-                        if (workspace.dirty()) {
+                        if (!workspace.isSaved()) {
                             return workspace.get('title');
                         }
                     })

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/focus.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/focus.less
@@ -1,13 +1,12 @@
 *:focus {
-  outline-offset: -1px;
   animation: focusFade 1s ease-in-out;
 }
 
 @keyframes focusFade {
   0% {
-    outline: @primary-color solid 1px;
+    box-shadow: inset 0px 0px 0px 1px @primary-color;
   }
   100% {
-    outline: transparent solid 1px;
+    box-shadow: inset 0px 0px 0px 1px transparent;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/components/input.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/components/input.less
@@ -31,3 +31,8 @@ input[type=number]::-webkit-outer-spin-button {
 input[type=number] {
   -moz-appearance: textfield;
 }
+
+input:focus {
+  outline: none !important;
+  box-shadow: inset 0px 0px 0px 1px grey;
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/less/mixins.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/less/mixins.less
@@ -30,20 +30,20 @@
   display: block;
 }
 
-.inlineBlockDisplay(@thingToInline) {
+.inlineBlockDisplay(@thingToInline; @fontSize: @minimumFontSize) {
 
   > @{thingToInline} {
     display: inline-block;
     vertical-align: middle;
   }
 
-  .inlineFix;
+  .inlineFix(@fontSize);
 }
 
-.inlineFix {
+.inlineFix(@fontSize: @minimumFontSize) {
   font-size: 0px;
   > * > * {
-    font-size: @minimumFontSize;
+    font-size: @fontSize;
   }
 }
 

--- a/catalog/ui/catalog-ui-search/yarn.lock
+++ b/catalog/ui/catalog-ui-search/yarn.lock
@@ -446,7 +446,7 @@ abab@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
-abbrev@1, abbrev@~1.0.4:
+abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -559,25 +559,9 @@ ansi-red@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-regex@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.1.0.tgz#55ca60db6900857c423ae9297980026f941ed903"
-
-ansi-regex@^0.2.0, ansi-regex@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
-
-ansi-regex@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-1.1.1.tgz#41c847194646375e6a1a5d10c3ca054ef9fc980d"
-
 ansi-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
-
-ansi-styles@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -601,10 +585,6 @@ anymatch@^1.3.0:
 aproba@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.0.4.tgz#2713680775e7614c8ba186c065d4e2e52d1072c0"
-
-archy@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/archy/-/archy-0.0.2.tgz#910f43bf66141fc335564597abc189df44b3d35e"
 
 are-we-there-yet@~1.1.2:
   version "1.1.2"
@@ -739,7 +719,7 @@ async@2.1.4, async@^2.0.0, async@^2.0.1:
   dependencies:
     lodash "^4.14.0"
 
-async@^0.9.0, async@~0.9.0:
+async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
@@ -747,11 +727,7 @@ async@^1.3.0, async@^1.4.0, async@^1.5.0, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@~0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.1.22.tgz#0fc1aaa088a0e3ef0ebe2d8831bab0dcf8845061"
-
-async@~0.2.10, async@~0.2.6, async@~0.2.8:
+async@~0.2.10, async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
@@ -1145,7 +1121,7 @@ binary-search-bounds@^2.0.0, binary-search-bounds@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz#5ff8616d6dd2ca5388bc85b2d6266e2b9da502dc"
 
-binary@^0.3.0, binary@~0.3.0:
+binary@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
   dependencies:
@@ -1160,7 +1136,7 @@ bit-twiddle@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/bit-twiddle/-/bit-twiddle-0.0.2.tgz#c2eaebb952a3b94acc140497e1cdcd2f1a33f58e"
 
-bl@^0.9.0, bl@^0.9.4, bl@~0.9.0:
+bl@^0.9.4:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/bl/-/bl-0.9.5.tgz#c06b797af085ea00bc527afc8efcf11de2232054"
   dependencies:
@@ -1234,12 +1210,6 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
-boom@0.4.x:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-0.4.2.tgz#7a636e9ded4efcefb19cef4947a3c67dfaee911b"
-  dependencies:
-    hoek "0.9.x"
-
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1265,94 +1235,6 @@ boundary-cells@^2.0.0:
   resolved "https://registry.yarnpkg.com/boundary-cells/-/boundary-cells-2.0.1.tgz#e905a8d1419cf47cb36be3dbf525db5e24de0042"
   dependencies:
     tape "^4.0.0"
-
-bower-config@~0.5.0, bower-config@~0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/bower-config/-/bower-config-0.5.2.tgz#1f7d2e899e99b70c29a613e70d4c64590414b22e"
-  dependencies:
-    graceful-fs "~2.0.0"
-    mout "~0.9.0"
-    optimist "~0.6.0"
-    osenv "0.0.3"
-
-bower-endpoint-parser@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
-
-bower-json@~0.4.0:
-  version "0.4.0"
-  resolved "http://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz#a99c3ccf416ef0590ed0ded252c760f1c6d93766"
-  dependencies:
-    deep-extend "~0.2.5"
-    graceful-fs "~2.0.0"
-    intersect "~0.0.3"
-
-bower-logger@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/bower-logger/-/bower-logger-0.2.2.tgz#39be07e979b2fc8e03a94634205ed9422373d381"
-
-bower-registry-client@~0.2.0:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/bower-registry-client/-/bower-registry-client-0.2.4.tgz#269fc7e898b627fb939d1144a593254d7fbbeebc"
-  dependencies:
-    async "~0.2.8"
-    bower-config "~0.5.0"
-    graceful-fs "~2.0.0"
-    lru-cache "~2.3.0"
-    mkdirp "~0.3.5"
-    request "~2.51.0"
-    request-replay "~0.2.0"
-    rimraf "~2.2.0"
-
-bower@1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/bower/-/bower-1.7.9.tgz#b7296c2393e0d75edaa6ca39648132dd255812b0"
-
-bower@~1.3.0:
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/bower/-/bower-1.3.12.tgz#37de0edb3904baf90aee13384a1a379a05ee214c"
-  dependencies:
-    abbrev "~1.0.4"
-    archy "0.0.2"
-    bower-config "~0.5.2"
-    bower-endpoint-parser "~0.2.2"
-    bower-json "~0.4.0"
-    bower-logger "~0.2.2"
-    bower-registry-client "~0.2.0"
-    cardinal "0.4.0"
-    chalk "0.5.0"
-    chmodr "0.1.0"
-    decompress-zip "0.0.8"
-    fstream "~1.0.2"
-    fstream-ignore "~1.0.1"
-    glob "~4.0.2"
-    graceful-fs "~3.0.1"
-    handlebars "~2.0.0"
-    inquirer "0.7.1"
-    insight "0.4.3"
-    is-root "~1.0.0"
-    junk "~1.0.0"
-    lockfile "~1.0.0"
-    lru-cache "~2.5.0"
-    mkdirp "0.5.0"
-    mout "~0.9.0"
-    nopt "~3.0.0"
-    opn "~1.0.0"
-    osenv "0.1.0"
-    p-throttler "0.1.0"
-    promptly "0.2.0"
-    q "~1.0.1"
-    request "~2.42.0"
-    request-progress "0.3.0"
-    retry "0.6.0"
-    rimraf "~2.2.0"
-    semver "~2.3.0"
-    shell-quote "~1.4.1"
-    stringify-object "~1.0.0"
-    tar-fs "0.5.2"
-    tmp "0.0.23"
-    update-notifier "0.2.0"
-    which "~1.0.5"
 
 box-intersect@^1.0.1:
   version "1.0.1"
@@ -1553,23 +1435,9 @@ caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000604:
   version "1.0.30000607"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000607.tgz#f9d5b542f30d064c305544ff8938b217c67b88e9"
 
-cardinal@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-0.4.0.tgz#7d10aafb20837bde043c45e43a0c8c28cdaae45e"
-  dependencies:
-    redeyed "~0.4.0"
-
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-
-caseless@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.6.0.tgz#8167c1ab8397fb5bb95f96d28e5a81c50f247ac4"
-
-caseless@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.8.0.tgz#5bca2881d41437f54b2407ebe34888c7b9ad4f7d"
 
 catharsis@~0.8.8:
   version "0.8.8"
@@ -1619,26 +1487,6 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@0.5.0, chalk@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.0.tgz#375dfccbc21c0a60a8b61bc5b78f3dc2a55c212f"
-  dependencies:
-    ansi-styles "^1.1.0"
-    escape-string-regexp "^1.0.0"
-    has-ansi "^0.1.0"
-    strip-ansi "^0.3.0"
-    supports-color "^0.2.0"
-
-chalk@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
-  dependencies:
-    ansi-styles "^1.1.0"
-    escape-string-regexp "^1.0.0"
-    has-ansi "^0.1.0"
-    strip-ansi "^0.3.0"
-    supports-color "^0.2.0"
-
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1679,10 +1527,6 @@ change-case@3.0.x:
     title-case "^2.1.0"
     upper-case "^1.1.1"
     upper-case-first "^1.1.0"
-
-chmodr@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chmodr/-/chmodr-0.1.0.tgz#e09215a1d51542db2a2576969765bcf6125583eb"
 
 chokidar@^1.0.0:
   version "1.6.1"
@@ -1736,15 +1580,6 @@ clean-pslg@^1.1.0:
     robust-segment-intersect "^1.0.1"
     union-find "^1.0.2"
     uniq "^1.0.1"
-
-cli-color@~0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-0.3.3.tgz#12d5bdd158ff8a0b0db401198913c03df069f6f5"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.6"
-    memoizee "~0.3.8"
-    timers-ext "0.1"
 
 cli@~1.0.0:
   version "1.0.1"
@@ -1885,12 +1720,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.1, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@~0.0.4, combined-stream@~0.0.5:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f"
-  dependencies:
-    delayed-stream "0.0.5"
-
 commander@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
@@ -2011,26 +1840,6 @@ concat-stream@~1.4.5:
     inherits "~2.0.1"
     readable-stream "~1.1.9"
     typedarray "~0.0.5"
-
-config-chain@~1.1.8:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
-  dependencies:
-    ini "^1.3.4"
-    proto-list "~1.2.1"
-
-configstore@^0.3.0, configstore@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-0.3.2.tgz#25e4c16c3768abf75c5a65bc61761f495055b459"
-  dependencies:
-    graceful-fs "^3.0.1"
-    js-yaml "^3.1.0"
-    mkdirp "^0.5.0"
-    object-assign "^2.0.0"
-    osenv "^0.1.0"
-    user-home "^1.0.0"
-    uuid "^2.0.1"
-    xdg-basedir "^1.0.0"
 
 connect-history-api-fallback@1.1.0:
   version "1.1.0"
@@ -2203,12 +2012,6 @@ country-regex@^1.0.0:
 crc@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.3.0.tgz#fa622e1bc388bf257309082d6b65200ce67090ba"
-
-cryptiles@0.2.x:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
-  dependencies:
-    boom "0.4.x"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -2463,18 +2266,6 @@ decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-decompress-zip@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/decompress-zip/-/decompress-zip-0.0.8.tgz#4a265b22c7b209d7b24fa66f2b2dfbced59044f3"
-  dependencies:
-    binary "~0.3.0"
-    graceful-fs "~3.0.0"
-    mkpath "~0.1.0"
-    nopt "~2.2.0"
-    q "~1.0.0"
-    readable-stream "~1.1.8"
-    touch "0.0.2"
-
 decompress-zip@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/decompress-zip/-/decompress-zip-0.3.0.tgz#ae3bcb7e34c65879adfe77e19c30f86602b4bdb0"
@@ -2496,10 +2287,6 @@ deep-eql@0.1.3:
 deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-
-deep-extend@~0.2.5:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.2.11.tgz#7a16ba69729132340506170494bc83f7076fe08f"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -2526,10 +2313,6 @@ delaunay-triangulate@^1.1.6:
   dependencies:
     incremental-convex-hull "^1.0.1"
     uniq "^1.0.1"
-
-delayed-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2713,12 +2496,6 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
-  dependencies:
-    once "~1.3.0"
-
 engine.io-client@1.6.11:
   version "1.6.11"
   resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-1.6.11.tgz#7d250d8fa1c218119ecde51390458a57d5171376"
@@ -2880,7 +2657,7 @@ es6-symbol@~2.0.1:
     d "~0.1.1"
     es5-ext "~0.10.5"
 
-es6-weak-map@^0.1.2, es6-weak-map@~0.1.4:
+es6-weak-map@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-0.1.4.tgz#706cef9e99aa236ba7766c239c8b9e286ea7d228"
   dependencies:
@@ -2901,7 +2678,7 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2952,7 +2729,7 @@ espree@~3.1.7:
     acorn "^3.3.0"
     acorn-jsx "^3.0.0"
 
-esprima@^1.0.3, esprima@~1.0.2, esprima@~1.0.4:
+esprima@^1.0.3, esprima@~1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
 
@@ -3197,7 +2974,7 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-figures@^1.0.1, figures@^1.3.2:
+figures@^1.0.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -3302,29 +3079,9 @@ foreachasync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
 
-forever-agent@~0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.5.2.tgz#6d0e09c4921f94a27f63d3b49c5feff1ea4c5130"
-
 forever-agent@~0.6.0, forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-
-form-data@~0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.1.4.tgz#91abd788aba9702b1aabfa8bc01031a2ac9e3b12"
-  dependencies:
-    async "~0.9.0"
-    combined-stream "~0.0.4"
-    mime "~1.2.11"
-
-form-data@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.2.0.tgz#26f8bc26da6440e299cbdcfb69035c4f77a6e466"
-  dependencies:
-    async "~0.9.0"
-    combined-stream "~0.0.4"
-    mime-types "~2.0.3"
 
 form-data@~1.0.0-rc1, form-data@~1.0.0-rc4:
   version "1.0.1"
@@ -3399,7 +3156,7 @@ fsevents@^1.0.0:
     nan "^2.3.0"
     node-pre-gyp "^0.6.29"
 
-fstream-ignore@~1.0.1, fstream-ignore@~1.0.5:
+fstream-ignore@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
   dependencies:
@@ -3407,7 +3164,7 @@ fstream-ignore@~1.0.1, fstream-ignore@~1.0.5:
     inherits "2"
     minimatch "^3.0.0"
 
-fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10, fstream@~1.0.2:
+fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.10.tgz#604e8a92fe26ffd9f6fae30399d4984e1ab22822"
   dependencies:
@@ -3887,15 +3644,6 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@~4.0.2:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-4.0.6.tgz#695c50bdd4e2fb5c5d370b091f388d3707e291a7"
-  dependencies:
-    graceful-fs "^3.0.2"
-    inherits "2"
-    minimatch "^1.0.0"
-    once "^1.3.0"
-
 globals@^9.0.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
@@ -4065,12 +3813,6 @@ glslify@^4.0.0:
     through2 "^0.6.3"
     xtend "^4.0.0"
 
-got@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-0.3.0.tgz#888ec66ca4bc735ab089dbe959496d0f79485493"
-  dependencies:
-    object-assign "^0.3.0"
-
 graceful-fs@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.2.tgz#fe2239b7574972e67e41f808823f9bfa4a991e37"
@@ -4079,19 +3821,9 @@ graceful-fs@4.1.5, graceful-fs@^4.1.2:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.5.tgz#f4745e8caed5e0dd2ef21bb5e2d229a32e8093c0"
 
-graceful-fs@^3.0.1, graceful-fs@^3.0.2, graceful-fs@~3.0.0, graceful-fs@~3.0.1:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
-  dependencies:
-    natives "^1.1.0"
-
 graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-graceful-fs@~1.1:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.1.14.tgz#07078db5f6377f6321fceaaedf497de124dc9465"
 
 graceful-fs@~2.0.0:
   version "2.0.3"
@@ -4112,17 +3844,6 @@ gray-matter@^2.0.0:
 growl@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.8.1.tgz#4b2dec8d907e93db336624dcec0183502f8c9428"
-
-grunt-bower-task@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/grunt-bower-task/-/grunt-bower-task-0.4.0.tgz#daea0a55682a79a8c79db895b79be6f3ecb65817"
-  dependencies:
-    async "~0.1.22"
-    bower "~1.3.0"
-    colors "~0.6.0-1"
-    lodash "~0.10.0"
-    rimraf "~2.0.2"
-    wrench "~1.4.3"
 
 grunt-cli@1.2.0, grunt-cli@~1.2.0:
   version "1.2.0"
@@ -4279,14 +4000,6 @@ handlebars@4.0.6:
   optionalDependencies:
     uglify-js "^2.6"
 
-handlebars@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-2.0.0.tgz#6e9d7f8514a3467fa5e9f82cc158ecfc1d5ac76f"
-  dependencies:
-    optimist "~0.3"
-  optionalDependencies:
-    uglify-js "~2.3"
-
 har-validator@^1.6.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-1.8.0.tgz#d83842b0eb4c435960aeb108a067a3aa94c0eeb2"
@@ -4304,12 +4017,6 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
-
-has-ansi@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
-  dependencies:
-    ansi-regex "^0.2.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -4362,15 +4069,6 @@ hasha@^2.2.0:
     is-stream "^1.0.1"
     pinkie-promise "^2.0.0"
 
-hawk@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-1.1.1.tgz#87cd491f9b46e4e2aeaca335416766885d2d1ed9"
-  dependencies:
-    boom "0.4.x"
-    cryptiles "0.2.x"
-    hoek "0.9.x"
-    sntp "0.2.x"
-
 hawk@~3.1.0, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -4390,10 +4088,6 @@ header-case@^1.0.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.3"
-
-hoek@0.9.x:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-0.9.1.tgz#3d322462badf07716ea7eb85baf88079cddce505"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -4501,14 +4195,6 @@ http-proxy@1.13.2, http-proxy@^1.11.2:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
 
-http-signature@~0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-0.10.1.tgz#4fbdac132559aa8323121e540779c0a012b27e66"
-  dependencies:
-    asn1 "0.1.11"
-    assert-plus "^0.1.5"
-    ctype "0.5.3"
-
 http-signature@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-0.11.0.tgz#1796cf67a001ad5cd6849dca0991485f09089fe6"
@@ -4600,7 +4286,7 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@^1.2.0, ini@^1.3.4, ini@~1.3.0:
+ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
@@ -4609,31 +4295,6 @@ inline-source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
   dependencies:
     source-map "~0.5.3"
-
-inquirer@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.7.1.tgz#b8acf140165bd581862ed1198fb6d26430091fac"
-  dependencies:
-    chalk "^0.5.0"
-    cli-color "~0.3.2"
-    figures "^1.3.2"
-    lodash "~2.4.1"
-    mute-stream "0.0.4"
-    readline2 "~0.1.0"
-    rx "^2.2.27"
-    through "~2.3.4"
-
-inquirer@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.6.0.tgz#614d7bb3e48f9e6a8028e94a0c38f23ef29823d3"
-  dependencies:
-    chalk "^0.5.0"
-    cli-color "~0.3.2"
-    lodash "~2.4.1"
-    mute-stream "0.0.4"
-    readline2 "~0.1.0"
-    rx "^2.2.27"
-    through "~2.3.4"
 
 insert-module-globals@^7.0.0:
   version "7.0.1"
@@ -4648,20 +4309,6 @@ insert-module-globals@^7.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-insight@0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/insight/-/insight-0.4.3.tgz#76d653c5c0d8048b03cdba6385a6948f74614af0"
-  dependencies:
-    async "^0.9.0"
-    chalk "^0.5.1"
-    configstore "^0.3.1"
-    inquirer "^0.6.0"
-    lodash.debounce "^2.4.1"
-    object-assign "^1.0.0"
-    os-name "^1.0.0"
-    request "^2.40.0"
-    tough-cookie "^0.12.1"
-
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
@@ -4669,10 +4316,6 @@ interpret@^0.6.4:
 interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
-
-intersect@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/intersect/-/intersect-0.0.3.tgz#c1a4a5e5eac6ede4af7504cc07e0ada7bc9f4920"
 
 interval-tree-1d@^1.0.1:
   version "1.0.3"
@@ -4815,10 +4458,6 @@ is-regex@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.3.tgz#0d55182bddf9f2fde278220aec3a75642c908637"
 
-is-root@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
-
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -4897,7 +4536,7 @@ jquery-ui@1.10.4:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.10.4.tgz#a096fe5f4e0f2ab69a0585cf10455877f57506bd"
 
-jquery@1.12.4, jquery@>=1.7.1, jquery@>=1.8, "jquery@^1.8.3 || ^2.0":
+jquery@1.12.4, jquery@>=1.7.1, jquery@>=1.8, "jquery@>=1.8.3 <2.2.0":
   version "1.12.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
 
@@ -4909,18 +4548,18 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@^3.1.0, js-yaml@~3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
 js-yaml@^3.4.3, js-yaml@~3.5.2:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.5.5.tgz#0377c38017cabc7322b0d1fbcd25a491641f2fbe"
   dependencies:
     argparse "^1.0.2"
+    esprima "^2.6.0"
+
+js-yaml@~3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  dependencies:
+    argparse "^1.0.7"
     esprima "^2.6.0"
 
 js2xmlparser@~1.0.0:
@@ -5063,10 +4702,6 @@ junk@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.2.tgz#cc71db3c05d53b3238d0f1dec97a88267c10700e"
 
-junk@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
-
 kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
@@ -5090,12 +4725,6 @@ labeled-stream-splicer@^2.0.0:
     inherits "^2.0.1"
     isarray "~0.0.1"
     stream-splicer "^2.0.0"
-
-latest-version@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-0.2.0.tgz#adaf898d5f22380d3f9c45386efdff0a1b5b7501"
-  dependencies:
-    package-json "^0.2.0"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -5158,10 +4787,6 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-lockfile@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
 lodash-es@^4.2.1:
   version "4.17.4"
@@ -5241,14 +4866,6 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
-lodash._isnative@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash._isnative/-/lodash._isnative-2.4.1.tgz#3ea6404b784a7be836c7b57580e1cdf79b14832c"
-
-lodash._objecttypes@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz#7c0b7f69d98a1f76529f890b0cdb1b4dfec11c11"
-
 lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
@@ -5258,14 +4875,6 @@ lodash.camelcase@^3.0.1:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz#932c8b87f8a4377897c67197533282f97aeac298"
   dependencies:
     lodash._createcompounder "^3.0.0"
-
-lodash.debounce@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-2.4.1.tgz#d8cead246ec4b926e8b85678fc396bfeba8cc6fc"
-  dependencies:
-    lodash.isfunction "~2.4.1"
-    lodash.isobject "~2.4.1"
-    lodash.now "~2.4.1"
 
 lodash.deburr@^3.0.0:
   version "3.2.0"
@@ -5284,6 +4893,10 @@ lodash.find@^3.2.1:
     lodash.isarray "^3.0.0"
     lodash.keys "^3.0.0"
 
+lodash.get@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.indexof@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.indexof/-/lodash.indexof-4.0.5.tgz#53714adc2cddd6ed87638f893aa9b6c24e31ef3c"
@@ -5299,16 +4912,6 @@ lodash.isarray@^3.0.0:
 lodash.isequal@^4.2.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-
-lodash.isfunction@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz#2cfd575c73e498ab57e319b77fa02adef13a94d1"
-
-lodash.isobject@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
-  dependencies:
-    lodash._objecttypes "~2.4.1"
 
 lodash.isplainobject@^3.0.0, lodash.isplainobject@^3.2.0:
   version "3.2.0"
@@ -5361,12 +4964,6 @@ lodash.merge@^3.3.2:
     lodash.keysin "^3.0.0"
     lodash.toplainobject "^3.0.0"
 
-lodash.now@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash.now/-/lodash.now-2.4.1.tgz#6872156500525185faf96785bb7fe7fe15b562c6"
-  dependencies:
-    lodash._isnative "~2.4.1"
-
 lodash.omit@^4.0.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
@@ -5398,7 +4995,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@2.4.1, lodash@~2.4.1:
+lodash@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
 
@@ -5417,10 +5014,6 @@ lodash@^3.10.1, lodash@~3.10.1:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@^4.8.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@~0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-0.10.0.tgz#5254bbc2c46c827f535a27d631fd4f2bff374ce7"
 
 lodash@~1.2.0:
   version "1.2.1"
@@ -5471,19 +5064,9 @@ lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.3.tgz#c92393d976793eee5ba4edb583cf8eae35bd9bfb"
 
-lru-cache@2, lru-cache@~2.5.0:
+lru-cache@2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.5.2.tgz#1fddad938aae1263ce138680be1b3f591c0ab41c"
-
-lru-cache@~2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.3.1.tgz#b3adf6b3d856e954e2c390e6cef22081245a53d6"
-
-lru-queue@0.1:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  dependencies:
-    es5-ext "~0.10.2"
 
 macaddress@^0.2.8:
   version "0.2.8"
@@ -5559,18 +5142,6 @@ maxmin@^1.1.0:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
-memoizee@~0.3.8:
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.3.10.tgz#4eca0d8aed39ec9d017f4c5c2f2f6432f42e5c8f"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-weak-map "~0.1.4"
-    event-emitter "~0.3.4"
-    lru-queue "0.1"
-    next-tick "~0.2.2"
-    timers-ext "0.1"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -5685,11 +5256,7 @@ mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, 
   dependencies:
     mime-db "~1.25.0"
 
-mime-types@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-1.0.2.tgz#995ae1392ab8affcbfcb2641dd054e943c0d5dce"
-
-mime-types@~2.0.3, mime-types@~2.0.4:
+mime-types@~2.0.4:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6"
   dependencies:
@@ -5698,10 +5265,6 @@ mime-types@~2.0.3, mime-types@~2.0.4:
 mime@1.3.4, mime@^1.2.11, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-
-mime@~1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
 
 "minimatch@2 || 3", minimatch@3.0.3, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0, minimatch@~3.0.2:
   version "3.0.3"
@@ -5714,13 +5277,6 @@ minimatch@3.0.2:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
   dependencies:
     brace-expansion "^1.0.0"
-
-minimatch@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-1.0.0.tgz#e0dd2120b49e1b724ce8d714c520822a9438576d"
-  dependencies:
-    lru-cache "2"
-    sigmund "~1.0.0"
 
 minimatch@~0.2.11:
   version "0.2.14"
@@ -5761,11 +5317,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-mkdirp@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
-
-mkpath@^0.1.0, mkpath@~0.1.0:
+mkpath@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-0.1.0.tgz#7554a6f8d871834cc97b5462b122c4c124d6de91"
 
@@ -5878,10 +5430,6 @@ mout@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/mout/-/mout-0.10.0.tgz#27994ef59f965d7de1c34cc45320437127d9a6f1"
 
-mout@~0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/mout/-/mout-0.9.1.tgz#84f0f3fd6acc7317f63de2affdcc0cee009b0477"
-
 ms@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.6.2.tgz#d89c2124c6fdc1353d65a8b77bf1aac4b193708c"
@@ -5914,17 +5462,9 @@ murmurhash-js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
 
-mute-stream@0.0.4, mute-stream@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.4.tgz#a9219960a6d5d5d046597aee51252c6655f7177e"
-
 nan@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
-
-natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
 
 ncname@1.0.x:
   version "1.0.0"
@@ -6015,10 +5555,6 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-next-tick@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-0.2.2.tgz#75da4a927ee5887e39065880065b7336413b310d"
-
 nextafter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/nextafter/-/nextafter-1.0.0.tgz#b7d77b535310e3e097e6025abb0a903477ec1a3a"
@@ -6097,7 +5633,7 @@ nomnom@1.8.1:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
-nopt@^3.0.1, nopt@~3.0.0, nopt@~3.0.1, nopt@~3.0.6:
+nopt@^3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -6106,12 +5642,6 @@ nopt@^3.0.1, nopt@~3.0.0, nopt@~3.0.1, nopt@~3.0.6:
 nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  dependencies:
-    abbrev "1"
-
-nopt@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.2.1.tgz#2aa09b7d1768487b3b89a9c5aa52335bff0baea7"
   dependencies:
     abbrev "1"
 
@@ -6144,20 +5674,6 @@ normalize-url@^1.4.0:
 normals@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/normals/-/normals-1.1.0.tgz#325b595ed34afe467a6c55a14fd9085787ff59c0"
-
-npmconf@^2.0.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/npmconf/-/npmconf-2.1.2.tgz#66606a4a736f1e77a059aa071a79c94ab781853a"
-  dependencies:
-    config-chain "~1.1.8"
-    inherits "~2.0.0"
-    ini "^1.2.0"
-    mkdirp "^0.5.0"
-    nopt "~3.0.1"
-    once "~1.3.0"
-    osenv "^0.1.0"
-    semver "2 || 3 || 4"
-    uid-number "0.0.5"
 
 npmlog@4.0.0:
   version "4.0.0"
@@ -6199,29 +5715,9 @@ numeric@^1.2.6:
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
 
-oauth-sign@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.4.0.tgz#f22956f31ea7151a821e5f2fb32c113cad8b9f69"
-
-oauth-sign@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.5.0.tgz#d767f5169325620eab2e087ef0c472e773db6461"
-
 oauth-sign@~0.8.0, oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-
-object-assign@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-0.3.1.tgz#060e2a2a27d7c0d77ec77b78f11aa47fd88008d2"
-
-object-assign@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-1.0.0.tgz#e65dc8766d3b47b4b8307465c8311da030b070a6"
-
-object-assign@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
 
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
@@ -6270,10 +5766,6 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-once@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.2.0.tgz#de1905c636af874a8fba862d9aabddd1f920461c"
-
 once@~1.3.0, once@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
@@ -6307,11 +5799,7 @@ openlayers@3.20.1:
     vector-tile "1.3.0"
     walk "2.3.9"
 
-opn@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-1.0.2.tgz#b909643346d00a1abc977a8b96f3ce3c53d5cf5f"
-
-optimist@0.3, optimist@~0.3, optimist@~0.3.5:
+optimist@0.3:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
   dependencies:
@@ -6360,43 +5848,9 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-name@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-1.0.3.tgz#1b379f64835af7c5a7f498b357cb95215c159edf"
-  dependencies:
-    osx-release "^1.0.0"
-    win-release "^1.0.0"
-
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
-osenv@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.0.3.tgz#cd6ad8ddb290915ad9e22765576025d411f29cb6"
-
-osenv@0.1.0, osenv@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.0.tgz#61668121eec584955030b9f470b1d2309504bfcb"
-
-osx-release@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/osx-release/-/osx-release-1.1.0.tgz#f217911a28136949af1bf9308b241e2737d3cd6c"
-  dependencies:
-    minimist "^1.1.0"
-
-p-throttler@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/p-throttler/-/p-throttler-0.1.0.tgz#1b16907942c333e6f1ddeabcb3479204b8c417c4"
-  dependencies:
-    q "~0.9.2"
-
-package-json@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-0.2.0.tgz#0316e177b8eb149985d34f706b4a5543b274bec5"
-  dependencies:
-    got "^0.3.0"
-    registry-url "^0.1.0"
 
 pad-left@^1.0.2:
   version "1.0.2"
@@ -6947,16 +6401,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promptly@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/promptly/-/promptly-0.2.0.tgz#73ef200fa8329d5d3a8df41798950b8646ca46d9"
-  dependencies:
-    read "~1.0.4"
-
-proto-list@~1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
-
 protocol-buffers-schema@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz#d29c6cd73fb655978fb6989691180db844119f61"
@@ -6979,18 +6423,11 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-pump@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-0.3.5.tgz#ae5ff8c1f93ed87adc6530a97565b126f585454b"
-  dependencies:
-    end-of-stream "~1.0.0"
-    once "~1.2.0"
-
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@>=0.2.0, punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
+punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
@@ -6998,17 +6435,13 @@ q@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.0.0.tgz#dc1f92c4587be54f7853b29dc28e6d243a88498d"
 
-q@1.0.1, q@~1.0.0, q@~1.0.1:
+q@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.0.1.tgz#11872aeedee89268110b10a718448ffb10112a14"
 
 q@^1.1.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
-
-q@~0.9.2:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/q/-/q-0.9.7.tgz#4de2e6cb3b29088c9e4cbc03bf9d42fb96ce2f75"
 
 qs@2.4.2:
   version "2.4.2"
@@ -7025,14 +6458,6 @@ qs@5.2.0:
 qs@6.2.0, qs@~6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
-
-qs@~1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-1.2.2.tgz#19b57ff24dc2a99ce1f8bdf6afcda59f8ef61f88"
-
-qs@~2.3.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
 
 qs@~5.1.0:
   version "5.1.0"
@@ -7195,12 +6620,6 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read@~1.0.4:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
-  dependencies:
-    mute-stream "~0.0.4"
-
 readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.26, readable-stream@~1.0.27-1:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -7263,13 +6682,6 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-readline2@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-0.1.1.tgz#99443ba6e83b830ef3051bfd7dc241a82728d568"
-  dependencies:
-    mute-stream "0.0.4"
-    strip-ansi "^2.0.1"
-
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -7288,12 +6700,6 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
-
-redeyed@~0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-0.4.4.tgz#37e990a6f2b21b2a11c2e6a48fd4135698cba97f"
-  dependencies:
-    esprima "~1.0.4"
 
 reduce-css-calc@^1.2.6:
   version "1.3.0"
@@ -7353,12 +6759,6 @@ regexpu-core@^1.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-registry-url@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-0.1.1.tgz#1739427b81b110b302482a1c7cd727ffcc82d5be"
-  dependencies:
-    npmconf "^2.0.1"
-
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -7397,12 +6797,6 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-progress@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-0.3.0.tgz#bdf2062bfc197c5d492500d44cb3aff7865b492e"
-  dependencies:
-    throttleit "~0.0.2"
-
 request-progress@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-0.3.1.tgz#0721c105d8a96ac6b2ce8b2c89ae2d5ecfcf6b3a"
@@ -7414,12 +6808,6 @@ request-progress@~2.0.1:
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-2.0.1.tgz#5d36bb57961c673aa5b788dbc8141fdf23b44e08"
   dependencies:
     throttleit "^1.0.0"
-
-request-replay@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/request-replay/-/request-replay-0.2.0.tgz#9b693a5d118b39f5c596ead5ed91a26444057f60"
-  dependencies:
-    retry "~0.6.0"
 
 request@2.61.0:
   version "2.61.0"
@@ -7445,7 +6833,7 @@ request@2.61.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@^2.40.0, request@^2.55.0, request@^2.72.0, request@~2.74.0:
+request@^2.55.0, request@^2.72.0, request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -7495,48 +6883,6 @@ request@^2.79.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
-
-request@~2.42.0:
-  version "2.42.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.42.0.tgz#572bd0148938564040ac7ab148b96423a063304a"
-  dependencies:
-    bl "~0.9.0"
-    caseless "~0.6.0"
-    forever-agent "~0.5.0"
-    json-stringify-safe "~5.0.0"
-    mime-types "~1.0.1"
-    node-uuid "~1.4.0"
-    qs "~1.2.0"
-    tunnel-agent "~0.4.0"
-  optionalDependencies:
-    aws-sign2 "~0.5.0"
-    form-data "~0.1.0"
-    hawk "1.1.1"
-    http-signature "~0.10.0"
-    oauth-sign "~0.4.0"
-    stringstream "~0.0.4"
-    tough-cookie ">=0.12.0"
-
-request@~2.51.0:
-  version "2.51.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.51.0.tgz#35d00bbecc012e55f907b1bd9e0dbd577bfef26e"
-  dependencies:
-    aws-sign2 "~0.5.0"
-    bl "~0.9.0"
-    caseless "~0.8.0"
-    combined-stream "~0.0.5"
-    forever-agent "~0.5.0"
-    form-data "~0.2.0"
-    hawk "1.1.1"
-    http-signature "~0.10.0"
-    json-stringify-safe "~5.0.0"
-    mime-types "~1.0.1"
-    node-uuid "~1.4.0"
-    oauth-sign "~0.5.0"
-    qs "~2.3.1"
-    stringstream "~0.0.4"
-    tough-cookie ">=0.12.0"
-    tunnel-agent "~0.4.0"
 
 requirejs@^2.3.2:
   version "2.3.2"
@@ -7589,11 +6935,7 @@ resumer@~0.0.0:
   dependencies:
     through "~2.3.4"
 
-retry@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.6.0.tgz#1c010713279a6fd1e8def28af0c3ff1871caa537"
-
-retry@0.6.1, retry@~0.6.0:
+retry@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.6.1.tgz#fdc90eed943fde11b893554b8cc63d0e899ba918"
 
@@ -7613,13 +6955,7 @@ rimraf@2, rimraf@2.5.4, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@~2.5.1, rimraf@~2.5
   dependencies:
     glob "^7.0.5"
 
-rimraf@~2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.0.3.tgz#f50a2965e7144e9afd998982f15df706730f56a9"
-  optionalDependencies:
-    graceful-fs "~1.1"
-
-rimraf@~2.2.0, rimraf@~2.2.6, rimraf@~2.2.8:
+rimraf@~2.2.6, rimraf@~2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
@@ -7707,10 +7043,6 @@ rw@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.2.tgz#14ef5137ff7547c73ecf0e0af1f0aee07e5401ee"
 
-rx@^2.2.27:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-2.5.3.tgz#21adc7d80f02002af50dae97fd9dbf248755f566"
-
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
@@ -7735,17 +7067,11 @@ script-loader@~0.6.0:
   dependencies:
     raw-loader "~0.5.1"
 
-semver-diff@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-0.1.0.tgz#4f6057ca3eba23cc484b51f64aaf88b131a3855d"
-  dependencies:
-    semver "^2.2.1"
-
-"semver@2 || 3 || 4", "semver@2 || 3 || 4 || 5", semver@^2.2.1, semver@~2.3.0:
+"semver@2 || 3 || 4 || 5":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-2.3.2.tgz#b9848f25d6cf36333073ec9ef8856d42f1233e52"
 
-semver@^5.0.1, semver@~5.3.0:
+semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -7907,7 +7233,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.4.3, shell-quote@~1.4.1:
+shell-quote@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.4.3.tgz#952c44e0b1ed9013ef53958179cc643e8777466b"
   dependencies:
@@ -8024,12 +7350,6 @@ snap-points-2d@^3.0.0:
   dependencies:
     typedarray-pool "^1.1.0"
 
-sntp@0.2.x:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-0.2.4.tgz#fb885f18b0f3aad189f824862536bceeec750900"
-  dependencies:
-    hoek "0.9.x"
-
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -8128,7 +7448,7 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.3"
 
-source-map@0.1.x, source-map@~0.1.33, source-map@~0.1.38, source-map@~0.1.7:
+source-map@0.1.x, source-map@~0.1.33, source-map@~0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -8287,12 +7607,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
-string-length@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-0.1.2.tgz#ab04bb33867ee74beed7fb89bb7f089d392780f2"
-  dependencies:
-    strip-ansi "^0.2.1"
-
 string-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
@@ -8319,31 +7633,9 @@ string_decoder@~0.10.0, string_decoder@~0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-stringify-object@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-1.0.1.tgz#86d35e7dbfbce9aa45637d7ecdd7847e159db8a2"
-
 stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
-
-strip-ansi@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.2.2.tgz#854d290c981525fc8c397a910b025ae2d54ffc08"
-  dependencies:
-    ansi-regex "^0.1.0"
-
-strip-ansi@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
-  dependencies:
-    ansi-regex "^0.2.1"
-
-strip-ansi@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-2.0.1.tgz#df62c1aa94ed2f114e1d0f21fd1d50482b79a60e"
-  dependencies:
-    ansi-regex "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -8476,14 +7768,6 @@ tape@^4.0.0:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-tar-fs@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-0.5.2.tgz#0f59424be7eeee45232316e302f66d3f6ea6db3e"
-  dependencies:
-    mkdirp "^0.5.0"
-    pump "^0.3.5"
-    tar-stream "^0.4.6"
-
 tar-pack@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.3.0.tgz#30931816418f55afc4d21775afdd6720cee45dae"
@@ -8496,15 +7780,6 @@ tar-pack@~3.3.0:
     rimraf "~2.5.1"
     tar "~2.2.1"
     uid-number "~0.0.6"
-
-tar-stream@^0.4.6:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-0.4.7.tgz#1f1d2ce9ebc7b42765243ca0e8f1b7bfda0aadcd"
-  dependencies:
-    bl "^0.9.0"
-    end-of-stream "^1.0.0"
-    readable-stream "^1.0.27-1"
-    xtend "^4.0.0"
 
 tar@1.0.1:
   version "1.0.1"
@@ -8598,13 +7873,6 @@ timers-browserify@^1.0.1:
   dependencies:
     process "~0.11.0"
 
-timers-ext@0.1:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.0.tgz#00345a2ca93089d1251322054389d263e27b77e2"
-  dependencies:
-    es5-ext "~0.10.2"
-    next-tick "~0.2.2"
-
 tiny-lr@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tiny-lr/-/tiny-lr-0.2.1.tgz#b3fdba802e5d56a33c2f6f10794b32e477ac729d"
@@ -8626,10 +7894,6 @@ title-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.0.3"
-
-tmp@0.0.23:
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.23.tgz#de874aa5e974a85f0a32cdfdbd74663cb3bd9c74"
 
 tmp@0.0.27:
   version "0.0.27"
@@ -8670,12 +7934,6 @@ toposort@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.0.tgz#b66cf385a1a8a8e68e45b8259e7f55875e8b06ef"
 
-touch@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-0.0.2.tgz#a65a777795e5cbbe1299499bdc42281ffb21b5f4"
-  dependencies:
-    nopt "~1.0.10"
-
 touch@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/touch/-/touch-0.0.3.tgz#51aef3d449571d4f287a5d87c9c8b49181a0db1d"
@@ -8687,12 +7945,6 @@ tough-cookie@>=0.12.0, tough-cookie@^2.2.0, tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
-
-tough-cookie@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-0.12.1.tgz#8220c7e21abd5b13d96804254bd5a81ebf2c7d62"
-  dependencies:
-    punycode ">=0.2.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -8802,21 +8054,9 @@ uglify-js@^2.6, uglify-js@^2.6.0:
     uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
 
-uglify-js@~2.3:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.3.6.tgz#fa0984770b428b7a9b2a8058f46355d14fef211a"
-  dependencies:
-    async "~0.2.6"
-    optimist "~0.3.5"
-    source-map "~0.1.7"
-
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-
-uid-number@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.5.tgz#5a3db23ef5dbd55b81fce0ec9a2ac6fccdebb81e"
 
 uid-number@~0.0.6:
   version "0.0.6"
@@ -8893,16 +8133,6 @@ unyield@0.0.1:
   dependencies:
     co "~3.1.0"
 
-update-notifier@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-0.2.0.tgz#a010c928adcf02090b8e0ce7fef6fb0a7cacc34a"
-  dependencies:
-    chalk "^0.5.0"
-    configstore "^0.3.0"
-    latest-version "^0.2.0"
-    semver-diff "^0.1.0"
-    string-length "^0.1.2"
-
 upper-case-first@^1.1.0, upper-case-first@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
@@ -8941,10 +8171,6 @@ url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-user-home@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
 "usng.js@https://github.com/codice/usng.js#b756a1dddd6292d7af44db363131d848a87a2be2":
   version "0.1.1"
   resolved "https://github.com/codice/usng.js#b756a1dddd6292d7af44db363131d848a87a2be2"
@@ -8979,7 +8205,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@2.0.2, uuid@^2.0.1, uuid@^2.0.2:
+uuid@2.0.2, uuid@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.2.tgz#48bd5698f0677e3c7901a1c46ef15b1643794726"
 
@@ -9182,10 +8408,6 @@ whet.extend@~0.9.9:
   version "0.9.9"
   resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
 
-which@~1.0.5:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
-
 which@~1.2.1, which@~1.2.10:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
@@ -9201,12 +8423,6 @@ wide-align@^1.1.0:
 win-fork@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/win-fork/-/win-fork-1.1.1.tgz#8f58e0656fca00adc8c86a2b89e3cd2d6a2d5e5e"
-
-win-release@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
-  dependencies:
-    semver "^5.0.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -9234,10 +8450,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-wrench@~1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/wrench/-/wrench-1.4.4.tgz#7f523efdb71b0100e77dce834c06523cbe3d54e0"
-
 ws@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.0.1.tgz#7d0b2a2e58cddd819039c29c9de65045e1b310e9"
@@ -9251,12 +8463,6 @@ ws@1.1.0:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
-
-xdg-basedir@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-1.0.1.tgz#14ff8f63a4fdbcb05d5b6eea22b36f3033b9f04e"
-  dependencies:
-    user-home "^1.0.0"
 
 xml-char-classes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### What does this PR do?
 - Updates various views to listen to workspace changes and update to show an indication of unsaved workspace changes.
 - The css gets a little trickier than it appears it needs to be, mostly to support the same look and feel on IE10, IE11, and IE Edge.  These browsers do not support transitions on height or width that involve calc.  Unfortunately, that means we have to get clever.
 - Updates focus styling to be more consistent across browsers.  IE does not support outline-offset.
 - Breaks out part of workspace-item into workspace-details.  Updates workspace-item html to be simpler.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@pklinef 
@clockard 
@djblue 
@rzwiefel 
@andrewkfiedler

#### How should this be tested? (List steps with links to updated documentation)
Do this both logged in, then while logged out.  
Make a workspace.  Verify that no indicator appears.  Make a change to the workspace (change the title, add a query, remove a query, change a query, add or remove a bookmark).  Verify the indicator appears for these actions.  Run a query.  Verify the indicator does not appear when a query is run.

Try saving from the workspace route, then from the workspaces route.  Verify that deleting the only unsaved workspace removes indicators.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2847

#### Screenshots (if appropriate)
![screen shot 2017-03-06 at 12 11 06 am](https://cloud.githubusercontent.com/assets/11984853/23599982/75996478-0201-11e7-9d79-3253a6ed8f43.png)
![screen shot 2017-03-06 at 12 10 55 am](https://cloud.githubusercontent.com/assets/11984853/23599984/759cc870-0201-11e7-8860-5a93a5481511.png)
![screen shot 2017-03-06 at 12 10 44 am](https://cloud.githubusercontent.com/assets/11984853/23599983/759bb214-0201-11e7-9a08-18ae97dae86f.png)