### PR TITLE
DDF-2828 Added Association and Location attributes to MetacardTypeImpl

### DIFF
--- a/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,11 +32,9 @@
         <argument value="confluence"/>
         <argument>
             <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
@@ -30,7 +30,9 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
 import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 
 /**
@@ -123,6 +125,8 @@ public class MetacardTypeImpl implements MetacardType {
         List<String> attributeNames = new ArrayList<>();
         addAttributeDescriptors(attributeNames, new CoreAttributes().getAttributeDescriptors());
         addAttributeDescriptors(attributeNames, new SecurityAttributes().getAttributeDescriptors());
+        addAttributeDescriptors(attributeNames, new AssociationsAttributes().getAttributeDescriptors());
+        addAttributeDescriptors(attributeNames, new LocationAttributes().getAttributeDescriptors());
 
         if (metacardTypes != null) {
             metacardTypes.forEach(metacardType -> addAttributeDescriptors(attributeNames,

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
@@ -429,6 +429,8 @@ public class MetacardTypeImplTest {
         int expectedSize = DATE_TIME_ATTRIBUTES.getAttributeDescriptors()
                 .size() + CORE_ATTRIBUTES.getAttributeDescriptors()
                 .size() + SECURITY_ATTRIBUTES.getAttributeDescriptors()
+                .size() + LOCATION_ATTRIBUTES.getAttributeDescriptors()
+                .size() + ASSOCIATIONS_ATTRIBUTES.getAttributeDescriptors()
                 .size();
 
         assertThat(metacardType.getAttributeDescriptors()

--- a/catalog/core/catalog-core-metacardtype/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-metacardtype/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,7 +18,6 @@
         <argument value="common"/>
         <argument>
             <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,12 +18,10 @@
         <argument value="gmdMetacardType" />
         <argument>
             <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
             </list>
         </argument>
@@ -33,7 +31,6 @@
         <argument value="cswMetacardType" />
         <argument>
             <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>

--- a/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,7 +19,6 @@
         <argument value="pdf"/>
         <argument>
             <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -51,7 +51,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -65,7 +64,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -79,7 +77,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -93,7 +90,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.transformer.common.tika.Mp4MetacardType"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
@@ -108,7 +104,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -122,7 +117,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -136,7 +130,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
@@ -150,7 +143,6 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>


### PR DESCRIPTION
#### What does this PR do?
This PR adds Association and Location attributes to MetacardTypeImpl constructor and cleans up type definitions throughout DDF
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build DDF / Install / Test CSW, Tika , Confluence Metacard associations
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2828](https://codice.atlassian.net/browse/DDF-2828)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
