### PR TITLE
DDF-2862 Added configurable default QueryResponse queue timeout

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/QueryResponseImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/QueryResponseImpl.java
@@ -50,6 +50,8 @@ public class QueryResponseImpl extends ResponseImpl<QueryRequest> implements Que
 
     List<Result> resultList = null;
 
+    private long timeoutMillis = 30000;
+
     /**
      * Instantiates a new QueryResponseImpl with a $(@link QueryRequest)
      *
@@ -114,6 +116,11 @@ public class QueryResponseImpl extends ResponseImpl<QueryRequest> implements Que
         resultList = new ArrayList<Result>();
         if (closeResultQueue) {
             closeResultQueue();
+        }
+
+        if (request != null && request.getQuery() != null) {
+            timeoutMillis = request.getQuery()
+                    .getTimeoutMillis();
         }
     }
 
@@ -285,7 +292,7 @@ public class QueryResponseImpl extends ResponseImpl<QueryRequest> implements Que
     private Result handleTake() {
         Result result = null;
         try {
-            result = queue.take();
+            result = queue.poll(timeoutMillis, TimeUnit.MILLISECONDS);
             if (POISON_PILL_RESULT.equals(result)) {
                 result = null;
             }

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/QueryResponseImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/operation/impl/QueryResponseImpl.java
@@ -50,7 +50,7 @@ public class QueryResponseImpl extends ResponseImpl<QueryRequest> implements Que
 
     List<Result> resultList = null;
 
-    private long timeoutMillis = 30000;
+    private long timeoutMillis = 300000;
 
     /**
      * Instantiates a new QueryResponseImpl with a $(@link QueryRequest)

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheQueryFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheQueryFactory.java
@@ -52,6 +52,8 @@ public class CacheQueryFactory {
                     .getStartIndex());
             sourceQuery.setSortBy(input.getQuery()
                     .getSortBy());
+            sourceQuery.setTimeoutMillis(input.getQuery()
+                    .getTimeoutMillis());
             queryWithSources = new QueryRequestImpl(sourceQuery,
                     input.isEnterprise(),
                     input.getSourceIds(),

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -93,7 +93,7 @@ public class QueryOperations extends DescribableImpl {
 
     private List<String> fanoutProxyTagBlacklist = new ArrayList<>();
 
-    private long queryTimeoutMillis = 30000;
+    private long queryTimeoutMillis = 300000;
 
     public QueryOperations(FrameworkProperties frameworkProperties,
             SourceOperations sourceOperations, OperationsSecuritySupport opsSecuritySupport,

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -62,6 +62,7 @@
                 <value>registry-remote</value>
             </list>
         </property>
+        <property name="queryTimeoutMillis" value="300000"/>
     </bean>
 
     <bean id="cfResourceOps" class="ddf.catalog.impl.operations.ResourceOperations">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -36,6 +36,9 @@
             type="String" cardinality="100"
             default="registry,registry-remote"
             description="Query operations with tags in this list will not be passed through."/>
+        <AD name="Query timeout (milliseconds)" id="queryTimeoutMillis" required="true" type="Long"
+            default="300000"
+            description="Time in milliseconds that a query will wait on the queue before timeout."/>
 
     </OCD>
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -308,10 +308,14 @@ public class CatalogFrameworkImplTest {
         mockFederationStrategy = mock(FederationStrategy.class);
         Result mockFederationResult = mock(Result.class);
         when(mockFederationResult.getMetacard()).thenReturn(new MetacardImpl());
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryRequest mockQueryRequest = mock(QueryRequest.class);
+        Query mockQuery = mock(Query.class);
+        when(mockQuery.getTimeoutMillis()).thenReturn(1L);
+        when(mockQueryRequest.getQuery()).thenReturn(mockQuery);
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mockQueryRequest,
                 Collections.singletonList(mockFederationResult),
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         federatedSources = createDefaultFederatedSourceList(true);
 
@@ -825,10 +829,11 @@ public class CatalogFrameworkImplTest {
         MetacardImpl metacard = new MetacardImpl();
         metacard.setId(insertedCard.getId());
         when(mockFederationResult.getMetacard()).thenReturn(metacard);
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 Collections.singletonList(mockFederationResult),
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         List<Entry<Serializable, Metacard>> updatedEntries =
                 new ArrayList<Entry<Serializable, Metacard>>();
@@ -879,10 +884,10 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         UpdateRequest updateRequest = new UpdateRequestImpl(new String[] {"1", "2", "3", "4", "5"},
                 createResponse.getCreatedMetacards());
@@ -935,10 +940,10 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         final UpdateResponse response = framework.update(request);
 
@@ -999,10 +1004,11 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
+
         // send update to framework
         List<Update> returnedCards = framework.update(request)
                 .getUpdatedMetacards();
@@ -1128,10 +1134,11 @@ public class CatalogFrameworkImplTest {
         MetacardImpl metacard = new MetacardImpl();
         metacard.setId(ids[0]);
         when(mockFederationResult.getMetacard()).thenReturn(metacard);
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 Collections.singletonList(mockFederationResult),
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         // send delete to framework
         List<Metacard> returnedCards = framework.delete(new DeleteRequestImpl(ids))
@@ -1178,10 +1185,10 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         final DeleteResponse response = framework.delete(request);
 
@@ -1232,10 +1239,10 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
         // send update to framework
         UpdateResponse updateResponse = framework.update(request);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -1089,10 +1089,11 @@ public class CatalogFrameworkImplTest {
                 })
                 .collect(Collectors.toList());
 
-        when(mockFederationStrategy.federate(anyList(),
-                anyObject())).thenReturn(new QueryResponseImpl(mock(QueryRequest.class),
+        QueryResponseImpl queryResponse = new QueryResponseImpl(mock(QueryRequest.class),
                 mockFederationResults,
-                1));
+                1);
+        when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
+
         // send update to framework
         List<Update> returnedCards = framework.update(request)
                 .getUpdatedMetacards();

--- a/distribution/docs/src/main/resources/_contents/_queries/developing-query-options-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_queries/developing-query-options-contents.adoc
@@ -56,7 +56,7 @@ A developer should consult a Source's documentation for the limitations, capabil
 |Determines whether the total number of results should be returned.
 
 |`TimeoutMillis`
-|The amount of time in milliseconds before the query is to be abandoned.
+|The amount of time in milliseconds before the query is to be abandoned. If a zero or negative timeout is set, the catalog framework will default to a value configurable via the Admin UI under Catalog -> Configuration -> Query Operations.
 
 |===
 


### PR DESCRIPTION
#### What does this PR do?
This timeout will be applied in cases where the timeout is set
to a negative value or to 0 in the query.

* Added documentation for configuring query timeout
* Added unit tests for query timeout setting

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel
@brendan-hofmann

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison 

#### Any background context you want to provide?
A solr update seems to have resolved us being able to replicate the system freezing, but the timeout is still being added.

#### What are the relevant tickets?
[DDF-2862](https://codice.atlassian.net/browse/DDF-2862)

#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
