### PR TITLE
DDF-2851 Added a file pattern blacklist to the content directory monitor

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -154,19 +154,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.23</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.13</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.16</minimum>
+                                            <minimum>0.34</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -40,8 +40,7 @@
 
         <AD description="Optional: Metacard attribute overrides (Key-Value pairs) that can be set on the content monitor.  If an attribute is specified here, it will overwrite the metacard's attribute that was created from the content directory.   The format should be 'key=value'. To specify multiple values for a key, add each value as a separate Key-Value pair."
             name="Attribute Overrides" id="attributeOverrides" required="false" type="String"
-            cardinality="100"
-            default=""/>
+            cardinality="100" />
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor"

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -115,8 +115,8 @@ jdk.tls.ephemeralDHKeySize=matched
 
 # Files uploaded with these bad file extensions or names will have their file names sanitized
 # before being saved
-bad.file.extensions=.exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht
-bad.files=crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt
+bad.file.extensions=.exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht,.tmp
+bad.files=crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db
 
 # Files uploaded matching these mime types will be excluded from being stored
 bad.mime.types=text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile

--- a/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
@@ -72,6 +72,12 @@ To set multi-valued attributes, use a separate override for each value. For exam
 `*topic.keyword=PPI*` +
 `*topic.keyword=radiology*`
 
+.Blacklist
+The CDM blacklist uses the "bad.files" and "bad.file.extensions" properties from the system.properties file in "etc/" in order to prevent
+malicious or unwanted data from being ingested into DDF.  While the CDM automatically omits hidden files, this is particularly useful when
+an operating system automatically generates files that should not be ingested.  One such example of this is "thumbs.db" in Windows.
+This file type and any temporary files are included in the blacklist.
+
 .Errors
 If the CDM fails to read the file, an error will be logged in the ingest log. If the directory monitor is
 configured to *Delete* or *Move*, the original file is also moved to the `\.errors` directory.


### PR DESCRIPTION
#### What does this PR do?
This PR reads the bad.files.* properties in the system.properties file and creates a blacklist for ingesting files through the CDM.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure CDM / Observe blacklisted file types
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2851](https://codice.atlassian.net/browse/DDF-2851)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
