### PR TITLE
DDF 2951 Test transformation of federated results

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -937,7 +937,7 @@ public class TestFederation extends AbstractIntegrationTest {
         ValidatableResponse response = getAndValidateCswResponse(metacardTitle, OPEN_GIS_SCHEMA_URI,
                 assertions);
 
-        // Extract the port of the response that can be transformed into a metacard
+        // Extract the part of the response that can be transformed into a metacard
         String cswRecordXml = extractRecord(response, extractXmlRegex);
 
         // Get the OPEN GIS CSW Record input transformer and create a metacard

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -920,7 +920,6 @@ public class TestFederation extends AbstractIntegrationTest {
     @Test
     public void testCswQueryForOpenGisXml() throws Exception {
 
-        //TODO: IF THUMBNAIL TRULY CANNOT BE EXTRACTED FROM OPEN GIS CSW RECORDS, REMOVE THIS VARIABLE.
         String thumbNailBase64EncSubstring = "/9j/4AAQSkZJRgABAQAAAQABAAD";
         String metacardTitle = "myTitle";
         String extractXmlRegex = ".*?(<csw:Record>.*?</csw:Record>).*";
@@ -934,7 +933,8 @@ public class TestFederation extends AbstractIntegrationTest {
         assertions.add(hasXPath("//*[local-name()='LowerCorner']/text()", equalTo("30.0 10.0")));
 
         // Query for CSW result and assert expected results
-        ValidatableResponse response = getAndValidateCswResponse(metacardTitle, OPEN_GIS_SCHEMA_URI,
+        ValidatableResponse response = getAndValidateCswResponse(metacardTitle,
+                OPEN_GIS_SCHEMA_URI,
                 assertions);
 
         // Extract the part of the response that can be transformed into a metacard

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -934,8 +934,6 @@ public class TestFederation extends AbstractIntegrationTest {
         // Define the assertions that test the query results conform to expectations
         List<Matcher<?>> assertions = getXpathMatchers(OPEN_GIS_SCHEMA_URI, 1);
         assertions.add(hasXPath("//title/text()", equalTo(metacardTitle)));
-        assertions.add(hasXPath("//*[local-name()='references']/text()",
-                startsWith(THUMB_NAIL_BASE_64_ENC_SUBSTRING)));
         assertions.add(hasXPath("//references/text()",
                 startsWith(THUMB_NAIL_BASE_64_ENC_SUBSTRING)));
         assertions.add(hasXPath("//*[local-name()='LowerCorner']/text()", equalTo("30.0 10.0")));

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -876,8 +876,8 @@ public class TestFederation extends AbstractIntegrationTest {
                 "UTF-8"));
 
         // Assert the newly created metacard's attributes are properly populated.
-        assertThat("Incorrect metacard's title", metacard.getTitle(), equalTo(metacardTitle));
-        assertThat("Incorrect metacard's thumbnail",
+        assertThat("Incorrect title", metacard.getTitle(), equalTo(metacardTitle));
+        assertThat("Incorrect thumbnail",
                 new String(Base64.getEncoder()
                         .encode(metacard.getThumbnail())),
                 startsWith(thumbNailBase64EncSubstring));
@@ -913,7 +913,7 @@ public class TestFederation extends AbstractIntegrationTest {
                         "UTF-8"));
 
         // Assert the newly created metacard's attributes are properly populated.
-        assertThat("Incorrect metacard's title", metacard.getTitle(), equalTo(metacardTitle));
+        assertThat("Incorrect title", metacard.getTitle(), equalTo(metacardTitle));
         assertThat("Incorrect geometry", "POINT (30 10)", equalTo(metacard.getLocation()));
     }
 
@@ -946,7 +946,7 @@ public class TestFederation extends AbstractIntegrationTest {
                 "UTF-8"));
 
         // Assert the newly created metacard's attributes are properly populated.
-        assertThat("Incorrect metacard's title", metacard.getTitle(), equalTo(metacardTitle));
+        assertThat("Incorrect title", metacard.getTitle(), equalTo(metacardTitle));
         assertThat("Incorrect geometry", "POINT (30.0 10.0)", equalTo(metacard.getLocation()));
 
         // TODO: THIS ASSERTION FAILS. VERIFY WITH CHRIS IT IS WORKING AS DESIGNED.

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -867,7 +867,7 @@ public class TestFederation extends AbstractIntegrationTest {
                 METACARD_URI,
                 assertions);
 
-        // Extract the port of the response that can be transformed into a metacard
+        // Extract the part of the response that can be transformed into a metacard
         String metacardXml = extractRecord(response, extractXmlRegex);
 
         // Get the metacard XML input transformer and attempt to create a metacard object
@@ -903,7 +903,7 @@ public class TestFederation extends AbstractIntegrationTest {
                 GMD_SCHEMA_URI,
                 assertions);
 
-        // Extract the port of the response that can be transformed into a metacard
+        // Extract the part of the response that can be transformed into a metacard
         String metacardXml = extractRecord(response, extractXmlRegex);
 
         // Get the metacard XML input transformer and attempt to create a metacard object

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -949,7 +949,11 @@ public class TestFederation extends AbstractIntegrationTest {
         assertThat("Incorrect title", metacard.getTitle(), equalTo(metacardTitle));
         assertThat("Incorrect geometry", "POINT (30.0 10.0)", equalTo(metacard.getLocation()));
 
-        // TODO: THIS ASSERTION FAILS. VERIFY WITH CHRIS IT IS WORKING AS DESIGNED.
+        // TODO: THIS ASSERTION FAILS. SEE DDF-2476 (https://codice.atlassian.net/browse/DDF-2476)
+        // The CSW Record metacard transformer preserves the metacard's thumbnail as a
+        // base-64 encoded string in an element named "<dct:references>".
+        // However the CSW input transformer does not used the "<dct:references>" element to
+        // populate the thumbnail attribute when it creates a metacard.
       /*  assertThat("Incorrect metacard's thumbnail",
                 new String(Base64.getEncoder()
                         .encode(metacard.getThumbnail())),


### PR DESCRIPTION
#### What does this PR do?
Enhance TestFederation itests to verify results can be transformed back into metacards. The basic flow is to use the CSW endpoint to retrieve a metacard using the three supported output schema: Open GIS, native Metacard, and GDM. The record return by the query is then passed to the appropriate input transformer. The test case verifies (implicitly) that no exception occurs and that the newly created metacard has a few of the attributes that it does. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)? @brendan-hofmann  @emanns95 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
Run the integration tests on DDF. 
#### Any background context you want to provide?
Part of team effort to increase itest coverage.
#### What are the relevant tickets?
[DDF-2951](https://codice.atlassian.net/browse/DDF-2951)
#### Screenshots (if appropriate)
#### Checklist:
- [X ] Update / Add Integration Tests