### PR TITLE
DDF-2862 Fixes cache queries to carry over the query timeout passed to them

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheQueryFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheQueryFactory.java
@@ -52,6 +52,8 @@ public class CacheQueryFactory {
                     .getStartIndex());
             sourceQuery.setSortBy(input.getQuery()
                     .getSortBy());
+            sourceQuery.setTimeoutMillis(input.getQuery()
+                    .getTimeoutMillis());
             queryWithSources = new QueryRequestImpl(sourceQuery,
                     input.isEnterprise(),
                     input.getSourceIds(),


### PR DESCRIPTION
#### What does this PR do?
When the `CacheQueryFactory` wraps and modifies queries to hit the cache, it was neglecting to include the timeout for the query. This PR resolves that.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emanns95 @AzGoalie 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@stustison

#### How should this be tested? (List steps with links to updated documentation)
On a slow or resource constrained machine, run the `TestFederation.testMetacardCache` integration test several times. It should pass successfully.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2862](https://codice.atlassian.net/browse/DDF-2862)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
