### PR TITLE
DDF-2940 Improve unit test coverage for DeleteOperations

### DIFF
--- a/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
+++ b/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
@@ -199,12 +199,12 @@ public class FederationStrategyTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                opsMetacard,
-                opsCatStore);
+                opsMetacard);
 
         opsStorage.setHistorian(historian);
         updateOperations.setHistorian(historian);
         deleteOperations.setHistorian(historian);
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         CatalogFrameworkImpl framework = new CatalogFrameworkImpl(createOperations,
                 updateOperations,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -616,16 +616,8 @@ public class DeleteOperations {
         }
     }
 
-    OperationsCatalogStoreSupport getOpsCatStoreSupport() {
-        return opsCatStoreSupport;
-    }
-
     public void setOpsCatStoreSupport(OperationsCatalogStoreSupport opsCatStoreSupport) {
         this.opsCatStoreSupport = opsCatStoreSupport;
-    }
-
-    public RemoteDeleteOperations getRemoteDeleteOperations() {
-        return remoteDeleteOperations;
     }
 
     public void setRemoteDeleteOperations(RemoteDeleteOperations remoteDeleteOperations) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -100,14 +100,12 @@ public class DeleteOperations {
     public DeleteOperations(FrameworkProperties frameworkProperties,
             QueryOperations queryOperations, SourceOperations sourceOperations,
             OperationsSecuritySupport opsSecuritySupport,
-            OperationsMetacardSupport opsMetacardSupport,
-            OperationsCatalogStoreSupport opsCatStoreSupport) {
+            OperationsMetacardSupport opsMetacardSupport) {
         this.frameworkProperties = frameworkProperties;
         this.queryOperations = queryOperations;
         this.sourceOperations = sourceOperations;
         this.opsSecuritySupport = opsSecuritySupport;
         this.opsMetacardSupport = opsMetacardSupport;
-        this.setOpsCatStoreSupport(opsCatStoreSupport);
     }
 
     public void setHistorian(Historian historian) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -46,13 +46,11 @@ import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.Operation;
 import ddf.catalog.operation.OperationTransaction;
-import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.DeleteResponseImpl;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
-import ddf.catalog.operation.impl.ProcessingDetailsImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.plugin.AccessPlugin;
@@ -63,7 +61,6 @@ import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.plugin.PreAuthorizationPlugin;
 import ddf.catalog.plugin.PreIngestPlugin;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.catalog.source.CatalogStore;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.InternalIngestException;
 import ddf.catalog.source.SourceUnavailableException;
@@ -79,8 +76,7 @@ import ddf.catalog.util.impl.Requests;
 public class DeleteOperations {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteOperations.class);
 
-    private static final Logger INGEST_LOGGER =
-            LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
+    static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
 
     private static final String PRE_INGEST_ERROR = "Error during pre-ingest:\n\n";
 
@@ -95,9 +91,11 @@ public class DeleteOperations {
 
     private final OperationsMetacardSupport opsMetacardSupport;
 
-    private final OperationsCatalogStoreSupport opsCatStoreSupport;
+    private OperationsCatalogStoreSupport opsCatStoreSupport;
 
     private Historian historian;
+
+    private RemoteDeleteOperations remoteDeleteOperations;
 
     public DeleteOperations(FrameworkProperties frameworkProperties,
             QueryOperations queryOperations, SourceOperations sourceOperations,
@@ -109,7 +107,7 @@ public class DeleteOperations {
         this.sourceOperations = sourceOperations;
         this.opsSecuritySupport = opsSecuritySupport;
         this.opsMetacardSupport = opsMetacardSupport;
-        this.opsCatStoreSupport = opsCatStoreSupport;
+        this.setOpsCatStoreSupport(opsCatStoreSupport);
     }
 
     public void setHistorian(Historian historian) {
@@ -168,7 +166,9 @@ public class DeleteOperations {
                             .size());
 
             deleteResponse = performLocalDelete(deleteRequest, deleteStorageRequest);
-            deleteResponse = performRemoteDelete(deleteRequest, deleteResponse);
+
+            deleteResponse = remoteDeleteOperations.performRemoteDelete(deleteRequest,
+                    deleteResponse);
 
             deleteResponse = postProcessPreAuthorizationPlugins(deleteResponse);
             deleteRequest = populateDeleteRequestPolicyMap(deleteRequest, deleteResponse);
@@ -298,25 +298,6 @@ public class DeleteOperations {
                 .put(PolicyPlugin.OPERATION_SECURITY, responsePolicyMap);
 
         return deleteRequest;
-    }
-
-    private DeleteResponse performRemoteDelete(DeleteRequest deleteRequest,
-            DeleteResponse deleteResponse) {
-        if (!opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)) {
-            return deleteResponse;
-        }
-
-        DeleteResponse remoteDeleteResponse = doRemoteDelete(deleteRequest);
-        if (deleteResponse == null) {
-            deleteResponse = remoteDeleteResponse;
-            deleteResponse = injectAttributes(deleteResponse);
-        } else {
-            deleteResponse.getProperties()
-                    .putAll(remoteDeleteResponse.getProperties());
-            deleteResponse.getProcessingErrors()
-                    .addAll(remoteDeleteResponse.getProcessingErrors());
-        }
-        return deleteResponse;
     }
 
     private DeleteResponse performLocalDelete(DeleteRequest deleteRequest,
@@ -512,7 +493,8 @@ public class DeleteOperations {
         QueryImpl queryImpl =
                 new QueryImpl(queryOperations.getFilterWithAdditionalFilters(idFilters),
                         1,  /* start index */
-                        deleteRequest.getAttributeValues().size(),  /* page size */
+                        deleteRequest.getAttributeValues()
+                                .size(),  /* page size */
                         null,
                         false, /* total result count */
                         0   /* timeout */);
@@ -529,19 +511,6 @@ public class DeleteOperations {
         }
 
         return deleteRequest;
-    }
-
-    private DeleteResponse injectAttributes(DeleteResponse response) {
-        List<Metacard> deletedMetacards = response.getDeletedMetacards()
-                .stream()
-                .map((original) -> opsMetacardSupport.applyInjectors(original,
-                        frameworkProperties.getAttributeInjectors()))
-                .collect(Collectors.toList());
-
-        return new DeleteResponseImpl(response.getRequest(),
-                response.getProperties(),
-                deletedMetacards,
-                response.getProcessingErrors());
     }
 
     /**
@@ -567,36 +536,6 @@ public class DeleteOperations {
         }
 
         return deleteRequest;
-    }
-
-    private DeleteResponse doRemoteDelete(DeleteRequest deleteRequest) {
-        HashSet<ProcessingDetails> exceptions = new HashSet<>();
-        Map<String, Serializable> properties = new HashMap<>();
-
-        List<CatalogStore> stores = opsCatStoreSupport.getCatalogStoresForRequest(deleteRequest,
-                exceptions);
-
-        List<Metacard> metacards = new ArrayList<>();
-        for (CatalogStore store : stores) {
-            try {
-                if (!store.isAvailable()) {
-                    exceptions.add(new ProcessingDetailsImpl(store.getId(),
-                            null,
-                            "CatalogStore is not available"));
-                } else {
-                    DeleteResponse response = store.delete(deleteRequest);
-                    properties.put(store.getId(), new ArrayList<>(response.getDeletedMetacards()));
-                    metacards = response.getDeletedMetacards();
-                }
-            } catch (IngestException e) {
-                INGEST_LOGGER.error("Error deleting metacards for CatalogStore {}",
-                        store.getId(),
-                        e);
-                exceptions.add(new ProcessingDetailsImpl(store.getId(), e));
-            }
-        }
-
-        return new DeleteResponseImpl(deleteRequest, properties, metacards, exceptions);
     }
 
     /**
@@ -637,6 +576,21 @@ public class DeleteOperations {
         return true;
     }
 
+    // TODO: 4/24/17 Move to future utility class (called in RemoteDeleteOperations as well)
+    // https://codice.atlassian.net/browse/DDF-2962
+    private DeleteResponse injectAttributes(DeleteResponse response) {
+        List<Metacard> deletedMetacards = response.getDeletedMetacards()
+                .stream()
+                .map((original) -> opsMetacardSupport.applyInjectors(original,
+                        frameworkProperties.getAttributeInjectors()))
+                .collect(Collectors.toList());
+
+        return new DeleteResponseImpl(response.getRequest(),
+                response.getProperties(),
+                deletedMetacards,
+                response.getProcessingErrors());
+    }
+
     private void logFailedQueryInfo(DeleteRequest deleteRequest, QueryResponse query) {
         if (LOGGER.isDebugEnabled()) {
             final String attributeName = deleteRequest.getAttributeName();
@@ -661,4 +615,21 @@ public class DeleteOperations {
                     .collect(Collectors.joining(", ", "[", "]")));
         }
     }
+
+    OperationsCatalogStoreSupport getOpsCatStoreSupport() {
+        return opsCatStoreSupport;
+    }
+
+    public void setOpsCatStoreSupport(OperationsCatalogStoreSupport opsCatStoreSupport) {
+        this.opsCatStoreSupport = opsCatStoreSupport;
+    }
+
+    public RemoteDeleteOperations getRemoteDeleteOperations() {
+        return remoteDeleteOperations;
+    }
+
+    public void setRemoteDeleteOperations(RemoteDeleteOperations remoteDeleteOperations) {
+        this.remoteDeleteOperations = remoteDeleteOperations;
+    }
+
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.impl.operations;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.impl.FrameworkProperties;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.operation.impl.ProcessingDetailsImpl;
+import ddf.catalog.source.CatalogStore;
+import ddf.catalog.source.IngestException;
+
+public class RemoteDeleteOperations {
+
+    static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
+
+    private OperationsCatalogStoreSupport opsCatStoreSupport;
+
+    private FrameworkProperties frameworkProperties;
+
+    private OperationsMetacardSupport opsMetacardSupport;
+
+    public RemoteDeleteOperations(FrameworkProperties frameworkProperties,
+            OperationsMetacardSupport opsMetacardSupport,
+            OperationsCatalogStoreSupport opsCatStoreSupport) {
+
+        this.opsCatStoreSupport = opsCatStoreSupport;
+        this.frameworkProperties = frameworkProperties;
+        this.opsMetacardSupport = opsMetacardSupport;
+
+    }
+
+    public DeleteResponse performRemoteDelete(DeleteRequest deleteRequest, DeleteResponse deleteResponse) {
+
+        if (!opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)) {
+            return deleteResponse;
+        }
+
+        DeleteResponse remoteDeleteResponse = doRemoteDelete(deleteRequest);
+        if (deleteResponse == null) {
+            deleteResponse = remoteDeleteResponse;
+            deleteResponse = injectAttributes(deleteResponse);
+        } else {
+            deleteResponse.getProperties()
+                    .putAll(remoteDeleteResponse.getProperties());
+            deleteResponse.getProcessingErrors()
+                    .addAll(remoteDeleteResponse.getProcessingErrors());
+        }
+        return deleteResponse;
+    }
+
+    private DeleteResponse doRemoteDelete(DeleteRequest deleteRequest) {
+        HashSet<ProcessingDetails> exceptions = new HashSet<>();
+        Map<String, Serializable> properties = new HashMap<>();
+
+        List<CatalogStore> stores = opsCatStoreSupport.getCatalogStoresForRequest(deleteRequest,
+                exceptions);
+
+        List<Metacard> metacards = new ArrayList<>();
+        for (CatalogStore store : stores) {
+            try {
+                if (!store.isAvailable()) {
+                    exceptions.add(new ProcessingDetailsImpl(store.getId(),
+                            null,
+                            "CatalogStore is not available"));
+                } else {
+                    DeleteResponse response = store.delete(deleteRequest);
+                    properties.put(store.getId(), new ArrayList<>(response.getDeletedMetacards()));
+                    metacards = response.getDeletedMetacards();
+                }
+            } catch (IngestException e) {
+                INGEST_LOGGER.error("Error deleting metacards for CatalogStore {}",
+                        store.getId(),
+                        e);
+                exceptions.add(new ProcessingDetailsImpl(store.getId(), e));
+            }
+        }
+
+        return new DeleteResponseImpl(deleteRequest, properties, metacards, exceptions);
+    }
+
+    void setOpsCatStoreSupport(OperationsCatalogStoreSupport opsCatStoreSupport) {
+        this.opsCatStoreSupport = opsCatStoreSupport;
+    }
+
+    // TODO: 4/24/17 Move to future utility class (called in DeleteOperations as well)
+    // https://codice.atlassian.net/browse/DDF-2962
+    private DeleteResponse injectAttributes(DeleteResponse response) {
+        List<Metacard> deletedMetacards = response.getDeletedMetacards()
+                .stream()
+                .map((original) -> opsMetacardSupport.applyInjectors(original,
+                        frameworkProperties.getAttributeInjectors()))
+                .collect(Collectors.toList());
+
+        return new DeleteResponseImpl(response.getRequest(),
+                response.getProperties(),
+                deletedMetacards,
+                response.getProcessingErrors());
+    }
+
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sun.istack.Nullable;
+
 import ddf.catalog.Constants;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.impl.FrameworkProperties;
@@ -40,23 +42,23 @@ public class RemoteDeleteOperations {
 
     static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
 
-    private OperationsCatalogStoreSupport opsCatStoreSupport;
-
     private FrameworkProperties frameworkProperties;
 
     private OperationsMetacardSupport opsMetacardSupport;
 
+    private OperationsCatalogStoreSupport opsCatStoreSupport;
+
     public RemoteDeleteOperations(FrameworkProperties frameworkProperties,
             OperationsMetacardSupport opsMetacardSupport,
             OperationsCatalogStoreSupport opsCatStoreSupport) {
-
-        this.opsCatStoreSupport = opsCatStoreSupport;
         this.frameworkProperties = frameworkProperties;
         this.opsMetacardSupport = opsMetacardSupport;
-
+        this.opsCatStoreSupport = opsCatStoreSupport;
     }
 
-    public DeleteResponse performRemoteDelete(DeleteRequest deleteRequest, DeleteResponse deleteResponse) {
+    @Nullable
+    public DeleteResponse performRemoteDelete(DeleteRequest deleteRequest,
+            @Nullable DeleteResponse deleteResponse) {
 
         if (!opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)) {
             return deleteResponse;
@@ -90,6 +92,7 @@ public class RemoteDeleteOperations {
                             null,
                             "CatalogStore is not available"));
                 } else {
+                    // TODO: 4/27/17 Address bug in DDF-2970 for overwriting deleted metacards
                     DeleteResponse response = store.delete(deleteRequest);
                     properties.put(store.getId(), new ArrayList<>(response.getDeletedMetacards()));
                     metacards = response.getDeletedMetacards();
@@ -105,7 +108,7 @@ public class RemoteDeleteOperations {
         return new DeleteResponseImpl(deleteRequest, properties, metacards, exceptions);
     }
 
-    void setOpsCatStoreSupport(OperationsCatalogStoreSupport opsCatStoreSupport) {
+    public void setOpsCatStoreSupport(OperationsCatalogStoreSupport opsCatStoreSupport) {
         this.opsCatStoreSupport = opsCatStoreSupport;
     }
 

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -67,12 +67,6 @@
         <property name="masker" ref="sourceListener"/>
     </bean>
 
-    <bean id="remoteDeleteOperations" class="ddf.catalog.impl.operations.RemoteDeleteOperations">
-        <argument ref="frameworkProperties"/>
-        <argument ref="cfOpsMetacard"/>
-        <argument ref="cfOpsCatStore"/>
-    </bean>
-
     <bean id="sourcePoller" class="ddf.catalog.util.impl.SourcePoller">
         <cm:managed-properties persistent-id="ddf.catalog.util.impl.SourcePoller"
                                update-strategy="container-managed"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -67,6 +67,12 @@
         <property name="masker" ref="sourceListener"/>
     </bean>
 
+    <bean id="remoteDeleteOperations" class="ddf.catalog.impl.operations.RemoteDeleteOperations">
+        <argument ref="frameworkProperties"/>
+        <argument ref="cfOpsMetacard"/>
+        <argument ref="cfOpsCatStore"/>
+    </bean>
+
     <bean id="sourcePoller" class="ddf.catalog.util.impl.SourcePoller">
         <cm:managed-properties persistent-id="ddf.catalog.util.impl.SourcePoller"
                                update-strategy="container-managed"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -105,6 +105,7 @@
         <argument ref="cfOpsMetacard"/>
         <argument ref="cfOpsCatStore"/>
         <property name="historian" ref="historian"/>
+        <property name="remoteDeleteOperations" ref="remoteDeleteOperations"/>
     </bean>
 
     <bean id="cfTransformOps" class="ddf.catalog.impl.operations.TransformOperations">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -103,9 +103,9 @@
         <argument ref="cfSourceOps"/>
         <argument ref="cfOpsSecurity"/>
         <argument ref="cfOpsMetacard"/>
-        <argument ref="cfOpsCatStore"/>
         <property name="historian" ref="historian"/>
         <property name="remoteDeleteOperations" ref="remoteDeleteOperations"/>
+        <property name="opsCatStoreSupport" ref="cfOpsCatStore"/>
     </bean>
 
     <bean id="cfTransformOps" class="ddf.catalog.impl.operations.TransformOperations">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -112,4 +112,9 @@
         <argument ref="frameworkProperties"/>
     </bean>
 
+    <bean id="remoteDeleteOperations" class="ddf.catalog.impl.operations.RemoteDeleteOperations">
+        <argument ref="frameworkProperties"/>
+        <argument ref="cfOpsMetacard"/>
+        <argument ref="cfOpsCatStore"/>
+    </bean>
 </blueprint>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -432,8 +432,9 @@ public class CatalogFrameworkImplTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                opsMetacard,
-                opsCatStore);
+                opsMetacard);
+
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         ResourceOperations resOps = new ResourceOperations(frameworkProperties,
                 queryOperations,
@@ -1416,8 +1417,7 @@ public class CatalogFrameworkImplTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                opsMetacard,
-                opsCatStore);
+                opsMetacard);
         ResourceOperations resourceOperations = new ResourceOperations(frameworkProperties,
                 queryOperations,
                 opsSecurity);
@@ -1429,6 +1429,7 @@ public class CatalogFrameworkImplTest {
         opsStorage.setHistorian(historian);
         updateOperations.setHistorian(historian);
         deleteOperations.setHistorian(historian);
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         CatalogFrameworkImpl catalogFramework = new CatalogFrameworkImpl(createOperations,
                 updateOperations,

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.AdditionalAnswers.returnsSecondArg;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyMap;
@@ -130,6 +131,7 @@ import ddf.catalog.impl.operations.OperationsMetacardSupport;
 import ddf.catalog.impl.operations.OperationsSecuritySupport;
 import ddf.catalog.impl.operations.OperationsStorageSupport;
 import ddf.catalog.impl.operations.QueryOperations;
+import ddf.catalog.impl.operations.RemoteDeleteOperations;
 import ddf.catalog.impl.operations.ResourceOperations;
 import ddf.catalog.impl.operations.SourceOperations;
 import ddf.catalog.impl.operations.TransformOperations;
@@ -232,6 +234,10 @@ public class CatalogFrameworkImplTest {
 
     FederationStrategy mockFederationStrategy;
 
+    DeleteOperations deleteOperations;
+
+    RemoteDeleteOperations mockRemoteDeleteOperations;
+
     @Rule
     public MethodRule watchman = new TestWatchman() {
         public void starting(FrameworkMethod method) {
@@ -327,6 +333,8 @@ public class CatalogFrameworkImplTest {
         when(mimeTypeToTransformerMapper.findMatches(any(Class.class),
                 any(MimeType.class))).thenReturn(Collections.singletonList(inputTransformer));
 
+        mockRemoteDeleteOperations = mock(RemoteDeleteOperations.class);
+
         FrameworkProperties frameworkProperties = new FrameworkProperties();
         frameworkProperties.setAccessPlugins(new ArrayList<>());
         frameworkProperties.setPolicyPlugins(new ArrayList<>());
@@ -420,7 +428,7 @@ public class CatalogFrameworkImplTest {
                 opsMetacard,
                 opsCatStore,
                 opsStorage);
-        DeleteOperations deleteOperations = new DeleteOperations(frameworkProperties,
+        deleteOperations = new DeleteOperations(frameworkProperties,
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
@@ -1141,6 +1149,9 @@ public class CatalogFrameworkImplTest {
                 1);
         when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
 
+        when(mockRemoteDeleteOperations.performRemoteDelete(any(), any())).then(returnsSecondArg());
+        deleteOperations.setRemoteDeleteOperations(mockRemoteDeleteOperations);
+
         // send delete to framework
         List<Metacard> returnedCards = framework.delete(new DeleteRequestImpl(ids))
                 .getDeletedMetacards();
@@ -1190,6 +1201,9 @@ public class CatalogFrameworkImplTest {
                 mockFederationResults,
                 1);
         when(mockFederationStrategy.federate(anyList(), anyObject())).thenReturn(queryResponse);
+
+        when(mockRemoteDeleteOperations.performRemoteDelete(any(), any())).then(returnsSecondArg());
+        deleteOperations.setRemoteDeleteOperations(mockRemoteDeleteOperations);
 
         final DeleteResponse response = framework.delete(request);
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
@@ -139,8 +139,7 @@ public class CatalogFrameworkQueryTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                opsMetacard,
-                opsCatStore);
+                opsMetacard);
 
         Historian historian = new Historian();
         historian.setHistoryEnabled(false);
@@ -148,6 +147,7 @@ public class CatalogFrameworkQueryTest {
         opsStorage.setHistorian(historian);
         updateOperations.setHistorian(historian);
         deleteOperations.setHistorian(historian);
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         framework = new CatalogFrameworkImpl(createOperations,
                 updateOperations,

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
@@ -160,8 +160,8 @@ public class FanoutCatalogFrameworkTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                null,
-                opsCatStore);
+                null);
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         framework = new CatalogFrameworkImpl(createOperations,
                 updateOperations,
@@ -459,8 +459,8 @@ public class FanoutCatalogFrameworkTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                null,
-                opsCatStore);
+                null);
+        deleteOperations.setOpsCatStoreSupport(opsCatStore);
 
         framework = new CatalogFrameworkImpl(null,
                 null,

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.impl.operations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.activation.MimeType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.cache.solr.impl.ValidationQueryFactory;
+import ddf.catalog.content.impl.MockMemoryStorageProvider;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.federation.FederationStrategy;
+import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.impl.FrameworkProperties;
+import ddf.catalog.impl.QueryResponsePostProcessor;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.plugin.PostIngestPlugin;
+import ddf.catalog.plugin.PostResourcePlugin;
+import ddf.catalog.source.CatalogProvider;
+import ddf.catalog.source.CatalogStore;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceMonitor;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import ddf.catalog.util.impl.SourcePoller;
+import ddf.mime.MimeTypeResolver;
+import ddf.mime.MimeTypeToTransformerMapper;
+import ddf.mime.mapper.MimeTypeMapperImpl;
+
+public class RemoteDeleteOperationsTest {
+    DeleteOperations deleteOperations;
+
+    DeleteRequest deleteRequest;
+
+    DeleteResponse deleteResponse;
+
+    List<String> fanoutTagBlacklist;
+
+    RemoteDeleteOperations remoteDeleteOperations;
+
+    OperationsCatalogStoreSupport opsCatStoreSupport;
+
+    OperationsMetacardSupport opsMetacardSupport;
+
+    OperationsSecuritySupport opsSecuritySupport;
+
+    FrameworkProperties frameworkProperties;
+
+    SourcePoller mockPoller;
+
+    CatalogProvider provider;
+
+    FederationStrategy mockFederationStrategy;
+
+    ArrayList<PostIngestPlugin> postIngestPlugins;
+
+    MockMemoryStorageProvider storageProvider;
+
+    MimeTypeResolver mimeTypeResolver;
+
+    MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
+
+    InputTransformer inputTransformer;
+
+    PostResourcePlugin mockPostResourcePlugin;
+
+    List<PostResourcePlugin> mockPostResourcePlugins;
+
+    @Before
+    public void setUp() throws Exception {
+        setUpMocks();
+        setUpDeleteRequest();
+        setUpFrameworkProperties();
+        setUpDeleteOperations();
+        setUpBlacklist();
+    }
+
+    @Test
+    public void testIsNotCatalogStoreRequestExpectsDeleteResponse() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(false);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+
+        assertThat("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+
+    }
+
+    @Test
+    public void testIsCatalogStoreRequestExpectsDeleteResponse() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(true);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+
+        assertThat("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+    }
+
+    @Test
+    public void testDeleteResponseNullExpectsEmptyResponse() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(true);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        deleteResponse = null;
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+
+        assertThat("Null request should return an empty response",
+                resultDeleteResponse.getDeletedMetacards(),
+                is(empty()));
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+    }
+
+    @Test
+    public void testNonEmptyStoreNotAvailableExpectProcessingErrors() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(true);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        deleteResponse = null;
+
+        CatalogStore catalogStoreMock = mock(CatalogStore.class);
+
+        ArrayList<CatalogStore> stores = new ArrayList<>();
+        stores.add(catalogStoreMock);
+
+        when(opsCatStoreSupport.getCatalogStoresForRequest(any(), any())).thenReturn(stores);
+        when(catalogStoreMock.isAvailable()).thenReturn(false);
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+        assertThat("Assert processing error occurs",
+                resultDeleteResponse.getProcessingErrors()
+                        .size() >= 1);
+
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+        verify(opsCatStoreSupport).getCatalogStoresForRequest(any(), any());
+        verify(catalogStoreMock).isAvailable();
+    }
+
+    @Test
+    public void testNonEmptyStoreAvailableExpectsDeleteResponse() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(true);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        CatalogStore catalogStoreMock = mock(CatalogStore.class);
+
+        ArrayList<CatalogStore> stores = new ArrayList<>();
+        stores.add(catalogStoreMock);
+
+        when(opsCatStoreSupport.getCatalogStoresForRequest(any(), any())).thenReturn(stores);
+        when(catalogStoreMock.isAvailable()).thenReturn(true);
+        when(catalogStoreMock.delete(any())).thenReturn(deleteResponse);
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+        assertThat("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+        verify(opsCatStoreSupport).getCatalogStoresForRequest(any(), any());
+        verify(catalogStoreMock).isAvailable();
+        verify(catalogStoreMock).delete(any());
+    }
+
+    @Test
+    public void testNonEmptyStoreAvailableExpectsCaughtIngestException() throws Exception {
+
+        when(opsCatStoreSupport.isCatalogStoreRequest(deleteRequest)).thenReturn(true);
+        remoteDeleteOperations.setOpsCatStoreSupport(opsCatStoreSupport);
+
+        CatalogStore catalogStoreMock = mock(CatalogStore.class);
+
+        ArrayList<CatalogStore> stores = new ArrayList<>();
+        stores.add(catalogStoreMock);
+
+        IngestException ingestException = new IngestException();
+
+        when(opsCatStoreSupport.getCatalogStoresForRequest(any(), any())).thenReturn(stores);
+        when(catalogStoreMock.isAvailable()).thenReturn(true);
+        when(catalogStoreMock.delete(any())).thenThrow(ingestException);
+
+        DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
+                deleteRequest,
+                deleteResponse);
+        assertThat("Assert caught IngestException",
+                resultDeleteResponse.getProcessingErrors()
+                        .size() >= 1);
+
+        verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
+        verify(opsCatStoreSupport).getCatalogStoresForRequest(any(), any());
+        verify(catalogStoreMock).isAvailable();
+        verify(catalogStoreMock).delete(any());
+    }
+
+    private void setUpFrameworkProperties() {
+        frameworkProperties = new FrameworkProperties();
+        frameworkProperties.setAccessPlugins(new ArrayList<>());
+        frameworkProperties.setPolicyPlugins(new ArrayList<>());
+        frameworkProperties.setSourcePoller(mockPoller);
+        frameworkProperties.setCatalogProviders(Collections.singletonList((CatalogProvider) provider));
+        frameworkProperties.setPostResource(mockPostResourcePlugins);
+        frameworkProperties.setFederationStrategy(mockFederationStrategy);
+        frameworkProperties.setFilterBuilder(new GeotoolsFilterBuilder());
+        frameworkProperties.setPreIngest(new ArrayList<>());
+        frameworkProperties.setPostIngest(postIngestPlugins);
+        frameworkProperties.setPreQuery(new ArrayList<>());
+        frameworkProperties.setPostQuery(new ArrayList<>());
+        frameworkProperties.setPreResource(new ArrayList<>());
+        frameworkProperties.setPostResource(new ArrayList<>());
+        frameworkProperties.setQueryResponsePostProcessor(mock(QueryResponsePostProcessor.class));
+        frameworkProperties.setStorageProviders(Collections.singletonList(storageProvider));
+        frameworkProperties.setMimeTypeMapper(new MimeTypeMapperImpl(Collections.singletonList(
+                mimeTypeResolver)));
+        frameworkProperties.setMimeTypeToTransformerMapper(mimeTypeToTransformerMapper);
+        frameworkProperties.setValidationQueryFactory(new ValidationQueryFactory(new GeotoolsFilterAdapterImpl(),
+                new GeotoolsFilterBuilder()));
+    }
+
+    private void setUpMocks() throws IOException, CatalogTransformerException {
+        String localProviderName = "ddf";
+
+        mockPoller = mock(SourcePoller.class);
+        when(mockPoller.getCachedSource(isA(Source.class))).thenReturn(null);
+
+        provider = mock(CatalogProvider.class);
+        when(provider.getId()).thenReturn(localProviderName);
+        when(provider.isAvailable(isA(SourceMonitor.class))).thenReturn(true);
+        when(provider.isAvailable()).thenReturn(true);
+
+        mockPostResourcePlugin = mock(PostResourcePlugin.class);
+        mockPostResourcePlugins = new ArrayList<PostResourcePlugin>();
+        mockPostResourcePlugins.add(mockPostResourcePlugin);
+
+        mockFederationStrategy = mock(FederationStrategy.class);
+
+        postIngestPlugins = new ArrayList<>();
+
+        storageProvider = new MockMemoryStorageProvider();
+        mimeTypeResolver = mock(MimeTypeResolver.class);
+
+        mimeTypeToTransformerMapper = mock(MimeTypeToTransformerMapper.class);
+
+        inputTransformer = mock(InputTransformer.class);
+        when(inputTransformer.transform(any(InputStream.class))).thenReturn(new MetacardImpl());
+        when(mimeTypeToTransformerMapper.findMatches(any(Class.class),
+                any(MimeType.class))).thenReturn(Collections.singletonList(inputTransformer));
+    }
+
+    private void setUpDeleteRequest() {
+        MetacardImpl metacard = new MetacardImpl();
+        ArrayList<Metacard> metacardList = new ArrayList<>();
+        metacard.setId("Bob");
+        metacard.setTitle("Bob's Title");
+        metacardList.add(metacard);
+
+        metacard = new MetacardImpl();
+        metacard.setId("Bobbert");
+        metacard.setTitle("Bobbert's Title");
+        metacardList.add(metacard);
+
+        deleteRequest = new DeleteRequestImpl(metacard.getId());
+        deleteResponse = new DeleteResponseImpl(deleteRequest, new HashMap(), metacardList);
+    }
+
+    private void setUpBlacklist() {
+        fanoutTagBlacklist = new ArrayList<>();
+        fanoutTagBlacklist.add("");
+
+        opsSecuritySupport = mock(OperationsSecuritySupport.class);
+
+        opsMetacardSupport = mock(OperationsMetacardSupport.class);
+
+        opsCatStoreSupport = mock(OperationsCatalogStoreSupport.class);
+
+        remoteDeleteOperations = new RemoteDeleteOperations(frameworkProperties,
+                opsMetacardSupport,
+                opsCatStoreSupport);
+
+    }
+
+    private void setUpDeleteOperations() {
+        SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
+        OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
+        MetacardFactory metacardFactory = new MetacardFactory(mimeTypeToTransformerMapper);
+        OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
+                metacardFactory);
+
+        QueryOperations queryOperations = new QueryOperations(frameworkProperties,
+                sourceOperations,
+                opsSecurity,
+                opsMetacard);
+
+        OperationsCatalogStoreSupport opsCatStore = new OperationsCatalogStoreSupport(
+                frameworkProperties,
+                sourceOperations);
+
+        deleteOperations = new DeleteOperations(frameworkProperties,
+                queryOperations,
+                sourceOperations,
+                opsSecurity,
+                opsMetacard,
+                opsCatStore);
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -350,7 +350,6 @@ public class RemoteDeleteOperationsTest {
                 queryOperations,
                 sourceOperations,
                 opsSecurity,
-                opsMetacard,
-                opsCatStore);
+                opsMetacard);
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -15,6 +15,7 @@
 package ddf.catalog.impl.operations;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.activation.MimeType;
 
@@ -120,8 +122,10 @@ public class RemoteDeleteOperationsTest {
                 deleteRequest,
                 deleteResponse);
 
-        assertThat("Assert return of identical deleteResponse",
-                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+        assertEqualMetacards("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards(),
+                deleteResponse.getDeletedMetacards());
+
         verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
 
     }
@@ -136,8 +140,10 @@ public class RemoteDeleteOperationsTest {
                 deleteRequest,
                 deleteResponse);
 
-        assertThat("Assert return of identical deleteResponse",
-                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+        assertEqualMetacards("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards(),
+                deleteResponse.getDeletedMetacards());
+
         verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
     }
 
@@ -205,8 +211,10 @@ public class RemoteDeleteOperationsTest {
         DeleteResponse resultDeleteResponse = remoteDeleteOperations.performRemoteDelete(
                 deleteRequest,
                 deleteResponse);
-        assertThat("Assert return of identical deleteResponse",
-                resultDeleteResponse.getDeletedMetacards() == deleteResponse.getDeletedMetacards());
+
+        assertEqualMetacards("Assert return of identical deleteResponse",
+                resultDeleteResponse.getDeletedMetacards(),
+                deleteResponse.getDeletedMetacards());
 
         verify(opsCatStoreSupport).isCatalogStoreRequest(deleteRequest);
         verify(opsCatStoreSupport).getCatalogStoresForRequest(any(), any());
@@ -242,6 +250,26 @@ public class RemoteDeleteOperationsTest {
         verify(opsCatStoreSupport).getCatalogStoresForRequest(any(), any());
         verify(catalogStoreMock).isAvailable();
         verify(catalogStoreMock).delete(any());
+    }
+
+    private void assertEqualMetacards(String reason, List<Metacard> metacardList1,
+            List<Metacard> metacardList2) {
+
+        List<String> idList1 = metacardList1.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList());
+        List<String> idList2 = metacardList2.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList());
+        List<String> titleList1 = metacardList1.stream()
+                .map(Metacard::getTitle)
+                .collect(Collectors.toList());
+        List<String> titleList2 = metacardList2.stream()
+                .map(Metacard::getTitle)
+                .collect(Collectors.toList());
+
+        assertThat(reason, idList1, containsInAnyOrder(idList2));
+        assertThat(reason, titleList1, containsInAnyOrder(titleList2));
     }
 
     private void setUpFrameworkProperties() {

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -268,8 +268,8 @@ public class RemoteDeleteOperationsTest {
                 .map(Metacard::getTitle)
                 .collect(Collectors.toList());
 
-        assertThat(reason, idList1, containsInAnyOrder(idList2));
-        assertThat(reason, titleList1, containsInAnyOrder(titleList2));
+        assertThat(reason, idList1, containsInAnyOrder(idList2.toArray()));
+        assertThat(reason, titleList1, containsInAnyOrder(titleList2.toArray()));
     }
 
     private void setUpFrameworkProperties() {


### PR DESCRIPTION
#### What does this PR do?
Adds test coverage to DeleteOperations (ddf/catalog/impl/operations) by separating out the RemoteDeleteOperations into their own class.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @rzwiefel  @emanns95 @jrnorth  

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Test](https://github.com/orgs/codice/teams/test)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl 
@clockard 

#### How should this be tested? (List steps with links to updated documentation)
Running test coverage on all tests in `ddf/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog` should cover all of RemoteDeleteOperations and DeleteOperations.

#### Any background context you want to provide?
Follows a string of goals to increase unit test coverage throughout DDF.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2940)

#### Checklist:
- [X] Update / Add Unit Tests
