### PR TITLE
DDF-2932 Adding new system properties for internal ports.

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -6,7 +6,7 @@
 org.osgi.service.http.enabled=false
 
 # Default port for the OSGI HTTP Service
-org.osgi.service.http.port=${org.codice.ddf.system.httpPort}
+org.osgi.service.http.port=${org.codice.ddf.system.internalHttpPort}
 
 ######################
 # HTTPS settings
@@ -19,7 +19,7 @@ org.osgi.service.http.secure.enabled=true
 # (Verify this port does not conflict with any other secure ports being used in your
 # network. For example, JBoss and other application servers use port 8443 by default)
 
-org.osgi.service.http.port.secure=${org.codice.ddf.system.httpsPort}
+org.osgi.service.http.port.secure=${org.codice.ddf.system.internalHttpsPort}
 
 # They keystore and passwords pull from the Java System Properties which are set
 # in the system.properties file.  It is recommended that the keystore values are changed 

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -46,11 +46,17 @@ javax.net.ssl.trustStoreType=jks
 #
 # Global URL Properties
 #
+
+# The httpsPort, httpPort, and port properties are used to advertise the system externally
+# The internalHttpsPort and internalHttpPort properties are the ports that the system will run on
+
 org.codice.ddf.system.protocol=https://
 org.codice.ddf.system.hostname=localhost
 org.codice.ddf.system.httpsPort=8993
 org.codice.ddf.system.httpPort=8181
-org.codice.ddf.system.port=8993
+org.codice.ddf.system.port=${org.codice.ddf.system.httpsPort}
+org.codice.ddf.system.internalHttpsPort=${org.codice.ddf.system.httpsPort}
+org.codice.ddf.system.internalHttpPort=${org.codice.ddf.system.httpPort}
 org.codice.ddf.system.rootContext=/services
 
 

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
@@ -103,28 +103,46 @@ Does not change the address the system runs on.
 |HTTPS Port
 |org.codice.ddf.system.httpsPort
 |String
-|The https port used by the system.
+|The https port used to advertise the system.
 
-NOTE: This *DOES* change the port the system runs on.
+NOTE: This does not change the port the system runs on.
 |8993
 |Yes
 
 |HTTP Port
 |org.codice.ddf.system.httpPort
 |String
-|The http port used by the system.
+|The http port used to advertise the system.
 
-NOTE: This *DOES* change the port the system runs on.
+NOTE: This does not change the port the system runs on.
 |8181
 |Yes
 
 |Default Port
 |org.codice.ddf.system.port
 |String
-|The default port used to advertise the system. This should match either the http or https port.
+|The default port used to advertise the system. This should match either the above http or https port.
 
 NOTE: Does not change the port the system runs on.
 |8993
+|Yes
+
+|Internal HTTPS Port
+|org.codice.ddf.system.internalHttpsPort
+|String
+|The https port that the system uses.
+
+NOTE: This *DOES* change the port the system runs on.
+|8993
+|Yes
+
+|Internal HTTP Port
+|org.codice.ddf.system.internalHttpPort
+|String
+|The http port that the system uses.
+
+NOTE: This *DOES* change the port the system runs on.
+|8181
 |Yes
 
 |Root Context

--- a/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
+++ b/platform/platform-commands/src/main/java/org/codice/ddf/commands/platform/DescribeCommand.java
@@ -26,8 +26,14 @@ public class DescribeCommand extends PlatformCommands {
         System.out.printf("%s=%s%n", "Host", SystemBaseUrl.getHost());
         System.out.printf("%s=%s%n", "Port", SystemBaseUrl.getPort());
         System.out.printf("%s=%s%n", "Root Context", SystemBaseUrl.getRootContext());
-        System.out.printf("%s=%s%n", "Http Port", SystemBaseUrl.getHttpPort());
-        System.out.printf("%s=%s%n", "Https Port", SystemBaseUrl.getHttpsPort());
+        System.out.printf("%s=%s%n", "External Http Port", SystemBaseUrl.getHttpPort());
+        System.out.printf("%s=%s%n", "External Https Port", SystemBaseUrl.getHttpsPort());
+        System.out.printf("%s=%s%n",
+                "Internal Http Port",
+                System.getProperty("org.codice.ddf.system.internalHttpPort"));
+        System.out.printf("%s=%s%n",
+                "Internal Https Port",
+                System.getProperty("org.codice.ddf.system.internalHttpsPort"));
 
         System.out.printf("%s=%s%n", "Site Name", SystemInfo.getSiteName());
         System.out.printf("%s=%s%n", "Organization", SystemInfo.getOrganization());


### PR DESCRIPTION
 - Also modifying the pax-web config to run jetty on the new internal ports.

#### What does this PR do?
This provides new system properties to allow an admin to run the DDF on a specific port, but advertise a different, external port. This is needed for certain features to work when DDF is behind a proxy or running in a container.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @oconnormi
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic 
#### How should this be tested? (List steps with links to updated documentation)
- Run a full build.
- Change the `org.codice.ddf.system.httpsPort` property (external port) to be different than 8993. Run a proxy on that "external" port and put DDF behind it.
- Verify a resource can be downloaded (i.e. that the resource url uses the external port)
- Verify you can logout through the UI
- Verify the describe command prints out the correct ports (`platform:describe`)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2932](https://codice.atlassian.net/browse/DDF-2932)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
