### PR TITLE
DDF-2921 update VideoThumbnailPlugin and test code to use null for qualifier strings that represent the original content

### DIFF
--- a/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
@@ -191,7 +191,7 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
                 }
 
                 // create a thumbnail for the unqualified content item
-                Path tmpPath = contentPaths.get("");
+                Path tmpPath = contentPaths.get(null);
                 if (tmpPath != null) {
                     createThumbnail(contentItem, tmpPath);
                 }

--- a/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/TestVideoThumbnailPlugin.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/TestVideoThumbnailPlugin.java
@@ -141,7 +141,7 @@ public class TestVideoThumbnailPlugin {
         HashMap<String, Path> contentItemPaths = new HashMap<>();
         Path tmpPath = Paths.get(getClass().getResource(resource)
                 .toURI());
-        contentItemPaths.put("", tmpPath);
+        contentItemPaths.put(null, tmpPath);
 
         HashMap<String, Map> tmpContentPaths = new HashMap<>();
         tmpContentPaths.put(ID, contentItemPaths);


### PR DESCRIPTION
#### What does this PR do?

The ContentItem documentation states that null should be used as the qualifier for the original content. The video thumbnail plugin was assuming the qualifier is the empty string. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@troymohl 
@peterhuffer 
@emmberk 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)
@jlcsmith 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
Ingest a video and verify that the thumbnail is created.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2921](https://codice.atlassian.net/browse/DDF-2921)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
