### PR TITLE
DDF-2900 Undid removal of FuzzyFunctionFactory.java

### DIFF
--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/FuzzyFunctionFactory.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/FuzzyFunctionFactory.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.impl.filter;
+
+@Deprecated
+public class FuzzyFunctionFactory extends GeoToolsFunctionFactory {
+
+}

--- a/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/FuzzyFunctionTest.java
+++ b/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/FuzzyFunctionTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.Test;
 import org.opengis.filter.expression.Expression;
 
+@Deprecated
 public class FuzzyFunctionTest {
 
     @Test(expected = NullPointerException.class)

--- a/distribution/docs/src/main/resources/_contents/_app-whitelists/catalog-whitelist-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_app-whitelists/catalog-whitelist-contents.adoc
@@ -13,7 +13,6 @@ The following packages have been exported by the ${ddf-catalog} application and 
 * `ddf.catalog.federation.impl`
 * `ddf.catalog.filter`
 * `ddf.catalog.filter.delegate`
-* `ddf.catalog.impl.filter`
 * `ddf.catalog.operation`
 * `ddf.catalog.plugin`
 * `ddf.catalog.plugin.groomer`


### PR DESCRIPTION
#### What does this PR do?
This PR undoes the removal of the FuzzyFunctionFactory and deprecates it.
It also removes `ddf.catalog.filter.impl` from the whitelist.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@coyotesqrl  
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@millerw8
@pklinef
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Verify that the CqlEndpoint still recognizes proximity searches.  Since this functionality was already hero'd in the main PR, this should be sufficient.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2900](https://codice.atlassian.net/browse/DDF-2900)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
