### PR TITLE
DDF-2858 [2.10.x] Removes Bouncy castle from platform-util shaded jar

### DIFF
--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -66,7 +66,6 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.bouncycastle:bcprov-jdk15on</include>
                             <include>ddf.platform.util:platform-util</include>
                             <include>net.jodah:failsafe</include>
                         </includes>


### PR DESCRIPTION
#### What does this PR do?
Removes bouncy castle from platform-util's shaded jar as the libraries are already included in bundle 0.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @Lambeaux 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full CI run, then an installation and verification that common security tasks (authC/Z) work by logging into Admin and Search, preferably using both Karaf and LDAP realms.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2858](https://codice.atlassian.net/browse/DDF-2858)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
