### PR TITLE
DDF-2896: added iframeresizer to documentation to fix scrolling issue.

### DIFF
--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -927,3 +927,8 @@ include::{adoc-include}/_formats/complete-list-file-types-contents.adoc[]
 == ${branding} Dependency List
 
 include::{adoc-include}/_dependency-list/ddf-dependency-list.adoc[]
+
+// Include iframeResizer to fix scolling issue when displayed in admin-ui.
+++++
+<script type="text/javascript" src="/admin/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js"></script>
+++++


### PR DESCRIPTION
#### What does this PR do?

When the iframe-resizer was added for admin modules, it caused usability issues for documentation. This PR fixes those issues by adding the iframe-resizer script to documentation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@garrettfreibott 
@andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)

- quick build, but include documentation
- open admin ui
- ensure the docs are usable

#### What are the relevant tickets?

[DDF-2896](https://codice.atlassian.net/browse/DDF-2896)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
