### PR TITLE
DDF-2512 Added WMTS support to OpenLayers

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -47,9 +47,16 @@ define(['underscore',
                 var type = imageryProviderTypes[model.get('type')];
                 var initObj = _.omit(model.attributes, 'type', 'label', 'index', 'modelCid');
 
-                /* Set the tiling scheme for WMTS imagery providers that are EPSG:4326 */
-                if(model.get('type') === "WMT" && properties.projection === "EPSG:4326") {
-                    initObj.tilingScheme = new Cesium.GeographicTilingScheme();
+                if (model.get('type') === "WMT") {
+
+                    /* If matrixSet is present (OpenLayers WMTS keyword) set tileMatrixSetID (Cesium WMTS keyword) */
+                    if (initObj.matrixSet) {
+                        initObj.tileMatrixSetID = initObj.matrixSet;
+                    }
+                    /* Set the tiling scheme for WMTS imagery providers that are EPSG:4326 */
+                    if (properties.projection === "EPSG:4326") {
+                        initObj.tilingScheme = new Cesium.GeographicTilingScheme();
+                    }
                 }
 
                 var provider = new type(initObj);


### PR DESCRIPTION
#### What does this PR do?
This PR adds WMTS support for OpenLayers.  It uses the `optionsFromCapabilities` functionality provided by OpenLayers to dynamically create the proper options and TileGrid for the layer.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure Catalog UI Imagery Provider with a WMTS layer / Verify layer is positioned properly in both OpenLayers and Cesium.
Sample layer : http://suite.opengeo.org/geoserver/gwc/service/wmts
`[{"type": "WMT","url": "http://suite.opengeo.org/geoserver/gwc/service/wmts", "layer" : "opengeo:countries", "style" : "", "format" : "image/jpeg", "tileMatrixSetID": "EPSG:4326", "tileMatrixLabels" : ['EPSG:4326:0', 'EPSG:4326:1', 'EPSG:4326:2', 'EPSG:4326:3', 'EPSG:4326:4', 'EPSG:4326:5', 'EPSG:4326:6', 'EPSG:4326:7', 'EPSG:4326:8', 'EPSG:4326:9', 'EPSG:4326:10', 'EPSG:4326:11', 'EPSG:4326:12', 'EPSG:4326:13', 'EPSG:4326:14', 'EPSG:4326:15', 'EPSG:4326:16', 'EPSG:4326:17', 'EPSG:4326:18', 'EPSG:4326:19', 'EPSG:4326:20', 'EPSG:4326:21']}]`
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2512](https://codice.atlassian.net/browse/DDF-2512)
#### Screenshots (if appropriate)
![screen shot 2017-03-07 at 8 44 37 am](https://cloud.githubusercontent.com/assets/6551038/23664280/5f47db20-0312-11e7-8f76-30f3bd98242c.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
