### PR TITLE
DDF-2917 Update caching to exclude base app pages and html

### DIFF
--- a/platform/platform-filter-response/src/main/java/org/codice/ddf/platform/response/filter/ResponseFilter.java
+++ b/platform/platform-filter-response/src/main/java/org/codice/ddf/platform/response/filter/ResponseFilter.java
@@ -23,6 +23,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
@@ -59,16 +60,17 @@ public class ResponseFilter implements Filter {
             X_CONTENT_SECURITY_POLICY + "=" + DEFAULT_CONTENT_SECURITY_POLICY,
             CACHE_CONTROL + "=" + DEFAULT_CACHE_CONTROL_VALUE);
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-        LOGGER.debug("Initializing Response Security Filter.");
+    // Index paths (such as /search/catalog/ or /admin/) should never be cached
+    private void disableCachingForHtml(HttpServletRequest request, HttpServletResponse response) {
+        String requestURI = request.getRequestURI();
+        if (requestURI.endsWith("/") || requestURI.endsWith(".html")) {
+            response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
+            response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
+            response.setHeader("Expires", "0"); // Proxies.
+        }
     }
 
-    @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
-            FilterChain filterChain) throws IOException, ServletException {
-        HttpServletResponse response = (HttpServletResponse) servletResponse;
-
+    private void addCommonHeaders(HttpServletResponse response) {
         for (String header : headers) {
             String[] keyVal = header.split("=", 2);
             if (keyVal.length != 2) {
@@ -77,6 +79,21 @@ public class ResponseFilter implements Filter {
             }
             response.setHeader(keyVal[0], keyVal[1]);
         }
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOGGER.trace("Initializing Response Security Filter.");
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain filterChain) throws IOException, ServletException {
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        addCommonHeaders(response);
+
+        disableCachingForHtml((HttpServletRequest) servletRequest, response);
 
         filterChain.doFilter(servletRequest, response);
     }


### PR DESCRIPTION
#### What does this PR do?
 - As of DDF-2893, we're caching everything far too aggressively.
 - This update allows apps to perform their own cache busting between versions, see DDF-2916.
 - Without this, a user will need to clear their cache (or wait a week) when upgrading to new versions.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@djblue 
@rzwiefel 
@kcwire
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Go to the admin application.  Verify that the main app page and any html pages within do not get cached.  Verify that other assets do.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2917
