### PR TITLE
DDF-2862 Increase query timeout for TestMetacardCache

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
@@ -30,6 +30,8 @@ public class ConfigureTestCommons {
 
     public static final String CACHING_FEDERATION_STRATEGY_PID = "ddf.catalog.federation.impl.CachingFederationStrategy";
 
+    public static final String QUERY_OPERATIONS_PID = "ddf.catalog.impl.operations.QueryOperations";
+
 
     public static void configureMetacardValidityFilterPlugin(List<String> securityAttributeMappings, AdminConfig configAdmin)
             throws IOException {
@@ -87,6 +89,17 @@ public class ConfigureTestCommons {
 
         Dictionary<String, Object> properties = new Hashtable<>();
         properties.put("enforcedMetacardValidators", enforcedValidators);
+        config.update(properties);
+    }
+
+    public static void configureQueryTimeoutMillis(long timeoutMillis, AdminConfig configAdmin)
+            throws IOException {
+        Configuration config = configAdmin.getConfiguration(
+                QUERY_OPERATIONS_PID,
+                null);
+
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put("queryTimeoutMillis", timeoutMillis);
         config.update(properties);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Increases the query timeout in TestFederation.testMetacardCache to stop CI build failures.

Also adds an integration test to assert the query timeout working.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
WIP. Will add later. Wanted to try the CI.

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
WIP. Will add later. Wanted to try the CI.

#### How should this be tested? (List steps with links to updated documentation)
Successful CI build.

#### Any background context you want to provide?
CI build failures may have been introduced by https://github.com/codice/ddf/commit/9c4d9df3768158b8d6484164b99d8fcd4113e89f. But the tests passed when run again.

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
