### PR TITLE
DDF-2871 Modified Update to not set resource-size when the item has a qualifier

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/data/impl/ContentItemImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/data/impl/ContentItemImpl.java
@@ -86,7 +86,7 @@ public class ContentItemImpl implements ContentItem {
      * An incoming content item where the item's GUID and size should be known.
      *
      * @param id              the {@link ContentItem}'s GUID - can be null
-     * @param qualifier       the {@link ContentItem}'s qualifier - can be null
+     * @param qualifier       the {@link ContentItem}'s qualifier - can be null; blank qualifiers are treated as null
      * @param byteSource      the {@link ContentItem}'s input stream containing its actual data
      * @param mimeTypeRawData the {@link ContentItem}'s mime type
      * @param metacard        the {@link ContentItem}'s associated metacard
@@ -108,14 +108,14 @@ public class ContentItemImpl implements ContentItem {
      */
     public ContentItemImpl(String id, ByteSource byteSource, String mimeTypeRawData,
             String filename, long size, Metacard metacard) {
-        this(id, "", byteSource, mimeTypeRawData, filename, size, metacard);
+        this(id, null, byteSource, mimeTypeRawData, filename, size, metacard);
     }
 
     /**
      * An incoming content item where the item's GUID and size should be known.
      *
      * @param id              the {@link ContentItem}'s GUID - can be null
-     * @param qualifier       the {@link ContentItem}'s qualifier - can be null
+     * @param qualifier       the {@link ContentItem}'s qualifier - can be null; blank qualifiers are treated as null
      * @param byteSource      the {@link ContentItem}'s input stream containing its actual data
      * @param mimeTypeRawData the {@link ContentItem}'s mime type
      * @param filename        the {@link ContentItem}'s file name - can be null
@@ -126,7 +126,11 @@ public class ContentItemImpl implements ContentItem {
             String mimeTypeRawData, String filename, long size, Metacard metacard) {
         this.byteSource = byteSource;
         this.id = id;
-        this.qualifier = qualifier;
+        if (StringUtils.isNotBlank(qualifier)) {
+            this.qualifier = qualifier;
+        } else {
+            this.qualifier = null;
+        }
         this.mimeType = null;
         this.size = size;
         if (filename != null) {
@@ -145,11 +149,7 @@ public class ContentItemImpl implements ContentItem {
             LOGGER.debug("Unable to create MimeType from raw data {}", mimeTypeRawData);
         }
         try {
-            if (StringUtils.isNotBlank(this.qualifier)) {
-                uri = new URI(CONTENT_SCHEME, this.id, this.qualifier);
-            } else {
-                uri = new URI(CONTENT_SCHEME, this.id, null);
-            }
+            uri = new URI(CONTENT_SCHEME, this.id, this.qualifier);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Unable to create content URI.", e);
         }

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/content/data/impl/ContentItemValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/content/data/impl/ContentItemValidatorTest.java
@@ -14,6 +14,7 @@
 package ddf.catalog.content.data.impl;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -49,6 +50,24 @@ public class ContentItemValidatorTest {
         String id = "634e8505-bd4b-436e-97e8-2045d1b0d265".replace("-", "");
         String qualifier = "zoom-and-enhanced-overview";
         ContentItem item = new ContentItemImpl(id, qualifier, null, "", null);
+        assertThat(ContentItemValidator.validate(item), is(true));
+    }
+
+    @Test
+    public void testValidItemWithEmptyQualifier() throws Exception {
+        String id = "634e8505-bd4b-436e-97e8-2045d1b0d265".replace("-", "");
+        String qualifier = "";
+        ContentItem item = new ContentItemImpl(id, qualifier, null, "", null);
+        assertThat(item.getQualifier(), nullValue());
+        assertThat(ContentItemValidator.validate(item), is(true));
+    }
+
+    @Test
+    public void testValidItemWithBlankNotEmptyQualifier() throws Exception {
+        String id = "634e8505-bd4b-436e-97e8-2045d1b0d265".replace("-", "");
+        String qualifier = "              ";
+        ContentItem item = new ContentItemImpl(id, qualifier, null, "", null);
+        assertThat(item.getQualifier(), nullValue());
         assertThat(ContentItemValidator.validate(item), is(true));
     }
 

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/data/ContentItem.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/data/ContentItem.java
@@ -63,28 +63,29 @@ public interface ContentItem {
     String getUri();
 
     /**
-     * An optional field to provide additional information about a {@link ContentItem}
+     * Return the optional field to describe the {@link ContentItem} as an additional product for a {@link Metacard}.
+     * {@link ContentItem}s added to a {@link Metacard} as an additional product must have a non-blank qualifier.
      *
-     * @return the qualifier of the {@link ContentItem}
+     * @return the qualifier of the {@link ContentItem}. A null qualifier designates this as the main {@link ContentItem} of the associated {@link Metacard}.
      */
     String getQualifier();
 
     /**
-     * The filename of the {@link ContentItem}. If not set it will default to {@link #DEFAULT_FILE_NAME}
+     * Return the filename of the {@link ContentItem}. If not set it will default to {@link #DEFAULT_FILE_NAME}.
      *
      * @return the filename of the {@link ContentItem}
      */
     String getFilename();
 
     /**
-     * Return the mime type for the content item, e.g., image/nitf or application/pdf
+     * Return the mime type for the content item, e.g., image/nitf or application/pdf.
      *
      * @return the mime type for the content item
      */
     MimeType getMimeType();
 
     /**
-     * Return the mime type raw data for the content item, e.g., image/nitf or application/json;id=geojson
+     * Return the mime type raw data for the content item, e.g., image/nitf or application/json;id=geojson.
      *
      * @return the mime type raw data for the content item
      */
@@ -108,7 +109,7 @@ public interface ContentItem {
     long getSize() throws IOException;
 
     /**
-     * Returns the metacard associated with this product.
+     * Return the metacard associated with this product.
      *
      * @return Metacard
      */

--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -199,7 +199,7 @@ public class FileSystemStorageProvider implements StorageProvider {
 
         for (ContentItem contentItem : updatedItems) {
             if (contentItem.getMetacard()
-                    .getResourceURI() == null) {
+                    .getResourceURI() == null && StringUtils.isBlank(contentItem.getQualifier())) {
                 contentItem.getMetacard()
                         .setAttribute(new AttributeImpl(Metacard.RESOURCE_URI,
                                 contentItem.getUri()));

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -196,19 +197,22 @@ public class UpdateOperations {
                 updateStorageResponse = processPostUpdateStoragePlugins(updateStorageResponse);
 
                 for (ContentItem contentItem : updateStorageResponse.getUpdatedContentItems()) {
-                    Metacard metacard = metacardMap.get(contentItem.getId());
+                    if (StringUtils.isBlank(contentItem.getQualifier())) {
+                        Metacard metacard = metacardMap.get(contentItem.getId());
 
-                    Metacard overrideMetacard = contentItem.getMetacard();
+                        Metacard overrideMetacard = contentItem.getMetacard();
 
-                    Metacard updatedMetacard = OverrideAttributesSupport.overrideMetacard(metacard,
-                            overrideMetacard,
-                            true,
-                            true);
+                        Metacard updatedMetacard = OverrideAttributesSupport.overrideMetacard(
+                                metacard,
+                                overrideMetacard,
+                                true,
+                                true);
 
-                    updatedMetacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_SIZE,
-                            String.valueOf(contentItem.getSize())));
+                        updatedMetacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_SIZE,
+                                String.valueOf(contentItem.getSize())));
 
-                    metacardMap.put(contentItem.getId(), updatedMetacard);
+                        metacardMap.put(contentItem.getId(), updatedMetacard);
+                    }
                 }
             }
 

--- a/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
+++ b/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
@@ -109,7 +109,7 @@ public class FilterPlugin implements AccessPlugin {
         }
         if (!userNotPermittedTitles.isEmpty()) {
             throw new StopProcessingException(
-                    "Metacard creation not permitted for" + SubjectUtils.getName(subject) + ": [ "
+                    "Metacard creation not permitted for " + SubjectUtils.getName(subject) + ": [ "
                             + listToString(userNotPermittedTitles) + " ]");
         }
         if (!systemNotPermittedTitles.isEmpty()) {


### PR DESCRIPTION
#### What does this PR do?
The PR adds a check to see if the the update content item has a qualifier before setting the `resource-size` attribute on the metacard. I also added to the javadoc for ContentItem#Qualifier.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @troymohl @bdeining @brendan-hofmann
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef 
@kcwire
#### How should this be tested? (List steps with links to updated documentation)

1. Full build.
2. Full build with https://github.com/codice/alliance/pull/225. Especially, confirm that `ImagingTest` succeeds.

#### Any background context you want to provide?
This PR is required for https://github.com/codice/alliance/pull/225.
#### What are the relevant tickets?
[DDF-2871](https://codice.atlassian.net/browse/DDF-2871)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
