### PR TITLE
DDF-2954 TestApplicationService.cTestAppStartStop() is unstable

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
@@ -36,8 +36,11 @@ import org.codice.ddf.admin.application.service.ApplicationServiceException;
 import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
+import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -57,6 +60,9 @@ import ddf.security.common.util.Security;
 @ExamReactorStrategy(PerSuite.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestApplicationService extends AbstractIntegrationTest {
+
+    @Rule
+    public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestApplicationService.class);
 
@@ -160,6 +166,7 @@ public class TestApplicationService extends AbstractIntegrationTest {
     }
 
     @Test
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = SkipUnstableTest.class) // DDF-2954
     public void cTestAppStartStop() throws ApplicationServiceException {
 
         systemSubject.execute(() -> {


### PR DESCRIPTION
#### What does this PR do?
Marks `TestApplicationService.cTestAppStartStop()` as unstable.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@emanns95 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Test](https://github.com/orgs/codice/teams/test)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Full build including integration tests and make sure `TestApplicationService.cTestAppStartStop()` isn't run.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2954](https://codice.atlassian.net/browse/DDF-2954)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
