### PR TITLE
DDF-2896 Changes script link to iframe resizer in documentation.

### DIFF
--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -920,5 +920,5 @@ include::{adoc-include}/_dependency-list/ddf-dependency-list.adoc[]
 
 // Include iframeResizer to fix scolling issue when displayed in admin-ui.
 ++++
-<script type="text/javascript" src="/admin/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js"></script>
+<script type="text/javascript" src="/admin/lib/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 ++++


### PR DESCRIPTION
#### What does this PR do?
Updates the link to the script in 2.10 to reflect its correct location.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue @garrettfreibott 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
- Full build including documentation.
- Install and run
- Check `Documentation` link in Admin Console to ensure that it displays correctly and scrolls.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2896](https://codice.atlassian.net/browse/DDF-2896)

#### Screenshots (if appropriate)
<img width="1104" alt="screen shot 2017-03-31 at 7 41 26 am" src="https://cloud.githubusercontent.com/assets/1469860/24555311/829daf4c-15e5-11e7-9e0c-76884c928e72.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
