### PR TITLE
DDF-2859 [2.10.x] Adds ddf-branding-plugin dependency to kernel module

### DIFF
--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -69,6 +69,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.distribution</groupId>
+            <artifactId>ddf-branding-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>ddf-common</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
#### What does this PR do?
A build order issue appeared after the 2.10.1 release was cut. A dependency was not included in the pom for kernel even though it is being packaged into its feature. This adds that missing dependency.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@oconnormi @emanns95 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
A successful CI build should be sufficient.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2859](https://codice.atlassian.net/browse/DDF-2859)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
