### PR TITLE
DDF-2862 Add null check for QueryRequest in doQuery

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -193,6 +193,11 @@ public class QueryOperations extends DescribableImpl {
      */
     QueryResponse doQuery(QueryRequest queryRequest, FederationStrategy strategy)
             throws FederationException {
+        if (queryRequest == null) {
+            throw new FederationException(
+                "Query could not be performed because the query request was null.");
+        }
+        
         Set<String> sourceIds = getCombinedIdSet(queryRequest);
         LOGGER.debug("source ids: {}", sourceIds);
 


### PR DESCRIPTION
#### What does this PR do?
Protected against possible null pointer exception due to null QueryRequest being passed into doQuery in QueryOperations.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer 
@codymacdonald 
@mweser 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests

#### Any background context you want to provide?
Discovered via Sonarqube analysis.

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
