### PR TITLE
DDF-2936 Separating Metacard backup storage from backup configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,8 @@ _This is a preview of a pending release and is subject to change._
     </li>
     <li><a href='https://codice.atlassian.net/browse/DDF-2916'>DDF-2916</a> - Add cache busting to the Catalog (Intrigue) UI
     </li>
+    <li><a href='https://codice.atlassian.net/browse/DDF-2936'>DDF-2936</a> - As an integrator, I would like to have configurable writers for the MetacardBackupPlugin
+    </li>
 </ul>
     
 <h3>Task</h3>

--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -581,7 +581,17 @@
         </dependency>
         <dependency>
             <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
             <artifactId>catalog-plugin-metacardbackup</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-metacardbackup-filestorage</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -443,12 +443,26 @@
         </bundle>
     </feature>
 
+    <feature name="catalog-metacardbackup-storage-api" install="manual" version="${project.version"
+             description="File system storage provider for metacard backup">
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-storage-api/${project.version}
+        </bundle>
+    </feature>
+
     <feature name="catalog-metacard-backup" install="manual" version="${project.version}"
              description="Backup Metacards on Ingest">
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-async-inmemory</feature>
         <feature prerequisite="true">catalog-transformer-metadata</feature>
+        <feature prerequisite="true">catalog-metacardbackup-storage-api</feature>
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup/${project.version}
+        </bundle>
+    </feature>
+
+    <feature name="catalog-metacard-backup-filestorage" install="manual" version="${project.version"
+             description="File system storage provider for metacard backup">
+        <feature prerequisite="true">catalog-metacardbackup-storage-api</feature>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-filestorage/${project.version}
         </bundle>
     </feature>
 

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -443,7 +443,7 @@
         </bundle>
     </feature>
 
-    <feature name="catalog-metacardbackup-storage-api" install="manual" version="${project.version"
+    <feature name="catalog-metacard-backup-storage-api" install="manual" version="${project.version"
              description="API for the metacard backup storage provider">
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-storage-api/${project.version}
         </bundle>
@@ -454,14 +454,14 @@
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-async-inmemory</feature>
         <feature prerequisite="true">catalog-transformer-metadata</feature>
-        <feature prerequisite="true">catalog-metacardbackup-storage-api</feature>
+        <feature prerequisite="true">catalog-metacard-backup-storage-api</feature>
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup/${project.version}
         </bundle>
     </feature>
 
     <feature name="catalog-metacard-backup-filestorage" install="manual" version="${project.version"
              description="File system storage provider for metacard backup">
-        <feature prerequisite="true">catalog-metacardbackup-storage-api</feature>
+        <feature prerequisite="true">catalog-metacard-backup-storage-api</feature>
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-filestorage/${project.version}
         </bundle>
     </feature>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -444,7 +444,7 @@
     </feature>
 
     <feature name="catalog-metacardbackup-storage-api" install="manual" version="${project.version"
-             description="File system storage provider for metacard backup">
+             description="API for the metacard backup storage provider">
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-storage-api/${project.version}
         </bundle>
     </feature>

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
-    <name>DDF :: Catalog :: Plugin :: Metacard Backup Storage API</name>
+    <name>DDF :: Catalog :: Plugin :: Metacard Backup Storage :: API</name>
     <dependencies>
         <dependency>
             <groupId>ddf.platform.api</groupId>
@@ -42,6 +42,9 @@
                     <instructions>
                         <Embed-Dependency>
                         </Embed-Dependency>
+                        <Export-Package>
+                            org.codice.ddf.catalog.plugin.metacard.backup.storage.internal*
+                        </Export-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>
                 </configuration>

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
@@ -22,44 +22,9 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>catalog-plugin-metacardbackup</artifactId>
-    <name>DDF :: Catalog :: Plugin :: Metacard Backup Plugin</name>
+    <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Metacard Backup Storage API</name>
     <packaging>bundle</packaging>
-
-    <dependencies>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.async</groupId>
-            <artifactId>catalog-async-plugin-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.plugin</groupId>
-            <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.plugin</groupId>
-            <artifactId>catalog-plugin-metacardbackup-filestorage</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>
@@ -68,10 +33,10 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package/>
+                        <Export-Package>
+                            org.codice.ddf.catalog.plugin.metacard.backup.storage.api*
+                        </Export-Package>
                         <Embed-Dependency>
-                            catalog-core-api-impl,
-                            platform-util
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>
@@ -95,17 +60,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.00</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.00</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.00</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/pom.xml
@@ -24,6 +24,13 @@
 
     <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
     <name>DDF :: Catalog :: Plugin :: Metacard Backup Storage API</name>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.platform.api</groupId>
+            <artifactId>platform-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
     <packaging>bundle</packaging>
 
     <build>
@@ -33,9 +40,6 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>
-                            org.codice.ddf.catalog.plugin.metacard.backup.storage.api*
-                        </Export-Package>
                         <Embed-Dependency>
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupException.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupException.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.api;
+
+public class MetacardBackupException  extends Exception {
+
+    /** The Constant serialVersionUID. */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Instantiates a new MetacardBackupException from a given string.
+     *
+     * @param string
+     *            the string to use for the exception.
+     */
+    public MetacardBackupException(String string) {
+        super(string);
+    }
+
+    /**
+     * Instantiates a new MetacardBackupException.
+     */
+    public MetacardBackupException() {
+        super();
+    }
+
+    /**
+     * Instantiates a new MetacardBackupException with a message.
+     *
+     * @param message
+     *            the message
+     * @param throwable
+     *            the throwable
+     */
+    public MetacardBackupException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    /**
+     * Instantiates a new MetacardBackupException.
+     *
+     * @param throwable
+     *            the throwable
+     */
+    public MetacardBackupException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupStorageProvider.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupStorageProvider.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.api;
+
+import java.io.IOException;
+
+public interface MetacardBackupStorageProvider {
+    void deleteData(String id) throws IOException, MetacardBackupException;
+
+    void storeData(String id, byte[] data) throws IOException, MetacardBackupException;
+}

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupStorageProvider.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/api/MetacardBackupStorageProvider.java
@@ -15,8 +15,35 @@ package org.codice.ddf.catalog.plugin.metacard.backup.storage.api;
 
 import java.io.IOException;
 
-public interface MetacardBackupStorageProvider {
+import org.codice.ddf.platform.services.common.Describable;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ * <p>
+ * The {@code MetacardBackupStorageProvider} interface is used by the Metacard Backup Plugin
+ * to represent storage providers for the transformed metacard data.
+ */
+
+public interface MetacardBackupStorageProvider extends Describable {
+    /**
+     * Deletes backed up metacard with the provided metacard ID
+     *
+     * @param id - Identifier of the metacard to remove
+     * @throws IOException
+     * @throws MetacardBackupException
+     */
     void deleteData(String id) throws IOException, MetacardBackupException;
 
+    /**
+     * Stores data for the provided metacard ID
+     *
+     * @param id   - Identifier of the metacard to remove
+     * @param data - Bytes of the metacard to store
+     * @throws IOException
+     * @throws MetacardBackupException
+     */
     void storeData(String id, byte[] data) throws IOException, MetacardBackupException;
 }

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupException.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupException.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.catalog.plugin.metacard.backup.storage.api;
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.internal;
 
 public class MetacardBackupException  extends Exception {
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupStorageProvider.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupStorageProvider.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.catalog.plugin.metacard.backup.storage.api;
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.internal;
 
 import java.io.IOException;
 
@@ -35,7 +35,7 @@ public interface MetacardBackupStorageProvider extends Describable {
      * @throws IOException
      * @throws MetacardBackupException
      */
-    void deleteData(String id) throws IOException, MetacardBackupException;
+    void delete(String id) throws IOException, MetacardBackupException;
 
     /**
      * Stores data for the provided metacard ID
@@ -45,5 +45,5 @@ public interface MetacardBackupStorageProvider extends Describable {
      * @throws IOException
      * @throws MetacardBackupException
      */
-    void storeData(String id, byte[] data) throws IOException, MetacardBackupException;
+    void store(String id, byte[] data) throws IOException, MetacardBackupException;
 }

--- a/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupStorageProvider.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-api/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/internal/MetacardBackupStorageProvider.java
@@ -40,7 +40,7 @@ public interface MetacardBackupStorageProvider extends Describable {
     /**
      * Stores data for the provided metacard ID
      *
-     * @param id   - Identifier of the metacard to remove
+     * @param id   - Identifier of the metacard to create or update
      * @param data - Bytes of the metacard to store
      * @throws IOException
      * @throws MetacardBackupException

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
@@ -45,9 +45,19 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -56,10 +66,12 @@
                     <instructions>
                         <Export-Package/>
                         <Embed-Dependency>
+                            platform-util,
                             commons-lang3,
                             commons-io
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Include-Resource>{maven-resources},target/classes/describable.properties</Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>
@@ -81,17 +93,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.59</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.51</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>catalog-plugin-metacardbackup-filestorage</artifactId>
-    <name>DDF :: Catalog :: Plugin :: Metacard Backup File Storage</name>
+    <name>DDF :: Catalog :: Plugin :: Metacard Backup Storage :: File Impl</name>
     <packaging>bundle</packaging>
 
     <dependencies>
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -64,7 +63,6 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package/>
                         <Embed-Dependency>
                             platform-util,
                             commons-lang3,

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
@@ -22,42 +22,28 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>catalog-plugin-metacardbackup</artifactId>
-    <name>DDF :: Catalog :: Plugin :: Metacard Backup Plugin</name>
+    <artifactId>catalog-plugin-metacardbackup-filestorage</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Metacard Backup File Storage</name>
     <packaging>bundle</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.async</groupId>
-            <artifactId>catalog-async-plugin-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-        </dependency>
         <dependency>
             <groupId>ddf.catalog.plugin</groupId>
             <artifactId>catalog-plugin-metacardbackup-storage-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.catalog.plugin</groupId>
-            <artifactId>catalog-plugin-metacardbackup-filestorage</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -70,8 +56,8 @@
                     <instructions>
                         <Export-Package/>
                         <Embed-Dependency>
-                            catalog-core-api-impl,
-                            platform-util
+                            commons-lang3,
+                            commons-io
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>
@@ -95,17 +81,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
@@ -129,7 +129,7 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
             }
             Files.createFile(metacardPath);
         } catch (IOException e) {
-            LOGGER.debug("Unable to create backup file {}.  File may already exist.",
+            LOGGER.trace("Unable to create empty backup file {}.  File may already exist.",
                     metacardPath,
                     e);
         }

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
@@ -28,8 +28,8 @@ import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupException;
-import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider;
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.internal.MetacardBackupException;
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.internal.MetacardBackupStorageProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
                 DESCRIBABLE_PROPERTIES_FILE)) {
             describableProperties.load(properties);
         } catch (IOException e) {
-            LOGGER.info(e.getMessage(), e);
+            LOGGER.debug("Unable to load describable properties", e);
         }
     }
 
@@ -95,7 +95,8 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
         this.id = id;
     }
 
-    public void deleteData(String id) throws IOException, MetacardBackupException {
+    @Override
+    public void delete(String id) throws IOException, MetacardBackupException {
         if (StringUtils.isEmpty(outputDirectory)) {
             throw new MetacardBackupException(
                     "Unable to delete stored data; no output directory specified.");
@@ -104,7 +105,8 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
         deleteBackupIfPresent(id);
     }
 
-    public void storeData(String id, byte[] data) throws IOException, MetacardBackupException {
+    @Override
+    public void store(String id, byte[] data) throws IOException, MetacardBackupException {
         if (StringUtils.isEmpty(outputDirectory)) {
             throw new MetacardBackupException("Unable to store data; no output directory specified.");
         }
@@ -149,7 +151,6 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
         Object outputDirectory = properties.get(OUTPUT_DIRECTORY_PROPERTY);
         if (outputDirectory instanceof String && StringUtils.isNotBlank((String) outputDirectory)) {
             this.outputDirectory = (String) outputDirectory;
-            LOGGER.debug("Updating {} with {}", OUTPUT_DIRECTORY_PROPERTY, outputDirectory);
         }
 
         Object id = properties.get(ID);
@@ -161,7 +162,7 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
     private void deleteBackupIfPresent(String filename) throws MetacardBackupException {
         Path metacardPath = getMetacardDirectory(filename);
         if (metacardPath == null) {
-            LOGGER.trace("Unable to delete backup for: {}", filename);
+            LOGGER.debug("Unable to delete backup for: {}", filename);
             throw new MetacardBackupException("Unable to delete backup");
         }
 
@@ -176,7 +177,7 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
                 }
             }
         } catch (IOException e) {
-            LOGGER.trace("Unable to delete backup file {}", metacardPath, e);
+            LOGGER.debug("Unable to delete backup file {}", metacardPath, e);
             throw new MetacardBackupException("Unable to delete backup file", e);
         }
     }

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
@@ -66,10 +66,6 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
         }
     }
 
-    public MetacardBackupFileStorage() {
-
-    }
-
     @Override
     public String getId() {
         return id;
@@ -119,8 +115,9 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
 
         Path metacardPath = getMetacardDirectory(id);
         if (metacardPath == null) {
-            LOGGER.debug(String.format("Unable to create metacard path directory for %s", id));
-            throw new MetacardBackupException("Unable to create metacard backup directory");
+            String message = String.format("Unable to create metacard path directory for %s", id);
+            LOGGER.debug(message);
+            throw new MetacardBackupException(message);
         }
 
         try {
@@ -164,7 +161,7 @@ public class MetacardBackupFileStorage implements MetacardBackupStorageProvider 
     private void deleteBackupIfPresent(String filename) throws MetacardBackupException {
         Path metacardPath = getMetacardDirectory(filename);
         if (metacardPath == null) {
-            LOGGER.trace(String.format("Unable to delete backup for  %s", filename));
+            LOGGER.trace("Unable to delete backup for: {}", filename);
             throw new MetacardBackupException("Unable to delete backup");
         }
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorage.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupException;
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetacardBackupFileStorage implements MetacardBackupStorageProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetacardBackupFileStorage.class);
+
+    private static final String OUTPUT_DIRECTORY_PROPERTY = "outputDirectory";
+
+    private String outputDirectory;
+
+    public MetacardBackupFileStorage() {
+
+    }
+
+    public void deleteData(String id) throws IOException, MetacardBackupException {
+        if (StringUtils.isEmpty(outputDirectory)) {
+            throw new MetacardBackupException(
+                    "Unable to delete stored data; no output directory specified.");
+        }
+
+        deleteBackupIfPresent(id);
+    }
+
+    public void storeData(String id, byte[] data) throws IOException, MetacardBackupException {
+        if (StringUtils.isEmpty(outputDirectory)) {
+            throw new MetacardBackupException(
+                    "Unable to store data; no output directory specified.");
+        }
+
+        if (data == null) {
+            throw new MetacardBackupException("No data to store");
+        }
+
+        Path metacardPath = getMetacardDirectory(id);
+        if (metacardPath == null) {
+            throw new MetacardBackupException(String.format(
+                    "Unable to create metacard path directory for %s",
+                    id));
+        }
+
+        try {
+            Path parent = metacardPath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.createFile(metacardPath);
+        } catch (IOException e) {
+            LOGGER.debug("Unable to create backup file {}.  File may already exist.",
+                    metacardPath,
+                    e);
+        }
+
+        try (OutputStream outputStream = new FileOutputStream(metacardPath.toFile())) {
+            IOUtils.write(data, outputStream);
+        }
+    }
+
+    public void setOutputDirectory(String outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public String getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    public void refresh(Map<String, Object> properties) {
+        Object outputDirectory = properties.get(OUTPUT_DIRECTORY_PROPERTY);
+        if (outputDirectory instanceof String && StringUtils.isNotBlank((String) outputDirectory)) {
+            this.outputDirectory = (String) outputDirectory;
+            LOGGER.debug("Updating {} with {}", OUTPUT_DIRECTORY_PROPERTY, outputDirectory);
+        }
+    }
+
+    private void deleteBackupIfPresent(String filename) throws MetacardBackupException {
+        Path metacardPath = getMetacardDirectory(filename);
+        if (metacardPath == null) {
+            throw new MetacardBackupException(String.format("Unable to delete backup for  %s",
+                    filename));
+        }
+
+        try {
+            Files.deleteIfExists(metacardPath);
+            while (metacardPath.getParent() != null && !metacardPath.getParent()
+                    .toString()
+                    .equals(outputDirectory)) {
+                metacardPath = metacardPath.getParent();
+                if (isDirectoryEmpty(metacardPath)) {
+                    FileUtils.deleteDirectory(metacardPath.toFile());
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Unable to delete backup file {}", metacardPath, e);
+            throw new MetacardBackupException(String.format("Unable to delete backup file for  %s",
+                    filename), e);
+        }
+    }
+
+    public Path getMetacardDirectory(String id) {
+        if (StringUtils.isEmpty(id)) {
+            return null;
+        }
+
+        if (id.length() < 6) {
+            id = StringUtils.rightPad(id, 6, "0");
+        }
+
+        try {
+            return Paths.get(outputDirectory, id.substring(0, 3), id.substring(3, 6), id);
+        } catch (InvalidPathException e) {
+            LOGGER.debug("Unable to create path from id {}", outputDirectory, e);
+            return null;
+        }
+    }
+
+    private boolean isDirectoryEmpty(Path dir) throws IOException {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(dir)) {
+            return !dirStream.iterator()
+                    .hasNext();
+        } catch (IOException e) {
+            LOGGER.debug("Unable to open directory stream for {}", dir.toString(), e);
+            throw e;
+        }
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
         <cm:managed-component class="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
-            <property name="id" value="File_Storage_Provider"/>
+            <property name="id" value="fileStorageProvider"/>
             <property name="outputDirectory" value="data/backup/metacard"/>
         </cm:managed-component>
     </cm:managed-service-factory>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <cm:managed-service-factory
+            id="metacardFileBackup"
+            factory-pid="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage"
+            interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider">
+        <service-properties>
+            <cm:cm-properties persistent-id="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage" />
+        </service-properties>
+        <cm:managed-component class="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
+            <cm:managed-properties persistent-id="" update-strategy="component-managed"
+                                   update-method="refresh"/>
+            <property name="outputDirectory" value="data/backup/metacard"/>
+        </cm:managed-component>
+    </cm:managed-service-factory>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,7 +17,7 @@
     <cm:managed-service-factory
             id="metacardFileBackup"
             factory-pid="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage"
-            interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider">
+            interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.internal.MetacardBackupStorageProvider">
         <service-properties>
             <cm:cm-properties persistent-id="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage" />
         </service-properties>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,6 +24,7 @@
         <cm:managed-component class="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
+            <property name="id" value=""/>
             <property name="outputDirectory" value="data/backup/metacard"/>
         </cm:managed-component>
     </cm:managed-service-factory>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
         <cm:managed-component class="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
-            <property name="id" value=""/>
+            <property name="id" value="File_Storage_Provider"/>
             <property name="outputDirectory" value="data/backup/metacard"/>
         </cm:managed-component>
     </cm:managed-service-factory>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,10 +21,9 @@
             required="true"
             type="String" default="File_Storage_Provider"/>
 
-        <AD
-                description="Output directory to place backup files."
-                name="Output Directory" id="outputDirectory" required="true" type="String"
-                default="data/backup/metacard"/>
+        <AD description="Output directory to place backup files."
+            name="Output Directory" id="outputDirectory" required="true" type="String"
+            default="data/backup/metacard"/>
     </OCD>
 
     <Designate

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,7 +19,7 @@
          id="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
         <AD description="The unique name of the storage provider" name="Storage Provider ID" id="id"
             required="true"
-            type="String" default="File_Storage_Provider"/>
+            type="String" default="fileStorageProvider"/>
 
         <AD description="Output directory to place backup files."
             name="Output Directory" id="outputDirectory" required="true" type="String"

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,6 +17,10 @@
 
     <OCD name="Metacard Backup File Storage Provider"
          id="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
+        <AD description="The unique name of the storage provider" name="Storage Provider ID" id="id"
+            required="true"
+            type="String" default="File_Storage_Provider"/>
+
         <AD
                 description="Output directory to place backup files."
                 name="Output Directory" id="outputDirectory" required="true" type="String"

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -15,21 +15,18 @@
  -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-    <OCD name="Metacard Backup Plugin"
-         id="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
+    <OCD name="Metacard Backup File Storage Provider"
+         id="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
         <AD
-                description="Keep the Metacard backup file when Metacards are deleted from the framework."
-                name="Keep Deleted Metacards" id="keepDeletedMetacards" required="true" type="Boolean"
-                default="false"/>
-
-        <AD
-                description="Metacard Transformer ID to use to backup."
-                name="Metacard Transformer ID" id="metacardTransformerId" required="true" type="String"
-                default="metadata"/>
+                description="Output directory to place backup files."
+                name="Output Directory" id="outputDirectory" required="true" type="String"
+                default="data/backup/metacard"/>
     </OCD>
 
-    <Designate pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin" factoryPid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
-        <Object ocdref="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"/>
+    <Designate
+            pid="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage"
+            factoryPid="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage">
+        <Object ocdref="org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage"/>
     </Designate>
 
 </metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/describable.properties
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/describable.properties
@@ -1,0 +1,4 @@
+version=${version}
+description=${description}
+organization=${organization.name}
+name=${artifactId}

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupException;
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.internal.MetacardBackupException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,11 +52,11 @@ public class MetacardBackupFileStorageTest {
     public void cleanUp() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
         if (fileExists(TEST_ID)) {
-            fileStorageProvider.deleteData(TEST_ID);
+            fileStorageProvider.delete(TEST_ID);
         }
 
         if (fileExists(TEST_SHORT_ID)) {
-            fileStorageProvider.deleteData(TEST_SHORT_ID);
+            fileStorageProvider.delete(TEST_SHORT_ID);
         }
     }
 
@@ -97,19 +97,19 @@ public class MetacardBackupFileStorageTest {
 
     @Test(expected = MetacardBackupException.class)
     public void testDeleteNotStored() throws Exception {
-        fileStorageProvider.deleteData(TEST_ID_NOT_STORED);
+        fileStorageProvider.delete(TEST_ID_NOT_STORED);
     }
 
     @Test(expected = MetacardBackupException.class)
     public void testStoreWithEmptyOutputDirectory() throws Exception {
         fileStorageProvider.setOutputDirectory("");
-        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_ID, TEST_BYTES);
     }
 
     @Test(expected = MetacardBackupException.class)
     public void testDeleteWithEmptyOutputDirectory() throws Exception {
         fileStorageProvider.setOutputDirectory("");
-        fileStorageProvider.deleteData(TEST_ID);
+        fileStorageProvider.delete(TEST_ID);
     }
 
     @Test
@@ -122,43 +122,43 @@ public class MetacardBackupFileStorageTest {
     @Test
     public void testStoreTwice() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
-        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
-        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_ID, TEST_BYTES);
         assertFile(TEST_ID, true);
     }
 
     @Test
     public void testStoreAndDelete() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
-        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
-        fileStorageProvider.storeData(TEST_SHORT_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_SHORT_ID, TEST_BYTES);
         assertFile(TEST_ID, true);
         assertFile(TEST_SHORT_ID, true);
 
-        fileStorageProvider.deleteData(TEST_ID);
+        fileStorageProvider.delete(TEST_ID);
         assertFile(TEST_ID, false);
 
-        fileStorageProvider.deleteData(TEST_SHORT_ID);
+        fileStorageProvider.delete(TEST_SHORT_ID);
         assertFile(TEST_SHORT_ID, false);
     }
 
     @Test
     public void testStoreShortId() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
-        fileStorageProvider.storeData(TEST_SHORT_ID, TEST_BYTES);
+        fileStorageProvider.store(TEST_SHORT_ID, TEST_BYTES);
         assertFile(TEST_SHORT_ID, true);
     }
 
     @Test(expected = MetacardBackupException.class)
     public void testStoreNullId() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
-        fileStorageProvider.storeData(null, TEST_BYTES);
+        fileStorageProvider.store(null, TEST_BYTES);
     }
 
     @Test(expected = MetacardBackupException.class)
     public void testStoreNullData() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
-        fileStorageProvider.storeData(TEST_ID, null);
+        fileStorageProvider.store(TEST_ID, null);
     }
 
     @Test

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
@@ -42,7 +42,6 @@ public class MetacardBackupFileStorageTest {
 
     private MetacardBackupFileStorage fileStorageProvider = new MetacardBackupFileStorage();
 
-    @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
         fileStorageProvider.setId(PLUGIN_ID);

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
@@ -15,6 +15,7 @@ package org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -27,11 +28,15 @@ import org.junit.Test;
 
 public class MetacardBackupFileStorageTest {
 
+    private static final String PLUGIN_ID = "PluginId";
+
     private static final String OUTPUT_DIRECTORY = "test-output/";
 
     private static final String TEST_ID = "TestId";
 
     private static final String TEST_SHORT_ID = "a";
+
+    private static final String TEST_ID_NOT_STORED = "NotStoredId";
 
     private static final byte[] TEST_BYTES = "Test String".getBytes();
 
@@ -40,6 +45,7 @@ public class MetacardBackupFileStorageTest {
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
+        fileStorageProvider.setId(PLUGIN_ID);
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
     }
 
@@ -63,24 +69,36 @@ public class MetacardBackupFileStorageTest {
     @Test
     public void testRefresh() {
         String newBackupDir = "target/temp";
+        String newId = "test2";
         Map<String, Object> properties = new HashMap<>();
         properties.put("outputDirectory", newBackupDir);
+        properties.put("id", newId);
         fileStorageProvider.refresh(properties);
         assertThat(fileStorageProvider.getOutputDirectory(), is(newBackupDir));
+        assertThat(fileStorageProvider.getId(), is(newId));
     }
 
     @Test
     public void testRefreshBadValues() {
         Map<String, Object> properties = new HashMap<>();
         properties.put("outputDirectory", 2);
+        properties.put("id", 5);
+        fileStorageProvider.refresh(properties);
         assertThat(fileStorageProvider.getOutputDirectory(), is(OUTPUT_DIRECTORY));
+        assertThat(fileStorageProvider.getId(), is(PLUGIN_ID));
     }
 
     @Test
     public void testRefreshEmptyStrings() {
         Map<String, Object> properties = new HashMap<>();
         properties.put("outputDirectory", "");
+        fileStorageProvider.refresh(properties);
         assertThat(fileStorageProvider.getOutputDirectory(), is(OUTPUT_DIRECTORY));
+    }
+
+    @Test(expected = MetacardBackupException.class)
+    public void testDeleteNotStored() throws Exception {
+        fileStorageProvider.deleteData(TEST_ID_NOT_STORED);
     }
 
     @Test(expected = MetacardBackupException.class)
@@ -114,10 +132,15 @@ public class MetacardBackupFileStorageTest {
     public void testStoreAndDelete() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
         fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        fileStorageProvider.storeData(TEST_SHORT_ID, TEST_BYTES);
         assertFile(TEST_ID, true);
+        assertFile(TEST_SHORT_ID, true);
 
         fileStorageProvider.deleteData(TEST_ID);
         assertFile(TEST_ID, false);
+
+        fileStorageProvider.deleteData(TEST_SHORT_ID);
+        assertFile(TEST_SHORT_ID, false);
     }
 
     @Test
@@ -137,6 +160,22 @@ public class MetacardBackupFileStorageTest {
     public void testStoreNullData() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
         fileStorageProvider.storeData(TEST_ID, null);
+    }
+
+    @Test
+    public void testId() {
+        String id = "TEST";
+        fileStorageProvider.setId(id);
+        String retrieveId = fileStorageProvider.getId();
+        assertThat(retrieveId, is(id));
+    }
+
+    @Test
+    public void testDescribableProps() {
+        assertThat(fileStorageProvider.getDescription(), notNullValue());
+        assertThat(fileStorageProvider.getTitle(), notNullValue());
+        assertThat(fileStorageProvider.getOrganization(), notNullValue());
+        assertThat(fileStorageProvider.getVersion(), notNullValue());
     }
 
     private void assertFile(String id, boolean exists) {

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetacardBackupFileStorageTest {
+
+    private static final String OUTPUT_DIRECTORY = "test-output/";
+
+    private static final String TEST_ID = "TestId";
+
+    private static final String TEST_SHORT_ID = "a";
+
+    private static final byte[] TEST_BYTES = "Test String".getBytes();
+
+    private MetacardBackupFileStorage fileStorageProvider = new MetacardBackupFileStorage();
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        if (fileExists(TEST_ID)) {
+            fileStorageProvider.deleteData(TEST_ID);
+        }
+
+        if (fileExists(TEST_SHORT_ID)) {
+            fileStorageProvider.deleteData(TEST_SHORT_ID);
+        }
+    }
+
+    @Test
+    public void testOutputDirectory() {
+        assertThat(fileStorageProvider.getOutputDirectory(), is(OUTPUT_DIRECTORY));
+    }
+
+    @Test
+    public void testRefresh() {
+        String newBackupDir = "target/temp";
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("outputDirectory", newBackupDir);
+        fileStorageProvider.refresh(properties);
+        assertThat(fileStorageProvider.getOutputDirectory(), is(newBackupDir));
+    }
+
+    @Test
+    public void testRefreshBadValues() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("outputDirectory", 2);
+        assertThat(fileStorageProvider.getOutputDirectory(), is(OUTPUT_DIRECTORY));
+    }
+
+    @Test
+    public void testRefreshEmptyStrings() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("outputDirectory", "");
+        assertThat(fileStorageProvider.getOutputDirectory(), is(OUTPUT_DIRECTORY));
+    }
+
+    @Test(expected = MetacardBackupException.class)
+    public void testStoreWithEmptyOutputDirectory() throws Exception {
+        fileStorageProvider.setOutputDirectory("");
+        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+    }
+
+    @Test(expected = MetacardBackupException.class)
+    public void testDeleteWithEmptyOutputDirectory() throws Exception {
+        fileStorageProvider.setOutputDirectory("");
+        fileStorageProvider.deleteData(TEST_ID);
+    }
+
+    @Test
+    public void testPath() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        Path path = fileStorageProvider.getMetacardDirectory(TEST_ID);
+        assertThat(path.toString(), is(OUTPUT_DIRECTORY + "Tes/tId/TestId"));
+    }
+
+    @Test
+    public void testStoreTwice() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        assertFile(TEST_ID, true);
+    }
+
+    @Test
+    public void testStoreAndDelete() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        fileStorageProvider.storeData(TEST_ID, TEST_BYTES);
+        assertFile(TEST_ID, true);
+
+        fileStorageProvider.deleteData(TEST_ID);
+        assertFile(TEST_ID, false);
+    }
+
+    @Test
+    public void testStoreShortId() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        fileStorageProvider.storeData(TEST_SHORT_ID, TEST_BYTES);
+        assertFile(TEST_SHORT_ID, true);
+    }
+
+    @Test(expected = MetacardBackupException.class)
+    public void testStoreNullId() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        fileStorageProvider.storeData(null, TEST_BYTES);
+    }
+
+    @Test(expected = MetacardBackupException.class)
+    public void testStoreNullData() throws Exception {
+        fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
+        fileStorageProvider.storeData(TEST_ID, null);
+    }
+
+    private void assertFile(String id, boolean exists) {
+        assertThat(fileExists(id), is(exists));
+    }
+
+    private boolean fileExists(String id) {
+        Path path  = fileStorageProvider.getMetacardDirectory(id);
+        return path.toFile().exists();
+    }
+}

--- a/catalog/plugin/catalog-plugin-metacardbackup/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/pom.xml
@@ -100,7 +100,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -39,7 +39,7 @@
             <property name="storageBackupPlugins" ref="metacardBackupStorageSortedList"/>
             <property name="metacardOutputProviderIds">
                 <list>
-                    <value>File_Storage_Provider</value>
+                    <value>fileStorageProvider</value>
                 </list>
             </property>
         </cm:managed-component>

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,19 +14,29 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
 
+    <bean id="metacardBackupStorageSortedList" class="ddf.catalog.util.impl.SortedServiceList"/>
+    <reference-list id="metacardBackupStoragePluginList"
+                    availability="optional"
+                    interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider">
+        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin"
+                            ref="metacardBackupStorageSortedList"/>
+    </reference-list>
+
     <cm:managed-service-factory
             id="metacardBackup"
             factory-pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"
             interface="org.codice.ddf.catalog.async.plugin.api.internal.PostProcessPlugin">
         <service-properties>
-            <cm:cm-properties persistent-id="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin" />
+            <cm:cm-properties
+                    persistent-id="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"/>
         </service-properties>
-        <cm:managed-component class="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
+        <cm:managed-component
+                class="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
             <property name="metacardTransformerId" value="metadata"/>
-            <property name="outputDirectory" value="data/backup/metacard"/>
             <property name="keepDeletedMetacards" value="false"/>
+            <property name="storageBackupPlugins" ref="metacardBackupStorageSortedList"/>
         </cm:managed-component>
     </cm:managed-service-factory>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,7 +17,7 @@
     <bean id="metacardBackupStorageSortedList" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardBackupStoragePluginList"
                     availability="optional"
-                    interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.api.MetacardBackupStorageProvider">
+                    interface="org.codice.ddf.catalog.plugin.metacard.backup.storage.internal.MetacardBackupStorageProvider">
         <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin"
                             ref="metacardBackupStorageSortedList"/>
     </reference-list>

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,6 +37,11 @@
             <property name="metacardTransformerId" value="metadata"/>
             <property name="keepDeletedMetacards" value="false"/>
             <property name="storageBackupPlugins" ref="metacardBackupStorageSortedList"/>
+            <property name="metacardOutputProviderIds">
+                <list>
+                    <value>File_Storage_Provider</value>
+                </list>
+            </property>
         </cm:managed-component>
     </cm:managed-service-factory>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,24 +17,21 @@
 
     <OCD name="Metacard Backup Plugin"
          id="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
-        <AD
-                description="Keep the Metacard backup file when Metacards are deleted from the framework."
-                name="Keep Deleted Metacards" id="keepDeletedMetacards" required="true"
-                type="Boolean"
-                default="false"/>
+        <AD description="Keep the Metacard backup file when Metacards are deleted from the framework."
+            name="Keep Deleted Metacards" id="keepDeletedMetacards" required="true"
+            type="Boolean"
+            default="false"/>
 
-        <AD
-                description="Metacard Transformer ID to use to backup."
-                name="Metacard Transformer ID" id="metacardTransformerId" required="true"
-                type="String"
-                default="metadata"/>
+        <AD description="Metacard Transformer ID to use to backup."
+            name="Metacard Transformer ID" id="metacardTransformerId" required="true"
+            type="String"
+            default="metadata"/>
 
-        <AD
-                description="Metacard Backup Provider IDs to use for this backup plugin"
-                cardinality="100"
-                name="Metacard Backup Output Provider(s)" id="metacardOutputProviderIds"
-                required="true" type="String"
-                default="File_Storage_Provider"/>
+        <AD description="Metacard Backup Provider IDs to use for this backup plugin"
+            cardinality="100"
+            name="Metacard Backup Output Provider(s)" id="metacardOutputProviderIds"
+            required="true" type="String"
+            default="File_Storage_Provider"/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,16 +19,26 @@
          id="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
         <AD
                 description="Keep the Metacard backup file when Metacards are deleted from the framework."
-                name="Keep Deleted Metacards" id="keepDeletedMetacards" required="true" type="Boolean"
+                name="Keep Deleted Metacards" id="keepDeletedMetacards" required="true"
+                type="Boolean"
                 default="false"/>
 
         <AD
                 description="Metacard Transformer ID to use to backup."
-                name="Metacard Transformer ID" id="metacardTransformerId" required="true" type="String"
+                name="Metacard Transformer ID" id="metacardTransformerId" required="true"
+                type="String"
                 default="metadata"/>
+
+        <AD
+                description="Metacard Backup Provider IDs to use for this backup plugin"
+                cardinality="100"
+                name="Metacard Backup Output Provider(s)" id="metacardOutputProviderIds"
+                required="true" type="String"
+                default="File_Storage_Provider"/>
     </OCD>
 
-    <Designate pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin" factoryPid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
+    <Designate pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"
+               factoryPid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin">
         <Object ocdref="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"/>
     </Designate>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -31,7 +31,7 @@
             cardinality="100"
             name="Metacard Backup Output Provider(s)" id="metacardOutputProviderIds"
             required="true" type="String"
-            default="File_Storage_Provider"/>
+            default="fileStorageProvider"/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin"

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -35,6 +35,8 @@
         <module>catalog-plugin-clientinfo</module>
         <module>catalog-plugin-metacardingest-network</module>
         <module>catalog-plugin-pointofcontactupdate</module>
+        <module>catalog-plugin-metacardbackup-api</module>
+        <module>catalog-plugin-metacardbackup-filestorage</module>
         <module>catalog-plugin-metacardbackup</module>
     </modules>
 </project>

--- a/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-filestorage-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-filestorage-contents.adoc
@@ -1,0 +1,24 @@
+==== Metacard Backup File Storage Provider
+
+The Metacard Backup File Storage Provider is a storage provider that will store backed up metacards at
+the specified file system location.
+
+===== Installing the Metacard Backup File Storage Provider
+
+To install the Metacard Backup File Storage Provider
+
+. Navigate to the *${admin-console}*.
+. Select ${ddf-catalog} application.
+. Select *Features* tab.
+. Install the `catalog-metacard-backup-filestorage` feature.
+
+===== Configuring the Metacard Backup File Storage Provider
+
+To configure the Metacard Backup File Storage Provider
+
+. Navigate to the *${admin-console}*.
+. Select ${ddf-catalog} application.
+. Select *Configuration* tab.
+. Select *Metacard Backup File Storage Provider*.
+
+include::{adoc-include}/_tables/plugin.metacard-backup-filestorage-table-contents.adoc[]

--- a/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-plugin-contents.adoc
@@ -1,7 +1,7 @@
 ==== Metacard Backup Plugin
 
 The Metacard Backup Plugin is used to enable data backup of metacards using a configurable transformer.
-The plugin will store backups using a configured Metacard Backup Storage provider.
+The plugin will store backups using all configured Metacard Backup Storage provider.
 
 ===== Installing the Metacard Backup Plugin
 

--- a/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/metacard-backup-plugin-contents.adoc
@@ -1,0 +1,24 @@
+==== Metacard Backup Plugin
+
+The Metacard Backup Plugin is used to enable data backup of metacards using a configurable transformer.
+The plugin will store backups using a configured Metacard Backup Storage provider.
+
+===== Installing the Metacard Backup Plugin
+
+To install the Metacard Backup Plugin
+
+. Navigate to the *${admin-console}*.
+. Select ${ddf-catalog} application.
+. Select *Features* tab.
+. Install the `catalog-metacard-backup` feature.
+
+===== Configuring the Metacard Backup Plugin
+
+To configure the Metacard Backup Plugin:
+
+. Navigate to the *${admin-console}*.
+. Select ${ddf-catalog} application.
+. Select *Configuration* tab.
+. Select *Metacard Backup Plugin*.
+
+include::{adoc-include}/_tables/plugin.metacard-backup-table-contents.adoc[]

--- a/distribution/docs/src/main/resources/_contents/_plugins/plugin-compatibility-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/plugin-compatibility-table-contents.adoc
@@ -14,6 +14,8 @@
 
 |<<_catalog_backup_plugin,Catalog Backup Plugin>>
 |||||||
+|<<_metacard_backup_plugin,Metacard Backup Plugin>>
+|||||||
 |<<_caching_federation_strategy,Caching Federation Strategy>>
 |||||||
 |<<_catalog_metrics_plugin,Catalog Metrics Plugin>>
@@ -71,6 +73,8 @@
 |<<_access_plugins,Access>>
 
 |<<_catalog_backup_plugin,Catalog Backup Plugin>>
+|x||||||
+|<<_metacard_backup_plugin,Metacard Backup Plugin>>
 |x||||||
 |<<_caching_federation_strategy,Caching Federation Strategy>>
 |x||||||

--- a/distribution/docs/src/main/resources/_contents/_plugins/post-ingest-plugins-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/post-ingest-plugins-contents.adoc
@@ -2,6 +2,8 @@
 .[[_included_post-ingest_plugins]]Included Post-Ingest Plugins
 <<_catalog_backup_plugin,Catalog Backup Plugin>>:: Enables data backup of the catalog and the metacards it contains.
 
+<<_metacard_backup_plugin,Metacard Backup Plugin>>:: Enable data backup of metacards using a configurable transformer.
+
 <<_catalog_metrics_plugin,Catalog Metrics Plugin>>:: The Catalog Metrics Plugin captures metrics on catalog operations.
 
 <<_event_processor,Event Processor>>:: Creates, updates, and deletes subscriptions for event notification.

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-filestorage-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-filestorage-table-contents.adoc
@@ -1,0 +1,20 @@
+.[[plugin.backup]]Backup Post-Ingest Plugin
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Output Directory
+|outputDirectory
+|String
+|Directory used to store metacard backups
+|data/backup/metacard
+|true
+
+|===
+

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
@@ -23,5 +23,11 @@
 | false
 | true
 
+| Metacard Backup Output Provider(s)
+| metacardOutputProviderIds
+| Comma delimited list of metacard output provider IDs.
+| Metacard Backup Provider IDs to use for this backup plugin.
+| File_Storage_Provider
+| true
 |===
 

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
@@ -1,0 +1,27 @@
+.[[plugin.backup]]Metacard Backup Plugin
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Metacard Transformer Id
+|metacardTransformerId
+|String
+|ID of the metacard transformer to use to serialize metacard for backup.
+|metacard
+|true
+
+| Keep Deleted Metacard
+| keepDeletedMetacards
+| Boolean
+| Should backups for deleted metacards be kept or removed.
+| false
+| true
+
+|===
+

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
@@ -27,7 +27,7 @@
 | metacardOutputProviderIds
 | Comma delimited list of metacard output provider IDs.
 | Metacard Backup Provider IDs to use for this backup plugin.
-| File_Storage_Provider
+| fileStorageProvider
 | true
 |===
 

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -613,6 +613,10 @@ include::{adoc-include}/_plugins/catalog-backup-plugin-contents.adoc[]
 
 include::{adoc-include}/_plugins/event-processor-contents.adoc[]
 
+include::{adoc-include}/_plugins/metacard-backup-plugin-contents.adoc[]
+
+include::{adoc-include}/_plugins/metacard-backup-filestorage-contents.adoc[]
+
 //post-query
 include::{adoc-include}/_plugins/post-query-plugin-intro-contents.adoc[]
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -458,7 +458,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     @Test
     public void testCswIngestWithMetadataBackup() throws Exception {
         getServiceManager().startFeature(true, METACARD_BACKUP_FILE_STORAGE_FEATURE);
-        String fileStorageId = "File_Storage_Provider";
+        String fileStorageId = "fileStorageProvider";
         Map<String, Object> storageProps = new HashMap<>();
         storageProps.put("id", fileStorageId);
         storageProps.put("outputDirectory", METACARD_BACKUP_DIRECTORY);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -134,6 +134,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     private static final String METACARD_BACKUP_DIRECTORY = "data/tmp/backup";
 
+    private static final String METACARD_BACKUP_FILE_STORAGE_FEATURE = "catalog-metacard-backup-filestorage";
+
     private static final String METACARD_BACKUP_PLUGIN_FEATURE = "catalog-metacard-backup";
 
     private static final String DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS = "data/products";
@@ -454,10 +456,16 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     @Test
     public void testCswIngestWithMetadataBackup() throws Exception {
+        getServiceManager().startFeature(true, METACARD_BACKUP_FILE_STORAGE_FEATURE);
+        Map<String, Object> storageProps = new HashMap<>();
+        storageProps.put("outputDirectory", METACARD_BACKUP_DIRECTORY);
+        getServiceManager().createManagedService(
+                "org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage",
+                storageProps);
+
         getServiceManager().startFeature(true, METACARD_BACKUP_PLUGIN_FEATURE);
         Map<String, Object> properties = new HashMap<>();
         properties.put("metacardTransformerId", "metadata");
-        properties.put("outputDirectory", METACARD_BACKUP_DIRECTORY);
         properties.put("keepDeletedMetacards", false);
         getServiceManager().createManagedService(
                 "org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin",
@@ -474,6 +482,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 hasXPath("//TransactionResponse/InsertResult/BriefRecord/BoundingBox"));
         verifyMetadataBackup();
         getServiceManager().stopFeature(true, METACARD_BACKUP_PLUGIN_FEATURE);
+        getServiceManager().stopFeature(true, METACARD_BACKUP_FILE_STORAGE_FEATURE);
         try {
             CatalogTestCommons.deleteMetacardUsingCswResponseId(response);
         } catch (IOException | XPathExpressionException e) {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -56,6 +56,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -457,7 +458,9 @@ public class TestCatalog extends AbstractIntegrationTest {
     @Test
     public void testCswIngestWithMetadataBackup() throws Exception {
         getServiceManager().startFeature(true, METACARD_BACKUP_FILE_STORAGE_FEATURE);
+        String fileStorageId = "File_Storage_Provider";
         Map<String, Object> storageProps = new HashMap<>();
+        storageProps.put("id", fileStorageId);
         storageProps.put("outputDirectory", METACARD_BACKUP_DIRECTORY);
         getServiceManager().createManagedService(
                 "org.codice.ddf.catalog.plugin.metacard.backup.storage.filestorage.MetacardBackupFileStorage",
@@ -467,6 +470,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         Map<String, Object> properties = new HashMap<>();
         properties.put("metacardTransformerId", "metadata");
         properties.put("keepDeletedMetacards", false);
+        properties.put("metacardOutputProviderIds", Collections.singletonList(fileStorageId));
         getServiceManager().createManagedService(
                 "org.codice.ddf.catalog.plugin.metacard.backup.MetacardBackupPlugin",
                 properties);


### PR DESCRIPTION
#### What does this PR do?
Separates the storage for the Metacard Backup Plugin from the plugin itself.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@glenhein 
@ricklarsen 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@millerw8 
@coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
1. Install DDF
2. Catalog:Features and install `catalog-metacard-backup-filestorage` and `catalog-metacard-backup`
3. Refresh Admin UI
4. Catalog:Configuration -> Backup Post-Ingest Plugin, disable this.
5. Catalog:Configuration -> Metacard Backup File Storage Provider, select directory. By default it is $DDF_HOME/data/backup/metacard. Click Save changes to create an instance.
6. Catalog:Configuration -> Metacard Backup Plugin. Click Save changes to create an instance.
7. Upload data to the catalog.
8. Ensure that a copy of the metacards is created in the directory specified in step 4.

#### Any background context you want to provide?
Broke out an API, and file system storage provider from existing Metacard Backup Plugin. API exists such that other non-filesystem implementations can be added in the future.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2936

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated
- [X] Change Log Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests
