### PR TITLE
DDF-2950 Fixes filtering in Historian

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -171,8 +171,8 @@ public class Historian {
                 .filter(ci -> ci.getQualifier() == null || ci.getQualifier()
                         .equals(""))
                 .map(ContentItem::getMetacard)
-                .filter(isVersionOrDeleted().negate())
                 .filter(Objects::nonNull)
+                .filter(isVersionOrDeleted().negate())
                 .collect(Collectors.toList());
 
         Collection<ReadStorageRequest> ids = getReadStorageRequests(updatedMetacards);
@@ -219,7 +219,6 @@ public class Historian {
         List<Metacard> deletedMetacards = deleteResponse.getDeletedMetacards()
                 .stream()
                 .filter(isVersionOrDeleted().negate())
-
                 .collect(Collectors.toList());
 
         // [ContentItem.getId: content items]
@@ -512,18 +511,7 @@ public class Historian {
     }
 
     private Predicate<Metacard> isVersionOrDeleted() {
-        return (m) -> {
-            String metacardTypeName = m.getMetacardType()
-                    .getName();
-
-            String metacardVersionTypeName = MetacardVersionImpl.getMetacardVersionType()
-                    .getName();
-            String deletedMetacardTypeName = DeletedMetacardImpl.getDeletedMetacardType()
-                    .getName();
-
-            return metacardVersionTypeName.equals(metacardTypeName)
-                    || deletedMetacardTypeName.equals(metacardTypeName);
-        };
+        return (m) -> MetacardVersionImpl.isVersion(m) || DeletedMetacardImpl.isDeleted(m);
     }
 
     private static class WrappedByteSource extends ByteSource {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.codice.ddf.security.common.Security;
 import org.opengis.filter.Filter;
 import org.osgi.framework.Bundle;
@@ -89,8 +90,9 @@ import ddf.security.SubjectUtils;
 public class Historian {
     private static final Logger LOGGER = LoggerFactory.getLogger(Historian.class);
 
-    private final Predicate<Metacard> isVersionOrDeleted =
-            (m) -> MetacardVersionImpl.isVersion(m) || DeletedMetacardImpl.isDeleted(m);
+    private final Predicate<Metacard> isNotVersionNorDeleted =
+            ((Predicate<Metacard>) MetacardVersionImpl::isVersion).or(DeletedMetacardImpl::isDeleted)
+                    .negate();
 
     private boolean historyEnabled = true;
 
@@ -137,7 +139,7 @@ public class Historian {
         List<Metacard> inputMetacards = updateResponse.getUpdatedMetacards()
                 .stream()
                 .map(Update::getOldMetacard)
-                .filter(isVersionOrDeleted.negate())
+                .filter(isNotVersionNorDeleted)
                 .collect(Collectors.toList());
 
         final Map<String, Metacard> versionedMetacards = getVersionMetacards(inputMetacards,
@@ -171,11 +173,10 @@ public class Historian {
 
         List<Metacard> updatedMetacards = updateStorageResponse.getUpdatedContentItems()
                 .stream()
-                .filter(ci -> ci.getQualifier() == null || ci.getQualifier()
-                        .equals(""))
+                .filter(ci -> StringUtils.isBlank(ci.getQualifier()))
                 .map(ContentItem::getMetacard)
                 .filter(Objects::nonNull)
-                .filter(isVersionOrDeleted.negate())
+                .filter(isNotVersionNorDeleted)
                 .collect(Collectors.toList());
 
         Collection<ReadStorageRequest> ids = getReadStorageRequests(updatedMetacards);
@@ -221,7 +222,7 @@ public class Historian {
 
         List<Metacard> deletedMetacards = deleteResponse.getDeletedMetacards()
                 .stream()
-                .filter(isVersionOrDeleted.negate())
+                .filter(isNotVersionNorDeleted)
                 .collect(Collectors.toList());
 
         // [ContentItem.getId: content items]
@@ -497,14 +498,14 @@ public class Historian {
     private StorageProvider storageProvider() {
         return storageProviders.stream()
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(
+                .orElseThrow(() -> new IllegalStateException(
                         "Cannot version metacards without a storage provider"));
     }
 
     private CatalogProvider catalogProvider() {
         return catalogProviders.stream()
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(
+                .orElseThrow(() -> new IllegalStateException(
                         "Cannot version metacards without a storage provider"));
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -89,6 +89,9 @@ import ddf.security.SubjectUtils;
 public class Historian {
     private static final Logger LOGGER = LoggerFactory.getLogger(Historian.class);
 
+    private final Predicate<Metacard> isVersionOrDeleted =
+            (m) -> MetacardVersionImpl.isVersion(m) || DeletedMetacardImpl.isDeleted(m);
+
     private boolean historyEnabled = true;
 
     private List<StorageProvider> storageProviders;
@@ -134,7 +137,7 @@ public class Historian {
         List<Metacard> inputMetacards = updateResponse.getUpdatedMetacards()
                 .stream()
                 .map(Update::getOldMetacard)
-                .filter(isVersionOrDeleted().negate())
+                .filter(isVersionOrDeleted.negate())
                 .collect(Collectors.toList());
 
         final Map<String, Metacard> versionedMetacards = getVersionMetacards(inputMetacards,
@@ -172,7 +175,7 @@ public class Historian {
                         .equals(""))
                 .map(ContentItem::getMetacard)
                 .filter(Objects::nonNull)
-                .filter(isVersionOrDeleted().negate())
+                .filter(isVersionOrDeleted.negate())
                 .collect(Collectors.toList());
 
         Collection<ReadStorageRequest> ids = getReadStorageRequests(updatedMetacards);
@@ -218,7 +221,7 @@ public class Historian {
 
         List<Metacard> deletedMetacards = deleteResponse.getDeletedMetacards()
                 .stream()
-                .filter(isVersionOrDeleted().negate())
+                .filter(isVersionOrDeleted.negate())
                 .collect(Collectors.toList());
 
         // [ContentItem.getId: content items]
@@ -227,12 +230,11 @@ public class Historian {
         Action action = contentItems.isEmpty() ? Action.DELETED : Action.DELETED_CONTENT;
 
         // [MetacardVersion.VERSION_OF_ID: versioned metacard]
-        Map<String, Metacard> versionedMap =
-                getVersionMetacards(deletedMetacards,
-                        action,
-                        (Subject) deleteResponse.getRequest()
-                                .getProperties()
-                                .get(SecurityConstants.SECURITY_SUBJECT));
+        Map<String, Metacard> versionedMap = getVersionMetacards(deletedMetacards,
+                action,
+                (Subject) deleteResponse.getRequest()
+                        .getProperties()
+                        .get(SecurityConstants.SECURITY_SUBJECT));
 
         CreateStorageResponse createStorageResponse = versionContentItems(contentItems,
                 versionedMap);
@@ -508,10 +510,6 @@ public class Historian {
 
     public void setMetacardTypes(List<MetacardType> metacardTypes) {
         this.metacardTypes = metacardTypes;
-    }
-
-    private Predicate<Metacard> isVersionOrDeleted() {
-        return (m) -> MetacardVersionImpl.isVersion(m) || DeletedMetacardImpl.isDeleted(m);
     }
 
     private static class WrappedByteSource extends ByteSource {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -172,6 +172,7 @@ public class Historian {
                         .equals(""))
                 .map(ContentItem::getMetacard)
                 .filter(isVersionOrDeleted().negate())
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         Collection<ReadStorageRequest> ids = getReadStorageRequests(updatedMetacards);
@@ -218,6 +219,7 @@ public class Historian {
         List<Metacard> deletedMetacards = deleteResponse.getDeletedMetacards()
                 .stream()
                 .filter(isVersionOrDeleted().negate())
+
                 .collect(Collectors.toList());
 
         // [ContentItem.getId: content items]

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
@@ -14,8 +14,11 @@
 package ddf.catalog.core.versioning.impl;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,14 +89,16 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
         }
     }
 
-    public static boolean isNotDeleted(Metacard metacard) {
+    public static boolean isNotDeleted(@Nullable Metacard metacard) {
         return !isDeleted(metacard);
     }
 
-    public static boolean isDeleted(Metacard metacard) {
+    public static boolean isDeleted(@Nullable Metacard metacard) {
         return metacard instanceof DeletedMetacard || getDeletedMetacardType().getName()
-                .equals(metacard.getMetacardType()
-                        .getName());
+                .equals(Optional.ofNullable(metacard)
+                        .map(Metacard::getMetacardType)
+                        .map(MetacardType::getName)
+                        .orElse(null));
     }
 
     public static MetacardType getDeletedMetacardType() {

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -36,6 +36,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -285,14 +287,17 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
         return (MetacardVersion) metacard;
     }
 
-    public static boolean isNotVersion(Metacard metacard) {
+    public static boolean isNotVersion(@Nullable Metacard metacard) {
         return !isVersion(metacard);
     }
 
-    public static boolean isVersion(Metacard metacard) {
+    public static boolean isVersion(@Nullable Metacard metacard) {
+
         return metacard instanceof MetacardVersion || getMetacardVersionType().getName()
-                .equals(metacard.getMetacardType()
-                        .getName());
+                .equals(Optional.ofNullable(metacard)
+                        .map(Metacard::getMetacardType)
+                        .map(MetacardType::getName)
+                        .orElse(null));
     }
 
     public URI getVersionResourceUri() {


### PR DESCRIPTION
#### What does this PR do? 
- Previously inside of versioning a delete we were fetching content before
   filtering out the deleted & revision metacards, which could have lead to
   an NPE later. Now we filter out all version & history at the beginning
   of all 3 entry points into the file
 - Now when getting a storage or catalog provider from the reference
   list, we throw an exception when none are found instead of letting an
ambiguous NPE be thrown later.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@AzGoalie @bdeining 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
@coyotesqrl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@clockard 🎉  🎉 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Send a delete request to the catalog framework containing ids of both resource metacards and version metacards. (Requires a user with the `system-history` permission to delete version metacards)

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2950

