### PR TITLE
DDF-2874 Add query change listener for workspace change detection

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -74,6 +74,7 @@ define([
                     this.trigger('change');
                 });
                 this.listenTo(this.get('queries'), 'update add remove', this.handleQueryChange);
+                this.listenTo(this.get('queries'), 'change', this.handleChange);
                 this.listenTo(this, 'change', this.handleChange);
                 this.listenTo(this, 'error', this.handleError);
             },


### PR DESCRIPTION
#### What does this PR do?
 - This listener got dropped at some point, so query changes won't be properly detected without this.  The logic to ignore query changes to results is already in though.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@djblue 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Make a change to a query and verify the workspace change icon appears.  Run the query and verify it does not appear.  

#### Any background context you want to provide?
The logic to ignore results changes was already in, but at some point the listener got accidentally removed.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2847
