### PR TITLE
DDF-2925 (2.10.x) - Update openlayers circle drawing to be projection agnostic

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.circle.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.circle.js
@@ -56,12 +56,12 @@ define([
                 this.model.set({
                     lat: center[1],
                     lon: center[0],
-                    radius: geometry.getRadius()
+                    radius: geometry.getRadius() * this.map.getView().getProjection().getMetersPerUnit()
                 });
             },
 
             modelToCircle: function (model) {
-                var rectangle = new ol.geom.Circle(translateToOpenlayersCoordinate([model.get('lon'), model.get('lat')]), model.get('radius'));
+                var rectangle = new ol.geom.Circle(translateToOpenlayersCoordinate([model.get('lon'), model.get('lat')]), model.get('radius') / this.map.getView().getProjection().getMetersPerUnit());
                 return rectangle;
             },
 
@@ -90,7 +90,7 @@ define([
                 }
 
                 var point = Turf.point(translateFromOpenlayersCoordinate(rectangle.getCenter()));
-                var turfCircle = new TurfCircle(point,rectangle.getRadius(), 64, 'meters');
+                var turfCircle = new TurfCircle(point, rectangle.getRadius() * this.map.getView().getProjection().getMetersPerUnit(), 64, 'meters');
                 var geometryRepresentation = new ol.geom.LineString(translateToOpenlayersCoordinates(turfCircle.geometry.coordinates[0]));
 
                 if (this.vectorLayer) {


### PR DESCRIPTION
#### What does this PR do?
 - The units of the radius for circles in openlayers depends upon the map projection.  As a result, we need to convert back and forth as needed using getMetersPerUnit.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@mcalcote 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Verify that drawing circles works with openlayers.  Update the projection and switch back and forth from EPSG:3857 and EPSG:4326.  Verify old drawings work as they should, and new drawings as well.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2925
