### PR TITLE
DDF-2878 Added AlertService API

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
@@ -1,0 +1,53 @@
+
+[NOTE]
+====
+This code is experimental. While this interface is functional and tested, it may change or be removed in a future version of the library.
+
+This API will be modified and built upon as the need for ${admin-console} notifications evolves. See https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications[Design ${admin-console} Notifications].
+====
+
+The *Alert Service* has two interfaces which are exposed on top of the OSGi runtime for other applications to use.
+For more information on these interfaces, see <<_alert_service_interfaces,Alert Service Interfaces>>.
+
+=== JMX Managed Bean
+
+Some of the *Alert Service* API is exposed via JMX.
+It can either be accessed using the JMX API or from a REST-based interface created by http://jolokia.org[Jolokia] that comes with ${branding}.
+Here are the methods that are exposed in the Managed Bean:
+
+`addAlert(Alert alert)`:: Adds an `Alert` to the current ``Alert``s
+`getAlerts()`:: Returns the current `Alert`
+`dismissAlert(String keyToDismiss)`:: Dismisses an `Alert` with the given key
+
+=== Alert Service Data Classes
+
+==== `Alert` Class
+
+An `Alert` holds the content for a System Administrator alert.
+An `Alert` consists of a type (e.g. info, warning), a title, an optional list of details, and an optional key.
+
+==== `AlertDetail` Class
+
+An `AlertDetail` contains a single secondary message of an Alert.
+An `Alert` may contain a list of ``AlertDetail``s.
+An `AlertDetail` consists of a message and a level (e.g. warning, error).
+
+=== Alert Service Interfaces
+
+The interfaces used by that *Alert Service* subsystem are `AlertService` and `AlertSupplier`.
+The purpose of these interfaces and their public methods are explained below.
+
+==== `AlertService` Interface
+
+The `AlertService` interface is the main interface that is used to get, add, and dismiss ``Alert``s.
+
+`addAlert(Alert alert)`:: Adds an `Alert` to the current ``Alert``s
+`getAlerts()`:: Returns the current `Alert`
+`dismissAlert(String keyToDismiss)`:: Dismisses the first `Alert` with the given key from the current `Alert`
+
+==== `AlertSupplier` Interface
+
+While some ``Alert``s will be pushed to the `AlertService`, other ``Alert``s will be polled each time the current ``Alert``s is retrieved.
+An `AlertsSupplier` will return a list of ``Alert``s every time that the `getAlerts` method is called.
+
+`getAlerts()`:: Generates and returns a list of ``Alert``s

--- a/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
@@ -15,8 +15,8 @@ Some of the *Alert Service* API is exposed via JMX.
 It can either be accessed using the JMX API or from a REST-based interface created by http://jolokia.org[Jolokia] that comes with ${branding}.
 Here are the methods that are exposed in the Managed Bean:
 
-`addAlert(Alert alert)`:: Adds an `Alert` to the current ``Alert``s
-`getAlerts()`:: Returns the current `Alert`
+`addAlert(Alert alert)`:: Adds an `Alert`
+`getAlerts()`:: Returns the current `Alert`s
 `dismissAlert(String keyToDismiss)`:: Dismisses an `Alert` with the given key
 
 === Alert Service Data Classes
@@ -34,20 +34,20 @@ An `AlertDetail` consists of a message and a level (e.g. warning, error).
 
 === Alert Service Interfaces
 
-The interfaces used by that *Alert Service* subsystem are `AlertService` and `AlertSupplier`.
+The interfaces used by the *Alert Service* subsystem are `AlertService` and `AlertsSupplier`.
 The purpose of these interfaces and their public methods are explained below.
 
 ==== `AlertService` Interface
 
 The `AlertService` interface is the main interface that is used to get, add, and dismiss ``Alert``s.
 
-`addAlert(Alert alert)`:: Adds an `Alert` to the current ``Alert``s
-`getAlerts()`:: Returns the current `Alert`
-`dismissAlert(String keyToDismiss)`:: Dismisses the first `Alert` with the given key from the current `Alert`
+`addAlert(Alert alert)`:: Adds an `Alert`
+`getAlerts()`:: Returns the current `Alert`s
+`dismissAlert(String keyToDismiss)`:: Dismisses the first `Alert` with the given key from the current collection of `Alert`s
 
-==== `AlertSupplier` Interface
+==== `AlertsSupplier` Interface
 
-While some ``Alert``s will be pushed to the `AlertService`, other ``Alert``s will be polled each time the current ``Alert``s is retrieved.
-An `AlertsSupplier` will return a list of ``Alert``s every time that the `getAlerts` method is called.
+While some ``Alert``s will be pushed to the `AlertService`, other ``Alert``s are pulled from ``AlertsSupplier``s by the `AlertService`. 
+The `getAlerts()` method returns the ``AlertsSupplier``'s list of ``Alert``s.
 
-`getAlerts()`:: Generates and returns a list of ``Alert``s
+`getAlerts()`:: Returns a list of ``Alert``s specific to the `AlertsSupplier`

--- a/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
@@ -24,13 +24,13 @@ Here are the methods that are exposed in the Managed Bean:
 ==== `Alert` Class
 
 An `Alert` holds the content for a System Administrator alert.
-An `Alert` consists of a type (e.g. info, warning), a title, an optional list of details, and an optional key.
+An `Alert` consists of a level ("INFO", "WARN", or "ERROR"), a title, an optional list of details, and an optional key.
 
 ==== `AlertDetail` Class
 
 An `AlertDetail` contains a single secondary message of an Alert.
 An `Alert` may contain a list of ``AlertDetail``s.
-An `AlertDetail` consists of a message and a level (e.g. warning, error).
+An `AlertDetail` consists of a message String.
 
 === Alert Service Interfaces
 

--- a/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/alert-service-api-contents.adoc
@@ -6,7 +6,7 @@ This code is experimental. While this interface is functional and tested, it may
 This API will be modified and built upon as the need for ${admin-console} notifications evolves. See https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications[Design ${admin-console} Notifications].
 ====
 
-The *Alert Service* has two interfaces which are exposed on top of the OSGi runtime for other applications to use.
+The *Alert Service* has two interfaces that are available as OSGi services.
 For more information on these interfaces, see <<_alert_service_interfaces,Alert Service Interfaces>>.
 
 === JMX Managed Bean
@@ -16,7 +16,7 @@ It can either be accessed using the JMX API or from a REST-based interface creat
 Here are the methods that are exposed in the Managed Bean:
 
 `addAlert(Alert alert)`:: Adds an `Alert`
-`getAlerts()`:: Returns the current `Alert`s
+`getAlerts()`:: Returns the current ``Alert``s
 `dismissAlert(String keyToDismiss)`:: Dismisses an `Alert` with the given key
 
 === Alert Service Data Classes
@@ -25,6 +25,7 @@ Here are the methods that are exposed in the Managed Bean:
 
 An `Alert` holds the content for a System Administrator alert.
 An `Alert` consists of a level ("INFO", "WARN", or "ERROR"), a title, an optional list of details, and an optional key.
+``Alert``s with a non-empty `key` can be dismissed in the `AlertService` using the `dismissAlert(String keyToDismiss)` method.
 
 ==== `AlertDetail` Class
 
@@ -34,20 +35,21 @@ An `AlertDetail` consists of a message String.
 
 === Alert Service Interfaces
 
-The interfaces used by the *Alert Service* subsystem are `AlertService` and `AlertsSupplier`.
+The interfaces used by the *Alert Service* subsystem are `AlertService` and `AlertSupplier`.
 The purpose of these interfaces and their public methods are explained below.
 
 ==== `AlertService` Interface
 
 The `AlertService` interface is the main interface that is used to get, add, and dismiss ``Alert``s.
+The current ``Alert``s that the `getAlerts()` returns include the added ``Alert``s from the `addAlert(Alert alert)` method and the ``Alert``s gathered from the ``AlertSupplier``s.
 
 `addAlert(Alert alert)`:: Adds an `Alert`
-`getAlerts()`:: Returns the current `Alert`s
-`dismissAlert(String keyToDismiss)`:: Dismisses the first `Alert` with the given key from the current collection of `Alert`s
+`getAlerts()`:: Returns the current ``Alert``s
+`dismissAlert(String keyToDismiss)`:: Dismisses the first `Alert` with the given key from the current collection of ``Alert``s
 
-==== `AlertsSupplier` Interface
+==== `AlertSupplier` Interface
 
-While some ``Alert``s will be pushed to the `AlertService`, other ``Alert``s are pulled from ``AlertsSupplier``s by the `AlertService`. 
-The `getAlerts()` method returns the ``AlertsSupplier``'s list of ``Alert``s.
+While some ``Alert``s will be pushed to the `AlertService`, other ``Alert``s are pulled from ``AlertSupplier``s by the `AlertService`.
+The `getAlerts()` method returns the ``AlertSupplier``'s list of ``Alert``s.
 
-`getAlerts()`:: Returns a list of ``Alert``s specific to the `AlertsSupplier`
+`getAlerts()`:: Returns a list of ``Alert``s specific to the `AlertSupplier`

--- a/distribution/docs/src/main/resources/_contents/_apis/application-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/application-service-api-contents.adoc
@@ -1,5 +1,5 @@
 
-The Application service has multiple interfaces which are exposed on top of the OSGi runtime for other applications to use.
+The Application service has multiple interfaces that are available as OSGi services.
 For more information on these interfaces, see <<_application_service_interfaces,Application Service Interfaces>>.
 
 === JMX Managed Bean

--- a/distribution/docs/src/main/resources/_contents/_apis/application-service-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/application-service-api-contents.adoc
@@ -1,21 +1,19 @@
 
-=== Application Service API
-
 The Application service has multiple interfaces which are exposed on top of the OSGi runtime for other applications to use.
-For more information on these interfaces, see <<_application_service_api,Application Service Interfaces>>.
+For more information on these interfaces, see <<_application_service_interfaces,Application Service Interfaces>>.
 
-==== JMX Managed Bean
+=== JMX Managed Bean
 
 Some of the Application service API is exposed via JMX.
 It can either be accessed using the JMX API or from a REST-based interface created by http://jolokia.org[Jolokia] that comes with ${branding}.
-Here are the interfaces that are exposed in the Managed Bean:
+Here are the methods that are exposed in the Managed Bean:
 
 getApplicationTree:: Creates an application hierarchy tree that shows relationships between applications.
 startApplication:: Starts an application with the given name.
 stopApplication:: Stops an application with the given name.
 addApplications:: Adds a list of applications that are specified by their URL.
 
-==== Initial Application Installation
+=== Initial Application Installation
 
 In ${branding}, an *application* is a collection of one or more *features*.
 
@@ -48,12 +46,12 @@ opendj-embedded=file:/location/to/opendj-embedded-app-1.0.1-SNAPSHOT.kar
 Applications will be started in the order they are listed in the file.
 If an application is listed, ${branding} will also attempt to install all dependencies for that application.
 
-==== Application Service Interfaces
+=== Application Service Interfaces
 
 The interfaces used by that application service subsystem are `ApplicationService`, `Application`, `ApplicationStatus`, and `ApplicationNode`.
 The purpose of these interfaces and their public methods are explained below.
 
-===== ApplicationService Interface
+==== ApplicationService Interface
 
 The ApplicationService interface is the main class that is used to operate on applications.
 
@@ -68,20 +66,20 @@ The ApplicationService interface is the main class that is used to operate on ap
 `getApplicationTree()`:: Creates a hierarchy tree of application nodes that show the relationship between applications.
 `findFeature(Feature feature)`:: Determine which application contains a certain feature.
 
-===== Application Interface
+==== Application Interface
 
 `getName()`:: Returns the name of the application, which should be unique among applications.
 `getFeatures()`:: Returns all of the features that this application contains regardless if they are required.
 `getBundles()`:: Returns all of the bundles that are defined by the features and included in this application.
 
-===== ApplicationStatus Interface
+==== ApplicationStatus Interface
 
 `getApplication`:: Returns the application that is associated with this status.
 `getState`:: Returns the application's state as defined by ApplicationState.
 `getErrorFeatures`:: Returns a set of Features that were required for this application but did not start correctly.
 `getErrorBundles`:: Returns a set of Bundles that were required for this application but did not start correctly.
 
-===== ApplicationNode Interface
+==== ApplicationNode Interface
 
 `getApplication()`:: Returns the application for a node reference.
 `getStatus()`:: Returns the status for the referenced application.

--- a/distribution/docs/src/main/resources/_contents/_apis/migration-api-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_apis/migration-api-contents.adoc
@@ -1,6 +1,4 @@
 
-=== Migration API
-
 [NOTE]
 ====
 This code is experimental. While this interface is functional and tested, it may change or be removed in a future version of the library.
@@ -18,15 +16,13 @@ An export operation can be performed through the ${command-console} or through t
 The services that implement one of the migratable interfaces will be called one at a time, in any order, and do not need to be thread safe.
 A bundle or a feature can have as many services implementing the interfaces as needed.
 
-==== The Migratable API Interfaces
+=== The Migratable API Interfaces
 
 . `org.codice.ddf.migration.Migratable`
-. `org.codice.ddf.migration.AbstractMigratable`
-. `org.codice.ddf.migration.MigrationException`
-. `org.codice.ddf.migration.MigrationMetadata`
-. `org.codice.ddf.migration.MigrationWarning`
+. `org.codice.ddf.migration.ConfigurationMigratable`
+. `org.codice.ddf.migration.DataMigratable`
 
-===== `Migratable`
+==== `Migratable` Interface
 
 The contract for a `migratable` is stored here. It is used by both sub-interfaces `ConfigurationMigratable` and `DataMigratable`.
 
@@ -54,7 +50,7 @@ The description and optional flag are for display purposes in the ${admin-consol
 In order to create a `Migratable` for a module of the system, the `org.codice.ddf.migration.Migratable` interface must be implemented and the implementation must be registered under the `org.codice.ddf.migration.Migratable` interface as an OSGI service in the OSGI service registry.
 Creating an OSGI service allows for the `org.codice.ddf.configuration.migration.ConfigurationMigrationManager` to lookup all implementations of `org.codice.ddf.migration.Migratable` and command them to export.
 
-====== `ConfigurationMigratable`
+==== `ConfigurationMigratable` Interface
 
 This is the base interface that must be implemented by all bundles or features that need to export and/or import system related settings
 (e.g., bundle specific Java properties, XML or JSON configuration files) during system migration.
@@ -65,7 +61,7 @@ Only bundle- or feature-specific settings need be handled. All configurations st
 Also, any other data not related to the system's configuration and settings (for example, data stored in Solr) should be handled by a different
 service that implements the `DataMigratable` interface, not by implementors of this class.
 
-====== `DataMigratable`
+==== `DataMigratable` Interface
 
 This is the interface that must be implemented by all bundles or features that need to export and/or import data during system migration.
 The data is not mandatory for the system to come up (e.g., data stored in Solr) and doesn't affect the system's configuration,
@@ -74,20 +70,22 @@ i.e., without this data, the new system will still have the same configuration a
 Any system related configuration and settings should be handled by a different service that implements the
 `ConfigurationMigratable` interface, not by implementors of this class.
 
-===== `AbstractMigratable`
+=== The Migratable API Classes
 
-The abstract base class `org.codice.ddf.migration.AbstractMigratable` in the `platform-migratable-api` implements common boilerplate code required when implementing `org.codice.ddf.migration.Migratable` and should be extended when creating an `org.codice.ddf.migration.Migratable`.
+. `org.codice.ddf.migration.MigrationException`
+. `org.codice.ddf.migration.MigrationMetadata`
+. `org.codice.ddf.migration.MigrationWarning`
 
-===== `MigrationException`
+==== `MigrationException` Class
 
 An `org.codice.ddf.migration.MigrationException` should be thrown when an unrecoverable exception occurs that prevents required data from exporting.
 The exception message is displayed to the administrator.
 
-===== `MigrationMetadata`
+==== `MigrationMetadata` Class
 
 The `org.codice.ddf.migration.MigrationMetadata` provides metadata with details of the exported `org.codice.ddf.migration.Migratable`.
 
-===== `MigrationWarning`
+==== `MigrationWarning` Class
 
 An `org.codice.ddf.migration.MigrationWarning` should be used when a `Migratable` wants to warn an admin that certain aspects of the export may cause problems upon import.
 For example, if an absolute path is encountered, that path may not exist on the target system and cause the installation to fail.

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -800,6 +800,10 @@ include::{adoc-include}/_apis/migration-api-contents.adoc[]
 
 include::{adoc-include}/_apis/application-service-api-contents.adoc[]
 
+== Alert Service API
+
+include::{adoc-include}/_apis/alert-service-api-contents.adoc[]
+
 == General Development Guidelines
 
 include::{adoc-include}/_developing/contributing-intro-contents.adoc[]

--- a/platform/admin/core/admin-core-alertservice-api/pom.xml
+++ b/platform/admin/core/admin-core-alertservice-api/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>admin-core</artifactId>
+        <groupId>ddf.admin.core</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>admin-core-alertservice-api</artifactId>
+    <name>DDF :: Admin :: Core :: Alerts API</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--needed for NotEmpty annotation-->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-ws-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            org.codice.ddf.admin.core.alert.service.api.internal
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.93</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.88</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
@@ -34,7 +34,7 @@ import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
  */
 public class Alert {
 
-    private Type type;
+    private Level level;
 
     private String title;
 
@@ -42,22 +42,22 @@ public class Alert {
 
     private Optional<String> key;
 
-    public Alert(@Nonnull Type type, @Nonnull @NotEmpty String title, @Nonnull List<AlertDetail> details, @Nullable String key) {
-        notNull(type, "type may not be null");
+    public Alert(@Nonnull Level level, @Nonnull @NotEmpty String title, @Nonnull List<AlertDetail> details, @Nullable String key) {
+        notNull(level, "level may not be null");
         notEmpty(title, "title may not be empty");
         notNull(details, "details may not be null");
         if (key != null && key.equals("")) {
             throw new IllegalArgumentException("alert key may not be an empty string");
         }
-        this.type = type;
+        this.level = level;
         this.title = title;
         this.details = details;
         this.key = Optional.ofNullable(key);
     }
 
     @Nonnull
-    public Type getType() {
-        return type;
+    public Level getLevel() {
+        return level;
     }
 
     @Nonnull
@@ -75,7 +75,7 @@ public class Alert {
         return key;
     }
 
-    public enum Type {
+    public enum Level {
         INFO, WARN, ERROR
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
@@ -30,10 +30,6 @@ import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
  * removed in a future version of the library.</b>
  * </p>
  * <p>
- * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
- * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
- * </p>
- * <p>
  * An {@link Alert} holds the content for a system administrator alert.
  */
 public class Alert {
@@ -80,6 +76,6 @@ public class Alert {
     }
 
     public enum Type {
-        INFO, WARNING, DANGER
+        INFO, WARN, ERROR
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/Alert.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal;
+
+import static org.apache.commons.lang.Validate.notEmpty;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</b>
+ * </p>
+ * <p>
+ * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
+ * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
+ * </p>
+ * <p>
+ * An {@link Alert} holds the content for a system administrator alert.
+ */
+public class Alert {
+
+    private Type type;
+
+    private String title;
+
+    private List<AlertDetail> details;
+
+    private Optional<String> key;
+
+    public Alert(@Nonnull Type type, @Nonnull @NotEmpty String title, @Nonnull List<AlertDetail> details, @Nullable String key) {
+        notNull(type, "type may not be null");
+        notEmpty(title, "title may not be empty");
+        notNull(details, "details may not be null");
+        if (key != null && key.equals("")) {
+            throw new IllegalArgumentException("alert key may not be an empty string");
+        }
+        this.type = type;
+        this.title = title;
+        this.details = details;
+        this.key = Optional.ofNullable(key);
+    }
+
+    @Nonnull
+    public Type getType() {
+        return type;
+    }
+
+    @Nonnull
+    public String getTitle() {
+        return title;
+    }
+
+    @Nonnull
+    public List<AlertDetail> getDetails() {
+        return details;
+    }
+
+    @Nonnull
+    public Optional<String> getKey() {
+        return key;
+    }
+
+    public enum Type {
+        INFO, WARNING, DANGER
+    }
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
@@ -26,10 +26,6 @@ import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
  * removed in a future version of the library.</b>
  * </p>
  * <p>
- * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
- * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
- * </p>
- * <p>
  * An {@link AlertDetail} contains a single secondary message of an {@link Alert}. An {@link Alert} may contain
  * a list of {@link AlertDetail}s.
  */
@@ -57,6 +53,6 @@ public class AlertDetail {
     }
 
     public enum Level {
-        WARNING, ERROR
+        INFO, WARN, ERROR
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal;
+
+import static org.apache.commons.lang.Validate.notEmpty;
+import static org.apache.commons.lang.Validate.notNull;
+
+import javax.annotation.Nonnull;
+
+import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</b>
+ * </p>
+ * <p>
+ * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
+ * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
+ * </p>
+ * <p>
+ * An {@link AlertDetail} contains a single secondary message of an {@link Alert}. An {@link Alert} may contain
+ * a list of {@link AlertDetail}s.
+ */
+public class AlertDetail {
+
+    private String message;
+
+    private Level level;
+
+    public AlertDetail(@Nonnull Level level, @Nonnull @NotEmpty String message) {
+        notNull(level, "level may not be null");
+        notEmpty(message, "message may not be empty");
+        this.level = level;
+        this.message = message;
+    }
+
+    @Nonnull
+    public Level getLevel() {
+        return level;
+    }
+
+    @Nonnull
+    public String getMessage() {
+        return message;
+    }
+
+    public enum Level {
+        WARNING, ERROR
+    }
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetail.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.admin.core.alert.service.api.internal;
 
 import static org.apache.commons.lang.Validate.notEmpty;
-import static org.apache.commons.lang.Validate.notNull;
 
 import javax.annotation.Nonnull;
 
@@ -33,26 +32,13 @@ public class AlertDetail {
 
     private String message;
 
-    private Level level;
-
-    public AlertDetail(@Nonnull Level level, @Nonnull @NotEmpty String message) {
-        notNull(level, "level may not be null");
+    public AlertDetail(@Nonnull @NotEmpty String message) {
         notEmpty(message, "message may not be empty");
-        this.level = level;
         this.message = message;
-    }
-
-    @Nonnull
-    public Level getLevel() {
-        return level;
     }
 
     @Nonnull
     public String getMessage() {
         return message;
-    }
-
-    public enum Level {
-        INFO, WARN, ERROR
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</b>
+ * </p>
+ * <p>
+ * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
+ * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
+ * </p>
+ * <p>
+ * The {@link AlertService} is used to get, add, and dismiss {@link Alert}s.
+ */
+public interface AlertService {
+
+    /**
+     * Adds an {@link Alert} to the current {@link Alert}s
+     *
+     * @param alert
+     */
+    void addAlert(@Nonnull Alert alert);
+
+    /**
+     * @return the current {@link Alert}s
+     */
+    @Nonnull
+    List<Alert> getAlerts();
+
+    /**
+     * Dismisses the first {@link Alert} with the specified key from the current {@link Alert}s
+     *
+     * @param keyToDismiss the {@param keyToDismiss} of the {@link Alert} to be dismissed
+     * @return {@code true} if an {@link Alert} with the specified {@param keyToDismiss} was successfully removed from the current {@link Alert}s
+     */
+    Boolean dismissAlert(@Nonnull String keyToDismiss);
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
@@ -35,6 +35,8 @@ public interface AlertService {
     void addAlert(@Nonnull Alert alert);
 
     /**
+     * The current {@link Alert}s include the added {@link Alert}s from the {@link #addAlert(Alert)} method and the {@link Alert}s gathered from the {@link AlertSupplier}s.
+     *
      * @return the current {@link Alert}s
      */
     @Nonnull

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertService.java
@@ -23,16 +23,12 @@ import javax.annotation.Nonnull;
  * removed in a future version of the library.</b>
  * </p>
  * <p>
- * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
- * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
- * </p>
- * <p>
  * The {@link AlertService} is used to get, add, and dismiss {@link Alert}s.
  */
 public interface AlertService {
 
     /**
-     * Adds an {@link Alert} to the current {@link Alert}s
+     * Adds an {@link Alert}
      *
      * @param alert
      */
@@ -48,7 +44,7 @@ public interface AlertService {
      * Dismisses the first {@link Alert} with the specified key from the current {@link Alert}s
      *
      * @param keyToDismiss the {@param keyToDismiss} of the {@link Alert} to be dismissed
-     * @return {@code true} if an {@link Alert} with the specified {@param keyToDismiss} was successfully removed from the current {@link Alert}s
+     * @return {@code true} if an {@link Alert} with the specified {@param keyToDismiss} was successfully removed from the current collection of {@link Alert}s
      */
     Boolean dismissAlert(@Nonnull String keyToDismiss);
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertSupplier.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertSupplier.java
@@ -24,13 +24,13 @@ import javax.annotation.Nonnull;
  * </p>
  * <p>
  * While some {@link Alert}s will be pushed to the {@link AlertService}, other {@link Alert}s are
- * pulled from {@link AlertsSupplier}s by the {@link AlertService}. The {@link #getAlerts()} method
- * returns the {@link AlertsSupplier}'s list of {@link Alert}s.
+ * pulled from {@link AlertSupplier}s by the {@link AlertService}. The {@link #getAlerts()} method
+ * returns the {@link AlertSupplier}'s list of {@link Alert}s.
  */
-public interface AlertsSupplier {
+public interface AlertSupplier {
 
     /**
-     * Returns a list of {@link Alert}s specific to the {@link AlertsSupplier}
+     * Returns a list of {@link Alert}s specific to the {@link AlertSupplier}
      *
      * @return list of {@link Alert}s
      */

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertsSupplier.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertsSupplier.java
@@ -23,13 +23,9 @@ import javax.annotation.Nonnull;
  * removed in a future version of the library.</b>
  * </p>
  * <p>
- * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
- * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
- * </p>
- * <p>
- * While some {@link Alert}s will be pushed to the {@link AlertService}, other {@link Alert}s should
- * be polled each time the current {@link Alert}s is retrieved. An {@link AlertsSupplier} will
- * return a list of {@link Alert}s every time that the {@link #getAlerts} method is called.
+ * While some {@link Alert}s will be pushed to the {@link AlertService}, other {@link Alert}s are
+ * pulled from {@link AlertsSupplier}s by the {@link AlertService}. The {@link #getAlerts()} method
+ * returns the {@link AlertsSupplier}'s list of {@link Alert}s.
  */
 public interface AlertsSupplier {
 

--- a/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertsSupplier.java
+++ b/platform/admin/core/admin-core-alertservice-api/src/main/java/org/codice/ddf/admin/core/alert/service/api/internal/AlertsSupplier.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</b>
+ * </p>
+ * <p>
+ * <b> This API will be modified and built upon as the need for Admin UI notifications evolves.
+ * See <a href="https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications">Design Admin UI Notifications</a>.</b>
+ * </p>
+ * <p>
+ * While some {@link Alert}s will be pushed to the {@link AlertService}, other {@link Alert}s should
+ * be polled each time the current {@link Alert}s is retrieved. An {@link AlertsSupplier} will
+ * return a list of {@link Alert}s every time that the {@link #getAlerts} method is called.
+ */
+public interface AlertsSupplier {
+
+    /**
+     * Returns a list of {@link Alert}s specific to the {@link AlertsSupplier}
+     *
+     * @return list of {@link Alert}s
+     */
+    @Nonnull
+    List<Alert> getAlerts();
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetailTest.groovy
+++ b/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetailTest.groovy
@@ -22,27 +22,20 @@ class AlertDetailTest extends Specification {
             final message = _ as String
 
         when:
-            def alertDetail = new AlertDetail(level, message)
+            def alertDetail = new AlertDetail(message)
 
         then:
-            alertDetail.getLevel() == level
             alertDetail.getMessage() == message
-
-        where:
-            level << AlertDetail.Level.values()
     }
 
-    def 'test construct AlertDetail with an invalid parameter'() {
+    def 'test construct AlertDetail with an invalid message'() {
         when:
-            new AlertDetail(level, message)
+            new AlertDetail(message)
 
         then:
             thrown(IllegalArgumentException)
 
         where:
-            level                   | message
-            null                    | _ as String
-            AlertDetail.Level.ERROR | null
-            AlertDetail.Level.ERROR | ""
+            message << [null, ""]
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetailTest.groovy
+++ b/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertDetailTest.groovy
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal
+
+import spock.lang.Specification
+
+class AlertDetailTest extends Specification {
+
+    def 'test construct Alert'() {
+        given:
+            final message = _ as String
+
+        when:
+            def alertDetail = new AlertDetail(level, message)
+
+        then:
+            alertDetail.getLevel() == level
+            alertDetail.getMessage() == message
+
+        where:
+            level << AlertDetail.Level.values()
+    }
+
+    def 'test construct AlertDetail with an invalid parameter'() {
+        when:
+            new AlertDetail(level, message)
+
+        then:
+            thrown(IllegalArgumentException)
+
+        where:
+            level                   | message
+            null                    | _ as String
+            AlertDetail.Level.ERROR | null
+            AlertDetail.Level.ERROR | ""
+    }
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
+++ b/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
@@ -43,7 +43,7 @@ class AlertTest extends Specification {
     def 'test construct Alert with #details'(details) {
         given:
             final title = _ as String
-            final type = Alert.Type.DANGER
+            final type = Alert.Type.ERROR
             final key = _ as String
 
         when:
@@ -63,7 +63,7 @@ class AlertTest extends Specification {
     def 'test construct Alert with null key'() {
         given:
             final title = _ as String
-            final type = Alert.Type.DANGER
+            final type = Alert.Type.ERROR
             final List<AlertDetail> details = []
 
         when:
@@ -84,11 +84,11 @@ class AlertTest extends Specification {
             thrown(IllegalArgumentException)
 
         where:
-            type              | title       | details | key
-            null              | _ as String | _       | _ as String
-            Alert.Type.DANGER | null        | _       | _ as String
-            Alert.Type.DANGER | ""          | _       | _ as String
-            Alert.Type.DANGER | _ as String | null    | _ as String
-            Alert.Type.DANGER | _ as String | _       | ""
+            type             | title       | details | key
+            null             | _ as String | _       | _ as String
+            Alert.Type.ERROR | null        | _       | _ as String
+            Alert.Type.ERROR | ""          | _       | _ as String
+            Alert.Type.ERROR | _ as String | null    | _ as String
+            Alert.Type.ERROR | _ as String | _       | ""
     }
 }

--- a/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
+++ b/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.core.alert.service.api.internal
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AlertTest extends Specification {
+
+    @Unroll
+    def 'test construct Alert with with #type level'(type) {
+        given:
+            final String title = _ as String
+            final List<AlertDetail> details = []
+            final String key = _ as String
+
+        when:
+            def alert = new Alert(type, title, details, key)
+
+        then:
+            alert.getType() == type
+            alert.getTitle() == title
+            alert.getDetails() == details
+            alert.getKey().isPresent()
+            alert.getKey().get() == key
+
+        where:
+            type << Alert.Type.values()
+    }
+
+    @Unroll
+    def 'test construct Alert with #details'(details) {
+        given:
+            final title = _ as String
+            final type = Alert.Type.DANGER
+            final key = _ as String
+
+        when:
+            def alert = new Alert(type, title, details, key)
+
+        then:
+            alert.getType() == type
+            alert.getTitle() == title
+            alert.getDetails() == details
+            alert.getKey().isPresent()
+            alert.getKey().get() == key
+
+        where:
+            details << [[], [Mock(AlertDetail)], [Mock(AlertDetail), Mock(AlertDetail)]]
+    }
+
+    def 'test construct Alert with null key'() {
+        given:
+            final title = _ as String
+            final type = Alert.Type.DANGER
+            final List<AlertDetail> details = []
+
+        when:
+            def alert = new Alert(type, title, details, null)
+
+        then:
+            alert.getType() == type
+            alert.getTitle() == title
+            alert.getDetails() == details
+            !alert.getKey().isPresent()
+    }
+
+    def 'test construct Alert with an invalid parameter'() {
+        when:
+            new Alert(type, title, details, key)
+
+        then:
+            thrown(IllegalArgumentException)
+
+        where:
+            type              | title       | details | key
+            null              | _ as String | _       | _ as String
+            Alert.Type.DANGER | null        | _       | _ as String
+            Alert.Type.DANGER | ""          | _       | _ as String
+            Alert.Type.DANGER | _ as String | null    | _ as String
+            Alert.Type.DANGER | _ as String | _       | ""
+    }
+}

--- a/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
+++ b/platform/admin/core/admin-core-alertservice-api/src/test/groovy/org/codice/ddf/admin/core/alert/service/api/internal/AlertTest.groovy
@@ -19,38 +19,38 @@ import spock.lang.Unroll
 class AlertTest extends Specification {
 
     @Unroll
-    def 'test construct Alert with with #type level'(type) {
+    def 'test construct Alert with with #level level'(level) {
         given:
             final String title = _ as String
             final List<AlertDetail> details = []
             final String key = _ as String
 
         when:
-            def alert = new Alert(type, title, details, key)
+            def alert = new Alert(level, title, details, key)
 
         then:
-            alert.getType() == type
+            alert.getLevel() == level
             alert.getTitle() == title
             alert.getDetails() == details
             alert.getKey().isPresent()
             alert.getKey().get() == key
 
         where:
-            type << Alert.Type.values()
+            level << Alert.Level.values()
     }
 
     @Unroll
     def 'test construct Alert with #details'(details) {
         given:
             final title = _ as String
-            final type = Alert.Type.ERROR
+            final level = Alert.Level.ERROR
             final key = _ as String
 
         when:
-            def alert = new Alert(type, title, details, key)
+            def alert = new Alert(level, title, details, key)
 
         then:
-            alert.getType() == type
+            alert.getLevel() == level
             alert.getTitle() == title
             alert.getDetails() == details
             alert.getKey().isPresent()
@@ -63,14 +63,14 @@ class AlertTest extends Specification {
     def 'test construct Alert with null key'() {
         given:
             final title = _ as String
-            final type = Alert.Type.ERROR
+            final level = Alert.Level.ERROR
             final List<AlertDetail> details = []
 
         when:
-            def alert = new Alert(type, title, details, null)
+            def alert = new Alert(level, title, details, null)
 
         then:
-            alert.getType() == type
+            alert.getLevel() == level
             alert.getTitle() == title
             alert.getDetails() == details
             !alert.getKey().isPresent()
@@ -78,17 +78,17 @@ class AlertTest extends Specification {
 
     def 'test construct Alert with an invalid parameter'() {
         when:
-            new Alert(type, title, details, key)
+            new Alert(level, title, details, key)
 
         then:
             thrown(IllegalArgumentException)
 
         where:
-            type             | title       | details | key
-            null             | _ as String | _       | _ as String
-            Alert.Type.ERROR | null        | _       | _ as String
-            Alert.Type.ERROR | ""          | _       | _ as String
-            Alert.Type.ERROR | _ as String | null    | _ as String
-            Alert.Type.ERROR | _ as String | _       | ""
+            level             | title       | details | key
+            null              | _ as String | _       | _ as String
+            Alert.Level.ERROR | null        | _       | _ as String
+            Alert.Level.ERROR | ""          | _       | _ as String
+            Alert.Level.ERROR | _ as String | null    | _ as String
+            Alert.Level.ERROR | _ as String | _       | ""
     }
 }

--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/Alert.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/Alert.java
@@ -41,6 +41,10 @@ public class Alert {
         this.level = level;
     }
 
+    /**
+     * @deprecated TODO DDF-2897 Remove Level enum because it is not necessary
+     */
+    @Deprecated
     public enum Level {
         WARN,
         ERROR

--- a/platform/admin/core/pom.xml
+++ b/platform/admin/core/pom.xml
@@ -34,5 +34,6 @@
         <module>admin-core-migration-commands</module>
         <module>admin-core-logviewer</module>
         <module>admin-core-configpolicy</module>
+        <module>admin-core-alertservice-api</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API for System Administrator notifications.

I also made some documentation formatting fixes for the Migration API and the Application Service API.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote @vinamartin @brianfelix @ricklarsen @ahoffer @garrettfreibott 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
- Confirm full build succeeds.
- Review the Documentation.
#### Any background context you want to provide?
See [Design Admin UI Notifications](https://codice.atlassian.net/wiki/display/DDF/Design+Admin+UI+Notifications). This PR is meant to be a base API that should evolve as the need for and type of alerts evolves. The current need for Admin UI alerts (Admin UI banners) includes the `The system is insecure because default configuration values are in use` warning and an alert when logging has failed.
#### What are the relevant tickets?
[DDF-2878](https://codice.atlassian.net/browse/DDF-2878)
#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/8041246/24212696/70818436-0eed-11e7-9b13-435be197d864.png)
#### Checklist:
- [x] Documentation Updated
- [x] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
