### PR TITLE
DDF-2824 fixed missing include for Updating users in docs

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_configuring/updating-system-users.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/updating-system-users.adoc
@@ -1,0 +1,45 @@
+
+==== Updating System Users
+
+By default, all system users are located in the `<DDF_INSTALL_DIR>/etc/users.properties` and `<DDF_INSTALL_DIR>/etc/users.attributes` files.
+The default users included in these two files are "admin" and "localhost".
+The `users.properties` file contains username, password, and role information; while the `users.attributes` file is used to mix in additional attributes.
+The `users.properties` file must also contain the user corresponding to the fully qualified domain name (FQDN) of the system where ${branding} is running.
+This FQDN user represents this host system internally when making decisions about what operations the system is capable of performing.
+For example, when performing a ${branding} Catalog Ingest, the system's attributes will be checked against any security attributes present on the metacard, prior to ingest, to determine whether or not the system should be allowed to ingest that metacard.
+
+Additionally, the `users.attributes` file can contain user entries in a regex format.
+This allows an administrator to mix in attributes for external systems that match a particular regex pattern.
+The FQDN user within the `users.attributes` file should be filled out with attributes sufficient to allow the system to ingest the expected data.
+The `users.attributes` file uses a JSON format as shown below:
+
+[source,json,linenums]
+----
+{
+    "admin" : {
+        "test" : "testValue",
+        "test1" : [ "testing1", "testing2", "testing3" ]
+    },
+    "localhost" : {
+
+    },
+    ".*host.*" : {
+        "reg" : "ex"
+    }
+}
+----
+
+For this example, the "admin" user will end up with two additional claims of "test" and "test1" with values of "testValue" and [ "testing1", "testing2", "testing3" ] respectively.
+Also, any host matching the regex ".*host.*" would end up with the claim "reg" with the single value of "ex".
+The "localhost" user would have no additional attributes mixed in.
+
+[WARNING]
+====
+It is possible for a regex in `users.attributes` to match users as well as a system, so verify that the regex pattern's scope will not be too great when using this feature.
+====
+
+[WARNING]
+====
+If your data will contain security markings, and these markings are being parsed out into the METACARD.security attribute via a PolicyPlugin, then the FQDN user *MUST* be updated with attributes that would grant the privileges to ingest that data.
+Failure to update the FQDN user with sufficient attributes will result in an error being returned for any ingest request.
+====

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -116,8 +116,6 @@ include::{adoc-include}/_securing/securing-admin-console-contents.adoc[]
 
 include::{adoc-include}/_configuring/configuring-for-an-ldap-server-contents.adoc[]
 
-include::{adoc-include}/_securing/hardening-user-access-contents.adoc[]
-
 include::{adoc-include}/_securing/hardening-guest-user-access-contents.adoc[]
 
 include::{adoc-include}/_configuring/configuring-http-port-admin-console-contents.adoc[]
@@ -163,6 +161,10 @@ include::{adoc-include}/_securing/hardening-solr-index-contents.adoc[]
 include::{adoc-include}/_configuring/configuration-files-intro-contents.adoc[]
 
 include::{adoc-include}/_configuring/configuring-global-settings-contents.adoc[]
+
+include::{adoc-include}/_configuring/updating-system-users.adoc[]
+
+include::{adoc-include}/_securing/hardening-user-access-contents.adoc[]
 
 include::{adoc-include}/_configuring/configuring-with-config-files-contents.adoc[]
 


### PR DESCRIPTION
#### What does this PR do?

added section to configuring documentation for updating system user

#### Who is reviewing it?

@mcalcote @vinamartin @Lambeaux @jrnorth 

#### Select at least one member from relevant component team(s) from below.

[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR.

@clockard
@lessarderic
@pklinef
@shaundmorris
@stustison

#### How should this be tested? (List steps with links to updated documentation)

verify section updated successfully

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Screenshots (if appropriate)

[documentation.pdf](https://github.com/codice/ddf/files/931127/documentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
