### PR TITLE
DDF-2494 create an email service

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -468,11 +468,6 @@
                 <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>ddf.platform.solr</groupId>
                 <artifactId>solr-factory</artifactId>
                 <version>${project.version}</version>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -215,6 +215,11 @@
             <artifactId>jetty-servlets</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.email</groupId>
+            <artifactId>platform-email-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -249,6 +249,9 @@
     <reference id="workspacePersistentStore" availability="optional"
                interface="org.codice.ddf.catalog.ui.query.monitor.api.SubscriptionsPersistentStore"/>
 
+    <reference id="smtpClient" availability="mandatory"
+               interface="org.codice.ddf.platform.email.SmtpClient"/>
+
     <bean id="emailNotifierService"
           class="org.codice.ddf.catalog.ui.query.monitor.email.EmailNotifier">
 
@@ -260,7 +263,6 @@
                 value="The workspace '%[attribute=title]' contains up to %[hitCount] results. Log in to see results https://localhost:8993/search/catalog/#workspaces/%[attribute=id]."/>
         <argument value="Workspace '%[attribute=title]' notification"/>
         <argument value="donotreply@example.com"/>
-        <argument value="localhost"/>
         <argument>
             <bean class="org.codice.ddf.catalog.ui.query.monitor.impl.ListMetacardFormatter">
                 <argument>
@@ -274,6 +276,7 @@
             </bean>
         </argument>
         <argument ref="workspacePersistentStore"/>
+        <argument ref="smtpClient"/>
     </bean>
 
     <bean id="workspaceQueryService"

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.email.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.email.xml
@@ -27,10 +27,6 @@
             name="Body" id="bodyTemplate" required="true" type="String"
             default="The workspace '%[attribute=title]' contains up to %[hitCount] results. Log in to see results https://localhost:8993/search/catalog/#workspaces/%[attribute=id]."/>
 
-        <AD description="Set the hostname of the mail server."
-            name="Mail Server" id="mailHost" required="true" type="String"
-            default="localhost"/>
-
         <AD description="Set the 'from' email address."
             name="From Address" id="fromEmail" required="true" type="String"
             default="donotreply@example.com"/>

--- a/distribution/docs/src/main/resources/_contents/_platform-contents/managing-platform-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_platform-contents/managing-platform-contents.adoc
@@ -40,4 +40,6 @@ include::{adoc-include}/_tables/conf-ddf.platform.ui.config-table-contents.adoc[
 
 include::{adoc-include}/_tables/conf-org.codice.ddf.platform.response.filter.ResponseHeaderConfig-table-contents.adoc[]
 
+include::{adoc-include}/_tables/conf-org.codice.ddf.platform.email.impl.SmtpClientImpl-table-contents.adoc[]
+
 |===

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.platform.email.impl.SmtpClientImpl-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-org.codice.ddf.platform.email.impl.SmtpClientImpl-table-contents.adoc
@@ -1,0 +1,4 @@
+|<<org.codice.ddf.platform.email.impl.SmtpClientImpl,Email Service>>
+|org.codice.ddf.platform.email.impl.SmtpClientImpl
+|Configure the hostname (or IP address) and port number of an SMTP mail server that will receive the emails.
+

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.platform.email.impl.SmtpClientImpl-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.platform.email.impl.SmtpClientImpl-table-contents.adoc
@@ -1,0 +1,39 @@
+.[[Confluence_Federated_Source]]Confluence Federated Source
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+|Name
+|Property
+|Type
+|Description
+|Default Value
+|Required
+
+|Host
+|hostName
+|String
+|Mail server hostname (must be resolvable by DNS) or IP address.
+|
+|Yes
+
+|Port
+|portNumber
+|Integer
+|Mail server port number.
+|25
+|Yes
+
+|User Name
+|userName
+|String
+|Mail server user name used only for authenticated connections over TLS.
+|
+|No
+
+|Password
+|password
+|Password
+|Mail server password used only for authenticated connections over TLS.
+|
+|No
+
+|===

--- a/platform/email/platform-email-api/pom.xml
+++ b/platform/email/platform-email-api/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>email</artifactId>
+        <groupId>ddf.platform.email</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>platform-email-api</artifactId>
+    <name>DDF :: Platform :: Email :: API</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/email/platform-email-api/src/main/java/org/codice/ddf/platform/email/SmtpClient.java
+++ b/platform/email/platform-email-api/src/main/java/org/codice/ddf/platform/email/SmtpClient.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.email;
+
+import java.util.concurrent.Future;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+
+/**
+ * Provides a light-weight interface to javax.mail. The user should call {@link #createSession()}
+ * to get a session that is preconfigured with the hostname and port number of the email server.
+ * Next, construct a {@link Message} and submit it to {@link #send(Message)}.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ *
+ * SmtpClient smtpClient = <get an instance>
+ *
+ * Session session = emailService.createSession();
+ *
+ * MimeMessage mimeMessage = new MimeMessage(session);
+ * mimeMessage.setFrom(new InternetAddress("from@test.com"));
+ * mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress("to@test.com"));
+ * mimeMessage.setSubject("The Subject Line");
+ *
+ * BodyPart messageBodyPart = new MimeBodyPart();
+ * messageBodyPart.setText("The Body Text");
+ *
+ * Multipart multipart = new MimeMultipart();
+ * multipart.addBodyPart(messageBodyPart);
+ *
+ * mimeMessage.setContent(multipart);
+ *
+ * emailService.send(mimeMessage);
+ *
+ * }
+ * </pre>
+ * <p>
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public interface SmtpClient {
+
+    /**
+     * Create a session object that is pre-populated with the connection related parameters.
+     *
+     * @return session object
+     */
+    Session createSession();
+
+    /**
+     * Send the message. May be sent synchronously or asynchronously.
+     *
+     * @return a future that the caller can use to determine when the operation completes
+     * @see javax.mail.Transport.send(Message)
+     */
+    Future<Void> send(Message message) throws MessagingException;
+
+}

--- a/platform/email/platform-email-impl/pom.xml
+++ b/platform/email/platform-email-impl/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>email</artifactId>
+        <groupId>ddf.platform.email</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>platform-email-impl</artifactId>
+    <name>DDF :: Platform :: Email :: Impl</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.platform.email</groupId>
+            <artifactId>platform-email-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.simplejavamail</groupId>
+            <artifactId>simple-java-mail</artifactId>
+            <version>4.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>1.5.5</version>
+        </dependency>
+        <dependency>
+            <groupId>net.iharder</groupId>
+            <artifactId>base64</artifactId>
+            <version>2.3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>net.markenwerk</groupId>
+            <artifactId>utils-data-fetcher</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>net.markenwerk</groupId>
+            <artifactId>commons-nulls</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>dumbster</groupId>
+            <artifactId>dumbster</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
+            <version>1.3.9_1</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            simple-java-mail,
+                            base64,
+                            utils-data-fetcher,
+                            commons-nulls,
+                            org.apache.servicemix.bundles.jsr305
+                        </Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.8</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/email/platform-email-impl/src/main/java/org/codice/ddf/platform/email/impl/SmtpClientImpl.java
+++ b/platform/email/platform-email-impl/src/main/java/org/codice/ddf/platform/email/impl/SmtpClientImpl.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.email.impl;
+
+import static org.apache.commons.lang.Validate.isTrue;
+import static org.apache.commons.lang.Validate.notEmpty;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.annotation.Nullable;
+import javax.mail.Authenticator;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.email.SmtpClient;
+
+import ddf.security.common.audit.SecurityLogger;
+
+/**
+ * Supports unauthenticated connections to a mail server and username/password authenticated connections
+ * over TLS. If the username is not blank and the password is not empty, then auth/tls will be used.
+ * <p>
+ * The method {@link #send(Message)} will exceute asynchronously in a single thread. The number
+ * of operations awaiting execution is unbounded.
+ * <p>
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ */
+public class SmtpClientImpl implements SmtpClient {
+
+    private static final String SMTP_HOST_PROPERTY = "mail.smtp.host";
+
+    private static final String SMTP_PORT_PROPERTY = "mail.smtp.port";
+
+    private static final String SMTP_AUTH_PROPERTY = "mail.smtp.auth";
+
+    private static final String SMTP_START_TLS_ENABLE_PROPERTY = "mail.smtp.starttls.enable";
+
+    private static final String TRUE = Boolean.TRUE.toString();
+
+    private static final String FALSE = Boolean.FALSE.toString();
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+    private String hostName;
+
+    private Integer portNumber;
+
+    private String userName;
+
+    private String password;
+
+    /**
+     * Set the username for the email server.
+     *
+     * @param userName the username of the email server
+     */
+    public void setUserName(@Nullable String userName) {
+        this.userName = userName;
+    }
+
+    /**
+     * Set the password for the email server.
+     *
+     * @param password the password for the email server
+     */
+    public void setPassword(@Nullable String password) {
+        this.password = password;
+    }
+
+    /**
+     * @param hostName must be non-empty
+     */
+    public void setHostName(String hostName) {
+        notEmpty(hostName, "hostName must be non-empty");
+        this.hostName = hostName;
+    }
+
+    /**
+     * @param portNumber must be non-null and >0
+     */
+    public void setPortNumber(Integer portNumber) {
+        notNull(portNumber, "portNumber must be non-null");
+        isTrue(portNumber > 0, "portNumber must be >0");
+        this.portNumber = portNumber;
+    }
+
+    @Override
+    public Session createSession() {
+
+        Properties properties = new Properties();
+
+        properties.setProperty(SMTP_HOST_PROPERTY, hostName);
+        properties.setProperty(SMTP_PORT_PROPERTY, portNumber.toString());
+
+        if (StringUtils.isNotBlank(userName)) {
+            properties.put(SMTP_AUTH_PROPERTY, TRUE);
+            properties.put(SMTP_START_TLS_ENABLE_PROPERTY, TRUE);
+
+            return Session.getInstance(properties, createAuthenticator());
+        } else {
+            properties.setProperty(SMTP_AUTH_PROPERTY, FALSE);
+            return Session.getInstance(properties);
+        }
+    }
+
+    @Override
+    public Future<Void> send(Message message) throws MessagingException {
+        notNull(message, "message must be non-null");
+        return executorService.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                Transport.send(message);
+                SecurityLogger.audit("Sent an email: recipient={} subject={}",
+                        Arrays.toString(message.getAllRecipients()),
+                        message.getSubject());
+                return null;
+            }
+        });
+    }
+
+    Authenticator createAuthenticator() {
+        return new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(userName, password);
+            }
+        };
+    }
+
+}

--- a/platform/email/platform-email-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/email/platform-email-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="smtpClient" class="org.codice.ddf.platform.email.impl.SmtpClientImpl">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.platform.email.impl.SmtpClientImpl"
+                update-strategy="container-managed"/>
+    </bean>
+
+    <service ref="smtpClient" interface="org.codice.ddf.platform.email.SmtpClient">
+        <service-properties>
+            <entry key="id" value="email"/>
+            <entry key="title" value="Email Service"/>
+            <entry key="description" value="Sends Emails"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/email/platform-email-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/email/platform-email-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<metatype:MetaData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.2.0"
+                   xsi:schemaLocation="http://www.osgi.org/xmlns/metatype/v1.2.0 http://www.osgi.org/xmlns/metatype/v1.2.0">
+
+    <OCD name="Email Service"
+         id="org.codice.ddf.platform.email.impl.SmtpClientImpl"
+         description="Configure the hostname (or IP address) and port number of an SMTP mail server that will receive the emails.">
+
+        <AD
+                description="Mail server hostname (must be resolvable by DNS) or IP address."
+                name="Host" id="hostName" required="true"
+                type="String" default=""/>
+
+        <AD
+                description="Mail server port number."
+                name="Port" id="portNumber" required="true"
+                type="Integer" default="25"/>
+
+        <AD
+                description="Mail server user name used only for authenticated connections over TLS."
+                name="User Name" id="userName" required="false"
+                type="String" default=""/>
+
+        <AD
+                description="Mail server password used only for authenticated connections over TLS."
+                name="Password" id="password" required="false"
+                type="Password" default=""/>
+
+    </OCD>
+
+    <Designate pid="org.codice.ddf.platform.email.impl.SmtpClientImpl">
+        <Object ocdref="org.codice.ddf.platform.email.impl.SmtpClientImpl"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/platform/email/platform-email-impl/src/test/java/org/codice/ddf/platform/email/impl/SmtpClientImplITCase.java
+++ b/platform/email/platform-email-impl/src/test/java/org/codice/ddf/platform/email/impl/SmtpClientImplITCase.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.email.impl;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.UnknownHostException;
+import java.util.Iterator;
+import java.util.concurrent.ExecutionException;
+
+import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
+import javax.mail.BodyPart;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.dumbster.smtp.SimpleSmtpServer;
+import com.dumbster.smtp.SmtpMessage;
+
+public class SmtpClientImplITCase {
+
+    private static final String HOSTNAME = "127.0.0.1";
+
+    private static final String ATTACHMENT_TEXT = "text text text";
+
+    private static final String ATTACHMENT_FILENAME = "myFile.txt";
+
+    private static final String SUBJECT = "sample subject";
+
+    private static final String TO_ADDR = "user@example.com";
+
+    private static final String FROM_ADDR = "nobody@example.com";
+
+    private static final String BODY = "test body";
+
+    private static final String SUBJECT_HEADER = "Subject";
+
+    private static final String FROM_HEADER = "From";
+
+    private static final String TO_HEADER = "To";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testSendWithAttachments()
+            throws IOException, MessagingException, ExecutionException, InterruptedException {
+
+        int port = findAvailablePort();
+
+        SimpleSmtpServer server = SimpleSmtpServer.start(port);
+
+        SmtpClientImpl emailService = new SmtpClientImpl();
+
+        emailService.setHostName(HOSTNAME);
+        emailService.setPortNumber(port);
+
+        File tmpFile = folder.newFile("email.txt");
+
+        try (OutputStream os = new FileOutputStream(tmpFile)) {
+            os.write(ATTACHMENT_TEXT.getBytes());
+        }
+
+        Session session = emailService.createSession();
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setFrom(new InternetAddress(FROM_ADDR));
+        mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(TO_ADDR));
+        mimeMessage.setSubject(SUBJECT);
+
+        BodyPart messageBodyPart = new MimeBodyPart();
+        messageBodyPart.setText(BODY);
+
+        Multipart multipart = new MimeMultipart();
+        multipart.addBodyPart(messageBodyPart);
+
+        messageBodyPart = new MimeBodyPart();
+        messageBodyPart.setDataHandler(new DataHandler(new FileDataSource(tmpFile)));
+        messageBodyPart.setFileName(ATTACHMENT_FILENAME);
+        multipart.addBodyPart(messageBodyPart);
+
+        mimeMessage.setContent(multipart);
+
+        emailService.send(mimeMessage)
+                .get();
+
+        server.stop();
+
+        assertThat(server.getReceivedEmailSize(), is(1));
+        Iterator emailIterator = server.getReceivedEmail();
+        SmtpMessage email = (SmtpMessage) emailIterator.next();
+        assertThat(email.getHeaderValue(SUBJECT_HEADER), is(SUBJECT));
+        assertThat(email.getHeaderValue(FROM_HEADER), containsString(FROM_ADDR));
+        assertThat(email.getHeaderValue(TO_HEADER), containsString(TO_ADDR));
+        assertThat(email.getBody(), containsString(BODY));
+        assertThat(email.getBody(), containsString(ATTACHMENT_TEXT));
+        assertThat(email.getBody(), containsString(ATTACHMENT_FILENAME));
+
+    }
+
+    @Test
+    public void testSend()
+            throws IOException, MessagingException, ExecutionException, InterruptedException {
+
+        int port = findAvailablePort();
+
+        SimpleSmtpServer server = SimpleSmtpServer.start(port);
+
+        SmtpClientImpl emailService = new SmtpClientImpl();
+
+        emailService.setHostName(HOSTNAME);
+        emailService.setPortNumber(port);
+
+        Session session = emailService.createSession();
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setFrom(new InternetAddress(FROM_ADDR));
+        mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(TO_ADDR));
+        mimeMessage.setSubject(SUBJECT);
+
+        BodyPart messageBodyPart = new MimeBodyPart();
+        messageBodyPart.setText(BODY);
+
+        Multipart multipart = new MimeMultipart();
+        multipart.addBodyPart(messageBodyPart);
+
+        mimeMessage.setContent(multipart);
+
+        emailService.send(mimeMessage)
+                .get();
+
+        server.stop();
+
+        assertThat(server.getReceivedEmailSize(), is(1));
+        Iterator emailIterator = server.getReceivedEmail();
+        SmtpMessage email = (SmtpMessage) emailIterator.next();
+        assertThat(email.getHeaderValue(SUBJECT_HEADER), is(SUBJECT));
+        assertThat(email.getHeaderValue(FROM_HEADER), containsString(FROM_ADDR));
+        assertThat(email.getHeaderValue(TO_HEADER), containsString(TO_ADDR));
+        assertThat(email.getBody(), containsString(BODY));
+
+    }
+
+    /**
+     * There isn't a great way to test that authenticated email sending works in
+     * a unit test, but we can at least make sure the PasswordAuthentication object
+     * in the Session has the correct username and password.
+     */
+    @Test
+    public void testWithUsernamePassword() throws UnknownHostException {
+
+        String username = "username";
+        String password = "password";
+
+        validateUsernamePassword(username, password);
+
+    }
+
+    /**
+     * The password is allowed to be empty.
+     */
+    @Test
+    public void testWithUsernameEmptyPassword() throws UnknownHostException {
+
+        String username = "username";
+        String password = "";
+
+        validateUsernamePassword(username, password);
+
+    }
+
+    private void validateUsernamePassword(String username, String password)
+            throws UnknownHostException {
+        SmtpClientImpl emailService = new SmtpClientImpl();
+
+        emailService.setHostName("host.com");
+        emailService.setPortNumber(25);
+        emailService.setUserName(username);
+        emailService.setPassword(password);
+
+        Session session = emailService.createSession();
+
+        PasswordAuthentication actual = session.requestPasswordAuthentication(InetAddress.getByName(
+                "127.0.0.1"), 25, "smtp", "prompt", "defaultUserName");
+
+        assertThat(actual.getUserName(), is(username));
+        assertThat(actual.getPassword(), is(password));
+    }
+
+    private int findAvailablePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+
+}

--- a/platform/email/pom.xml
+++ b/platform/email/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>platform</artifactId>
+        <groupId>ddf.platform</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ddf.platform.email</groupId>
+    <artifactId>email</artifactId>
+    <name>DDF :: Platform :: Email</name>
+
+    <modules>
+        <module>platform-email-api</module>
+        <module>platform-email-impl</module>
+    </modules>
+    <packaging>pom</packaging>
+</project>

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -307,6 +307,16 @@
             <artifactId>platform-filter-response</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.email</groupId>
+            <artifactId>platform-email-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.email</groupId>
+            <artifactId>platform-email-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in used in platform-app's features.xml

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -52,6 +52,14 @@
             <!--mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.6_1-->
         <!--</bundle>-->
     <!--</feature>-->
+
+    <feature name='platform-email' install="automatic" version='${project.version}' start-level='50'>
+        <bundle dependency='true'>mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
+        <bundle dependency="true">mvn:com.sun.mail/javax.mail/1.5.5</bundle>
+        <bundle>mvn:ddf.platform.email/platform-email-api/${project.version}</bundle>
+        <bundle>mvn:ddf.platform.email/platform-email-impl/${project.version}</bundle>
+    </feature>
+
     <feature name='camel' install="manual" version='${camel.version}' start-level='50'>
         <!-- Added cxf as prereq to keep things ordered -->
         <feature prerequisite="true">cxf</feature>
@@ -1030,6 +1038,7 @@
         <feature>parser-xml</feature>
         <feature>landing-page</feature>
         <feature>platform-filter-response</feature>
+        <feature>platform-email</feature>
     </feature>
 
     <feature name="clientinfo-filter" install="auto" version="${project.version}"

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -379,5 +379,6 @@
         <module>platform-app</module>
         <module>platform-filter-clientinfo</module>
         <module>platform-filter-response</module>
+        <module>email</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
         <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
         <gib.baseBranch>HEAD</gib.baseBranch>
         <gib.enabled>false</gib.enabled>
+        <commons-lang3.version>3.4</commons-lang3.version>
     </properties>
     <!--
     NOTE: The properties ddf.scm.connection.url, snapshots.repository.url and releases.repository.url should be defined
@@ -213,6 +214,16 @@
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-core</artifactId>
                 <version>${apache.shiro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -265,6 +276,19 @@
                     <configuration>
                         <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.19.1</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
#### What does this PR do?
Create a centralized email service that handles the configuration details for connecting to an email server.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining 
@rzwiefel 
@michaelmenousek  [optional]

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis) @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)

For testing, you will need to know the hostname of your email server. If you don't know what it is, you can try asking your system administrator or run the un*x command "dig mx DOMAINNAME", where DOMAINNAME is the domain name portion of your email address.

There are two areas that need to be tested: non-authenticating and authenticating. A non-authenticating email server does not require a username/password. For the authenticating test, the only email server that I know of that uses authentication w/ TLS is gmail.

If you have a gmail account. The following should provide some help: https://support.google.com/mail/answer/7104828?ctx=gmail&hl=en&visit_id=1-636244123112925149-4219943305&rd=1
You may need to enable access from "less secure apps" in your gmail settings.

The only way to testing email from inside DDF is through the Catalog UI and standing query notifications.

1) Build and unzip DDF.

2) Add user:
  a) edit etc/user.properties, add the line:

     USERNAME=PASSWORD,group,admin,manager,viewer,system-admin,systembundles

     where USERNAME and PASSWORD are you preferred login credentials for DDF. These values are not related
     to the email server username and password mentioned earlier.

  b) edit etc/user.attributes, add the entry:

     "USERNAME" : { "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" : "EMAILADDR" },

     where USERNAME is the value used in Step 2a, and EMAILADDR your email address that will receive the test email.

3) Install DDF.

4) Under 'Platform', go to 'Configuration' and select 'Email Service'. If you are performing a non-authenticating test, then set the Host and Port fields. If you are performing an authenticating test, then set the Host, Port, User Name and Password fields. Click 'Save changes'.

5) Under 'Standard Search UI', go to 'Configuration' and select 'Email Notifier'. The default values should be sufficient. Click 'Save changes'.

6) Under 'Standard Search UI', go to 'Configuration' and select 'Workspace Query Monitor'. Set the Email Subscription Interval field to '0 * * * * ?'. This will cause an email to be sent every minute. More information on this field's format can be found at http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html

7) Using a webbrowser, navigate to the Catalog Search UI: https://localhost:8993/search/catalog/

8) Sign-in using the username and password used in Step 2a.

9) Create a new workspace by clicking the 'Blank' icon.

10) Create a new search, the default parameters should be sufficient.

11) From the menu next to the workspace name, select 'Subscribe'.

12) From the menu next to the workspace name, select 'Save'. If you get a workspace error, then try to logout and login.

13) In about a minute, you should start receiving an email notification every minute.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2494](https://codice.atlassian.net/browse/DDF-2494)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
