### PR TITLE
DDF-2858 Removes Bouncy castle from platform-util shaded jar

### DIFF
--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -68,7 +68,6 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>org.bouncycastle:bcprov-jdk15on</include>
                             <include>ddf.platform.util:platform-util</include>
                             <include>net.jodah:failsafe</include>
                         </includes>


### PR DESCRIPTION
#### What does this PR do?
Removes bouncy castle from platform-util's shaded jar as the libraries are already included in bundle 0.

Forward-port of #1775 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@stustison

#### How should this be tested? (List steps with links to updated documentation)
As a full heroing run was performed against 2.10.x, a successful CI run should be sufficient for this branch.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2858](https://codice.atlassian.net/browse/DDF-2858)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
