### PR TITLE
DDF-2909 usng4j services fail to start

### DIFF
--- a/platform/usng4j/platform-usng4j-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/usng4j/platform-usng4j-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,7 +28,7 @@
     </bean>
 
     <service id="CoordinateSystemTranslatorNad83Datum"
-             interface="org.codice.usng4j.api.CoordinateSystemTranslator"
+             interface="org.codice.usng4j.CoordinateSystemTranslator"
              ref="coordinateSystemTranslatorNad83Datum"
              ranking="100">
         <service-properties>
@@ -37,7 +37,7 @@
     </service>
 
     <service id="CoordinateSystemTranslatorNad27Datum"
-             interface="org.codice.usng4j.api.CoordinateSystemTranslator"
+             interface="org.codice.usng4j.CoordinateSystemTranslator"
              ref="coordinateSystemTranslatorNad27Datum"
              ranking="99">
         <service-properties>


### PR DESCRIPTION
Modified blueprint.xml to remove the '.api' portion of the service interface package name.

#### What does this PR do?
This PR fixes a bug that we preventing the usng4j services from starting up.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@roelens8 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jaymcnallie
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
1) build DDF
2) extract the ddf-2.11.0.zip
3) start DDF
4) in the Karaf shell, enter the command `feature:install platform-usng4j`
5) verify that the usng4j-api and usng4j-impl bundles have started.

#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2090

#### Screenshots (if appropriate)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Change Log Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
