### PR TITLE
DDF-2868 Removed "-p" flag from clearCatalog() command

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -101,9 +101,9 @@ public abstract class AbstractIntegrationTest {
 
     public static final String RESOURCE_VARIABLE_DELIMETER = "$";
 
-    public static final String REMOVE_ALL = "catalog:removeall -f -p";
+    public static final String REMOVE_ALL = "catalog:removeall -f";
 
-    private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
+    private static final String CLEAR_CACHE = "catalog:removeall -f --cache";
 
     protected static ServerSocket placeHolderSocket;
 


### PR DESCRIPTION
#### What does this PR do?
Changed clearCatalog() command from "catalog:removeall -f -p" to "catalog:removeall -f". Using the "-p" flag will result in non-resource metacards being deleted. This can cause issues with tests that need these metacards between tests.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emanns95 @brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Test](https://github.com/orgs/codice/teams/test)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Build DDF and run itests.

#### What are the relevant tickets?
[DDF-2868](https://codice.atlassian.net/browse/DDF-2868)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
