### PR TITLE
DDF-2919 [2.10.x] Create generic WebClients with SecureCxfClientFactory

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -111,6 +111,7 @@ public class SecureCxfClientFactory<T> {
     /**
      * Constructs a factory that will return security-aware cxf clients. Once constructed,
      * use the getClient* methods to retrieve a fresh client  with the same configuration.
+     * Providing {@link WebClient} to interfaceClass will create a generic web client.
      * <p>
      * This factory can and should be cached. The clients it constructs should not be.
      *
@@ -168,6 +169,7 @@ public class SecureCxfClientFactory<T> {
     /**
      * Constructs a factory that will return security-aware cxf clients. Once constructed,
      * use the getClient* methods to retrieve a fresh client  with the same configuration.
+     * Providing {@link WebClient} to interfaceClass will create a generic web client.
      * <p>
      * This factory can and should be cached. The clients it constructs should not be.
      *
@@ -194,6 +196,7 @@ public class SecureCxfClientFactory<T> {
     /**
      * Constructs a factory that will return security-aware cxf clients. Once constructed,
      * use the getClient* methods to retrieve a fresh client  with the same configuration.
+     * Providing {@link WebClient} to interfaceClass will create a generic web client.
      * <p>
      * This factory can and should be cached. The clients it constructs should not be.
      * <p>
@@ -268,7 +271,9 @@ public class SecureCxfClientFactory<T> {
     }
 
     private T getNewClient() {
-        T clientImpl = JAXRSClientFactory.fromClient(clientFactory.create(), interfaceClass);
+        T clientImpl = interfaceClass.equals(WebClient.class) ?
+                (T)clientFactory.create() :
+                JAXRSClientFactory.fromClient(clientFactory.create(), interfaceClass);
 
         ClientConfiguration clientConfig = WebClient.getConfig(clientImpl);
         clientConfig.getRequestContext()

--- a/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/SecureCxfClientFactoryTest.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/SecureCxfClientFactoryTest.java
@@ -213,6 +213,23 @@ public class SecureCxfClientFactoryTest {
         assertThat(result, notNullValue());
     }
 
+    @Test
+    public void testWebClient() {
+        PropertyResolver mockPropertyResolver = mock(PropertyResolver.class);
+        when(mockPropertyResolver.getResolvedString()).thenReturn(SECURE_ENDPOINT);
+        // positive case
+        SecureCxfClientFactory<WebClient> secureCxfClientFactory = new SecureCxfClientFactory<>(
+                SECURE_ENDPOINT,
+                WebClient.class,
+                null,
+                null,
+                false,
+                false,
+                mockPropertyResolver);
+        WebClient client = secureCxfClientFactory.getWebClient();
+        assertThat(client, notNullValue());
+    }
+
     private DummySubject getSubject() {
         return new DummySubject(new DefaultSecurityManager(), new SimplePrincipalCollection());
     }


### PR DESCRIPTION
#### What does this PR do?
This allows for the creation of unstructured, generic, security aware WebClients. Instead of being required to define an interface class, we can pass the WebClient class in to create a general purpose client as supported by the JAXRSClientFactory.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests is sufficient.

#### What are the relevant tickets?
[DDF-2919](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
