### PR TITLE
DDF-2915 Update the Admin UI loading scheme to reduce initial network cost

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/Module.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/Module.view.js
@@ -46,6 +46,7 @@ define([
                     },
                     setHeader: function() {
                         $('#pageHeader').html(this.model.get('name'));
+                        this.model.set('active', true);
                     },
                     onRender: function() {
                         if(this.model.get('active')) {
@@ -62,19 +63,22 @@ define([
                 itemView: Marionette.ItemView.extend({
                     tagName: 'div',
                     className: 'tab-pane',
-                    onShow: function () {
+                    initialize: function(){
+                        this.listenTo(this.model, 'change:active', this.render);
+                    },
+                    attachIframeResizer: function () {
                         setTimeout(function(){
                              this.$('iframe').ready(function() {
                                 this.$('iframe').iFrameResize();
                             }.bind(this));
                         }.bind(this), 0);
                     },
-                    onRender: function() {
-                        var view = this;
-                        this.$el.attr('id', this.model.get('id'));
-                        if(this.model.get('active')) {
-                            this.$el.addClass('active');
+                    loadContent: function(){
+                        if (this.model.get('loaded')){
+                            return;
                         }
+                        this.model.set('loaded', true);
+                        var view = this;
                         //this dynamically requires in our modules based on wherever the model says they could be found
                         //check if we already have the module
                         if(this.model.get('iframeLocation') && this.model.get('iframeLocation') !== "") {
@@ -109,6 +113,14 @@ define([
                                     });
                                 }
                             }
+                        }
+                        this.attachIframeResizer();
+                    },
+                    onRender: function() {
+                        this.$el.attr('id', this.model.get('id'));
+                        if(this.model.get('active')) {
+                            this.$el.addClass('active');
+                            this.loadContent();
                         }
                     },
                     onClose: function() {


### PR DESCRIPTION
#### What does this PR do?
- In order to reduce the initial network cost, each tab's content (Applications, Documentation, etc.) is now loaded on demand when the user clicks the tab for the first time.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 
@rzwiefel 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Go to the admin UI and verify that the documentation does not load until you go to the documentation tab.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2915
