### PR TITLE
DDF-2928 Fixed SolrCatalogProvider row size

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/resources/csw/request/CswUpdateAllByFilterRequest
+++ b/distribution/test/itests/test-itests-common/src/main/resources/csw/request/CswUpdateAllByFilterRequest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<csw:Transaction service="CSW" version="2.0.2" verboseResponse="true" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc">
+    <csw:Update>
+      <csw:RecordProperty>
+        <csw:Name>title</csw:Name>
+        <csw:Value>Updated Title</csw:Value>
+      </csw:RecordProperty>
+      <csw:Constraint version="2.0.0">
+            <ogc:Filter>
+                <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
+                    <ogc:PropertyName>id</ogc:PropertyName>
+                    <ogc:Literal>%</ogc:Literal>
+                </ogc:PropertyIsLike>
+            </ogc:Filter>
+      </csw:Constraint>
+    </csw:Update>
+</csw:Transaction>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -487,11 +487,11 @@ public class TestCatalog extends AbstractIntegrationTest {
         ValidatableResponse validatableResponse = response.then();
 
         validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalInserted",
-                is("1")),
-                hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is("0")),
-                hasXPath("//TransactionResponse/TransactionSummary/totalDeleted", is("0")),
-                hasXPath("//TransactionResponse/InsertResult/BriefRecord/title", is("myXmlTitle")),
-                hasXPath("//TransactionResponse/InsertResult/BriefRecord/BoundingBox"));
+                        is("1")), hasXPath("//TransactionResponse/TransactionSummary/totalUpdated",
+                        is("0")), hasXPath("//TransactionResponse/TransactionSummary/totalDeleted",
+                        is("0")), hasXPath("//TransactionResponse/InsertResult/BriefRecord/title",
+                        is("myXmlTitle")), hasXPath(
+                        "//TransactionResponse/InsertResult/BriefRecord/BoundingBox"));
 
         try {
             CatalogTestCommons.deleteMetacardUsingCswResponseId(response);
@@ -512,8 +512,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .then()
                 .assertThat()
                 .statusCode(equalTo(200))
-                .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned]"),
-                        not("0"));
+                .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned]"), not(
+                        "0"));
 
         try {
             CatalogTestCommons.deleteMetacardUsingCswResponseId(response);
@@ -634,9 +634,9 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .post(CSW_PATH.getUrl())
                 .then();
         validatableResponse.body(hasXPath("//TransactionResponse/TransactionSummary/totalDeleted",
-                is("0")),
-                hasXPath("//TransactionResponse/TransactionSummary/totalInserted", is("0")),
-                hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is("1")));
+                        is("0")), hasXPath("//TransactionResponse/TransactionSummary/totalInserted",
+                        is("0")), hasXPath("//TransactionResponse/TransactionSummary/totalUpdated",
+                        is("1")));
 
         String url = REST_PATH.getUrl() + id;
         when().get(url)
@@ -754,6 +754,25 @@ public class TestCatalog extends AbstractIntegrationTest {
 
         deleteMetacard(firstId);
         deleteMetacard(secondId);
+    }
+
+    @Test
+    public void testCswUpdateAllRecordsByFilterConstraint() {
+        int numRecords = 25;
+        for (int i=0; i<numRecords; i++) {
+            ingestCswRecord();
+        }
+
+        ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_XML)
+                .body(getFileContent(
+                        CSW_REQUEST_RESOURCE_PATH + "/CswUpdateAllByFilterRequest"))
+                .post(CSW_PATH.getUrl())
+                .then();
+
+        response.body(hasXPath("//TransactionResponse/TransactionSummary/totalDeleted", is("0")),
+                hasXPath("//TransactionResponse/TransactionSummary/totalInserted", is("0")),
+                hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is(Integer.toString(numRecords))));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where UpdateRequests were only updating the first 10 metacards.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest 20-25 Records / Bulk Edit All 25 Records / Verify all are updated
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2928](https://codice.atlassian.net/browse/DDF-2928)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
