### PR TITLE
DDF-2869 Rework ConfigurationFilesPoller to be more reliable

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/utils/LoggingUtils.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/utils/LoggingUtils.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.itests.common.utils;
+
+import static org.junit.Assert.fail;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class LoggingUtils {
+    /**
+     * The stacktrace of {@code throwable} will be appended to {@code message}.
+     * It is the responsibility of the caller to end their message with a space or newline.
+     *
+     * @param throwable contains the stacktrace to be logged
+     * @param message a descriptive message for the stacktrace
+     */
+    public static void failWithThrowableStacktrace(Throwable throwable, String message) {
+        StringWriter errors = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(errors));
+        fail(message + errors.toString());
+    }
+}

--- a/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/PaxExamRuleTest.java
+++ b/distribution/test/itests/test-itests-common/src/test/java/ddf/common/test/PaxExamRuleTest.java
@@ -38,14 +38,15 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
-
 public class PaxExamRuleTest {
 
     public static final String FAILING_TEST_MESSAGE = "test failed";
 
-    public static final String BEFORE_EXAM_EXCEPTION_MESSAGE = "BeforeExam exception";
+    public static final String BEFORE_EXAM_EXCEPTION_MESSAGE =
+            "java.lang.RuntimeException: BeforeExam exception";
 
-    public static final String AFTER_EXAM_EXCEPTION_MESSAGE = "AfterExam exception";
+    public static final String AFTER_EXAM_EXCEPTION_MESSAGE =
+            "java.lang.RuntimeException: AfterExam exception";
 
     public static final String EXPECTED_BEFORE_EXAM_ERROR_MESSAGE =
             String.format(PaxExamRule.BEFORE_EXAM_FAILURE_MESSAGE,
@@ -175,10 +176,16 @@ public class PaxExamRuleTest {
         JUnitCore core = new JUnitCore();
         Result result = core.run(FailingBeforeExamTest.class);
 
-        assertThat(result.getFailures()).extracting("message")
-                .containsOnly(EXPECTED_BEFORE_EXAM_ERROR_MESSAGE,
-                        PaxExamRule.EXAM_SETUP_FAILED_MESSAGE);
+        boolean examFail = result.getFailures()
+                .stream()
+                .anyMatch(failure -> failure.getMessage()
+                        .equals(PaxExamRule.EXAM_SETUP_FAILED_MESSAGE));
+        boolean beforeExamFail = result.getFailures()
+                .stream()
+                .anyMatch(failure -> failure.getMessage()
+                        .contains(EXPECTED_BEFORE_EXAM_ERROR_MESSAGE));
 
+        assertThat(examFail && beforeExamFail);
         assertResultCounts(result, 4);
     }
 
@@ -187,9 +194,16 @@ public class PaxExamRuleTest {
         JUnitCore core = new JUnitCore();
         Result result = core.run(FailingAfterExamTest.class);
 
-        assertThat(result.getFailures()).extracting("message")
-                .contains(EXPECTED_AFTER_EXAM_ERROR_MESSAGE, FAILING_TEST_MESSAGE);
+        boolean examFail = result.getFailures()
+                .stream()
+                .anyMatch(failure -> failure.getMessage()
+                        .equals(PaxExamRule.EXAM_SETUP_FAILED_MESSAGE));
+        boolean afterExamFail = result.getFailures()
+                .stream()
+                .anyMatch(failure -> failure.getMessage()
+                        .contains(EXPECTED_AFTER_EXAM_ERROR_MESSAGE));
 
+        assertThat(examFail && afterExamFail);
         assertResultCounts(result, 2);
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -92,6 +92,7 @@ import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
 import org.codice.ddf.itests.common.csw.CswQueryBuilder;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.codice.ddf.persistence.PersistentItem;
 import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
@@ -171,8 +172,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                     features,
                     sessionFactory);
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -1859,6 +1859,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         cdmProperties.putAll(getServiceManager().getMetatypeDefaults("content-core-directorymonitor",
                 "org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor"));
         cdmProperties.put("monitoredDirectoryPath", tmpDir.toString() + "/");
+        cdmProperties.put("processingMechanism", "delete");
         Configuration managedService = getServiceManager().createManagedService(
                 "org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor",
                 cdmProperties);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -17,7 +17,6 @@ import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SE
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
@@ -32,6 +31,7 @@ import java.util.Map;
 import org.boon.json.JsonFactory;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,8 +79,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
             getServiceManager().startFeature(true, "catalog-ui");
             getServiceManager().waitForHttpEndpoint(API_PATH.getUrl());
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -95,8 +94,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
                             .artifactId("boon")
                             .version("0.33")));
         } catch (IOException e) {
-            LOGGER.error("Failed to deploy configuration files: ", e);
-            fail("Failed to deploy configuration files: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed to deploy configuration files: ");
         }
         return null;
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
@@ -32,6 +32,7 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,8 +72,7 @@ public class TestEmbeddedSolr extends AbstractIntegrationTest {
             getCatalogBundle().waitForCatalogProvider();
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -34,6 +34,7 @@ import org.apache.http.HttpStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,8 +69,7 @@ public class TestFanout extends AbstractIntegrationTest {
                     .prettyPrint());
             getCatalogBundle().waitForCatalogProvider();
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -82,8 +82,7 @@ public class TestFanout extends AbstractIntegrationTest {
         try {
             getCatalogBundle().waitForCatalogProvider();
         } catch (Exception e) {
-            LOGGER.error("Failed in @Before ", e);
-            fail("Failed in @Before: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @Before: ");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -93,6 +93,7 @@ import org.codice.ddf.itests.common.csw.CswQueryBuilder;
 import org.codice.ddf.itests.common.csw.mock.FederatedCswMockServer;
 import org.codice.ddf.itests.common.restito.ChunkedContent;
 import org.codice.ddf.itests.common.restito.HeaderCapture;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -325,8 +326,7 @@ public class TestFederation extends AbstractIntegrationTest {
                     sessionFactory);
 
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -1552,7 +1552,7 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testEnterpriseSearch() throws Exception {
 
-        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q="+RECORD_TITLE_1+"&format=xml";
+        String queryUrl = OPENSEARCH_PATH.getUrl() + "?q=" + RECORD_TITLE_1 + "&format=xml";
         given().auth()
                 .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
                 .get(queryUrl)
@@ -1563,8 +1563,8 @@ public class TestFederation extends AbstractIntegrationTest {
                 .assertThat()
                 .body(hasXPath("/metacards/metacard/source[text()='ddf.distribution']"),
                         hasXPath("/metacards/metacard/source[text()='" + OPENSEARCH_SOURCE_ID
-                                + "']"), hasXPath("/metacards/metacard/source[text()='" + CSW_SOURCE_ID
-                                + "']"));
+                                + "']"),
+                        hasXPath("/metacards/metacard/source[text()='" + CSW_SOURCE_ID + "']"));
     }
 
     /**

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
@@ -47,6 +47,7 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.catalog.CatalogTestCommons;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -119,8 +120,7 @@ public class TestFtp extends AbstractIntegrationTest {
             getServiceManager().stopFeature(true, FTP_ENDPOINT_FEATURE);
 
         } catch (Exception e) {
-            LOGGER.error("Failed in @AfterExam: ", e);
-            fail("Failed in @AfterExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @AfterExam: ");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -45,6 +45,7 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
 import org.codice.ddf.itests.common.csw.mock.FederatedCswMockServer;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.federationadmin.service.internal.FederationAdminService;
 import org.codice.ddf.security.common.Security;
@@ -196,8 +197,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                     CSW_REGISTRY_TYPE);
             getCatalogBundle().waitForCatalogStore(storeId);
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
 
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
@@ -17,7 +17,6 @@ import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMeta
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestMetacards;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.given;
 
 import java.io.ByteArrayInputStream;
@@ -38,6 +37,7 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.http.HttpStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -134,6 +134,9 @@ public class TestSpatial extends AbstractIntegrationTest {
                     .put("CswCompoundBeforeDateAndLikeText",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_FAR_METACARD)})
+                    .put("CswCompoundNotBeforeDateAndLikeText",
+                            new ExpectedResultPair[] {
+                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
                     .put("CswLogicalOperatorContextualNotQuery",
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_NEAR_METACARD)})
@@ -145,11 +148,12 @@ public class TestSpatial extends AbstractIntegrationTest {
                             new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
                                     PLAINXML_FAR_METACARD)})
                     .put("CswXPathExpressionQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
-                    .put("CswFuzzyTextQuery",
-                            new ExpectedResultPair[] {
-                                    new ExpectedResultPair(ResultType.TITLE, CSW_METACARD)})
+                            new ExpectedResultPair[] {new ExpectedResultPair(ResultType.TITLE,
+                                    CSW_METACARD)})
+                    .put("CswFuzzyTextQuery", new ExpectedResultPair[] {new ExpectedResultPair(
+                                    ResultType.TITLE,
+                                    CSW_METACARD)})
+
                     .build();
 
     @BeforeExam
@@ -165,8 +169,7 @@ public class TestSpatial extends AbstractIntegrationTest {
 
             loadResourceQueries(CSW_QUERY_RESOURCES, savedCswQueries);
         } catch (Exception e) {
-            LOGGER.error("Failed to start required apps:", e);
-            fail("Failed to start required apps: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed to start required apps: ");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
@@ -37,6 +37,7 @@ import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -105,8 +106,7 @@ public class TestApplicationService extends AbstractIntegrationTest {
                     features,
                     sessionFactory);
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestConfiguration.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static com.jayway.restassured.RestAssured.when;
 
@@ -50,6 +49,7 @@ import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.callables.GetConfigurationProperties;
 import org.codice.ddf.itests.common.matchers.ConfigurationPropertiesEqualTo;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -231,8 +231,7 @@ public class TestConfiguration extends AbstractIntegrationTest {
             symbolicLink = Paths.get(ddfHome)
                     .resolve("link");
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -732,8 +731,7 @@ public class TestConfiguration extends AbstractIntegrationTest {
 
         console.runCommand(String.format("%s \"%s\"",
                 CATALOG_INGEST_COMMAND,
-                getDefaultExportDirectory().resolve("ddf.metacards")),
-                new RolePrincipal("admin"));
+                getDefaultExportDirectory().resolve("ddf.metacards")), new RolePrincipal("admin"));
 
         assertMetacardsIngested(metacardIds.size());
     }
@@ -761,9 +759,11 @@ public class TestConfiguration extends AbstractIntegrationTest {
 
     private List<String> ingestMetacardsForExport() {
         List<String> metacardIds = new ArrayList<>(2);
-        String metacardId1 = ingest(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"), "application/json");
+        String metacardId1 = ingest(getFileContent(
+                JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"), "application/json");
         metacardIds.add(metacardId1);
-        String metacardId2 = ingest(getFileContent(XML_RECORD_RESOURCE_PATH + "/SimpleXmlMetacard"), "text/xml");
+        String metacardId2 = ingest(getFileContent(XML_RECORD_RESOURCE_PATH + "/SimpleXmlMetacard"),
+                "text/xml");
         metacardIds.add(metacardId2);
 
         return metacardIds;
@@ -805,11 +805,11 @@ public class TestConfiguration extends AbstractIntegrationTest {
         FileUtils.forceMkdir(Paths.get(ddfHome)
                 .resolve(destinationDir)
                 .toFile());
-        FileUtils.copyInputStreamToFile(getFileContentAsStream(CRL_PEM), Paths.get(
-                ddfHome)
-                .resolve(destinationDir)
-                .resolve(CRL_PEM)
-                .toFile());
+        FileUtils.copyInputStreamToFile(getFileContentAsStream(CRL_PEM),
+                Paths.get(ddfHome)
+                        .resolve(destinationDir)
+                        .resolve(CRL_PEM)
+                        .toFile());
     }
 
     private void disableCrls() throws IOException {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -17,11 +17,11 @@ package ddf.test.itests.platform;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.fail;
 import static com.jayway.restassured.RestAssured.given;
 
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -30,19 +30,18 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 
 import com.jayway.restassured.response.Response;
 
-
-
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class TestPlatform extends AbstractIntegrationTest {
 
-    private static final DynamicUrl BANANA_URL = new DynamicUrl(DynamicUrl.SECURE_ROOT, HTTPS_PORT,
+    private static final DynamicUrl BANANA_URL = new DynamicUrl(DynamicUrl.SECURE_ROOT,
+            HTTPS_PORT,
             "/solr/banana");
 
-    private static final DynamicUrl LOGGING_SERVICE_JOLOKIA_URL = new DynamicUrl(
-            DynamicUrl.SECURE_ROOT,
-            HTTPS_PORT,
-            "/admin/jolokia/exec/org.codice.ddf.platform.logging.LoggingService:service=logging-service/retrieveLogEvents");
+    private static final DynamicUrl LOGGING_SERVICE_JOLOKIA_URL =
+            new DynamicUrl(DynamicUrl.SECURE_ROOT,
+                    HTTPS_PORT,
+                    "/admin/jolokia/exec/org.codice.ddf.platform.logging.LoggingService:service=logging-service/retrieveLogEvents");
 
     @BeforeExam
     public void beforeTest() throws Exception {
@@ -55,8 +54,7 @@ public class TestPlatform extends AbstractIntegrationTest {
             // We need to start the Search UI to test that it redirects properly
             getServiceManager().startFeature(true, "banana");
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -82,7 +80,8 @@ public class TestPlatform extends AbstractIntegrationTest {
                 .statusCode(200)
                 .when()
                 .get(LOGGING_SERVICE_JOLOKIA_URL.getUrl());
-        
-        assertThat(response.getBody().asString(), not(isEmptyString()));
+
+        assertThat(response.getBody()
+                .asString(), not(isEmptyString()));
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.hamcrest.xml.HasXPath;
 import org.junit.Test;
@@ -95,7 +96,8 @@ public class TestSecurity extends AbstractIntegrationTest {
                     "security-all");
 
     protected static final String ADD_SDK_APP_JOLOKIA_REQ =
-            "{\"type\":\"EXEC\",\"mbean\":\"org.codice.ddf.admin.application.service.ApplicationService:service=application-service\",\"operation\":\"addApplications\",\"arguments\":[[{\"value\":\"mvn:ddf.distribution/sdk-app/"+System.getProperty("ddf.version")+"/xml/features\"}]]}";
+            "{\"type\":\"EXEC\",\"mbean\":\"org.codice.ddf.admin.application.service.ApplicationService:service=application-service\",\"operation\":\"addApplications\",\"arguments\":[[{\"value\":\"mvn:ddf.distribution/sdk-app/"
+                    + System.getProperty("ddf.version") + "/xml/features\"}]]}";
 
     protected static final String SOAP_ENV =
             "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -318,7 +320,8 @@ public class TestSecurity extends AbstractIntegrationTest {
             configurePDP();
             Configuration config = getAdminConfig().getConfiguration(
                     "org.codice.ddf.admin.config.policy.AdminConfigPolicy");
-            config.setBundleLocation("mvn:ddf.admin.core/admin-core-configpolicy/" + System.getProperty("ddf.version"));
+            config.setBundleLocation("mvn:ddf.admin.core/admin-core-configpolicy/"
+                    + System.getProperty("ddf.version"));
             Dictionary properties = new Hashtable<>();
 
             List<String> featurePolicies = new ArrayList<>();
@@ -343,8 +346,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
             getCatalogBundle().waitForCatalogProvider();
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -466,16 +468,18 @@ public class TestSecurity extends AbstractIntegrationTest {
 
     @Test
     public void testSamlFederatedAuth() throws Exception {
-        String recordId = ingest(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"), "application/json");
+        String recordId = ingest(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"),
+                "application/json");
         configureRestForBasic();
 
         // Creating a new OpenSearch source with no username/password.
         // When an OpenSearch source attempts to authenticate without a username/password it will
         // use the subject in the request to create a SAML authentication token
         Map<String, Object> openSearchProperties = getOpenSearchSourceProperties(
-                OPENSEARCH_SAML_SOURCE_ID, OPENSEARCH_PATH.getUrl(), getServiceManager());
-        getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID,
-                openSearchProperties);
+                OPENSEARCH_SAML_SOURCE_ID,
+                OPENSEARCH_PATH.getUrl(),
+                getServiceManager());
+        getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID, openSearchProperties);
 
         getCatalogBundle().waitForFederatedSource(OPENSEARCH_SAML_SOURCE_ID);
 
@@ -507,18 +511,22 @@ public class TestSecurity extends AbstractIntegrationTest {
 
         waitForGuestAuthReady(SERVICE_ROOT.getUrl());
 
-        String recordId = ingest(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"), "application/json");
+        String recordId = ingest(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"),
+                "application/json");
         configureRestForBasic();
 
         //Positive tests
         Map<String, Object> openSearchProperties = getOpenSearchSourceProperties(
-                OPENSEARCH_SOURCE_ID, OPENSEARCH_PATH.getUrl(), getServiceManager());
+                OPENSEARCH_SOURCE_ID,
+                OPENSEARCH_PATH.getUrl(),
+                getServiceManager());
         openSearchProperties.put("username", "admin");
         openSearchProperties.put("password", "admin");
-        getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID,
-                openSearchProperties);
+        getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID, openSearchProperties);
 
-        Map<String, Object> cswProperties = getCswSourceProperties(CSW_SOURCE_ID, CSW_PATH.getUrl(), getServiceManager());
+        Map<String, Object> cswProperties = getCswSourceProperties(CSW_SOURCE_ID,
+                CSW_PATH.getUrl(),
+                getServiceManager());
         cswProperties.put("username", "admin");
         cswProperties.put("password", "admin");
         getServiceManager().createManagedService(CSW_FEDERATED_SOURCE_FACTORY_PID, cswProperties);
@@ -559,7 +567,9 @@ public class TestSecurity extends AbstractIntegrationTest {
 
         //Negative tests
         String unavailableCswSourceId = "Unavailable Csw";
-        cswProperties = getCswSourceProperties(unavailableCswSourceId, CSW_PATH.getUrl(), getServiceManager());
+        cswProperties = getCswSourceProperties(unavailableCswSourceId,
+                CSW_PATH.getUrl(),
+                getServiceManager());
         cswProperties.put("username", "bad");
         cswProperties.put("password", "auth");
         getServiceManager().createManagedService(CSW_FEDERATED_SOURCE_FACTORY_PID, cswProperties);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -56,6 +56,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -165,8 +166,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID, openSearchProperties);
             getCatalogBundle().waitForFederatedSource(OPENSEARCH_SOURCE_ID);
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -194,7 +194,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             try {
                 validator.validate(streamSource);
             } catch (SAXException e) {
-                fail("Failed to validate SAML " + e.getMessage());
+                LoggingUtils.failWithThrowableStacktrace(e, "Failed to validate SAML: ");
             }
         }
     }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.KarafConsole;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,10 +65,11 @@ public class TestSolrCommands extends AbstractIntegrationTest {
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
-            console = new KarafConsole(getServiceManager().getBundleContext(), features, sessionFactory);
+            console = new KarafConsole(getServiceManager().getBundleContext(),
+                    features,
+                    sessionFactory);
         } catch (Exception e) {
-            LOGGER.error("Failed in @BeforeExam: ", e);
-            fail("Failed in @BeforeExam: " + e.getMessage());
+            LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }
     }
 
@@ -111,11 +113,12 @@ public class TestSolrCommands extends AbstractIntegrationTest {
         // On run 3, backup C is created (backup A is deleted and backups B and C remain).
         console.runCommand(command);
         // Wait for the 3rd backup to replace the 1st backup
-        Set<File> thirdBackupDirSet = waitForFirstBackupDirToBeDeleted(CATALOG_CORE_NAME, firstBackupDirSet);
+        Set<File> thirdBackupDirSet = waitForFirstBackupDirToBeDeleted(CATALOG_CORE_NAME,
+                firstBackupDirSet);
 
         assertThat("Wrong number of backup directories kept. Number of backups found in "
-                + getSolrDataPath(CATALOG_CORE_NAME).getAbsolutePath() + " is : [" + thirdBackupDirSet.size()
-                + "]; Expected: [2].", thirdBackupDirSet, hasSize(2));
+                + getSolrDataPath(CATALOG_CORE_NAME).getAbsolutePath() + " is : ["
+                + thirdBackupDirSet.size() + "]; Expected: [2].", thirdBackupDirSet, hasSize(2));
 
         secondBackupDirSet.removeAll(firstBackupDirSet);
         assertTrue("Unexpected backup directories found on pass 3.",
@@ -135,7 +138,7 @@ public class TestSolrCommands extends AbstractIntegrationTest {
             backupDirs = getBackupDirectories(coreName);
         }
 
-        if(currentWaitTime >= timeout) {
+        if (currentWaitTime >= timeout) {
             fail("Timed out after " + timeout + " seconds waiting for correct number of backups in "
                     + getSolrDataPath(CATALOG_CORE_NAME).getAbsolutePath());
         }
@@ -153,8 +156,8 @@ public class TestSolrCommands extends AbstractIntegrationTest {
         });
     }
 
-    private Set<File> waitForBackupDirsToBeCreated(String coreName, final int numberOfDirs, int pass)
-            throws InterruptedException {
+    private Set<File> waitForBackupDirsToBeCreated(String coreName, final int numberOfDirs,
+            int pass) throws InterruptedException {
         Set<File> backupDirs = waitFor(coreName, new Predicate<Set<File>>() {
             @Override
             public boolean apply(Set<File> backupDirs) {
@@ -194,7 +197,7 @@ public class TestSolrCommands extends AbstractIntegrationTest {
 
     private void cleanUpBackups(String coreName) {
         Set<File> backupDirs = getBackupDirectories(coreName);
-        for(File backupDir : backupDirs) {
+        for (File backupDir : backupDirs) {
             FileUtils.deleteQuietly(backupDir);
         }
     }

--- a/platform/migration/platform-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/migration/platform-migration/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,13 +27,6 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
-    <bean id="watchThread" class="java.util.concurrent.Executors"
-          factory-method="newSingleThreadExecutor"/>
-
-    <bean id="defaultFileSystem" class="java.nio.file.FileSystems" factory-method="getDefault"/>
-
-    <bean id="watchService" factory-ref="defaultFileSystem" factory-method="newWatchService"/>
-
     <bean id="persistenceStrategy"
           class="org.codice.ddf.configuration.persistence.felix.FelixPersistenceStrategy"/>
 
@@ -73,12 +66,9 @@
     </bean>
 
     <bean id="configurationFilesPoller"
-          class="org.codice.ddf.configuration.admin.ConfigurationFilesPoller"
-          init-method="init" destroy-method="destroy">
+          class="org.codice.ddf.configuration.admin.ConfigurationFilesPoller">
         <argument ref="configDirectoryPath"/>
         <argument value="${configFileExtension}"/>
-        <argument ref="watchService"/>
-        <argument ref="watchThread"/>
     </bean>
 
     <bean id="configDirectoryStream" class="java.nio.file.Files"

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationFilesPollerTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationFilesPollerTest.java
@@ -25,23 +25,15 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,9 +44,6 @@ public class ConfigurationFilesPollerTest {
     private static final String INVALID_FILE_EXT = ".invalid";
 
     private static final String PID = "my.pid";
-
-    @Mock
-    private ExecutorService mockExecutorService;
 
     @Mock
     private ChangeListener mockChangeListener;
@@ -68,14 +57,17 @@ public class ConfigurationFilesPollerTest {
     @Mock(answer = RETURNS_DEEP_STUBS)
     private Path nonConfigFilePath;
 
+    private File tempFile;
+
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         File configFile = mock(File.class);
 
         when(configFilePath.toFile()).thenReturn(configFile);
         when(configFile.isDirectory()).thenReturn(false);
         when(configFilePath.getFileName()).thenReturn(configFilePath);
         when(configFilePath.endsWith(FILE_EXT)).thenReturn(true);
+        when(configFilePath.toAbsolutePath()).thenReturn(Paths.get("foo"));
 
         when(directoryPath.toFile()
                 .isDirectory()).thenReturn(true);
@@ -83,107 +75,8 @@ public class ConfigurationFilesPollerTest {
         when(nonConfigFilePath.toFile()
                 .isDirectory()).thenReturn(true);
         when(nonConfigFilePath.endsWith(FILE_EXT)).thenReturn(false);
-    }
-
-    /**
-     * Verify that poller gets started by the ExecutorService.
-     */
-    @Test
-    public void testInit() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
-
-        // Perform Test
-        configurationFilesPoller.init();
-
-        // Verify
-        verify(mockConfigurationDirectory).register(mockWatchService,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        verify(mockExecutorService).execute(configurationFilesPoller);
-    }
-
-    /**
-     * Verify that when the configurationDirectoryPath fails to register with the WatchService,
-     * the init method fails.
-     */
-    @Test(expected = IOException.class)
-    public void testInitFailsToRegisterPathWithWatchService() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        when(mockConfigurationDirectory.register(mockWatchService,
-                StandardWatchEventKinds.ENTRY_CREATE)).thenThrow(new IOException());
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
-
-        // Perform Test
-        try {
-            configurationFilesPoller.init();
-        } catch (IOException e) {
-            // Verify
-            verify(mockExecutorService, never()).execute(configurationFilesPoller);
-            verify(mockWatchService, never()).take();
-            throw e;
-        }
-    }
-
-    @Test
-    public void testResgiterFilesAlreadyExist() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-
-        Stream<Path> existingFiles = mock(Stream.class);
-        when(existingFiles.filter(any(Predicate.class))).thenReturn(Stream.of(configFilePath,
-                directoryPath,
-                nonConfigFilePath));
-        when(mockConfigurationDirectory.resolve(configFilePath)).thenReturn(configFilePath);
-
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService) {
-            @Override
-            Stream<Path> getExistingFiles() throws IOException {
-                return existingFiles;
-            }
-        };
-
-        // Perform Test
-        configurationFilesPoller.register(mockChangeListener);
-
-        // Verify
-        verify(mockChangeListener).notify(configFilePath);
-        verify(mockChangeListener, never()).notify(directoryPath);
-        verify(mockChangeListener, never()).notify(nonConfigFilePath);
+        tempFile = Files.createTempFile("foo", "bar")
+                .toFile();
     }
 
     /**
@@ -194,254 +87,190 @@ public class ConfigurationFilesPollerTest {
     public void testRegisterNullParameter() throws Exception {
         // Setup
         Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
         Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
                 mock(Path.class));
         ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
                 mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
+                FILE_EXT);
 
         // Perform Test
         configurationFilesPoller.register(null);
     }
 
     /**
-     * Verify that file modification events are not sent to the ChangeListener.
-     */
-    @Test
-    public void testRunFileModifiedChangeListenerNotNotified() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_MODIFY);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
-                mockWatchService,
-                mockConfigurationDirectory);
-        configurationFilesPoller.register(mockChangeListener);
-
-        // Perform Test
-        configurationFilesPoller.run();
-
-        // Verify
-        verify(mockChangeListener, never()).notify(any(Path.class));
-    }
-
-    /**
-     * Verify that overflow events are not sent to the ChangeListener.
-     */
-    @Test
-    public void testRunOverflowChangeListenerNotNotified() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.OVERFLOW);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
-                mockWatchService,
-                mockConfigurationDirectory);
-        configurationFilesPoller.register(mockChangeListener);
-
-        // Perform Test
-        configurationFilesPoller.run();
-
-        // Verify
-        verify(mockChangeListener, never()).notify(any(Path.class));
-    }
-
-    /**
-     * Verify that file deletion events are not sent to the ChangeListener.
-     */
-    @Test
-    public void testRunFileDeletedChangeListenerNotNotified() throws Exception {
-        // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_DELETE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-
-        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
-                mockWatchService,
-                mockConfigurationDirectory);
-        configurationFilesPoller.register(mockChangeListener);
-
-        // Perform Test
-        configurationFilesPoller.run();
-
-        // Verify
-        verify(mockChangeListener, never()).notify(any(Path.class));
-    }
-
-    /**
-     * Verify that the ChangeListener is notified on file creation events.
+     * Verify that the ChangeListener is notified on file create events.
      */
     @Test
     public void testRunFileCreatedChangeListenerNotified() throws Exception {
         // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path resolvedPath = mock(Path.class);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath, resolvedPath);
-        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
-                mockWatchService,
-                mockConfigurationDirectory);
-        configurationFilesPoller.register(mockChangeListener);
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
         // Perform Test
-        configurationFilesPoller.run();
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onFileCreate(tempFile);
 
         // Verify
-        verify(mockChangeListener).notify(resolvedPath);
+        verify(mockChangeListener).notify(Paths.get(tempFile.toURI()));
     }
 
     /**
-     * Verify that the ChangeListener is not notified for creation events
-     * involving invalid file extensions.
+     * Verify that the ChangeListener is not notified on file change events.
      */
     @Test
-    public void testRunInvalidFileExtension() throws Exception {
+    public void testRunFileChangedChangeListenerNotNotified() throws Exception {
         // Setup
-        Path mockPath = getMockPath(PID, INVALID_FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-
-        ConfigurationFilesPoller configurationFilesPoller = createConfigurationFilesPoller(
-                mockWatchService,
-                mockConfigurationDirectory);
-
-        configurationFilesPoller.register(mockChangeListener);
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
         // Perform Test
-        configurationFilesPoller.run();
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onFileChange(tempFile);
 
         // Verify
-        verify(mockChangeListener, never()).notify(any(Path.class));
+        verify(mockChangeListener, never()).notify(any());
     }
 
     /**
-     * Verify that when no listener is registered, an attempt is not made to call its
-     * notify method.
+     * Verify that the ChangeListener is not notified on file delete events.
      */
     @Test
-    public void testRunFileCreatedNoListenerRegistered() throws Exception {
+    public void testRunFileDeletedChangeListenerNotNotified() throws Exception {
         // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_CREATE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
         // Perform Test
-        configurationFilesPoller.run();
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onFileDelete(tempFile);
 
         // Verify
-        verify(mockChangeListener, never()).notify(any(Path.class));
+        verify(mockChangeListener, never()).notify(any());
     }
 
+    /**
+     * Verify that the ChangeListener is not notified on directory create events.
+     */
     @Test
-    public void testDestroyShutsdownAfterAwaitingTermination() throws Exception {
+    public void testRunDirectoryCreatedChangeListenerNotNotified() throws Exception {
         // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_DELETE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(true);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
         // Perform Test
-        configurationFilesPoller.destroy();
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onDirectoryCreate(tempFile);
 
-        // verify
-        verify(mockWatchService).close();
-        verify(mockExecutorService).shutdown();
-        verify(mockExecutorService).awaitTermination(10, TimeUnit.SECONDS);
+        // Verify
+        verify(mockChangeListener, never()).notify(any());
     }
 
+    /**
+     * Verify that the ChangeListener is not notified on directory change events.
+     */
     @Test
-    public void testDestroyShutsdownAfterSecondAwaitTermination() throws Exception {
+    public void testRunDirectoryChangedChangeListenerNotNotified() throws Exception {
         // Setup
-        Path mockPath = getMockPath(PID, FILE_EXT);
-        WatchEvent<?> mockWatchEvent = getMockWatchEvent(mockPath,
-                StandardWatchEventKinds.ENTRY_DELETE);
-        List<WatchEvent<?>> watchEvents = getSingleMockWatchEvent(mockWatchEvent);
-        WatchKey mockWatchKey = getMockWatchKey(watchEvents);
-        WatchService mockWatchService = getMockWatchService(mockWatchKey);
-        when(mockExecutorService.awaitTermination(10, TimeUnit.SECONDS)).thenReturn(false, true);
-        Path mockConfigurationDirectory = getMockConfigurationDirectoryPath(mockPath,
-                mock(Path.class));
-        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
-                mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService);
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
         // Perform Test
-        configurationFilesPoller.destroy();
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onDirectoryChange(tempFile);
 
-        // verify
-        verify(mockWatchService).close();
-        verify(mockExecutorService).shutdown();
-        verify(mockExecutorService).shutdownNow();
-        verify(mockExecutorService, times(2)).awaitTermination(10, TimeUnit.SECONDS);
+        // Verify
+        verify(mockChangeListener, never()).notify(any());
     }
 
-    private ConfigurationFilesPoller createConfigurationFilesPoller(
-            final WatchService mockWatchService, final Path mockConfigurationDirectory) {
-        Stream<Path> existingFiles = mock(Stream.class);
-        when(existingFiles.filter(any(Predicate.class))).thenReturn(existingFiles);
+    /**
+     * Verify that the ChangeListener is not notified on directory delete events.
+     */
+    @Test
+    public void testRunDirectoryDeletedChangeListenerNotNotified() throws Exception {
+        // Setup
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideWait();
 
-        return new ConfigurationFilesPoller(mockConfigurationDirectory,
-                FILE_EXT,
-                mockWatchService,
-                mockExecutorService) {
+        // Perform Test
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onDirectoryDelete(tempFile);
+
+        // Verify
+        verify(mockChangeListener, never()).notify(any());
+    }
+
+    /**
+     * Verify that the ChangeListener is not notified if a RuntimeException is thrown.
+     */
+    @Test
+    public void testRuntimeExceptionThrownChangeListenerNotNotified() throws Exception {
+        // Setup
+        ConfigurationFilesPoller configurationFilesPoller = new ConfigurationFilesPoller(
+                configFilePath,
+                FILE_EXT);
+        File file = mock(File.class);
+        when(file.length()).thenThrow(new RuntimeException());
+
+        // Perform Test
+        configurationFilesPoller.register(mockChangeListener);
+        configurationFilesPoller.onFileCreate(file);
+
+        // Verify
+        verify(mockChangeListener, never()).notify(any());
+    }
+
+    /**
+     * Verify that the Poller waits once for a typical file length
+     */
+    @Test
+    public void testWaitForFileToBeCompletelyWritten() throws Exception {
+        // Setup
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideSleepWithSpy();
+        File file = mock(File.class);
+        when(file.length()).thenReturn(1234L);
+
+        // Perform Test
+        configurationFilesPoller.waitForFileToBeCompletelyWritten(file);
+
+        // Verify
+        verify(configurationFilesPoller, times(1)).doSleep();
+    }
+
+    /**
+     * Verify that the Poller does an extra wait to give typical buffered writers time to finish
+     */
+    @Test
+    public void testWaitForFileToBeCompletelyWrittenByBufferedWriter() throws Exception {
+        // Setup
+        ConfigurationFilesPoller configurationFilesPoller =
+                getConfigurationFilesPollerOverrideSleepWithSpy();
+        File file = mock(File.class);
+        when(file.length()).thenReturn(1024L);
+
+        // Perform Test
+        configurationFilesPoller.waitForFileToBeCompletelyWritten(file);
+
+        // Verify
+        verify(configurationFilesPoller, times(2)).doSleep();
+    }
+
+    private ConfigurationFilesPoller getConfigurationFilesPollerOverrideWait() {
+        return new ConfigurationFilesPoller(configFilePath, FILE_EXT) {
             @Override
-            Stream<Path> getExistingFiles() throws IOException {
-                return existingFiles;
+            void waitForFileToBeCompletelyWritten(File file) throws InterruptedException {
+                return;
             }
         };
+    }
+
+    protected ConfigurationFilesPoller getConfigurationFilesPollerOverrideSleepWithSpy() {
+        return Mockito.spy(new ConfigurationFilesPoller(configFilePath, FILE_EXT) {
+            @Override
+            void doSleep() throws InterruptedException {
+                return;
+            }
+        });
     }
 
     private Path getMockPath(String baseFileName, String extension) {
@@ -457,32 +286,5 @@ public class ConfigurationFilesPollerTest {
         when(mockConfigurationDirectory.toFile()).thenReturn(mockFile);
         when(mockFile.list(any(FilenameFilter.class))).thenReturn(new String[0]);
         return mockConfigurationDirectory;
-    }
-
-    private <T> WatchEvent<T> getMockWatchEvent(T mockPath, Kind<T> mockKind) {
-        @SuppressWarnings("unchecked")
-        WatchEvent<T> mockWatchEvent = mock(WatchEvent.class);
-        when(mockWatchEvent.context()).thenReturn(mockPath);
-        when(mockWatchEvent.kind()).thenReturn(mockKind);
-        return mockWatchEvent;
-    }
-
-    private WatchKey getMockWatchKey(List<WatchEvent<?>> watchEvents) {
-        WatchKey mockWatchKey = mock(WatchKey.class);
-        when(mockWatchKey.pollEvents()).thenReturn(watchEvents);
-        when(mockWatchKey.reset()).thenReturn(false);
-        return mockWatchKey;
-    }
-
-    private WatchService getMockWatchService(WatchKey mockWatchKey) throws Exception {
-        WatchService mockWatchService = mock(WatchService.class);
-        when(mockWatchService.take()).thenReturn(mockWatchKey);
-        return mockWatchService;
-    }
-
-    private List<WatchEvent<?>> getSingleMockWatchEvent(WatchEvent<?> mockWatchEvent) {
-        List<WatchEvent<?>> watchEvents = new ArrayList<>(1);
-        watchEvents.add(mockWatchEvent);
-        return watchEvents;
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Replace nio with commons-io's file watcher, and replace the one second sleep with a poll for the file size to become stable.

These changes should mitigate itest stability problems in CI environments that are prone to IOWait spikes.

Also includes some improvements to itest logging that were needed to debug this solution anyways.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @clockard 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Continuous Integration](https://github.com/orgs/codice/teams/continuous-integration)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic
#### What are the relevant tickets?
[DDF-2869](https://codice.atlassian.net/browse/DDF-2869)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
