### PR TITLE
DDF-2905 Updated single image layer projection coordinate system

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -96,7 +96,7 @@ public class ConfigurationApplication implements SparkApplication {
 
     private Integer resultCount = 250;
 
-    private String projection = "EPSG:3857";
+    private String projection = "EPSG:4326";
 
     private String bingKey = "";
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -40,7 +40,7 @@
             name="Map Projection"
             description="Projection of imagery providers"
             type="String"
-            default="EPSG:3857"
+            default="EPSG:4326"
             required="false"/>
 
         <AD id="bingKey"

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -4,7 +4,7 @@ resultCount=I"250"
 imageryProviders=""
 terrainProvider="{\ \"type\":\ \"CT\",\ \"url\":\ \"http://assets.agi.com/stk-terrain/tilesets/world/tiles\"\ }"
 
-projection="EPSG:3857"
+projection="EPSG:4326"
 timeout=I"300000"
 sourcePollInterval=I"60000"
 signIn=B"true"

--- a/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
+++ b/catalog/ui/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
@@ -125,7 +125,7 @@ public class ConfigurationStore {
 
     private Integer resultCount = 250;
 
-    private String projection = "EPSG:3857";
+    private String projection = "EPSG:4326";
 
     private String bingKey = "";
 

--- a/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,7 +34,7 @@
         />
 
         <AD description="Projection of imagery providers" name="Map Projection" id="projection"
-            required="false" type="String" default="EPSG:3857"/>
+            required="false" type="String" default="EPSG:4326"/>
 
         <AD description="Bing Maps API key. This should only be set if you are using Bing Maps Imagery or Terrain Providers." name="Bing Maps Key" id="bingKey"
             required="false" type="String" default="" />

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -34,7 +34,7 @@
 |projection
 |String
 |Projection of imagery providers
-|EPSG:3857
+|EPSG:4326
 |false
 
 |Bing Maps Key


### PR DESCRIPTION
#### What does this PR do?
When using default layers with the 2D Map, geometries appear incorrectly positioned. This change utilizes the EPSG:4326 projection for the single image layer so that the metacard locations appear consistent across both the 3D Globe and 2D Map.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk @clockard @vinamartin

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Docs](https://github.com/orgs/codice/teams/docs) @ricklarsen 
[UI](https://github.com/orgs/codice/teams/ui) @brianfelix 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Install DDF, ingest a product with location information, then confirm the location of the metacard in both the 3D Globe and 2D Map in both the Catalog UI as well as the Standard UI.

#### Any background context you want to provide?
To access the 2D Map on the standard UI, navigate to `https://localhost:8993/search/standard/?map=2d`
To access the 2D Map in the catalog UI, select the cog in the upper right corner of the screen, then select `Visualization` and choose `2D Map`.

#### What are the relevant tickets?
[DDF-2905](https://codice.atlassian.net/browse/DDF-2905)

#### Screenshots (if appropriate)
![screen shot 2017-03-23 at 2 33 54 pm](https://cloud.githubusercontent.com/assets/11355332/24271610/08e111b2-0fd7-11e7-8504-798f21156fa5.png)
![screen shot 2017-03-23 at 2 34 18 pm](https://cloud.githubusercontent.com/assets/11355332/24271612/0aeae906-0fd7-11e7-8d50-2a62fb4754a9.png)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
