### PR TITLE
DDF-2825 [2.10.x] Contributes Configurator service and transactional implementation

### DIFF
--- a/platform/configurator/configurator-api/pom.xml
+++ b/platform/configurator/configurator-api/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>configurator</artifactId>
+        <version>2.10.2-SNAPSHOT</version>
+    </parent>
+
+    <name>DDF :: Configurator :: API</name>
+    <artifactId>configurator-api</artifactId>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Configurator.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Configurator.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface Configurator {
+    /**
+     * Sequentially invokes all the {@link Operation}s, committing their changes. If a failure
+     * occurs during the processing, a rollback is attempted of those handlers that had already been
+     * committed.
+     * <p>
+     * In the case of a successful commit, changes should be logged.
+     *
+     * @param auditMessage In the case of a successful commit, the message to pass to a
+     *                     {@code SecurityLogger}
+     * @param auditParams  In the case of a successful commit, the optional parameters to pass to a
+     *                     {@code SecurityLogger} to be interpolated into the message
+     * @return report of the commit status, whether successful, successfully rolled back, or partially
+     * rolled back with errors
+     */
+    OperationReport commit(String auditMessage, String... auditParams);
+
+    /**
+     * Sequentially invokes all the {@link Operation}s, committing their changes. If a failure
+     * occurs during the processing, a rollback is attempted of those handlers that had already been
+     * committed.
+     *
+     * @return report of the commit status, whether successful, successfully rolled back, or partially
+     * rolled back with errors
+     */
+    OperationReport commit();
+
+    /**
+     * Starts the bundle with the given name.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String startBundle(String bundleSymName);
+
+    /**
+     * Stops the bundle with the given name.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String stopBundle(String bundleSymName);
+
+    /**
+     * Determines if the bundle with the given name is started.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return true if started; else, false
+     */
+    boolean isBundleStarted(String bundleSymName);
+
+    /**
+     * Installs and starts the feature with the given name.
+     *
+     * @param featureName the name of the feature
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String startFeature(String featureName);
+
+    /**
+     * Stops the feature with the given name.
+     *
+     * @param featureName the name of the feature
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String stopFeature(String featureName);
+
+    /**
+     * Determines if the feature with the given name is started.
+     *
+     * @param featureName the name of the feature
+     * @return true if started; else, false
+     */
+    boolean isFeatureStarted(String featureName);
+
+    /**
+     * Creates a property file in the system with the given set of new key:value pairs.
+     *
+     * @param propFile   the property file to create
+     * @param properties the set of key:value pairs to save to the property file
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String createPropertyFile(Path propFile, Map<String, String> properties);
+
+    /**
+     * Deletes a property file in the system.
+     *
+     * @param propFile the property file to delete
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String deletePropertyFile(Path propFile);
+
+    /**
+     * Updates a property file in the system with the given set of new key:value pairs.
+     *
+     * @param propFile    the property file to update
+     * @param properties  the set of key:value pairs to save to the property file
+     * @param keepIgnored if true, then any keys already in the property file will retain their
+     *                    initial values if they are excluded from the {@code properties} param; if
+     *                    false, then the only properties that will be in the updated file are those
+     *                    provided by the {@code properties} param
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String updatePropertyFile(Path propFile, Map<String, String> properties, boolean keepIgnored);
+
+    /**
+     * Gets the current key:value pairs set in the given property file.
+     *
+     * @param propFile the property file to query
+     * @return the current set of key:value pairs
+     */
+    Map<String, String> getProperties(Path propFile);
+
+    /**
+     * Updates a bundle configuration file in the system with the given set of new key:value pairs.
+     *
+     * @param configPid   the configId of the bundle configuration file to update
+     * @param configs     the set of key:value pairs to save in the configuration
+     * @param keepIgnored if true, then any keys already in the config file will retain their
+     *                    initial values if they are excluded from the {@code properties} param; if
+     *                    false, then the only config entires that will be in the updated file are those
+     *                    provided by the {@code properties} param
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String updateConfigFile(String configPid, Map<String, Object> configs, boolean keepIgnored);
+
+    /**
+     * Gets the current key:value pairs set in the given configuration file.
+     *
+     * @param configPid the configId of the bundle configuration file to query
+     * @return the current set of key:value pairs
+     */
+    Map<String, Object> getConfig(String configPid);
+
+    /**
+     * Creates a new managed service for the given factory.
+     *
+     * @param factoryPid the factoryPid of the service to create
+     * @param configs    the set of key:value pairs to save in the new managed service's configuration
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String createManagedService(String factoryPid, Map<String, Object> configs);
+
+    /**
+     * Deletes a managed service.
+     *
+     * @param configPid the configPid of the instance of the service to delete
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    String deleteManagedService(String configPid);
+
+    Map<String, Map<String, Object>> getManagedServiceConfigs(String factoryPid);
+
+    /**
+     * Retrieves the service reference. The reference should only be used for reading purposes,
+     * any changes should be done through a commit
+     *
+     * @param serviceClass - Class of service to retrieve
+     * @return first found service reference of serviceClass
+     * @throws ConfiguratorException if any errors occur
+     */
+    <S> S getServiceReference(Class<S> serviceClass) throws ConfiguratorException;
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorException.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorException.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public class ConfiguratorException extends RuntimeException {
+    public ConfiguratorException(String message) {
+        super(message);
+    }
+
+    public ConfiguratorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorFactory.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorFactory.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface ConfiguratorFactory {
+    Configurator getConfigurator();
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Operation.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Operation.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+/**
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface Operation<T, S> {
+    T commit() throws ConfiguratorException;
+
+    T rollback() throws ConfiguratorException;
+
+    S readState() throws ConfiguratorException;
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/OperationReport.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/OperationReport.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+import java.util.List;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface OperationReport {
+    boolean txactSucceeded();
+
+    Result getResult(String key);
+
+    List<Result> getFailedResults();
+
+    boolean containsFailedResults();
+
+    void putResult(String key, Result result);
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Result.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Result.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+import java.util.Optional;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface Result {
+    boolean isTxactSucceeded();
+
+    Status getStatus();
+
+    Optional<Throwable> getBadOutcome();
+
+    String getConfigId();
+}

--- a/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Status.java
+++ b/platform/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Status.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+/**
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public enum Status {
+    COMMIT_PASSED, COMMIT_FAILED, SKIPPED, ROLLBACK_PASSED, ROLLBACK_FAILED;
+}

--- a/platform/configurator/configurator-impl/pom.xml
+++ b/platform/configurator/configurator-impl/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>configurator</artifactId>
+        <version>2.10.2-SNAPSHOT</version>
+    </parent>
+
+    <name>DDF :: Configurator :: Transactional Implementation</name>
+    <artifactId>configurator-impl</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>configurator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.bundle</groupId>
+            <artifactId>org.apache.karaf.bundle.core</artifactId>
+            <version>${karaf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>org.apache.karaf.features.core</artifactId>
+            <version>${karaf.version}</version>
+        </dependency>
+
+        <!--Spock dependencies-->
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.48</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.39</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.53</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/AdminOperation.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/AdminOperation.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.management.MalformedObjectNameException;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transactional handler for persisting bundle configuration file changes.
+ */
+public class AdminOperation implements OperationBase, Operation<Void, Map<String, Object>> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdminOperation.class);
+
+    private final String pid;
+
+    private final Map<String, Object> configs;
+
+    private final boolean keepIgnored;
+
+    private final ConfigurationAdminMBean cfgAdmMbean;
+
+    private Map<String, Object> currentProperties;
+
+    private AdminOperation(String pid, Map<String, Object> configs, boolean keepIgnored,
+            ConfigurationAdminMBean cfgAdmMbean) {
+        this.pid = pid;
+        this.configs = new HashMap<>(configs);
+        this.keepIgnored = keepIgnored;
+        this.cfgAdmMbean = cfgAdmMbean;
+
+        try {
+            currentProperties = cfgAdmMbean.getProperties(pid);
+        } catch (IOException e) {
+            LOGGER.debug("Error getting current configuration for pid {}", pid, e);
+            throw new ConfiguratorException("Internal error");
+        }
+    }
+
+    /**
+     * Creates a handler for persisting changes to a bundle configuration.
+     *
+     * @param pid                     the configPid of the bundle configuration to be updated
+     * @param configs                 map of key:value pairs to be written to the configuration
+     * @param keepIgnored             if true, any keys in the current config file that are not in the
+     *                                {@code configs} map will be left with their initial values; if false, they
+     *                                will be removed from the file
+     * @param configurationAdminMBean mbean used for updating configuration
+     * @return instance of this class
+     */
+    public static AdminOperation instance(String pid, Map<String, Object> configs,
+            boolean keepIgnored, ConfigurationAdminMBean configurationAdminMBean) {
+        return new AdminOperation(pid, configs, keepIgnored, configurationAdminMBean);
+    }
+
+    @Override
+    public Void commit() throws ConfiguratorException {
+        Map<String, Object> properties;
+        if (keepIgnored) {
+            properties = new HashMap<>(currentProperties);
+        } else {
+            properties = new HashMap<>();
+        }
+        properties.putAll(configs);
+
+        try {
+            saveConfigs(properties);
+        } catch (IOException | MalformedObjectNameException e) {
+            throw new ConfiguratorException(String.format("Error writing configuration for %s",
+                    pid));
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void rollback() throws ConfiguratorException {
+        try {
+            saveConfigs(currentProperties);
+        } catch (IOException | MalformedObjectNameException e) {
+            throw new ConfiguratorException(String.format("Error rolling back configuration for %s",
+                    pid));
+        }
+
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> readState() throws ConfiguratorException {
+        try {
+            Map<String, Object> configResults = getConfigAdminMBean().getProperties(pid);
+            if (configResults.isEmpty()) {
+                Optional<Map<String, Object>> defaultMetatypeValues =
+                        getConfigAdminMBean().listServices()
+                                .stream()
+                                .filter(service -> service.get("id") != null && service.get("id")
+                                        .equals(pid))
+                                .findFirst();
+
+                List<Map<String, Object>> metatypes = new ArrayList<>();
+                if (defaultMetatypeValues.isPresent()) {
+                    metatypes = (List) defaultMetatypeValues.get()
+                            .get("metatype");
+                }
+
+                if (metatypes.isEmpty()) {
+                    return new HashMap<>();
+                }
+
+                return metatypes.stream()
+                        .collect(Collectors.toMap(field -> (String) field.get("id"),
+                                field -> field.get("defaultValue")));
+            } else {
+                return configResults;
+            }
+            // return getConfigAdminMBean().getProperties(pid);
+        } catch (IOException | MalformedObjectNameException e) {
+            throw new ConfiguratorException(String.format("Unable to find configuration for pid, %s",
+                    pid), e);
+        }
+    }
+
+    private void saveConfigs(Map<String, Object> properties)
+            throws MalformedObjectNameException, IOException {
+        cfgAdmMbean.update(pid, properties);
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/BundleOperation.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/BundleOperation.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.util.Arrays;
+
+import org.apache.karaf.bundle.core.BundleState;
+import org.apache.karaf.bundle.core.BundleStateService;
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transactional handler for starting and stopping bundles.
+ */
+public class BundleOperation implements OperationBase, Operation<Void, Boolean> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BundleOperation.class);
+
+    private final boolean newState;
+
+    private final BundleContext bundleContext;
+
+    private final Bundle bundle;
+
+    private final boolean initActivationState;
+
+    private BundleOperation(String bundleSymName, boolean activate, BundleContext bundleContext) {
+        this.newState = activate;
+        this.bundleContext = bundleContext;
+
+        bundle = Arrays.stream(bundleContext.getBundles())
+                .filter(b -> b.getSymbolicName()
+                        .equals(bundleSymName))
+                .findFirst()
+                .orElseThrow(() -> new ConfiguratorException(String.format(
+                        "No bundle found with symbolic name %s",
+                        bundleSymName)));
+        initActivationState = lookupBundleState();
+    }
+
+    /**
+     * Creates a handler that will start a bundle as part of a transaction.
+     *
+     * @param bundleSymName the name of the bundle to start
+     * @param bundleContext context needed for OSGi interaction
+     * @return instance of this class
+     */
+    public static BundleOperation forStart(String bundleSymName, BundleContext bundleContext) {
+        return new BundleOperation(bundleSymName, true, bundleContext);
+    }
+
+    /**
+     * Creates a handler that will stop a bundle as part of a transaction.
+     *
+     * @param bundleSymName the name of the bundle to stop
+     * @param bundleContext context needed for OSGi interaction
+     * @return instance of this class
+     */
+    public static BundleOperation forStop(String bundleSymName, BundleContext bundleContext) {
+        return new BundleOperation(bundleSymName, false, bundleContext);
+    }
+
+    @Override
+    public Void commit() throws ConfiguratorException {
+        try {
+            if (initActivationState != newState) {
+                if (newState) {
+                    bundle.start();
+                } else {
+                    bundle.stop();
+                }
+            }
+        } catch (BundleException e) {
+            LOGGER.debug("Error starting/stopping bundle", e);
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void rollback() throws ConfiguratorException {
+        try {
+            if (initActivationState != lookupBundleState()) {
+                if (initActivationState) {
+                    bundle.start();
+                } else {
+                    bundle.stop();
+                }
+            }
+        } catch (BundleException e) {
+            LOGGER.debug("Error starting/stopping bundle", e);
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return null;
+    }
+
+    @Override
+    public Boolean readState() throws ConfiguratorException {
+        return lookupBundleState();
+    }
+
+    private BundleStateService getBundleStateService() {
+        ServiceReference<BundleStateService> serviceReference = bundleContext.getServiceReference(
+                BundleStateService.class);
+        return bundleContext.getService(serviceReference);
+    }
+
+    private boolean lookupBundleState() {
+        return getBundleStateService().getState(bundle) == BundleState.Active;
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorFactoryImpl.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorFactoryImpl.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfiguratorFactory;
+
+public class ConfiguratorFactoryImpl implements ConfiguratorFactory {
+    @Override
+    public Configurator getConfigurator() {
+        return new ConfiguratorImpl();
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
@@ -1,0 +1,425 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.management.MBeanServerInvocationHandler;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.ui.admin.api.ConfigurationAdmin;
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.security.common.audit.SecurityLogger;
+
+/**
+ * Transactional orchestrator for persisting configuration changes.
+ * <p>
+ * Sequentially processes {@link Operation}s, committing their changes. If a failure occurs
+ * during the processing, a rollback is attempted of those handlers that had already been committed.
+ * When the {@link #commit()} operation completes - either successfully, with a successful rollback,
+ * or with a failure to rollback - it returns a {@link OperationReport} of the outcome. In the case of
+ * rollback failures, callers of this class should inform users of those failures so they may manually
+ * intercede.
+ * <p>
+ * This class does not guarantee that it can reliably rollback changes in the case of failure. It
+ * makes a best-effort to revert changes and reports the outcome.
+ * <p>
+ * To use this class, first instantiate then invoke the various methods for feature, bundle, config,
+ * etc. updates in the order they should be applied. When all have been completed, call the
+ * {@link #commit()} method to write the changes to the system. The resulting {@link OperationReport}
+ * will have the outcome.
+ */
+public class ConfiguratorImpl implements Configurator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfiguratorImpl.class);
+
+    private final Map<String, Operation> configHandlers = new LinkedHashMap<>();
+
+    /**
+     * Sequentially invokes all the {@link Operation}s, committing their changes. If a failure
+     * occurs during the processing, a rollback is attempted of those handlers that had already been
+     * committed.
+     * <p>
+     * In the case of a successful commit, the {@link SecurityLogger} will be invoked to log changes.
+     *
+     * @param auditMessage In the case of a successful commit, the message to pass to the
+     *                     {@link SecurityLogger}
+     * @param auditParams  In the case of a successful commit, the optional parameters to pass to the
+     *                     {@link SecurityLogger} to be interpolated into the message
+     * @return report of the commit status, whether successful, successfully rolled back, or partially
+     * rolled back with errors
+     */
+    public OperationReport commit(String auditMessage, String... auditParams) {
+        OperationReport report = commit();
+        if (report.txactSucceeded()) {
+            SecurityLogger.audit(auditMessage, (Object[]) auditParams);
+        }
+
+        return report;
+    }
+
+    /**
+     * Sequentially invokes all the {@link Operation}s, committing their changes. If a failure
+     * occurs during the processing, a rollback is attempted of those handlers that had already been
+     * committed.
+     *
+     * @return report of the commit status, whether successful, successfully rolled back, or partially
+     * rolled back with errors
+     */
+    public OperationReport commit() {
+        OperationReport configReport = new OperationReportImpl();
+        for (Map.Entry<String, Operation> row : configHandlers.entrySet()) {
+            try {
+                Object commitResult = row.getValue()
+                        .commit();
+                if (commitResult instanceof String) {
+                    configReport.putResult(row.getKey(),
+                            ResultImpl.passManagedService((String) commitResult));
+                } else {
+                    configReport.putResult(row.getKey(), ResultImpl.pass());
+                }
+            } catch (ConfiguratorException e) {
+                LOGGER.debug("Error committing configuration change", e);
+
+                // On failure, attempt to rollback any config changes that have already been made
+                // and then break out of loop processing, only reporting the remaining as skipped
+                rollback(row.getKey(), configReport, e);
+                break;
+            }
+        }
+
+        return configReport;
+    }
+
+    /**
+     * Starts the bundle with the given name.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String startBundle(String bundleSymName) {
+        return registerHandler(BundleOperation.forStart(bundleSymName, getBundleContext()));
+    }
+
+    /**
+     * Stops the bundle with the given name.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String stopBundle(String bundleSymName) {
+        return registerHandler(BundleOperation.forStop(bundleSymName, getBundleContext()));
+    }
+
+    /**
+     * Determines if the bundle with the given name is started.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return true if started; else, false
+     */
+    public boolean isBundleStarted(String bundleSymName) {
+        try {
+            return BundleOperation.forStart(bundleSymName, getBundleContext())
+                    .readState();
+        } catch (ConfiguratorException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Installs and starts the feature with the given name.
+     *
+     * @param featureName the name of the feature
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String startFeature(String featureName) {
+        return registerHandler(FeatureOperation.forStart(featureName, getBundleContext()));
+    }
+
+    /**
+     * Stops the feature with the given name.
+     *
+     * @param featureName the name of the feature
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String stopFeature(String featureName) {
+        return registerHandler(FeatureOperation.forStop(featureName, getBundleContext()));
+    }
+
+    /**
+     * Determines if the feature with the given name is started.
+     *
+     * @param featureName the name of the feature
+     * @return true if started; else, false
+     */
+    public boolean isFeatureStarted(String featureName) {
+        return FeatureOperation.forStart(featureName, getBundleContext())
+                .readState();
+    }
+
+    /**
+     * Creates a property file in the system with the given set of new key:value pairs.
+     *
+     * @param propFile   the property file to create
+     * @param properties the set of key:value pairs to save to the property file
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String createPropertyFile(Path propFile, Map<String, String> properties) {
+        return registerHandler(PropertyOperation.forCreate(propFile, properties));
+    }
+
+    /**
+     * Deletes a property file in the system.
+     *
+     * @param propFile the property file to delete
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String deletePropertyFile(Path propFile) {
+        return registerHandler(PropertyOperation.forDelete(propFile));
+    }
+
+    /**
+     * Updates a property file in the system with the given set of new key:value pairs.
+     *
+     * @param propFile    the property file to update
+     * @param properties  the set of key:value pairs to save to the property file
+     * @param keepIgnored if true, then any keys already in the property file will retain their
+     *                    initial values if they are excluded from the {@code properties} param; if
+     *                    false, then the only properties that will be in the updated file are those
+     *                    provided by the {@code properties} param
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String updatePropertyFile(Path propFile, Map<String, String> properties,
+            boolean keepIgnored) {
+        return registerHandler(PropertyOperation.forUpdate(propFile, properties, keepIgnored));
+    }
+
+    /**
+     * Gets the current key:value pairs set in the given property file.
+     *
+     * @param propFile the property file to query
+     * @return the current set of key:value pairs
+     */
+    public Map<String, String> getProperties(Path propFile) {
+        return PropertyOperation.forUpdate(propFile, Collections.emptyMap(), true)
+                .readState();
+    }
+
+    /**
+     * Updates a bundle configuration file in the system with the given set of new key:value pairs.
+     *
+     * @param configPid   the configId of the bundle configuration file to update
+     * @param configs     the set of key:value pairs to save in the configuration
+     * @param keepIgnored if true, then any keys already in the config file will retain their
+     *                    initial values if they are excluded from the {@code properties} param; if
+     *                    false, then the only config entires that will be in the updated file are those
+     *                    provided by the {@code properties} param
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String updateConfigFile(String configPid, Map<String, Object> configs,
+            boolean keepIgnored) {
+        return registerHandler(AdminOperation.instance(configPid,
+                configs,
+                keepIgnored,
+                getConfigAdminMBean()));
+    }
+
+    /**
+     * Gets the current key:value pairs set in the given configuration file.
+     *
+     * @param configPid the configId of the bundle configuration file to query
+     * @return the current set of key:value pairs
+     */
+    public Map<String, Object> getConfig(String configPid) {
+        return AdminOperation.instance(configPid,
+                Collections.emptyMap(),
+                true,
+                getConfigAdminMBean())
+                .readState();
+    }
+
+    /**
+     * Creates a new managed service for the given factory.
+     *
+     * @param factoryPid the factoryPid of the service to create
+     * @param configs    the set of key:value pairs to save in the new managed service's configuration
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String createManagedService(String factoryPid, Map<String, Object> configs) {
+        return registerHandler(ManagedServiceOperation.forCreate(factoryPid,
+                configs,
+                getConfigAdmin(),
+                getConfigAdminMBean()));
+    }
+
+    /**
+     * Deletes a managed service.
+     *
+     * @param configPid the configPid of the instance of the service to delete
+     * @return a lookup key that can be used to correlate this operation in the
+     * final {@link OperationReport}
+     */
+    public String deleteManagedService(String configPid) {
+        return registerHandler(ManagedServiceOperation.forDelete(configPid,
+                getConfigAdmin(),
+                getConfigAdminMBean()));
+    }
+
+    public Map<String, Map<String, Object>> getManagedServiceConfigs(String factoryPid) {
+        return ManagedServiceOperation.forCreate(factoryPid,
+                Collections.emptyMap(),
+                getConfigAdmin(),
+                getConfigAdminMBean())
+                .readState();
+    }
+
+    /**
+     * Retrieves the service reference. The reference should only be used for reading purposes,
+     * any changes should be done through a commit
+     *
+     * @param serviceClass - Class of service to retrieve
+     * @param <S> type to be returned
+     * @return first found service reference of serviceClass
+     * @throws ConfiguratorException if any errors occur
+     */
+    public <S> S getServiceReference(Class<S> serviceClass) throws ConfiguratorException {
+        BundleContext context = getBundleContext();
+        ServiceReference<S> ref = context.getServiceReference(serviceClass);
+        if (ref == null) {
+            return null;
+        }
+
+        return context.getService(ref);
+    }
+
+    private String registerHandler(Operation handler) {
+        String key = UUID.randomUUID()
+                .toString();
+        configHandlers.put(key, handler);
+        return key;
+    }
+
+    private void rollback(String failedStep, OperationReport configReport,
+            ConfiguratorException exception) {
+        configReport.putResult(failedStep, ResultImpl.fail(exception));
+
+        Deque<Map.Entry<String, Operation>> undoStack = new ArrayDeque<>();
+        boolean skipRest = false;
+
+        for (Map.Entry<String, Operation> row : configHandlers.entrySet()) {
+            if (failedStep.equals(row.getKey())) {
+                skipRest = true;
+            }
+
+            if (!skipRest) {
+                undoStack.push(row);
+            } else if (!failedStep.equals(row.getKey())) {
+                configReport.putResult(row.getKey(), ResultImpl.skip());
+            }
+        }
+
+        for (Map.Entry<String, Operation> row : undoStack) {
+            try {
+                row.getValue()
+                        .rollback();
+
+                configReport.putResult(row.getKey(), ResultImpl.rollback());
+            } catch (ConfiguratorException e) {
+                String configId = configReport.getResult(row.getKey())
+                        .getConfigId();
+                if (configId == null) {
+                    configReport.putResult(row.getKey(), ResultImpl.rollbackFail(e));
+                } else {
+                    configReport.putResult(row.getKey(),
+                            ResultImpl.rollbackFailManagedService(e, configId));
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the OSGi bundle context.
+     *
+     * @return the bundle context
+     * @throws ConfiguratorException if this bundle cannot be found
+     */
+    private BundleContext getBundleContext() throws ConfiguratorException {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle == null) {
+            LOGGER.info("Unable to access bundle context");
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return bundle.getBundleContext();
+    }
+
+    /**
+     * Gets the config admin for working with OSGi features and bundles.
+     *
+     * @return the service wrapper to use for working with features and bundles
+     * @throws ConfiguratorException if there is an error accessing the config admin
+     */
+    private ConfigurationAdmin getConfigAdmin() throws ConfiguratorException {
+        BundleContext context = getBundleContext();
+        ServiceReference<org.osgi.service.cm.ConfigurationAdmin> serviceReference =
+                context.getServiceReference(org.osgi.service.cm.ConfigurationAdmin.class);
+        return new ConfigurationAdmin(context.getService(serviceReference));
+    }
+
+    /**
+     * Gets the config admin mbean for working with OSGi bundle configurations.
+     *
+     * @return the mbean to use for updating bundle configurations
+     * @throws ConfiguratorException if there is an error accessing the mbean
+     */
+    private ConfigurationAdminMBean getConfigAdminMBean() throws ConfiguratorException {
+        try {
+            ObjectName objectName = new ObjectName(ConfigurationAdminMBean.OBJECTNAME);
+            return MBeanServerInvocationHandler.newProxyInstance(ManagementFactory.getPlatformMBeanServer(),
+                    objectName,
+                    ConfigurationAdminMBean.class,
+                    false);
+        } catch (MalformedObjectNameException e) {
+            LOGGER.debug("Unexpected error finding ConfigurationAdminMBean", e);
+            throw new ConfiguratorException("Internal error");
+        }
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/FeatureOperation.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/FeatureOperation.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import static org.apache.karaf.features.FeaturesService.Option.NoAutoRefreshBundles;
+
+import java.util.EnumSet;
+
+import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeatureState;
+import org.apache.karaf.features.FeaturesService;
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transactional handler for starting and stopping features.
+ */
+public class FeatureOperation implements OperationBase, Operation<Void, Boolean> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FeatureOperation.class);
+
+    private final String featureName;
+
+    private final boolean newState;
+
+    private final BundleContext bundleContext;
+
+    private final boolean initActivationState;
+
+    private FeatureOperation(String featureName, boolean newState, BundleContext bundleContext) {
+        this.featureName = featureName;
+        this.newState = newState;
+        this.bundleContext = bundleContext;
+
+        initActivationState = lookupFeatureStatus(getFeaturesService(), featureName);
+    }
+
+    /**
+     * Creates a handler that will start a feature as part of a transaction.
+     *
+     * @param featureName   the name of the feature to start
+     * @param bundleContext context needed for OSGi interaction
+     * @return instance of this class
+     */
+    public static FeatureOperation forStart(String featureName, BundleContext bundleContext) {
+        return new FeatureOperation(featureName, true, bundleContext);
+    }
+
+    /**
+     * Creates a handler that will stop a feature as part of a transaction.
+     *
+     * @param featureName   the name of the feature to stop
+     * @param bundleContext context needed for OSGi interaction
+     * @return instance of this class
+     */
+    public static FeatureOperation forStop(String featureName, BundleContext bundleContext) {
+        return new FeatureOperation(featureName, false, bundleContext);
+    }
+
+    @Override
+    public Void commit() throws ConfiguratorException {
+        FeaturesService featuresService = getFeaturesService();
+        try {
+            if (initActivationState != newState) {
+                if (newState) {
+                    featuresService.installFeature(featureName, EnumSet.of(NoAutoRefreshBundles));
+                } else {
+                    featuresService.uninstallFeature(featureName);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Error installing/uninstalling feature", e);
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void rollback() throws ConfiguratorException {
+        FeaturesService featuresService = getFeaturesService();
+        try {
+            if (initActivationState != lookupFeatureStatus(featuresService, featureName)) {
+                if (initActivationState) {
+                    featuresService.installFeature(featureName, EnumSet.of(NoAutoRefreshBundles));
+                } else {
+                    featuresService.uninstallFeature(featureName);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Error installing/uninstalling feature", e);
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return null;
+    }
+
+    @Override
+    public Boolean readState() throws ConfiguratorException {
+        return lookupFeatureStatus(getFeaturesService(), featureName);
+    }
+
+    private FeaturesService getFeaturesService() {
+        ServiceReference<FeaturesService> serviceReference = bundleContext.getServiceReference(
+                FeaturesService.class);
+        return bundleContext.getService(serviceReference);
+    }
+
+    private Boolean lookupFeatureStatus(FeaturesService featuresService, String featureName)
+            throws ConfiguratorException {
+        try {
+            Feature feature = featuresService.getFeature(featureName);
+            return featuresService.getState(String.format("%s/%s",
+                    feature.getName(),
+                    feature.getVersion())) == FeatureState.Started;
+        } catch (Exception e) {
+            throw new ConfiguratorException(String.format("No feature found named %s", featureName),
+                    e);
+        }
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ManagedServiceOperation.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ManagedServiceOperation.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.admin.configurator.impl;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.MalformedObjectNameException;
+import javax.validation.constraints.NotNull;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.codice.ddf.ui.admin.api.ConfigurationAdmin;
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transactional handler factory for creating and deleting managed services.
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public abstract class ManagedServiceOperation
+        implements OperationBase, Operation<String, Map<String, Map<String, Object>>> {
+    /**
+     * Transactional handler for deleting managed services.
+     */
+    private static class DeleteHandler extends ManagedServiceOperation {
+        private final String configPid;
+
+        private Map<String, Object> currentProperties;
+
+        private DeleteHandler(String configPid, ConfigurationAdmin configAdmin,
+                ConfigurationAdminMBean cfgAdmMbean) {
+            super(configAdmin, cfgAdmMbean);
+
+            this.configPid = configPid;
+
+            try {
+                factoryPid = cfgAdmMbean.getFactoryPid(configPid);
+                currentProperties = cfgAdmMbean.getProperties(configPid);
+            } catch (IOException e) {
+                ManagedServiceOperation.LOGGER.debug(
+                        "Error getting current configuration for pid {}",
+                        configPid,
+                        e);
+                throw new ConfiguratorException("Internal error");
+            }
+        }
+
+        @Override
+        public String commit() throws ConfiguratorException {
+            deleteByPid(configPid);
+            return null;
+        }
+
+        @Override
+        public String rollback() throws ConfiguratorException {
+            return createManagedService(currentProperties);
+        }
+    }
+
+    /**
+     * Transactional handler for creating managed services.
+     */
+    private static class CreateHandler extends ManagedServiceOperation {
+        private final Map<String, Object> configs;
+
+        private String newConfigPid;
+
+        private CreateHandler(String factoryPid, Map<String, Object> configs,
+                ConfigurationAdmin configAdmin, ConfigurationAdminMBean cfgAdmMbean) {
+            super(configAdmin, cfgAdmMbean);
+
+            this.factoryPid = factoryPid;
+            this.configs = new HashMap<>(configs);
+        }
+
+        @Override
+        public String commit() throws ConfiguratorException {
+            newConfigPid = createManagedService(configs);
+            return newConfigPid;
+        }
+
+        @Override
+        public String rollback() throws ConfiguratorException {
+            deleteByPid(newConfigPid);
+            return null;
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagedServiceOperation.class);
+
+    protected String factoryPid;
+
+    protected final ConfigurationAdmin configAdmin;
+
+    protected final ConfigurationAdminMBean cfgAdmMbean;
+
+    private ManagedServiceOperation(ConfigurationAdmin configAdmin,
+            ConfigurationAdminMBean cfgAdmMbean) {
+        this.configAdmin = configAdmin;
+        this.cfgAdmMbean = cfgAdmMbean;
+    }
+
+    /**
+     * Creates a handler that will create a managed service as part of a transaction.
+     *
+     * @param factoryPid  the PID of the service factory
+     * @param configs     the configuration properties to apply to the service
+     * @param configAdmin service wrapper needed for OSGi interaction
+     * @param cfgAdmMbean mbean needed for saving configuration data
+     * @return a service operation object
+     */
+    public static ManagedServiceOperation forCreate(String factoryPid,
+            @NotNull Map<String, Object> configs, ConfigurationAdmin configAdmin,
+            ConfigurationAdminMBean cfgAdmMbean) {
+        return new CreateHandler(factoryPid, configs, configAdmin, cfgAdmMbean);
+    }
+
+    /**
+     * Creates a handler that will delete a managed service as part of a transaction.
+     *
+     * @param pid         the PID of the instance to be deleted
+     * @param configAdmin service wrapper needed for OSGi interaction
+     * @param cfgAdmMbean mbean needed for saving configuration data
+     * @return a service operation object
+     */
+    public static ManagedServiceOperation forDelete(String pid, ConfigurationAdmin configAdmin,
+            ConfigurationAdminMBean cfgAdmMbean) {
+        return new DeleteHandler(pid, configAdmin, cfgAdmMbean);
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> readState() throws ConfiguratorException {
+        try {
+            String[][] configurations = getConfigAdmin().getConfigurations(String.format(
+                    "(service.factoryPid=%s)",
+                    factoryPid));
+            if (configurations == null || configurations.length == 0) {
+                return Collections.emptyMap();
+            }
+
+            HashMap<String, Map<String, Object>> retVal = new HashMap<>();
+            ConfigurationAdminMBean configAdminMBean = getConfigAdminMBean();
+
+            for (String[] configuration : configurations) {
+                String configPid = configuration[0];
+                retVal.put(configPid, configAdminMBean.getProperties(configPid));
+            }
+
+            return retVal;
+        } catch (IOException | MalformedObjectNameException e) {
+            LOGGER.debug("Error retrieving configurations for factoryPid, {}", factoryPid, e);
+            throw new ConfiguratorException("Error retrieving configurations");
+        }
+    }
+
+    protected void deleteByPid(String configPid) {
+        try {
+            if (factoryPid == null) {
+                ManagedServiceOperation.LOGGER.debug("Error getting factory for pid {}", configPid);
+                throw new ConfiguratorException("Internal error");
+            }
+            cfgAdmMbean.delete(configPid);
+        } catch (IOException e) {
+            LOGGER.debug("Error deleting managed service with pid {}", configPid, e);
+            throw new ConfiguratorException("Internal error");
+        }
+    }
+
+    protected String createManagedService(Map<String, Object> properties) {
+        try {
+            String configPid = configAdmin.createFactoryConfiguration(factoryPid);
+            cfgAdmMbean.update(configPid, properties);
+            return configPid;
+        } catch (IOException e) {
+            LOGGER.debug("Error creating managed service for factoryPid {}", factoryPid, e);
+            throw new ConfiguratorException("Internal error");
+        }
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/OperationBase.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/OperationBase.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServerInvocationHandler;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.ui.admin.api.ConfigurationAdmin;
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface OperationBase {
+    Logger LOGGER = LoggerFactory.getLogger(OperationBase.class);
+
+    default BundleContext getBundleContext() throws ConfiguratorException {
+        Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+        if (bundle == null) {
+            LOGGER.info("Unable to access bundle context");
+            throw new ConfiguratorException("Internal error");
+        }
+
+        return bundle.getBundleContext();
+    }
+
+    default ConfigurationAdmin getConfigAdmin() {
+        BundleContext context = getBundleContext();
+        ServiceReference<org.osgi.service.cm.ConfigurationAdmin> serviceReference =
+                context.getServiceReference(org.osgi.service.cm.ConfigurationAdmin.class);
+        return new ConfigurationAdmin(context.getService(serviceReference));
+    }
+
+    default ConfigurationAdminMBean getConfigAdminMBean() throws MalformedObjectNameException {
+        ObjectName objectName = new ObjectName(ConfigurationAdminMBean.OBJECTNAME);
+
+        return MBeanServerInvocationHandler.newProxyInstance(ManagementFactory.getPlatformMBeanServer(),
+                objectName,
+                ConfigurationAdminMBean.class,
+                false);
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/OperationReportImpl.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/OperationReportImpl.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.configurator.Result;
+
+public class OperationReportImpl implements OperationReport {
+    private final Map<String, Result> results = new LinkedHashMap<>();
+
+    public boolean txactSucceeded() {
+        return results.values()
+                .stream()
+                .allMatch(Result::isTxactSucceeded);
+    }
+
+    public Result getResult(String key) {
+        return results.get(key);
+    }
+
+    public List<Result> getFailedResults() {
+        return results.values()
+                .stream()
+                .filter(((Predicate<Result>) Result::isTxactSucceeded).negate())
+                .collect(Collectors.toList());
+    }
+
+    public boolean containsFailedResults() {
+        return getFailedResults().size() != 0;
+    }
+
+    @Override
+    public void putResult(String key, Result result) {
+        results.put(key, result);
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/PropertyOperation.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/PropertyOperation.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+
+/**
+ * Transactional handler for persisting property file changes.
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public abstract class PropertyOperation
+        implements OperationBase, Operation<Void, Map<String, String>> {
+    /**
+     * Transactional handler for creating property files
+     */
+    private static class CreateHandler extends PropertyOperation {
+        private CreateHandler(Path configFile, Map<String, String> configs) {
+            super(configFile, configs, false);
+        }
+
+        @Override
+        public Void commit() throws ConfiguratorException {
+            Map<String, String> propertyMap = new HashMap<>();
+            propertyMap.putAll(configs);
+            saveProperties(propertyMap);
+
+            return null;
+        }
+
+        @Override
+        public Void rollback() throws ConfiguratorException {
+            boolean delete = configFile.delete();
+            if (!delete) {
+                LOGGER.debug("Problem deleting properties file {} for rollback", configFile);
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Transactional handler for deleting property files
+     */
+    private static class DeleteHandler extends PropertyOperation {
+        private DeleteHandler(Path configFile) {
+            super(configFile, Collections.emptyMap(), true);
+        }
+
+        @Override
+        public Void commit() throws ConfiguratorException {
+            boolean delete = configFile.delete();
+            if (!delete) {
+                LOGGER.debug("Problem deleting properties file {} for rollback", configFile);
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Transactional handler for updating property files
+     */
+    private static class UpdateHandler extends PropertyOperation {
+        private final boolean keepIgnored;
+
+        UpdateHandler(Path configFile, Map<String, String> configs, boolean keepIgnored) {
+            super(configFile, configs, true);
+
+            this.keepIgnored = keepIgnored;
+        }
+
+        @Override
+        public Void commit() throws ConfiguratorException {
+            Map<String, String> propertyMap = new HashMap<>();
+
+            if (keepIgnored) {
+                propertyMap.putAll(currentProperties);
+            }
+            propertyMap.putAll(configs);
+            saveProperties(propertyMap);
+
+            return null;
+        }
+    }
+
+    final File configFile;
+
+    protected final Map<String, String> configs;
+
+    final Map<String, String> currentProperties;
+
+    private PropertyOperation(Path configFile, Map<String, String> configs,
+            boolean loadCurrentProps) {
+        this.configFile = configFile.toFile();
+        this.configs = new HashMap<>(configs);
+
+        currentProperties = new HashMap<>();
+        if (loadCurrentProps) {
+            Properties result;
+            try {
+                Properties props = new Properties();
+                try (FileInputStream in = new FileInputStream(configFile.toFile())) {
+                    props.load(in);
+                }
+
+                result = props;
+            } catch (IOException e) {
+                throw new ConfiguratorException(String.format(
+                        "Error reading configuration from file %s",
+                        configFile.toFile()
+                                .getName()));
+            }
+
+            result.keySet()
+                    .stream()
+                    .map(String.class::cast)
+                    .forEach(k -> currentProperties.put(k, result.getProperty(k)));
+        }
+    }
+
+    /**
+     * Creates a handler for persisting property file changes to a new property file.
+     *
+     * @param configFile the property file to be created
+     * @param configs    map of key:value pairs to be written to the property file
+     * @return instance of this class
+     */
+    public static PropertyOperation forCreate(Path configFile, Map<String, String> configs) {
+        return new PropertyOperation.CreateHandler(configFile, configs);
+    }
+
+    /**
+     * Creates a handler for deleting a property file.
+     *
+     * @param configFile the property file to be deleted
+     * @return instance of this class
+     */
+    public static Operation forDelete(Path configFile) {
+        return new PropertyOperation.DeleteHandler(configFile);
+    }
+
+    /**
+     * Creates a handler for persisting property file changes to an existing property file.
+     *
+     * @param configFile  the property file to be updated
+     * @param configs     map of key:value pairs to be written to the property file
+     * @param keepIgnored if true, any keys in the current property file that are not in the
+     *                    {@code configs} map will be left with their initial values; if false, they
+     *                    will be removed from the file
+     * @return instance of this class
+     */
+    public static PropertyOperation forUpdate(Path configFile, Map<String, String> configs,
+            boolean keepIgnored) {
+        return new PropertyOperation.UpdateHandler(configFile, configs, keepIgnored);
+    }
+
+    @Override
+    public Void rollback() throws ConfiguratorException {
+        saveProperties(currentProperties);
+
+        return null;
+    }
+
+    @Override
+    public Map<String, String> readState() throws ConfiguratorException {
+        return currentProperties;
+    }
+
+    void saveProperties(Map<String, String> propertyMap) throws ConfiguratorException {
+        Properties properties = new Properties();
+        properties.putAll(propertyMap);
+        try (FileOutputStream out = new FileOutputStream(configFile)) {
+            properties.store(out, null);
+        } catch (IOException e) {
+            LOGGER.debug("Error writing properties to file {}", configFile, e);
+            throw new ConfiguratorException("Error writing properties to file");
+        }
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ResultImpl.java
+++ b/platform/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ResultImpl.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import java.util.Optional;
+
+import org.codice.ddf.admin.configurator.Result;
+import org.codice.ddf.admin.configurator.Status;
+
+public class ResultImpl implements Result {
+
+    private final Status status;
+
+    private final Throwable badOutcome;
+
+    private final String configId;
+
+    private ResultImpl(Status status, Throwable badOutcome, String configId) {
+        this.status = status;
+        this.badOutcome = badOutcome;
+        this.configId = configId;
+    }
+
+    static Result pass() {
+        return new ResultImpl(Status.COMMIT_PASSED, null, null);
+    }
+
+    static Result passManagedService(String configId) {
+        return new ResultImpl(Status.COMMIT_PASSED, null, configId);
+    }
+
+    static Result fail(Throwable throwable) {
+        return new ResultImpl(Status.COMMIT_FAILED, throwable, null);
+    }
+
+    static Result rollback() {
+        return new ResultImpl(Status.ROLLBACK_PASSED, null, null);
+    }
+
+    static Result rollbackFail(Throwable throwable) {
+        return new ResultImpl(Status.ROLLBACK_FAILED, throwable, null);
+    }
+
+    static Result rollbackFailManagedService(Throwable throwable, String configId) {
+        return new ResultImpl(Status.ROLLBACK_FAILED, throwable, configId);
+    }
+
+    static Result skip() {
+        return new ResultImpl(Status.SKIPPED, null, null);
+    }
+
+    @Override
+    public boolean isTxactSucceeded() {
+        return status == Status.COMMIT_PASSED;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public Optional<Throwable> getBadOutcome() {
+        return Optional.ofNullable(badOutcome);
+    }
+
+    @Override
+    public String getConfigId() {
+        return configId;
+    }
+}

--- a/platform/configurator/configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/configurator/configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <service interface="org.codice.ddf.admin.configurator.ConfiguratorFactory">
+        <service-properties>
+            <entry key="type" value="txact"/>
+        </service-properties>
+
+        <bean class="org.codice.ddf.admin.configurator.impl.ConfiguratorFactoryImpl"/>
+    </service>
+
+</blueprint>

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/AdminOperationTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/AdminOperationTest.groovy
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl
+
+import org.codice.ddf.admin.configurator.ConfiguratorException
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean
+import spock.lang.Specification
+
+class AdminOperationTest extends Specification {
+    def initProps
+
+    def setup() {
+        initProps = [key1: 'val1', key2: 'val2', key3: 'val3']
+    }
+
+    def 'test write configs to an unknown bundle fails'() {
+        setup:
+        def cfgMbean = Mock(ConfigurationAdminMBean)
+        cfgMbean.getProperties('xxx') >> { throw new IOException('unknown pid') }
+        def newProps = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+
+        when:
+        def handler = AdminOperation.instance('xxx', newProps, false, cfgMbean)
+
+        then:
+        thrown(ConfiguratorException)
+    }
+
+    def 'test write new configs and keep old configs'() {
+        setup:
+        def cfgMbean = Mock(ConfigurationAdminMBean)
+        def newProps = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def combinedProps = initProps << newProps
+
+        when:
+        def handler = AdminOperation.instance('xxx', newProps, true, cfgMbean)
+
+        then:
+        1 * cfgMbean.getProperties('xxx') >> initProps
+
+        when:
+        handler.commit()
+
+        then:
+        1 * cfgMbean.update('xxx', combinedProps)
+    }
+
+    def 'test write new configs and remove old configs'() {
+        setup:
+        def cfgMbean = Mock(ConfigurationAdminMBean)
+        def newProps = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+
+        when:
+        def handler = AdminOperation.instance('xxx', newProps, false, cfgMbean)
+
+        then:
+        1 * cfgMbean.getProperties('xxx') >> initProps
+
+        when:
+        handler.commit()
+
+        then:
+        1 * cfgMbean.update('xxx', newProps)
+    }
+
+    def 'test rollback'() {
+        setup:
+        def cfgMbean = Mock(ConfigurationAdminMBean)
+        def newProps = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+
+        when:
+        def handler = AdminOperation.instance('xxx', newProps, false, cfgMbean)
+
+        then:
+        1 * cfgMbean.getProperties('xxx') >> initProps
+
+        when:
+        handler.commit()
+
+        then:
+        1 * cfgMbean.update('xxx', newProps)
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * cfgMbean.update('xxx', initProps)
+    }
+}

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/BundleConfigHandlerTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/BundleConfigHandlerTest.groovy
@@ -1,0 +1,114 @@
+package org.codice.ddf.admin.configurator.impl
+
+import org.apache.karaf.bundle.core.BundleState
+import org.apache.karaf.bundle.core.BundleStateService
+import org.codice.ddf.admin.configurator.ConfiguratorException
+import org.osgi.framework.Bundle
+import org.osgi.framework.BundleContext
+import org.osgi.framework.ServiceReference
+import spock.lang.Specification
+
+class BundleConfigHandlerTest extends Specification {
+    private BundleStateService bundleStateService
+    private ServiceReference serviceReference
+    private BundleContext bundleContext
+    private Bundle bundle
+
+    def setup() {
+        bundle = Mock(Bundle)
+        bundle.getSymbolicName() >> 'xxx'
+
+        bundleStateService = Mock(BundleStateService)
+
+        serviceReference = Mock(ServiceReference)
+
+        bundleContext = Mock(BundleContext)
+        bundleContext.getServiceReference(BundleStateService) >> serviceReference
+        bundleContext.getService(serviceReference) >> bundleStateService
+        bundleContext.getBundles() >> [bundle]
+    }
+
+    def 'test start bundle that does not exist'() {
+        when:
+        BundleOperation.forStart('doesnotexist', bundleContext)
+
+        then:
+        thrown(ConfiguratorException)
+    }
+
+    def 'test start bundle that was stopped and rollback'() {
+        setup:
+        bundleStateService.getState(bundle) >>> [BundleState.Installed, BundleState.Active]
+        def handler = BundleOperation.forStart('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        1 * bundle.start()
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * bundle.stop()
+    }
+
+    def 'test stop bundle that was started and rollback'() {
+        setup:
+        bundleStateService.getState(bundle) >>> [BundleState.Active, BundleState.Installed]
+        def handler = BundleOperation.forStop('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        1 * bundle.stop()
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * bundle.start()
+    }
+
+    def 'test start bundle that was already started and rollback'() {
+        setup:
+        bundleStateService.getState(bundle) >> BundleState.Active
+        def handler = BundleOperation.forStart('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        0 * bundle.start()
+        0 * bundle.stop()
+
+        when:
+        handler.rollback()
+
+        then:
+        0 * bundle.start()
+        0 * bundle.stop()
+    }
+
+    def 'test stop bundle that was already stopped and rollback'() {
+        setup:
+        bundleStateService.getState(bundle) >> BundleState.Installed
+        def handler = BundleOperation.forStop('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        0 * bundle.start()
+        0 * bundle.stop()
+
+        when:
+        handler.rollback()
+
+        then:
+        0 * bundle.start()
+        0 * bundle.stop()
+    }
+}

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/FeatureConfigHandlerTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/FeatureConfigHandlerTest.groovy
@@ -1,0 +1,107 @@
+package org.codice.ddf.admin.configurator.impl
+
+import org.apache.karaf.features.Feature
+import org.apache.karaf.features.FeatureState
+import org.apache.karaf.features.FeaturesService
+import org.osgi.framework.BundleContext
+import org.osgi.framework.ServiceReference
+import spock.lang.Specification
+
+import static org.apache.karaf.features.FeaturesService.Option.NoAutoRefreshBundles
+
+class FeatureConfigHandlerTest extends Specification {
+    public static final String FEATURE_NAME_AND_VERSION = 'xxx/0.1.0'
+    private ServiceReference serviceReference
+    private FeaturesService featuresService
+    private BundleContext bundleContext
+
+    def setup() {
+        featuresService = Mock(FeaturesService)
+        def feature = Mock(Feature)
+        feature.getName() >> 'xxx'
+        feature.getVersion() >> '0.1.0'
+        featuresService.getFeature('xxx') >> feature
+
+        serviceReference = Mock(ServiceReference)
+
+        bundleContext = Mock(BundleContext)
+        bundleContext.getServiceReference(FeaturesService) >> serviceReference
+        bundleContext.getService(serviceReference) >> featuresService
+    }
+
+    def 'test start feature that was stopped and rollback'() {
+        setup:
+        featuresService.getState(FEATURE_NAME_AND_VERSION) >>> [FeatureState.Installed, FeatureState.Started]
+        def handler = FeatureOperation.forStart('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        1 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * featuresService.uninstallFeature('xxx')
+    }
+
+    def 'test stop feature that was started and rollback'() {
+        setup:
+        featuresService.getState(FEATURE_NAME_AND_VERSION) >>> [FeatureState.Started, FeatureState.Installed]
+        def handler = FeatureOperation.forStop('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        1 * featuresService.uninstallFeature('xxx')
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+    }
+
+    def 'test start feature that was already started and rollback'() {
+        setup:
+        featuresService.getState(FEATURE_NAME_AND_VERSION) >> FeatureState.Started
+        def handler = FeatureOperation.forStart('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        0 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+        0 * featuresService.uninstallFeature('xxx')
+
+        when:
+        handler.rollback()
+
+        then:
+        0 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+        0 * featuresService.uninstallFeature('xxx')
+    }
+
+    def 'test stop feature that was already stopped and rollback'() {
+        setup:
+        featuresService.getState(FEATURE_NAME_AND_VERSION) >> FeatureState.Installed
+        def handler = FeatureOperation.forStop('xxx', bundleContext)
+
+        when:
+        handler.commit()
+
+        then:
+        0 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+        0 * featuresService.uninstallFeature('xxx')
+
+        when:
+        handler.rollback()
+
+        then:
+        0 * featuresService.installFeature('xxx', EnumSet.of(NoAutoRefreshBundles))
+        0 * featuresService.uninstallFeature('xxx')
+    }
+}

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/ManagedServiceHandlerTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/ManagedServiceHandlerTest.groovy
@@ -1,0 +1,72 @@
+package org.codice.ddf.admin.configurator.impl
+
+import org.codice.ddf.admin.configurator.ConfiguratorException
+import org.codice.ddf.ui.admin.api.ConfigurationAdmin
+import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean
+import spock.lang.Specification
+
+class ManagedServiceHandlerTest extends Specification {
+    private ConfigurationAdmin configAdmin
+    private ConfigurationAdminMBean cfgAdmMbean
+
+    def setup() {
+        configAdmin = Mock(ConfigurationAdmin)
+        cfgAdmMbean = Mock(ConfigurationAdminMBean)
+    }
+
+    def 'test create managed service and rollback'() {
+        def configs = [k1: 'v1', k2: 'v2']
+        setup:
+        def handler = ManagedServiceOperation.forCreate('xxx', configs, configAdmin, cfgAdmMbean)
+
+        when:
+        def key = handler.commit()
+
+        then:
+        1 * configAdmin.createFactoryConfiguration('xxx') >> 'newPid'
+        1 * cfgAdmMbean.update('newPid', configs)
+        key == 'newPid'
+
+        when:
+        handler.rollback()
+
+        then:
+        1 * cfgAdmMbean.delete('newPid')
+    }
+
+    def 'test delete managed service and rollback'() {
+        setup:
+        def configs = [k1: 'v1', k2: 'v2']
+        cfgAdmMbean.getFactoryPid('xxx') >> 'factoryPid'
+        cfgAdmMbean.getProperties('xxx') >> configs
+        def handler = ManagedServiceOperation.forDelete('xxx', configAdmin, cfgAdmMbean)
+
+        when:
+        handler.commit()
+
+        then:
+        1 * cfgAdmMbean.delete('xxx')
+
+        when:
+        def key = handler.rollback()
+
+        then:
+        1 * configAdmin.createFactoryConfiguration('factoryPid') >> 'newPid'
+        1 * cfgAdmMbean.update('newPid', configs)
+        key == 'newPid'
+    }
+
+    def 'test delete of pid with unknown factory pid fails'() {
+        setup:
+        def configs = [k1: 'v1', k2: 'v2']
+        cfgAdmMbean.getFactoryPid('xxx') >> null
+        cfgAdmMbean.getProperties('xxx') >> configs
+        def handler = ManagedServiceOperation.forDelete('xxx', configAdmin, cfgAdmMbean)
+
+        when:
+        handler.commit()
+
+        then:
+        thrown ConfiguratorException
+    }
+}

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/OperationReportTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/OperationReportTest.groovy
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.configurator.impl
+
+import org.codice.ddf.admin.configurator.OperationReport
+import spock.lang.Specification
+
+class OperationReportTest extends Specification {
+    OperationReport report
+
+    def setup() {
+        report = new OperationReportImpl()
+    }
+
+    def 'check report with no failures'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def pass2 = ResultImpl.pass()
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', pass2)
+
+        then:
+        report.txactSucceeded()
+        !report.containsFailedResults()
+        report.getFailedResults() == []
+        report.getResult('a1') == pass1
+        report.getResult('b2') == pass2
+    }
+
+    def 'report with failures'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def throwable = Mock(Throwable)
+        def fail1 = ResultImpl.fail(throwable)
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', fail1)
+
+        then:
+        !report.txactSucceeded()
+        report.containsFailedResults()
+        report.getFailedResults() == [fail1]
+        report.getResult('a1') == pass1
+        report.getResult('b2') == fail1
+        report.getResult('b2').badOutcome.get() == throwable
+    }
+
+    def 'pass with a managed service'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def pass2 = ResultImpl.passManagedService('serviceId1')
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', pass2)
+
+        then:
+        report.txactSucceeded()
+        !report.containsFailedResults()
+        report.getFailedResults() == []
+        report.getResult('a1') == pass1
+        report.getResult('b2') == pass2
+        report.getResult('b2').configId == 'serviceId1'
+    }
+
+    def 'rollback success'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def roll1 = ResultImpl.rollback()
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', roll1)
+
+        then:
+        !report.txactSucceeded()
+        report.containsFailedResults()
+        report.getFailedResults() == [roll1]
+        report.getResult('a1') == pass1
+        report.getResult('b2') == roll1
+    }
+
+    def 'rollback failed'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def throwable = Mock(Throwable)
+        def roll1 = ResultImpl.rollbackFail(throwable)
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', roll1)
+
+        then:
+        !report.txactSucceeded()
+        report.containsFailedResults()
+        report.getFailedResults() == [roll1]
+        report.getResult('a1') == pass1
+        report.getResult('b2') == roll1
+        report.getResult('b2').badOutcome.get() == throwable
+    }
+
+    def 'rollback failed on a managed service'() {
+        setup:
+        def pass1 = ResultImpl.pass()
+        def throwable = Mock(Throwable)
+        def roll1 = ResultImpl.rollbackFailManagedService(throwable, 'serviceId1')
+
+        when:
+        report.putResult('a1', pass1)
+        report.putResult('b2', roll1)
+
+        then:
+        !report.txactSucceeded()
+        report.containsFailedResults()
+        report.getFailedResults() == [roll1]
+        report.getResult('a1') == pass1
+        report.getResult('b2') == roll1
+        report.getResult('b2').badOutcome.get() == throwable
+        report.getResult('b2').configId == 'serviceId1'
+    }
+
+    def 'test skipped rollback step'() {
+        setup:
+        def roll1 = ResultImpl.rollback()
+        def skip1 = ResultImpl.skip()
+
+        when:
+        report.putResult('b2', roll1)
+        report.putResult('c3', skip1)
+
+        then:
+        !report.txactSucceeded()
+        report.containsFailedResults()
+        report.getFailedResults() == [roll1, skip1]
+        report.getResult('b2') == roll1
+        report.getResult('c3') == skip1
+    }
+}

--- a/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/PropertyConfigHandlerTest.groovy
+++ b/platform/configurator/configurator-impl/src/test/groovy/org/codice/ddf/admin/configurator/impl/PropertyConfigHandlerTest.groovy
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl
+
+import org.codice.ddf.admin.configurator.ConfiguratorException
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+class PropertyConfigHandlerTest extends Specification {
+    @Rule
+    TemporaryFolder tempFolder
+
+    @Shared
+    File workFolder
+
+    @Shared
+    File file
+
+    def setup() {
+        workFolder = tempFolder.newFolder()
+        file = new File(workFolder, 'test.properties')
+
+        def initProps = new Properties()
+        initProps.put('key1', 'val1')
+        initProps.put('key2', 'val2')
+        initProps.put('key3', 'val3')
+        file.newWriter().with {
+            initProps.store(it, null)
+        }
+    }
+
+    def 'test write properties to a new file'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def newFile = new File(workFolder, "doesnotexistyet.properties")
+        def props = new Properties()
+        def handler = PropertyOperation.forCreate(newFile.toPath(), configs)
+
+        when:
+        handler.commit()
+        newFile.newReader().with {
+            props.load(it)
+        }
+
+        then:
+        props.getProperty('key1') == 'newVal1'
+        props.getProperty('key4') == 'val4'
+        props.getProperty('key5') == 'val5'
+    }
+
+    def 'test rollback new properties file causes delete'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def newFile = new File(workFolder, "doesnotexistyet.properties")
+        def handler = PropertyOperation.forCreate(newFile.toPath(), configs)
+
+        when:
+        handler.commit()
+        handler.rollback()
+
+        then:
+        !newFile.exists()
+    }
+
+    def 'test delete and rollback'() {
+        setup:
+        def handler = PropertyOperation.forDelete(file.toPath())
+        def props = new Properties()
+
+        when:
+        handler.commit()
+
+        then:
+        !file.exists()
+
+        when:
+        handler.rollback()
+        file.newReader().with {
+            props.load(it)
+        }
+
+        then:
+        file.exists()
+        props.getProperty('key1') == 'val1'
+        props.getProperty('key2') == 'val2'
+        props.getProperty('key3') == 'val3'
+    }
+
+    def 'test update properties to an unknown file fails'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def badFile = new File(workFolder, "doesnotexist")
+
+        when:
+        def handler = PropertyOperation.forUpdate(badFile.toPath(), configs, true)
+
+        then:
+        thrown(ConfiguratorException)
+    }
+
+    def 'test write new properties and keep old properties'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def handler = PropertyOperation.forUpdate(file.toPath(), configs, true)
+        def props = new Properties()
+
+        when:
+        handler.commit()
+        file.newReader().with {
+            props.load(it)
+        }
+
+        then:
+        props.getProperty('key1') == 'newVal1'
+        props.getProperty('key2') == 'val2'
+        props.getProperty('key3') == 'val3'
+        props.getProperty('key4') == 'val4'
+        props.getProperty('key5') == 'val5'
+    }
+
+    def 'test write new properties and remove old properties'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def handler = PropertyOperation.forUpdate(file.toPath(), configs, false)
+        def props = new Properties()
+
+        when:
+        handler.commit()
+        file.newReader().with {
+            props.load(it)
+        }
+
+        then:
+        props.getProperty('key1') == 'newVal1'
+        props.getProperty('key4') == 'val4'
+        props.getProperty('key5') == 'val5'
+    }
+
+    def 'test rollback'() {
+        setup:
+        def configs = [key1: 'newVal1', key4: 'val4', key5: 'val5']
+        def handler = PropertyOperation.forUpdate(file.toPath(), configs, false)
+        def props = new Properties()
+
+        when:
+        handler.commit()
+        handler.rollback()
+        file.newReader().with {
+            props.load(it)
+        }
+
+        then:
+        props.getProperty('key1') == 'val1'
+        props.getProperty('key2') == 'val2'
+        props.getProperty('key3') == 'val3'
+        props.getProperty('key4') == null
+        props.getProperty('key5') == null
+    }
+}

--- a/platform/configurator/pom.xml
+++ b/platform/configurator/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>platform</artifactId>
+        <version>2.10.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>configurator</artifactId>
+    <name>DDF :: Configurator</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>configurator-api</module>
+        <module>configurator-impl</module>
+    </modules>
+</project>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -371,6 +371,7 @@
         <module>error</module>
         <module>platform-http-proxy</module>
         <module>admin</module>
+        <module>configurator</module>
         <module>landing-page</module>
         <module>country-converter</module>
         <module>platform-app</module>


### PR DESCRIPTION
#### What does this PR do?
This pulls the Configurator service from the [admin-beta-console Connexta repository](https://github.com/connexta/admin-console-beta).

History on the service prior to this contribution can be found from this location: https://github.com/connexta/admin-console-beta/tree/f910923b5ff2b326cfb5654fb954c8ac851d9068/configurator

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@stustison @paouelle 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
This is a new service with no callers in DDF. To properly test, a caller can be written to utilize the Configurator to update/create services, properties files, etc.

#### Any background context you want to provide?
This functionality begins the process of extracting configuration away from low-level constructs to support simplified administration and node setup.

#### What are the relevant tickets?
[DDF-2825](https://codice.atlassian.net/browse/DDF-2825)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
