### PR TITLE
DDF-2934 (2.10.x) Remove injection opportunity from bind helper

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/association/association.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/association/association.view.js
@@ -16,6 +16,7 @@
 var template = require('./association.hbs');
 var Marionette = require('marionette');
 var CustomElements = require('js/CustomElements');
+var Common = require('js/Common');
 var DropdownView = require('component/dropdown/dropdown.view');
 var _ = require('underscore');
 
@@ -186,7 +187,7 @@ module.exports = Marionette.LayoutView.extend({
         var label = currentMetacard.get('metacard').id === currentId ?
             'Current Metacard' : this.getChoiceById(currentId).label;
         this.$el.find('.association-child').attr('data-label', label);
-        this.$el.find('.association-child-link a').attr('href', '#metacards/'+currentId).html(label);
+        this.$el.find('.association-child-link a').attr('href', '#metacards/'+currentId).html(Common.escapeHTML(label));
     },
     updateParentReadOnly: function() {
         var currentMetacard = this.options.currentMetacard;
@@ -194,7 +195,7 @@ module.exports = Marionette.LayoutView.extend({
         var label = currentMetacard.get('metacard').id === currentId ?
             'Current Metacard' : this.getChoiceById(currentId).label;
         this.$el.find('.association-parent').attr('data-label', label);
-        this.$el.find('.association-parent-link a').attr('href', '#metacards/'+currentId).html(label);
+        this.$el.find('.association-parent-link a').attr('href', '#metacards/'+currentId).html(Common.escapeHTML(label));
     },
     updateRelationshipReadOnly: function() {
         var currentMetacard = this.options.currentMetacard;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.view.js
@@ -139,7 +139,7 @@ define([
         },
         updatePanelTwoQueryTitle: function(){
             var queryRef = store.getQuery();
-            var title = queryRef._cloneOf === undefined ? 'New Query' : queryRef.get('title');
+            var title = queryRef._cloneOf === undefined ? 'New Query' : queryRef.escape('title');
             this.$el.find('.content-panelTwo-title').html(title);
         },
         hidePanelTwo: function(){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
@@ -354,7 +354,7 @@ define([
                 var callback = function() {
                     var $target = this.$el.find(options.hash.selector);
                     var value = _get(this.serializeData(), options.hash.key);
-                    $target.filter(':not(input)').html(value);
+                    $target.filter(':not(input)').html(Common.escapeHTML(value));
                     $target.filter('input').each(function(){
                         if ($(this).val() !== value){
                             $(this).val(value);


### PR DESCRIPTION
#### What does this PR do?
 - Removed possible injection opportunity from bind helper.
 - Updated two other areas to be safe from possible injection.

#### Who is reviewing
@rzwiefel 
@garrettfreibott 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Go to a workspace and update the name to include xss.  Verify it doesn't get executed.

#### Any background context you want to provide?
This was added in a backport to 2.10.x so it's not out in the wild yet.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2934

Thanks for finding this one @garrettfreibott !