### PR TITLE
DDF-2868 Reset catalog contents after every itest

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -103,6 +103,8 @@ public abstract class AbstractIntegrationTest {
 
     public static final String REMOVE_ALL = "catalog:removeall -f -p";
 
+    private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
+
     protected static ServerSocket placeHolderSocket;
 
     protected static Integer basePort;
@@ -143,8 +145,6 @@ public abstract class AbstractIntegrationTest {
     private CatalogBundle catalogBundle;
 
     private UrlResourceReaderConfigurator urlResourceReaderConfigurator;
-
-    private KarafConsole console;
 
     protected static final String[] DEFAULT_REQUIRED_APPS =
             {"catalog-app", "solr-app", "spatial-app", "sdk-app"};
@@ -619,10 +619,6 @@ public abstract class AbstractIntegrationTest {
         return Arrays.copyOf(DEFAULT_REQUIRED_APPS, DEFAULT_REQUIRED_APPS.length);
     }
 
-    protected KarafConsole getConsole() {
-        return console;
-    }
-
     protected AdminConfig getAdminConfig() {
         return adminConfig;
     }
@@ -720,5 +716,9 @@ public abstract class AbstractIntegrationTest {
 
     public void clearCatalog() {
         console.runCommand(REMOVE_ALL);
+    }
+
+    public void clearCache() {
+        console.runCommand(CLEAR_CACHE);
     }
 }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -101,6 +101,8 @@ public abstract class AbstractIntegrationTest {
 
     public static final String RESOURCE_VARIABLE_DELIMETER = "$";
 
+    public static final String REMOVE_ALL = "catalog:removeall -f -p";
+
     protected static ServerSocket placeHolderSocket;
 
     protected static Integer basePort;
@@ -146,6 +148,8 @@ public abstract class AbstractIntegrationTest {
 
     protected static final String[] DEFAULT_REQUIRED_APPS =
             {"catalog-app", "solr-app", "spatial-app", "sdk-app"};
+
+    public KarafConsole console;
 
     /**
      * An enum that returns a port number based on the class variable {@link #basePort}. Used to allow parallel itests
@@ -712,5 +716,9 @@ public abstract class AbstractIntegrationTest {
 
     public void configureRestForBasic(String whitelist) throws Exception {
         getSecurityPolicy().configureRestForBasic(whitelist);
+    }
+
+    public void clearCatalog() {
+        console.runCommand(REMOVE_ALL);
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -138,8 +138,6 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     private static final String DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS = "data/products";
 
-    private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
-
     public static final String ADMIN = "admin";
 
     public static final String ADMIN_EMAIL = "admin@localhost.local";
@@ -1025,8 +1023,6 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Test
     public void testCachedContentLengthHeader() throws IOException {
-
-        console.runCommand(CLEAR_CACHE);
 
         String fileName = "testCachedContentLengthHeader" + ".jpg";
         File tmpFile = createTemporaryFile(fileName,

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -77,7 +77,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
-import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
 import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule.ConditionalIgnore;
@@ -139,8 +138,6 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     private static final String DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS = "data/products";
 
-    private static KarafConsole console;
-
     private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
 
     public static final String ADMIN = "admin";
@@ -159,7 +156,6 @@ public class TestCatalog extends AbstractIntegrationTest {
     public void beforeExam() throws Exception {
         try {
             waitForSystemReady();
-            console = getConsole();
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
@@ -174,6 +170,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     public void tearDown() throws IOException {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(new String[] {
                 DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS});
+        clearCatalog();
     }
 
     @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -19,8 +19,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static com.jayway.restassured.RestAssured.given;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -19,6 +19,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static com.jayway.restassured.RestAssured.given;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -60,8 +61,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
     public static final DynamicUrl API_PATH = new DynamicUrl(SECURE_ROOT, HTTPS_PORT, PATH);
 
-    private List<String> ids = new ArrayList<>();
-
     @BeforeExam
     public void beforeExam() throws Exception {
         try {
@@ -76,9 +75,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
     @After
     public void cleanUp() {
-        ids.stream()
-                .forEach(TestCatalogSearchUi::delete);
-        ids.clear();
+        clearCatalog();
     }
 
     private static String api() {
@@ -160,7 +157,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         String id = (String) body.get("id");
         assertNotNull(id);
 
-        ids.add(id);
     }
 
     @Test
@@ -172,7 +168,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         String id = (String) body.get("id");
         assertNotNull(id);
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -186,7 +181,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
         expect(asGuest(), 404).get(api() + "/" + id);
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -202,7 +196,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
         expect(asGuest(), 200).get(api() + "/" + id);
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -219,7 +212,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         expect(asGuest(), 404).get(api() + "/" + id);
         expect(asUser("random", "password"), 200).get(api() + "/" + id);
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -237,7 +229,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         expect(asUser("random", "password").body(stringify(ImmutableMap.of(Core.METACARD_OWNER,
                 "random@localhost.local"))), 200).put(api() + "/" + id);
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -252,7 +243,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         assertNotNull(id);
         assertThat(body.get(WORKSPACE_METACARDS), is(metacards));
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -272,7 +262,6 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         assertNotNull(id);
         assertThat(body.get(WORKSPACE_QUERIES), is(queries));
 
-        ids.add(id); // for cleanUp
     }
 
     @Test
@@ -292,6 +281,5 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         assertNotNull(id);
         assertThat(body.get(WORKSPACE_QUERIES), is(queries));
 
-        ids.add(id); // for cleanUp
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
@@ -74,6 +74,7 @@ public class TestEmbeddedSolr extends AbstractIntegrationTest {
 
             configureRestForGuest();
             getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
+
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
@@ -88,6 +89,7 @@ public class TestEmbeddedSolr extends AbstractIntegrationTest {
     public void tearDown() throws IOException {
         urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
                 DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS);
+        clearCatalog();
     }
 
     @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -35,6 +35,7 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
+import org.junit.After;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +89,11 @@ public class TestFanout extends AbstractIntegrationTest {
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @Before: ");
         }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearCatalog();
     }
 
     private void startCswSource() throws Exception {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -35,8 +35,8 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
-import org.junit.After;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +72,7 @@ public class TestFanout extends AbstractIntegrationTest {
     }
 
     @AfterExam
-    public void afterExam() throws Exception{
+    public void afterExam() throws Exception {
         getCatalogBundle().setFanout(false);
         getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
         getCatalogBundle().waitForCatalogProvider();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -196,9 +196,7 @@ public class TestFederation extends AbstractIntegrationTest {
     private static final String LOCALHOST_USERNAME = "localhost";
 
     private static final String LOCALHOST_PASSWORD = "localhost";
-
-    private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
-
+    
     private static final int CSW_SOURCE_POLL_INTERVAL = 10;
 
     private static final int MAX_DOWNLOAD_RETRY_ATTEMPTS = 3;
@@ -391,13 +389,16 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testFederatedQueryByWildCardSearchPhrase() throws Exception {
         String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&format=xml&src=" + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat().body(hasXPath(
-                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_1 + "']"), hasXPath("/metacards/metacard/geometry/value"),
-                hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_2 + "']"), hasXPath("/metacards/metacard/stringxml"));
-        // @formatter:on
+        when().get(queryUrl)
+                .then()
+                .assertThat()
+                .body(hasXPath(
+                        "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                                + RECORD_TITLE_1 + "']"),
+                        hasXPath("/metacards/metacard/geometry/value"),
+                        hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE
+                                + "']/value[text()='" + RECORD_TITLE_2 + "']"),
+                        hasXPath("/metacards/metacard/stringxml"));
     }
 
     /**
@@ -410,8 +411,9 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testAtomFederatedQueryByWildCardSearchPhrase() throws Exception {
         String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=*&format=atom&src=" + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat()
+        when().get(queryUrl)
+                .then()
+                .assertThat()
                 .body(hasXPath("/feed/entry/title[text()='" + RECORD_TITLE_1 + "']"),
                         hasXPath("/feed/entry/title[text()='" + RECORD_TITLE_2 + "']"),
                         hasXPath("/feed/entry/content/metacard/geometry/value"));
@@ -428,13 +430,14 @@ public class TestFederation extends AbstractIntegrationTest {
         String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
                 + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat().body(hasXPath(
-                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_1 + "']"), hasXPath(
-                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_2 + "']"));
-        // @formatter:on
+        when().get(queryUrl)
+                .then()
+                .assertThat()
+                .body(hasXPath(
+                        "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                                + RECORD_TITLE_1 + "']"),
+                        hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE
+                                + "']/value[text()='" + RECORD_TITLE_2 + "']"));
     }
 
     /**
@@ -448,13 +451,14 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?lat=10.0&lon=30.0&radius=250000&spatialType=POINT_RADIUS" + "&format=xml&src="
                 + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat().body(hasXPath(
-                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_1 + "']"), hasXPath(
-                "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
-                        + RECORD_TITLE_2 + "']"));
-        // @formatter:on
+        when().get(queryUrl)
+                .then()
+                .assertThat()
+                .body(hasXPath(
+                        "/metacards/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                                + RECORD_TITLE_1 + "']"),
+                        hasXPath("/metacards/metacard/string[@name='" + Metacard.TITLE
+                                + "']/value[text()='" + RECORD_TITLE_2 + "']"));
     }
 
     /**
@@ -468,8 +472,9 @@ public class TestFederation extends AbstractIntegrationTest {
                 OPENSEARCH_PATH.getUrl() + "?lat=-10.0&lon=-30.0&radius=1&spatialType=POINT_RADIUS"
                         + "&format=xml&src=" + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat()
+        when().get(queryUrl)
+                .then()
+                .assertThat()
                 .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
     }
 
@@ -485,8 +490,9 @@ public class TestFederation extends AbstractIntegrationTest {
                 OPENSEARCH_PATH.getUrl() + "?q=" + negativeSearchPhrase + "&format=xml&src="
                         + OPENSEARCH_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat()
+        when().get(queryUrl)
+                .then()
+                .assertThat()
                 .body(not(containsString(RECORD_TITLE_1)), not(containsString(RECORD_TITLE_2)));
     }
 
@@ -500,11 +506,11 @@ public class TestFederation extends AbstractIntegrationTest {
         String restUrl = REST_PATH.getUrl() + "sources/" + OPENSEARCH_SOURCE_ID + "/"
                 + metacardIds[GEOJSON_RECORD_INDEX];
 
-        // @formatter:off
-        when().get(restUrl).then().assertThat().body(hasXPath(
-                "/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='" + RECORD_TITLE_1
-                        + "']"), not(containsString(RECORD_TITLE_2)));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .body(hasXPath("/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                        + RECORD_TITLE_1 + "']"), not(containsString(RECORD_TITLE_2)));
     }
 
     /**
@@ -533,11 +539,11 @@ public class TestFederation extends AbstractIntegrationTest {
             String restUrl = REST_PATH.getUrl() + "sources/" + newOpenSearchSourceId + "/"
                     + metacardIds[GEOJSON_RECORD_INDEX];
 
-            // @formatter:off
-            when().get(restUrl).then().assertThat().body(hasXPath(
-                    "/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='" + RECORD_TITLE_1
-                            + "']"), not(containsString(RECORD_TITLE_2)));
-            // @formatter:on
+            when().get(restUrl)
+                    .then()
+                    .assertThat()
+                    .body(hasXPath("/metacard/string[@name='" + Metacard.TITLE + "']/value[text()='"
+                            + RECORD_TITLE_1 + "']"), not(containsString(RECORD_TITLE_2)));
         } finally {
             //reset the opensearch source id
             Map<String, Object> openSearchProperties = getOpenSearchSourceProperties(
@@ -575,9 +581,10 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(restUrl).then().assertThat().body(is(SAMPLE_DATA));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .body(is(SAMPLE_DATA));
     }
 
     /**
@@ -610,9 +617,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Perform Test and Verify
-        // @formatter:off
-        given().header(CswConstants.RANGE_HEADER, String.format("bytes=%s-", offset)).get(restUrl)
-                .then().assertThat().contentType("text/plain")
+        given().header(CswConstants.RANGE_HEADER, String.format("bytes=%s-", offset))
+                .get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(partialSampleData));
     }
 
@@ -634,10 +643,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/html")
-                .statusCode(equalTo(500)).body(containsString("Unable to transform Metacard."));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/html")
+                .statusCode(equalTo(500))
+                .body(containsString("Unable to transform Metacard."));
     }
 
     /**
@@ -680,10 +691,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/html")
-                .statusCode(equalTo(500)).body(containsString("Unable to transform Metacard."));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/html")
+                .statusCode(equalTo(500))
+                .body(containsString("Unable to transform Metacard."));
     }
 
     @Test
@@ -697,8 +710,10 @@ public class TestFederation extends AbstractIntegrationTest {
         String restUrl = REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/"
                 + metacardIds[XML_RECORD_INDEX] + "?transform=resource";
 
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(SAMPLE_DATA));
     }
 
@@ -716,9 +731,10 @@ public class TestFederation extends AbstractIntegrationTest {
                 + metacardIds[GEOJSON_RECORD_INDEX] + "?transform=resource";
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(restUrl).then().assertThat().statusCode(equalTo(500));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .statusCode(equalTo(500));
     }
 
     @Test
@@ -729,9 +745,10 @@ public class TestFederation extends AbstractIntegrationTest {
         String restUrl = REST_PATH.getUrl() + "sources/" + CSW_SOURCE_ID + "/"
                 + metacardIds[GEOJSON_RECORD_INDEX] + "?transform=resource";
 
-        // @formatter:off
-        when().get(restUrl).then().assertThat().statusCode(equalTo(500));
-        // @formatter:on
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .statusCode(equalTo(500));
     }
 
     @Test
@@ -741,13 +758,16 @@ public class TestFederation extends AbstractIntegrationTest {
                 "application/xml",
                 "http://www.opengis.net/cat/csw/2.0.2");
 
-        // @formatter:off
-        given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_PATH.getUrl())
-                .then().assertThat()
-                .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
-                                metacardIds[GEOJSON_RECORD_INDEX] + "']"),
-                        hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='" +
-                                metacardIds[XML_RECORD_INDEX] + "']"),
+        given().contentType(ContentType.XML)
+                .body(wildcardQuery)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
+                .assertThat()
+                .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='"
+                                + metacardIds[GEOJSON_RECORD_INDEX] + "']"),
+                        hasXPath("/GetRecordsResponse/SearchResults/Record/identifier[text()='"
+                                + metacardIds[XML_RECORD_INDEX] + "']"),
                         hasXPath("/GetRecordsResponse/SearchResults/@numberOfRecordsReturned",
                                 is("2")),
                         hasXPath("/GetRecordsResponse/SearchResults/Record/relation",
@@ -774,14 +794,22 @@ public class TestFederation extends AbstractIntegrationTest {
                 containsString("/services/catalog/sources/"))};
 
         // Run a normal federated query to the CSW source and assert response
-        // @formatter:off
-        given().contentType(ContentType.XML).body(query).when().post(CSW_PATH.getUrl()).then().assertThat().body(assertion[0], assertion);
-        // @formatter:on
+        given().contentType(ContentType.XML)
+                .body(query)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
+                .assertThat()
+                .body(assertion[0], assertion);
 
         // Assert that response is the same as without the plugin
-        // @formatter:off
-        given().contentType(ContentType.XML).body(query).when().post(CSW_PATH.getUrl()).then().assertThat().body(assertion[0], assertion);
-        // @formatter:on
+        given().contentType(ContentType.XML)
+                .body(query)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
+                .assertThat()
+                .body(assertion[0], assertion);
     }
 
     @Test
@@ -791,8 +819,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 "application/xml",
                 "http://www.opengis.net/cat/csw/2.0.2");
 
-        // @formatter:off
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl()).then()
+        given().contentType(ContentType.XML)
+                .body(titleQuery)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
                 .assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/Record/identifier",
                         is(metacardIds[GEOJSON_RECORD_INDEX])),
@@ -807,8 +838,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 "application/xml",
                 "urn:catalog:metacard");
 
-        // @formatter:off
-        given().contentType(ContentType.XML).body(titleQuery).when().post(CSW_PATH.getUrl()).then()
+        given().contentType(ContentType.XML)
+                .body(titleQuery)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
                 .assertThat()
                 .body(hasXPath("/GetRecordsResponse/SearchResults/metacard/@id",
                         is(metacardIds[GEOJSON_RECORD_INDEX])),
@@ -823,7 +857,11 @@ public class TestFederation extends AbstractIntegrationTest {
         String titleQuery = getCswQuery("title", "myTitle", "application/json", null);
 
         given().headers("Accept", "application/json", "Content-Type", "application/xml")
-                .body(titleQuery).when().post(CSW_PATH.getUrl()).then().assertThat()
+                .body(titleQuery)
+                .when()
+                .post(CSW_PATH.getUrl())
+                .then()
+                .assertThat()
                 .contentType(ContentType.JSON)
                 .body("results[0].metacard.properties.title", equalTo(RECORD_TITLE_1));
     }
@@ -834,13 +872,14 @@ public class TestFederation extends AbstractIntegrationTest {
         String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
                 + CSW_SOURCE_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat()
-                .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
-                        "/metacards/metacard/string[@name='" + Metacard.RESOURCE_DOWNLOAD_URL
-                                + "']",
-                        containsString("/services/catalog/sources/" + CSW_SOURCE_ID)));
-        // @formatter:on
+        when().get(queryUrl)
+                .then()
+                .assertThat()
+                .body(containsString(RECORD_TITLE_1),
+                        containsString(RECORD_TITLE_2),
+                        hasXPath("/metacards/metacard/string[@name='"
+                                        + Metacard.RESOURCE_DOWNLOAD_URL + "']",
+                                containsString("/services/catalog/sources/" + CSW_SOURCE_ID)));
     }
 
     @Test
@@ -849,13 +888,14 @@ public class TestFederation extends AbstractIntegrationTest {
         String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + DEFAULT_KEYWORD + "&format=xml&src="
                 + CSW_SOURCE_WITH_METACARD_XML_ID;
 
-        // @formatter:off
-        when().get(queryUrl).then().assertThat()
-                .body(containsString(RECORD_TITLE_1), containsString(RECORD_TITLE_2), hasXPath(
-                        "/metacards/metacard/string[@name='" + Metacard.RESOURCE_DOWNLOAD_URL
-                                + "']",
-                        containsString("/services/catalog/sources/" + CSW_SOURCE_ID)));
-        // @formatter:on
+        when().get(queryUrl)
+                .then()
+                .assertThat()
+                .body(containsString(RECORD_TITLE_1),
+                        containsString(RECORD_TITLE_2),
+                        hasXPath("/metacards/metacard/string[@name='"
+                                        + Metacard.RESOURCE_DOWNLOAD_URL + "']",
+                                containsString("/services/catalog/sources/" + CSW_SOURCE_ID)));
     }
 
     @Test
@@ -885,10 +925,14 @@ public class TestFederation extends AbstractIntegrationTest {
         }
         */
 
-        // @formatter:off
-        given().auth().basic(ADMIN_USERNAME, ADMIN_PASSWORD).when().get(ADMIN_ALL_SOURCES_PATH.getUrl()).then()
-                .assertThat().body(containsString("\"fpid\":\"OpenSearchSource\""),
-                containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
+        given().auth()
+                .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+                .when()
+                .get(ADMIN_ALL_SOURCES_PATH.getUrl())
+                .then()
+                .assertThat()
+                .body(containsString("\"fpid\":\"OpenSearchSource\""),
+                        containsString("\"fpid\":\"Csw_Federated_Source\"")/*,
                 containsString("\"fpid\":\"Csw_Connected_Source\"")*/);
     }
 
@@ -907,9 +951,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("configurations"))).get(0)
                 .get("id");
 
-        // @formatter:off
-        given().auth().basic(ADMIN_USERNAME, ADMIN_PASSWORD).when()
-                .get(ADMIN_STATUS_PATH.getUrl() + openSearchPid).then().assertThat()
+        given().auth()
+                .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+                .when()
+                .get(ADMIN_STATUS_PATH.getUrl() + openSearchPid)
+                .then()
+                .assertThat()
                 .body(containsString("\"value\":true"));
     }
 
@@ -936,11 +983,13 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("id");
 
         // Test CSW Connected Source status
-        // @formatter:off
-        given().auth().basic(ADMIN_USERNAME, ADMIN_PASSWORD).when()
-                .get(ADMIN_STATUS_PATH.getUrl() + connectedSourcePid).then()
-                .assertThat().body(containsString("\"value\":true"));
-        // @formatter:on
+        given().auth()
+                .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+                .when()
+                .get(ADMIN_STATUS_PATH.getUrl() + connectedSourcePid)
+                .then()
+                .assertThat()
+                .body(containsString("\"value\":true"));
     }
 
     @Test
@@ -971,9 +1020,12 @@ public class TestFederation extends AbstractIntegrationTest {
 
         String wildcardQuery = getCswSubscription("xml", "*", RESTITO_STUB_SERVER.getUrl());
 
-        // @formatter:off
-        String subscriptionId = given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_SUBSCRIPTION_PATH.getUrl())
-                .then().assertThat()
+        String subscriptionId = given().contentType(ContentType.XML)
+                .body(wildcardQuery)
+                .when()
+                .post(CSW_SUBSCRIPTION_PATH.getUrl())
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -981,8 +1033,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("Acknowledgement.RequestId")
                 .toString();
 
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -999,9 +1054,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 new HashSet(0),
                 new HashSet(Arrays.asList(subscrptionIds)));
 
-        // @formatter:off
-        given().contentType(ContentType.XML).when().delete(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+        given().contentType(ContentType.XML)
+                .when()
+                .delete(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1009,9 +1066,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("Acknowledgement.RequestId")
                 .toString();
 
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat().statusCode(404);
-        // @formatter:on
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
+                .statusCode(404);
 
     }
 
@@ -1029,9 +1089,12 @@ public class TestFederation extends AbstractIntegrationTest {
         String wildcardQuery = getCswSubscription("xml", "*", RESTITO_STUB_SERVER.getUrl());
 
         //CswSubscribe
-        // @formatter:off
-        String subscriptionId = given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_SUBSCRIPTION_PATH.getUrl())
-                .then().assertThat()
+        String subscriptionId = given().contentType(ContentType.XML)
+                .body(wildcardQuery)
+                .when()
+                .post(CSW_SUBSCRIPTION_PATH.getUrl())
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1051,9 +1114,11 @@ public class TestFederation extends AbstractIntegrationTest {
         }
         getServiceManager().waitForHttpEndpoint(CSW_SUBSCRIPTION_PATH + "?_wadl");
         //get subscription
-        // @formatter:off
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1070,9 +1135,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 new HashSet(0),
                 new HashSet(Arrays.asList(subscrptionIds)));
 
-        // @formatter:off
-        given().contentType(ContentType.XML).when().delete(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+        given().contentType(ContentType.XML)
+                .when()
+                .delete(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1080,9 +1147,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("Acknowledgement.RequestId")
                 .toString();
 
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat().statusCode(404);
-        // @formatter:on
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
+                .statusCode(404);
 
     }
 
@@ -1102,9 +1172,12 @@ public class TestFederation extends AbstractIntegrationTest {
         String metacardId = "5b1688fa85fd46268e4ab7402a1750e0";
         String event = getFileContent("get-records-response.xml");
 
-        // @formatter:off
-        String subscriptionId = given().contentType(ContentType.XML).body(wildcardQuery).when().post(CSW_SUBSCRIPTION_PATH.getUrl())
-                .then().assertThat()
+        String subscriptionId = given().contentType(ContentType.XML)
+                .body(wildcardQuery)
+                .when()
+                .post(CSW_SUBSCRIPTION_PATH.getUrl())
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1112,8 +1185,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("Acknowledgement.RequestId")
                 .toString();
 
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1138,7 +1214,8 @@ public class TestFederation extends AbstractIntegrationTest {
         given().contentType(ContentType.XML)
                 .when()
                 .delete(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat()
+                .then()
+                .assertThat()
                 .body(hasXPath("/Acknowledgement/RequestId"))
                 .extract()
                 .body()
@@ -1146,9 +1223,12 @@ public class TestFederation extends AbstractIntegrationTest {
                 .get("Acknowledgement.RequestId")
                 .toString();
 
-        given().contentType(ContentType.XML).when().get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
-                .then().assertThat().statusCode(404);
-        // @formatter:on
+        given().contentType(ContentType.XML)
+                .when()
+                .get(CSW_SUBSCRIPTION_PATH.getUrl() + "/" + subscriptionId)
+                .then()
+                .assertThat()
+                .statusCode(404);
 
     }
 
@@ -1185,7 +1265,10 @@ public class TestFederation extends AbstractIntegrationTest {
 
         // Verify that the testData from the csw stub server is returned.
 
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
         expect("Waiting for notifications").within(10, SECONDS)
@@ -1257,11 +1340,14 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Verify that the testData from the csw stub server is returned.
-        // @formatter:off
-        given().auth().preemptive().basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
-                .get(restUrl).then()
-                .assertThat().contentType("text/plain").body(is(resourceData));
-        // @formatter:on
+        given().auth()
+                .preemptive()
+                .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
+                .get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
+                .body(is(resourceData));
 
         cswServer.verifyHttp()
                 .times(3,
@@ -1379,8 +1465,10 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource" + "&session=" + cometDClient.getClientId();
 
         // Verify that the testData from the csw stub server is returned.
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
         cswServer.verifyHttp()
@@ -1428,8 +1516,11 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource" + "&session=" + cometDClient.getClientId();
 
         // Verify that product retrieval fails from the csw stub server.
-        // @formatter:off
-        when().get(restUrl).then().assertThat().statusCode(500).contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .statusCode(500)
+                .contentType("text/plain")
                 .body(containsString("cannot retrieve product"));
 
         expect("Waiting for notifications").within(10, SECONDS)
@@ -1498,7 +1589,7 @@ public class TestFederation extends AbstractIntegrationTest {
     public void testMetacardCache() throws Exception {
 
         //Start with a clean cache
-        console.runCommand(CLEAR_CACHE);
+        clearCache();
         String cqlUrl = SEARCH_ROOT + "/catalog/internal/cql";
 
         String srcRequest = "{\"src\":\"" + OPENSEARCH_SOURCE_ID
@@ -1574,11 +1665,16 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource" + "&session=" + cometDClient.getClientId();
 
         // Download product twice, should only call the stub server to download once
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
         cswServer.verifyHttp()
@@ -1646,8 +1742,10 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource";
 
         // Download product twice, and change metacard on stub server between calls.
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
         cswServer.whenHttp()
                 .match(post("/services/csw"),
@@ -1655,8 +1753,12 @@ public class TestFederation extends AbstractIntegrationTest {
                         withPostBodyContaining(metacardId))
                 .then(ok(),
                         contentType("text/xml"),
-                        bytesContent(getCswQueryResponse(metacardId, OffsetDateTime.now()).getBytes()));
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+                        bytesContent(getCswQueryResponse(metacardId,
+                                OffsetDateTime.now()).getBytes()));
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
         cswServer.verifyHttp()
@@ -1705,11 +1807,16 @@ public class TestFederation extends AbstractIntegrationTest {
                 + "?transform=resource" + "&session=" + cometDClient.getClientId();
 
         // Verify that the testData from the csw stub server is returned.
-        // @formatter:off
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
-        when().get(restUrl).then().assertThat().contentType("text/plain")
+        when().get(restUrl)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is(resourceData));
 
         cswServer.verifyHttp()
@@ -1856,9 +1963,14 @@ public class TestFederation extends AbstractIntegrationTest {
                 RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID + "/" + metacardId;
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(resourceDownloadEndpoint).then().assertThat().contentType("text/plain")
-                .body(is(String.format("The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.", metacardId, CSW_SOURCE_ID)));
+        when().get(resourceDownloadEndpoint)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
+                .body(is(String.format(
+                        "The product associated with metacard [%s] from source [%s] is being downloaded to the product cache.",
+                        metacardId,
+                        CSW_SOURCE_ID)));
         // TODO - Need to update assertion when test is re-enabled
 
         assertThat(Files.exists(Paths.get(ddfHome)
@@ -1889,8 +2001,10 @@ public class TestFederation extends AbstractIntegrationTest {
                 RESOURCE_DOWNLOAD_ENDPOINT_ROOT.getUrl() + CSW_SOURCE_ID + "/" + metacardId;
 
         // Perform Test and Verify
-        // @formatter:off
-        when().get(resourceDownloadEndpoint).then().assertThat().contentType("text/plain")
+        when().get(resourceDownloadEndpoint)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
                 .body(is("Caching of products is not enabled."));
 
         assertThat(Files.exists(Paths.get(ddfHome)
@@ -1962,14 +2076,23 @@ public class TestFederation extends AbstractIntegrationTest {
                         CSW_STUB_SOURCE_ID,
                         metacardId2);
 
-        // @formatter:off
-        given().auth().preemptive().basic(ADMIN_USERNAME, ADMIN_PASSWORD).when()
-                .get(resourceDownloadUrlAdminUser).then()
-                .assertThat().contentType("text/plain").body(is(resourceData1));
-        given().auth().preemptive().basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
-                .get(resourceDownloadUrlLocalhostUser).then()
-                .assertThat().contentType("text/plain").body(is(resourceData2));
-        // @formatter:on
+        given().auth()
+                .preemptive()
+                .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+                .when()
+                .get(resourceDownloadUrlAdminUser)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
+                .body(is(resourceData1));
+        given().auth()
+                .preemptive()
+                .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
+                .get(resourceDownloadUrlLocalhostUser)
+                .then()
+                .assertThat()
+                .contentType("text/plain")
+                .body(is(resourceData2));
 
         cswServer.verifyHttp()
                 .times(1,

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
@@ -28,9 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketException;
 import java.util.Dictionary;
-import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManager;
@@ -49,7 +47,6 @@ import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -93,8 +90,6 @@ public class TestFtp extends AbstractIntegrationTest {
 
     private FTPClient client;
 
-    private Set<String> metacardsToDelete;
-
     @BeforeExam
     public void beforeExam() throws Exception {
         try {
@@ -120,16 +115,10 @@ public class TestFtp extends AbstractIntegrationTest {
         }
     }
 
-    @Before
-    public void setup() {
-        metacardsToDelete = new HashSet<>();
-    }
-
     @After
     public void tearDown() {
         disconnectClient(client);
-        metacardsToDelete.forEach(CatalogTestCommons::deleteMetacard);
-        metacardsToDelete.clear();
+        clearCatalog();
     }
 
     /**
@@ -557,10 +546,6 @@ public class TestFtp extends AbstractIntegrationTest {
 
                     boolean success =
                             numOfResults == expectedResults && title.equals(expectedTitle);
-
-                    if (success) {
-                        metacardsToDelete.add(getMetacardIdFromResponse(response));
-                    }
 
                     return success;
                 });

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
@@ -44,7 +44,6 @@ import org.apache.commons.net.util.KeyManagerUtils;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
-import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Test;

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -192,6 +192,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                     CSW_STUB_SERVER_PORT.getPort(),
                     CSW_REGISTRY_TYPE);
             getCatalogBundle().waitForCatalogStore(storeId);
+
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
@@ -216,6 +217,7 @@ public class TestRegistry extends AbstractIntegrationTest {
     @After
     public void tearDown() throws Exception {
         cswServer.stop();
+        clearCatalog();
     }
 
     @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
@@ -13,7 +13,6 @@
  */
 package ddf.test.itests.catalog;
 
-import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMetacard;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestMetacards;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
@@ -168,12 +167,7 @@ public class TestSpatial extends AbstractIntegrationTest {
 
     @After
     public void tearDown() throws Exception {
-        if (metacardIds != null) {
-            for (String metacardId : metacardIds.values()) {
-                deleteMetacard(metacardId);
-            }
-            metacardIds.clear();
-        }
+        clearCatalog();
     }
 
     @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
@@ -35,7 +35,6 @@ import org.codice.ddf.admin.application.service.ApplicationService;
 import org.codice.ddf.admin.application.service.ApplicationServiceException;
 import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
-import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.FixMethodOrder;
@@ -87,8 +86,6 @@ public class TestApplicationService extends AbstractIntegrationTest {
     private static final String SDK_APP = "sdk-app";
 
     private static final String INACTIVE_SDK = "[INACTIVE] " + SDK_APP;
-
-    private static KarafConsole console;
 
     private static final String APP_LIST_PROPERTIES_FILE =
             "/org.codice.ddf.admin.applicationlist.properties";

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
@@ -101,9 +101,6 @@ public class TestApplicationService extends AbstractIntegrationTest {
             waitForSystemReady();
             systemSubject =
                     org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
-            console = new KarafConsole(getServiceManager().getBundleContext(),
-                    features,
-                    sessionFactory);
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -183,8 +183,6 @@ public class TestConfiguration extends AbstractIntegrationTest {
 
     private static final String FILE_SEPARATOR = System.getProperty("file.separator");
 
-    private static KarafConsole console;
-
     private static Path symbolicLink;
 
     private static ManagedServiceConfigFile managedServiceStartupConfig =
@@ -220,9 +218,6 @@ public class TestConfiguration extends AbstractIntegrationTest {
     public void beforeExam() throws Exception {
         try {
             waitForSystemReady();
-            console = new KarafConsole(getServiceManager().getBundleContext(),
-                    features,
-                    sessionFactory);
             symbolicLink = Paths.get(ddfHome)
                     .resolve("link");
         } catch (Exception e) {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -44,7 +44,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.codice.ddf.configuration.persistence.felix.FelixPersistenceStrategy;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
-import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.callables.GetConfigurationProperties;

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
-import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
@@ -54,8 +53,6 @@ public class TestSolrCommands extends AbstractIntegrationTest {
 
     private static final String CATALOG_CORE_NAME = "catalog";
 
-    private static KarafConsole console;
-
     @BeforeExam
     public void beforeExam() throws Exception {
         try {
@@ -63,6 +60,15 @@ public class TestSolrCommands extends AbstractIntegrationTest {
             console = new KarafConsole(getServiceManager().getBundleContext(),
                     features,
                     sessionFactory);
+            basePort = getBasePort();
+            getAdminConfig().setLogLevels();
+            getServiceManager().waitForRequiredApps(getDefaultRequiredApps());
+            getServiceManager().waitForAllBundles();
+            getCatalogBundle().waitForCatalogProvider();
+            getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
+
+            configureRestForGuest();
+            getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -57,9 +57,6 @@ public class TestSolrCommands extends AbstractIntegrationTest {
     public void beforeExam() throws Exception {
         try {
             waitForSystemReady();
-            console = new KarafConsole(getServiceManager().getBundleContext(),
-                    features,
-                    sessionFactory);
             basePort = getBasePort();
             getAdminConfig().setLogLevels();
             getServiceManager().waitForRequiredApps(getDefaultRequiredApps());


### PR DESCRIPTION
#### What does this PR do?
All itests reset catalog contents in an @after with the karaf command "catalog:removeall -f -p". Previous cleanup logic has been removed from relevant itests. Additonally, data used by itests are now ingested in @before.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emanns95 @ahoffer @brendan-hofmann @mweser 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
DDF can be built and all itests run.

#### What are the relevant tickets?
[DDF-2868](https://codice.atlassian.net/browse/DDF-2868)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
