### PR TITLE
DDF-2911 Prevent directory monitor from creating extra DurableFileConsumer directory 

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/FileSystemPersistenceProvider.java
@@ -15,6 +15,7 @@ package ddf.camel.component.catalog.content;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class FileSystemPersistenceProvider
      * @return the path to root directory where serialized objects will be persisted
      */
     String getPersistencePath() {
-        return new AbsolutePathResolver("data" + File.separator).getPath();
+        return new AbsolutePathResolver("data").getPath();
     }
 
     /**
@@ -77,7 +78,8 @@ public class FileSystemPersistenceProvider
      * @return
      */
     String getMapStorePath() {
-        return getPersistencePath() + mapName + File.separator;
+        return Paths.get(getPersistencePath(), mapName)
+                .toString() + File.separator;
     }
 
     @Override

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/FileSystemPersistenceProviderTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/FileSystemPersistenceProviderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +57,8 @@ public class FileSystemPersistenceProviderTest {
         fileSystemPersistenceProvider = new FileSystemPersistenceProvider("test");
         fileSystemPersistenceProvider.fileSystemDataAccessObject = mockFileSystemDao;
         assertThat(fileSystemPersistenceProvider.getMapStorePath(),
-                is(fileSystemPersistenceProvider.getPersistencePath() + "test" + File.separator));
+                is(Paths.get(fileSystemPersistenceProvider.getPersistencePath(), "test")
+                        .toString()));
     }
 
     @Test

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/FileSystemPersistenceProviderTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/FileSystemPersistenceProviderTest.java
@@ -58,7 +58,7 @@ public class FileSystemPersistenceProviderTest {
         fileSystemPersistenceProvider.fileSystemDataAccessObject = mockFileSystemDao;
         assertThat(fileSystemPersistenceProvider.getMapStorePath(),
                 is(Paths.get(fileSystemPersistenceProvider.getPersistencePath(), "test")
-                        .toString()));
+                        .toString() + File.separator));
     }
 
     @Test

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
+import org.codice.ddf.configuration.AbsolutePathResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,13 +82,7 @@ public class FileSystemPersistenceProvider
      * @return the path to root directory where serialized objects will be persisted
      */
     String getPersistencePath() {
-        File file = new File("data" + File.separator);
-        try {
-            return file.getCanonicalPath();
-        } catch (IOException e) {
-            LOGGER.warn("Could not canonicalize {}. Verify the location is accessible.", file);
-            return file.getAbsolutePath();
-        }
+        return new AbsolutePathResolver("data").getPath();
     }
 
     /**

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
@@ -25,6 +25,7 @@ import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -95,7 +96,8 @@ public class FileSystemPersistenceProvider
      * @return
      */
     String getMapStorePath() {
-        return getPersistencePath() + mapName + File.separator;
+        return Paths.get(getPersistencePath(), mapName)
+                .toString() + File.separator;
     }
 
     @Override

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/FileSystemPersistenceProvider.java
@@ -26,6 +26,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,15 +54,13 @@ public class FileSystemPersistenceProvider
     private static final String SER = ".ser";
 
     private static final String SER_REGEX = "\\.ser";
-
-    private static final String PERSISTENCE_PATH = new AbsolutePathResolver("data/").getPath();
-
+    
     private String mapName = "default";
 
     FileSystemPersistenceProvider(String mapName) {
         LOGGER.trace("INSIDE: FileSystemPersistenceProvider constructor,  mapName = {}", mapName);
         this.mapName = mapName;
-        File dir = new File(PERSISTENCE_PATH);
+        File dir = new File(getPersistencePath());
         if (!dir.exists()) {
             boolean success = dir.mkdir();
             if (!success) {
@@ -71,12 +70,23 @@ public class FileSystemPersistenceProvider
     }
 
     /**
+     * Retrieve root directory of all persisted Hazelcast objects for this cache. The path is
+     * relative to containing bundle, i.e., DDF install directory.
+     *
+     * @return the path to root directory where serialized objects will be persisted
+     */
+    String getPersistencePath() {
+        return new AbsolutePathResolver("data").getPath();
+    }
+
+    /**
      * Path to where persisted Hazelcast objects will be stored to disk.
      *
      * @return
      */
     String getMapStorePath() {
-        return PERSISTENCE_PATH + mapName + "/";
+        return Paths.get(getPersistencePath(), mapName)
+                .toString() + File.separator;
     }
 
     @Override

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/FileSystemPersistenceProvider.java
@@ -54,7 +54,7 @@ public class FileSystemPersistenceProvider
     private static final String SER = ".ser";
 
     private static final String SER_REGEX = "\\.ser";
-    
+
     private String mapName = "default";
 
     FileSystemPersistenceProvider(String mapName) {

--- a/platform/notifications/core/platform-core-notifications/src/main/java/org/codice/ddf/notifications/impl/FileSystemPersistenceProvider.java
+++ b/platform/notifications/core/platform-core-notifications/src/main/java/org/codice/ddf/notifications/impl/FileSystemPersistenceProvider.java
@@ -25,6 +25,7 @@ import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,7 +79,7 @@ public class FileSystemPersistenceProvider
      * @return the path to root directory where serialized objects will be persisted
      */
     String getPersistencePath() {
-        return new AbsolutePathResolver("data" + File.separator).getPath();
+        return new AbsolutePathResolver("data").getPath();
     }
 
     /**
@@ -87,7 +88,8 @@ public class FileSystemPersistenceProvider
      * @return
      */
     String getMapStorePath() {
-        return getPersistencePath() + mapName + File.separator;
+        return Paths.get(getPersistencePath(), mapName)
+                .toString() + File.separator;
     }
 
     @Override


### PR DESCRIPTION
#### What does this PR do?
Replaced String concatenation with calls to Paths.get when constructing the path to the persistence store to prevent extra DurableFileConsumer directories from being mistakenly created.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emanns95 @ahoffer @brendan-hofmann @AzGoalie @mweser 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
1. Start and install a DDF instance
2. From the admin console, navigate to Catalog -> Configuration -> Catalog Content Directory Monitor
3. In the Directory Path field, add a local path to a directory from your machine for testing
4. Navigate to the `DDF_HOME/data` directory on your machine 
5. In the data directory, make sure there is only one `DurableFileConsumer` directory and one `processed` directory.
6. The `DurableFileConsumer` directory should contain only one .ser file, and .ser files for files in your test directory from step 3 should exist in `processed`.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2911/)
