### PR TITLE
DDF-2920 Added initial jenkinsfile for pipelines build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,64 @@
+//"Jenkins Pipeline is a suite of plugins which supports implementing and integrating continuous delivery pipelines into Jenkins. Pipeline provides an extensible set of tools for modeling delivery pipelines "as code" via the Pipeline DSL."
+//More information can be found on the Jenkins Documentation page https://jenkins.io/doc/
+pipeline {
+    agent none
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'25'))
+    }
+    stages {
+        stage('Setup') {
+            steps{
+                slackSend color: 'good', message: "STARTED: ${JOB_NAME} ${BUILD_NUMBER} ${BUILD_URL}"
+            }
+        }
+        stage('Parallel Build') {
+            // TODO refactor this stage from scripted syntax to declarative syntax to match the rest of the stages - https://issues.jenkins-ci.org/browse/JENKINS-41334
+            steps{
+                parallel(
+                    linux: {
+                        node('linux-large') {
+                            timeout(time: 3, unit: 'HOURS') {
+                                checkout scm
+                                withMaven(maven: 'M3', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
+                                    sh 'mvn clean install -pl !distribution/test/itests/test-itests-ddf'
+                                    sh 'mvn install -pl distribution/test/itests/test-itests-ddf'
+                                }
+                            }
+                        }
+                    }, windows: {
+                        node('proxmox-windows'){
+                            timeout(time: 3, unit: 'HOURS') {
+                                checkout scm
+                                withMaven(maven: 'M3', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
+                                    bat 'mvn clean install -pl !distribution/test/itests/test-itests-ddf'
+                                    bat 'mvn install -pl distribution/test/itests/test-itests-ddf'
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        }
+        stage('Deploy') {
+            agent { label 'linux-small' }
+            steps{
+                withMaven(maven: 'M3', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice_settings.xml') {
+                    checkout scm
+                    sh 'mvn javadoc:aggregate -Pjavadoc -DskipStatic=true -DskipTests=true'
+                    sh 'mvn deploy -DskipStatic=true -DskipTests=true'
+                }
+            }
+        }
+    }
+    post {
+        success {
+            slackSend color: 'good', message: "SUCCESS: ${JOB_NAME} ${BUILD_NUMBER}"
+        }
+        failure {
+            slackSend color: '#ea0017', message: "FAILURE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+        unstable {
+            slackSend color: '#ffb600', message: "UNSTABLE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
The goal of this change is to add the initial Jenkinsfile to the project repo and establish the format for follow-on work. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@oconnormi @LinkMJB @emmberk

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build) @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@clockard 

#### How should this be tested? (List steps with links to updated documentation)
This job is currently running in the test Jenkins environment. After this ticket is merged we can set up a job for it on the standard jenkins to eventually migrate our nightly (and beyond) to.

#### Any background context you want to provide?
This jenkinsfile utilizes the declarative syntax. This is currently in its 1.0 state and will likely have refinements and improvements rolling out in the near future.

#### What are the relevant tickets?
[DDF-2920](https://codice.atlassian.net/browse/DDF-2920)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
