### PR TITLE
DDF-2865 Fixed CDM handling of empty files and increased the default interval to a more reasonable number

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -373,17 +373,17 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
             public void configure() throws Exception {
                 StringBuilder stringBuilder = new StringBuilder();
                 // Configure the camel route to ignore changing files (larger files that are in the process of being copied)
-                // Set the readLockTimeout to continuously poll the directory so long as the directory monitor exists
+                // Set the readLockTimeout to 2 * readLockIntervalMilliseconds
                 // Set the readLockCheckInterval to check every readLockIntervalMilliseconds
+
                 stringBuilder.append("file:" + monitoredDirectory);
-                stringBuilder.append("?idempotent=true");
-                stringBuilder.append("&recursive=true");
+                stringBuilder.append("?recursive=true");
                 stringBuilder.append("&moveFailed=.errors");
 
                 /* ReadLock Configuration */
-                stringBuilder.append("&readLockMinLength=0");
+                stringBuilder.append("&readLockMinLength=1");
                 stringBuilder.append("&readLock=changed");
-                stringBuilder.append("&readLockTimeout=0");
+                stringBuilder.append("&readLockTimeout=" + (2 * readLockIntervalMilliseconds));
                 stringBuilder.append("&readLockCheckInterval=" + readLockIntervalMilliseconds);
 
                 /* File Exclusions */

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,7 @@
                               init-method="init" destroy-method="destroy">
             <argument ref="camelContext"/>
             <property name="numThreads" value="1"/>
-            <property name="readLockIntervalMilliseconds" value="1000"/>
+            <property name="readLockIntervalMilliseconds" value="500"/>
             <property name="monitoredDirectoryPath" value=""/>
             <property name="attributeOverrides">
                 <list/>

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,9 +25,9 @@
             name="Maximum Concurrent Files" id="numThreads" required="true"
             type="Integer" default="1"/>
 
-        <AD description="Specifies the time to wait (in milliseconds) before acquiring a lock on a file in the monitored directory.  This interval is used for sleeping between attempts to acquire the read lock on a file to be ingested.  The default value of 100 milliseconds is recommended. If the value provided is less than 100, the default value will be used."
+        <AD description="Specifies the time to wait (in milliseconds) before acquiring a lock on a file in the monitored directory.  This interval is used for sleeping between attempts to acquire the read lock on a file to be ingested.  The interval should be dependent on the speed of the copy to the directory monitor  (ex. network drive vs local disk).  For local files, the default value of 500 milliseconds is recommended. The recommended interval for network drives is 1000 - 2000 milliseconds.  If the value provided is less than 100, 100 milliseconds will be used."
             name="ReadLock Time Interval" id="readLockIntervalMilliseconds" required="true"
-            type="Integer" default="100"/>
+            type="Integer" default="500"/>
 
         <AD description="Choose what happens to the content item after it is ingested. Delete will remove the original file after storing it in the content store. Move will store the item in the content store, and a copy under ./ingested, then remove the original file. (NOTE: this will double the amount of disk space used.) Monitor in place will index the file and serve it from its original location."
             name="Processing Mechanism" id="processingMechanism" required="false"

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
@@ -338,7 +338,7 @@ public class ContentDirectoryMonitorTest extends CamelTestSupport {
                 .getUri();
 
         String expectedUri = "file:" + monitoredDirectory
-                + "?idempotent=true&recursive=true&moveFailed=.errors&readLockMinLength=0&readLock=changed&readLockTimeout=0&readLockCheckInterval=1000";
+                + "?recursive=true&moveFailed=.errors&readLockMinLength=1&readLock=changed&readLockTimeout=2000&readLockCheckInterval=1000";
         if (ContentDirectoryMonitor.DELETE.equals(processingMechanism)) {
             expectedUri += "&delete=true";
         } else if (ContentDirectoryMonitor.MOVE.equals(processingMechanism)) {

--- a/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_resources/content-directory-monitor-contents.adoc
@@ -52,7 +52,9 @@ The CDM supports parallel processing of files (up to 8 files processed concurren
 
 .Read Lock
 When the CDM is set up, the directory specified is continuously scanned, and files are locked for processing based on the *ReadLock Time Interval*.  This does not apply to the *Monitor in place* processing directive.  Files will not be ingested without having a ReadLock that has observed no change in the file size.
-This is done so that files that are in transit will not be ingested prematurely.  It is recommended that the *ReadLock Time Interval* be set to a lower amount of time when the *Maximum Concurrent Files* is set above 1 so that files are
+This is done so that files that are in transit will not be ingested prematurely. The interval should be dependent on the speed of the copy to the directory monitor (ex. network drive vs local disk).
+For local files, the default value of 500 milliseconds is recommended. The recommended interval for network drives is 1000 - 2000 milliseconds.  If the value provided is less than 100, 100 milliseconds will be used.
+It is also recommended that the *ReadLock Time Interval* be set to a lower amount of time when the *Maximum Concurrent Files* is set above 1 so that files are
 locked in a timely manner and processed as soon as possible.  When a higher *ReadLock Time Interval* is set, the time it takes for files to be processed is increased.
 
 .Attribute Mapper


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where files were being ingested prematurely by the CDM during slow copies, and increases the CDM readLockInterval to a more reasonable number due to user feedback.  Additionally, a readLockTimeout was added that is 2 * the readLockCheckInterval as per Apache Camel guidelines. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein @rzwiefel 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure CDM / Copy Files to directory (large and small) / Observe proper behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2865](https://codice.atlassian.net/browse/DDF-2865)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
