### PR TITLE
DDF-2963 Lower the memory usage of Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.catalog.ui.query.cql;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 import ddf.catalog.operation.ProcessingDetails;
@@ -30,6 +31,8 @@ public class Status {
 
     private final boolean successful;
 
+    private final ArrayList<String> messages;
+
     public Status(QueryResponse response, String source, long elapsedTime) {
         elapsed = elapsedTime;
         id = source;
@@ -38,6 +41,17 @@ public class Status {
                 .size();
         hits = response.getHits();
         successful = isSuccessful(response.getProcessingDetails());
+        messages = getMessages(response.getProcessingDetails());
+    }
+
+    private ArrayList<String> getMessages(final Set<ProcessingDetails> details) {
+        ArrayList<String> messages = new ArrayList<String>();
+        for (ProcessingDetails detail : details) {
+            if (detail.hasException()) {
+               messages.add(detail.getException().getMessage());
+            }
+        }
+        return messages;
     }
 
     private boolean isSuccessful(final Set<ProcessingDetails> details) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -48,7 +48,7 @@ public class Status {
         ArrayList<String> messages = new ArrayList<String>();
         for (ProcessingDetails detail : details) {
             if (detail.hasException()) {
-               messages.add(detail.getException().getMessage());
+                messages.add(detail.getException().getMessage());
             }
         }
         return messages;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -48,6 +48,9 @@
 @import 'result-selector/result-selector';
 @import 'query-basic/query-basic';
 @import 'query-status/query-status';
+@import 'query-status/query-status-row';
+@import 'query-status/query-status-header';
+@import 'query-status/query-status-body';
 @import 'metacard-history/metacard-history';
 @import 'metacard-associations/metacard-associations';
 @import 'metacard-quality/metacard-quality';
@@ -119,7 +122,7 @@
 @import 'tabs/query/tabs-query';
 @import 'visualization/visualization';
 @import 'visualization/histogram/histogram';
-@import 'visualization/table/table';
+@import 'visualization/table/table-viz';
 @import 'visualization/table/thead';
 @import 'visualization/table/tbody';
 @import 'visualization/table/row';
@@ -160,3 +163,4 @@
 @import 'unsaved-indicator/unsaved-indicator';
 @import 'query-feedback/query-feedback';
 @import 'input/textarea/input-textarea';
+@import 'table/table';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -41,9 +41,7 @@
 @import 'workspace-item/workspace-item';
 @import 'workspace-details/workspace-details';
 @import 'content/content';
-@import 'workspace-explore/workspace-explore';
 @import 'workspace-saved/workspace-saved';
-@import 'queries/queries';
 @import 'query-selector/query-selector';
 @import 'result-selector/result-selector';
 @import 'query-basic/query-basic';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -128,6 +128,7 @@
 @import 'visualization/table/table-rearrange';
 @import 'announcement/announcement';
 @import 'workspace-interactions/workspace-interactions';
+@import 'workspace-explore/workspace-explore';
 @import 'dropdown/workspace-interactions/dropdown.workspace-interactions.less';
 @import 'help/help';
 @import 'hint/hint';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.less
@@ -89,6 +89,7 @@
     > .content-panelTwo-content {
       height: ~"calc(100% - @{minimumButtonSize})";
       overflow: hidden;
+      background: inherit;
     }
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.less
@@ -23,5 +23,17 @@
   transform: translateX(0%);
   @{customElementNamespace}dropdown {
     display: block;
+    animation: help-spawn 2*@coreTransitionTime ease-in-out;
   }
+}
+
+@keyframes help-spawn{
+    0% {
+        opacity: 0;
+        transform: scale(0);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.less
@@ -102,6 +102,7 @@
   .if-homogeneous,
   .if-other {
     display: block;
+    margin-top: @minimumSpacing;
   }
 
   > .if-editing {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.view.js
@@ -23,9 +23,10 @@ define([
     'js/store',
     'component/router/router',
     'component/singletons/user-instance',
+    'component/singletons/sources-instance',
     'decorator/menu-navigation.decorator',
     'decorator/Decorators'
-], function (wreqr, Marionette, _, $, template, CustomElements, store, router, user, MenuNavigationDecorator, Decorators) {
+], function (wreqr, Marionette, _, $, template, CustomElements, store, router, user, sources, MenuNavigationDecorator, Decorators) {
 
     return Marionette.ItemView.extend(Decorators.decorate({
         template: template,
@@ -194,7 +195,7 @@ define([
             }
             var result = resultJSON[0];
             return {
-                remoteResourceCached: result.isResourceLocal && result.metacard.properties['source-id'] !== 'ddf.distribution',
+                remoteResourceCached: result.isResourceLocal && result.metacard.properties['source-id'] !== sources.localCatalog,
                 result: resultJSON,
                 workspace: workspaceJSON
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.view.js
@@ -47,6 +47,14 @@ define([
             this.handleRoute();
             this.handleResultChange();
             this.listenTo(metacardInstance, 'change:currentResult', this.handleResultChange);
+            this.listenToCurrentMetacard();
+        },
+        listenToCurrentMetacard: function(){
+            /*
+                The throttle on the result change should take care of issues with result set merging, but this is a good to have in case
+                the timing changes or something else goes awry that we haven't thought of yet.
+            */
+            this.listenTo(metacardInstance, 'change:currentMetacard', this.handleStatus); 
         },
         handleStatus: function(){
             this.$el.toggleClass('not-found', metacardInstance.get('currentMetacard') === undefined);
@@ -54,7 +62,7 @@ define([
         },
         handleResultChange: function(){
             this.handleStatus();
-            this.listenTo(metacardInstance.get('currentResult'), 'sync request error', this.handleStatus);
+            this.listenTo(metacardInstance.get('currentResult'), 'sync request error',  _.throttle(this.handleStatus, 60, {leading: false}));
         },
         handleRoute: function(){
             if (router.toJSON().name === 'openMetacard'){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-feed/query-feed.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-feed/query-feed.less
@@ -9,6 +9,10 @@
   .results-pending {
     display: none;
   }
+
+  .fa-warning {
+    color: @negative-color !important;
+  }
 }
 
 @{customElementNamespace}query-feed.is-failed {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-selector/query-selector.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-selector/query-selector.less
@@ -7,16 +7,15 @@
 
 
   > button {
-    margin-top: @buttonMargin;
     display: none;
     width: 100%;
-    padding: 10px;
-    height: @minimumButtonSize;
   }
 
   .querySelector-list {
     max-height: ~"calc(100%)";
     overflow: auto;
+    display: inline-block;
+    width: 100%;
   }
 
   &.can-addQuery {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-body.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-body.less
@@ -1,0 +1,2 @@
+@{customElementNamespace}query-status-tbody {
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-body.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-body.view.js
@@ -13,25 +13,15 @@
  *
  **/
 /*global require*/
-
 var Marionette = require('marionette');
-var template = require('./query-status.hbs');
 var CustomElements = require('js/CustomElements');
-var store = require('js/store');
-var TableView = require('component/table/query-status/table-query-status.view');
+var RowView = require('./query-status-row.view');
 
-module.exports = Marionette.LayoutView.extend({
-    template: template,
-    tagName: CustomElements.register('query-status'),
-    regions: {
-        table: '.table-container'
-    },
-    initialize: function () {
-        this.model = store.getQueryById(this.model.id);
-    },
-    onBeforeShow: function(){
-        this.table.show(new TableView({
-            model: this.model
-        }));
+module.exports = Marionette.CollectionView.extend({
+    tagName: CustomElements.register('query-status-tbody'),
+    className: 'is-tbody is-list has-list-highlighting',
+    childView: RowView,
+    filter: function(childModel){
+        return childModel.get('id') !== 'cache';
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
@@ -1,0 +1,49 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<th>
+    Source
+    <div class="column-absolute">
+    Source
+    </div>
+</th>
+<th>
+    Top 
+    <div class="column-absolute" data-help="This is the number of results that made it into the Top.">
+    Top
+    </div>
+</th>
+<th>
+    Possible 
+    <div class="column-absolute" data-help="This is the total number of results (hits) that matched your search.">
+    Possible
+    </div>
+</th>
+<th>
+    Local
+    <div class="column-absolute" data-help="This is the number of results in Top that were found locally.">
+    Local
+    </div>
+</th>
+<th>
+    Direct
+    <div class="column-absolute"  data-help="This is the number of results in Top that were found directly in the source.">
+    Direct
+    </div>
+</th>
+<th>
+    Time (s)
+    <div class="column-absolute"  data-help="This is the time (in seconds) that it took for the search to run.">
+    Time (s)
+    </div>
+</th>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
@@ -30,18 +30,6 @@
     </div>
 </th>
 <th>
-    Local
-    <div class="column-absolute" data-help="This is the number of results in Top that were found locally.">
-    Local
-    </div>
-</th>
-<th>
-    Direct
-    <div class="column-absolute"  data-help="This is the number of results in Top that were found directly in the source.">
-    Direct
-    </div>
-</th>
-<th>
     Time (s)
     <div class="column-absolute"  data-help="This is the time (in seconds) that it took for the search to run.">
     Time (s)

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
@@ -14,8 +14,8 @@
 <th>
     Source
 </th>
-<th data-help="This is the number of results that made it into the Top.">
-    Top 
+<th data-help="This is the number of results available based on the current sorting.">
+    Available 
 </th>
 <th data-help="This is the total number of results (hits) that matched your search.">
     Possible 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.hbs
@@ -13,25 +13,13 @@
  --}}
 <th>
     Source
-    <div class="column-absolute">
-    Source
-    </div>
 </th>
-<th>
+<th data-help="This is the number of results that made it into the Top.">
     Top 
-    <div class="column-absolute" data-help="This is the number of results that made it into the Top.">
-    Top
-    </div>
 </th>
-<th>
+<th data-help="This is the total number of results (hits) that matched your search.">
     Possible 
-    <div class="column-absolute" data-help="This is the total number of results (hits) that matched your search.">
-    Possible
-    </div>
 </th>
-<th>
+<th data-help="This is the time (in seconds) that it took for the search to run.">
     Time (s)
-    <div class="column-absolute"  data-help="This is the time (in seconds) that it took for the search to run.">
-    Time (s)
-    </div>
 </th>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.less
@@ -1,0 +1,3 @@
+@{customElementNamespace}query-status-header {
+
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-header.view.js
@@ -13,25 +13,12 @@
  *
  **/
 /*global require*/
-
+var template = require('./query-status-header.hbs');
 var Marionette = require('marionette');
-var template = require('./query-status.hbs');
 var CustomElements = require('js/CustomElements');
-var store = require('js/store');
-var TableView = require('component/table/query-status/table-query-status.view');
 
-module.exports = Marionette.LayoutView.extend({
+module.exports = Marionette.ItemView.extend({
+    className: 'is-thead',
     template: template,
-    tagName: CustomElements.register('query-status'),
-    regions: {
-        table: '.table-container'
-    },
-    initialize: function () {
-        this.model = store.getQueryById(this.model.id);
-    },
-    onBeforeShow: function(){
-        this.table.show(new TableView({
-            model: this.model
-        }));
-    }
+    tagName: CustomElements.register('query-status-header')
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
@@ -1,0 +1,76 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<td>
+    {{id}}
+    {{#if hasReturned}}
+        {{#unless successful}}
+            <span class="fa fa-warning" title="{{messages}}"></span>
+        {{/unless}}
+    {{/if}}
+</td>
+<td>
+    {{#if hasReturned}}
+        {{#if successful}}
+            {{top}}
+        {{else}}
+            <span class="fa fa-warning" title="{{messages}}"></span>
+        {{/if}}
+    {{else}}
+        <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
+    {{/if}}
+</td>
+<td>
+    {{#if hasReturned}}
+        {{#if successful}}
+            {{hits}}
+        {{else}}
+            <span class="fa fa-warning" title="{{messages}}"></span>
+        {{/if}}
+    {{else}}
+        <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
+    {{/if}}
+</td>
+<td>
+    {{#if cacheHasReturned}}
+        {{#if cacheSuccessful}}
+            {{fromcache}}
+        {{else}}
+            <span class="fa fa-warning" title="{{cacheMessages}}"></span>
+        {{/if}}
+    {{else}}
+        <span class="fa fa-circle-o-notch fa-spin" title="Checking for results locally"></span>
+    {{/if}}
+</td>
+<td>
+    {{#if hasReturned}}
+        {{#if successful}}
+            {{fromremote}}
+        {{else}}
+            <span class="fa fa-warning" title="{{messages}}"></span>
+        {{/if}}
+    {{else}}
+        <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
+    {{/if}}
+</td>
+<td>
+    {{#if hasReturned}}
+        {{#if successful}}
+            {{elapsed}}
+        {{else}}
+            <span class="fa fa-warning" title="{{messages}}"></span>
+        {{/if}}
+    {{else}}
+        <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
+    {{/if}}
+</td>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
@@ -43,28 +43,6 @@
     {{/if}}
 </td>
 <td>
-    {{#if cacheHasReturned}}
-        {{#if cacheSuccessful}}
-            {{fromcache}}
-        {{else}}
-            <span class="fa fa-warning" title="{{cacheMessages}}"></span>
-        {{/if}}
-    {{else}}
-        <span class="fa fa-circle-o-notch fa-spin" title="Checking for results locally"></span>
-    {{/if}}
-</td>
-<td>
-    {{#if hasReturned}}
-        {{#if successful}}
-            {{fromremote}}
-        {{else}}
-            <span class="fa fa-warning" title="{{messages}}"></span>
-        {{/if}}
-    {{else}}
-        <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
-    {{/if}}
-</td>
-<td>
     {{#if hasReturned}}
         {{#if successful}}
             {{elapsed}}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
@@ -20,12 +20,13 @@
     {{/if}}
 </td>
 <td>
+    {{#if anyHasReturned}}
+        {{top}}
+    {{/if}}
     {{#if hasReturned}}
-        {{#if successful}}
-            {{top}}
-        {{else}}
+        {{#unless successful}}
             <span class="fa fa-warning" title="{{messages}}"></span>
-        {{/if}}
+        {{/unless}}
     {{else}}
         <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
     {{/if}}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
@@ -27,7 +27,8 @@
         {{#unless successful}}
             <span class="fa fa-warning" title="{{messages}}"></span>
         {{/unless}}
-    {{else}}
+    {{/if}}
+    {{#if anyHasNotReturned}}
         <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
     {{/if}}
 </td>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.less
@@ -1,0 +1,6 @@
+@{customElementNamespace}query-status-row {
+
+    .fa-warning {
+        color: @negative-color !important;
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
@@ -13,25 +13,21 @@
  *
  **/
 /*global require*/
-
+var template = require('./query-status-row.hbs');
 var Marionette = require('marionette');
-var template = require('./query-status.hbs');
 var CustomElements = require('js/CustomElements');
-var store = require('js/store');
-var TableView = require('component/table/query-status/table-query-status.view');
 
-module.exports = Marionette.LayoutView.extend({
+module.exports = Marionette.ItemView.extend({
+    className: 'is-tr',
+    tagName: CustomElements.register('query-status-row'),
     template: template,
-    tagName: CustomElements.register('query-status'),
-    regions: {
-        table: '.table-container'
+    modelEvents: {
+        'change': 'render'
     },
-    initialize: function () {
-        this.model = store.getQueryById(this.model.id);
-    },
-    onBeforeShow: function(){
-        this.table.show(new TableView({
-            model: this.model
-        }));
+    serializeData: function(){
+        var modelJSON = this.model.toJSON();
+        modelJSON.fromremote = modelJSON.top - modelJSON.fromcache;
+        modelJSON.elapsed = modelJSON.elapsed / 1000;
+        return modelJSON;
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
@@ -29,6 +29,7 @@ module.exports = Marionette.ItemView.extend({
         modelJSON.fromremote = modelJSON.top - modelJSON.fromcache;
         modelJSON.elapsed = modelJSON.elapsed / 1000;
         modelJSON.anyHasReturned = modelJSON.hasReturned || modelJSON.cacheHasReturned;
+        modelJSON.anyHasNotReturned = !modelJSON.hasReturned || !modelJSON.cacheHasReturned;
         return modelJSON;
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.view.js
@@ -28,6 +28,7 @@ module.exports = Marionette.ItemView.extend({
         var modelJSON = this.model.toJSON();
         modelJSON.fromremote = modelJSON.top - modelJSON.fromcache;
         modelJSON.elapsed = modelJSON.elapsed / 1000;
+        modelJSON.anyHasReturned = modelJSON.hasReturned || modelJSON.cacheHasReturned;
         return modelJSON;
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-status/query-status.less
@@ -1,33 +1,14 @@
 @{customElementNamespace}query-status {
-
-  display: block;
-  padding: 10px;
-  width: 100%;
-  height: 100%;
-
-  .is-list > div {
-    height: @minimumLineSize;
-    line-height: @minimumLineSize;
-  }
+  .customElement;
+  background: inherit;
+  padding: 20px;
 
   .details {
     .is-bold();
   }
 
-  .status > div {
-    height: 100%;
-    width: 50%;
-    display: inline-block;
-    vertical-align: middle;
-  }
-
-  .status-source {
-    float: left;
-    .is-bold();
-  }
-
-  .status-result {
-    float: right;
-    text-align: right;
+  .table-container {
+    height: ~'calc(100% - @{minimumButtonSize})';
+    background: inherit;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-title/query-title.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-title/query-title.less
@@ -8,7 +8,6 @@
     display: inline-block;
     vertical-align: top;
     height: ~'calc(100% - 2px)';
-    margin-top: 2px;
   }
 
   input {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
@@ -30,10 +30,11 @@ define([
     'component/singletons/user-instance',
     'component/singletons/metacard-definitions',
     'moment',
+    'component/singletons/sources-instance',
     'behaviors/button.behavior'
 ], function (Backbone, Marionette, _, $, template, CustomElements, store, Common, DropdownModel,
              MetacardInteractionsDropdownView, ResultIndicatorView, properties, router, user,
-             metacardDefinitions, moment) {
+             metacardDefinitions, moment, sources) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -133,7 +134,7 @@ define([
         },
         massageResult: function(result){
             //make a nice date
-            result.local = Boolean(result.metacard.properties['source-id'] === 'ddf.distribution');
+            result.local = Boolean(result.metacard.properties['source-id'] === sources.localCatalog);
             var dateModified = moment(result.metacard.properties.modified);
             result.niceDiff = Common.getMomentDate(dateModified);
             //check validation errors

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.less
@@ -77,9 +77,9 @@
     width: 100%;
     position: absolute;
     left: 0px;
-    top: -.5*@minimumSpacing;
-    height: .5*@minimumSpacing;
-    background: @heavily-lighten-inherited-background-color;
+    border-top: @largeSpacing solid @heavily-lighten-inherited-background-color;
+    top: -@largeSpacing;
+    height: 100%;
     animation: result-selector-is-searching 10*@coreTransitionTime infinite ease-in-out;
   } 
 
@@ -141,9 +141,9 @@
 
 @keyframes result-selector-is-searching{
     0% {
-      top: -.5*@minimumSpacing;
+      transform: translate3d(0, -@largeSpacing, 0);
     }
     100% {
-      top: 100%;
+      transform: translate3d(0, 100%, 0);
     } 
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.hbs
@@ -11,6 +11,10 @@
  *
  **/
  --}}
-<div class="table-container">
-
+<div class="choice-details">
+</div>
+<div class="choice-save">
+</div>
+<div class="choice-actions is-button" title="Shows a list of actions to take on the workspace" 
+    data-help="Shows a list of actions to take on the workspace.">
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.less
@@ -1,0 +1,3 @@
+@{customElementNamespace}source-status {
+    .customElement;
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/source-status/source-status.view.js
@@ -13,25 +13,24 @@
  *
  **/
 /*global require*/
-
 var Marionette = require('marionette');
-var template = require('./query-status.hbs');
+var _ = require('underscore');
+var $ = require('jquery');
 var CustomElements = require('js/CustomElements');
-var store = require('js/store');
-var TableView = require('component/table/query-status/table-query-status.view');
+var template = require('./source-status.hbs');
+var DropdownModel = require('component/dropdown/dropdown');
+require('behaviors/button.behavior');
 
 module.exports = Marionette.LayoutView.extend({
     template: template,
-    tagName: CustomElements.register('query-status'),
+    tagName: CustomElements.register('source-status'),
     regions: {
-        table: '.table-container'
+        sourceActions: '.source-actions'
+    },
+    behaviors: {
+        button: {}
     },
     initialize: function () {
-        this.model = store.getQueryById(this.model.id);
-    },
-    onBeforeShow: function(){
-        this.table.show(new TableView({
-            model: this.model
-        }));
+        this.listenTo(this.model, 'change:saved', this.handleSaved);
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/query-status/table-query-status.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/query-status/table-query-status.view.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+var TableView = require('../table.view');
+var HeaderView = require('component/query-status/query-status-header.view');
+var BodyView = require('component/query-status/query-status-body.view');
+
+module.exports = TableView.extend({
+    className: 'is-query-status',
+    initialize: function(){
+         var result = this.model.get('result');
+         if (!result){
+            this.startListeningToSearch();
+         }
+    },
+    startListeningToSearch: function(){
+        this.listenToOnce(this.model, 'change:result', this.render);
+    }, 
+    getHeaderView: function(){
+        return new HeaderView({
+            model: this.model
+        });
+    },
+    getBodyView: function(){
+        var result = this.model.get('result');
+        var bodyView = new BodyView();
+        if (result){
+           bodyView.collection = result.get('status');
+        } 
+        return bodyView;
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/results/table-results.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/results/table-results.view.js
@@ -13,25 +13,21 @@
  *
  **/
 /*global require*/
+var TableView = require('../table.view');
+var HeaderView = require('component/visualization/table/thead.view');
+var BodyView = require('component/visualization/table/tbody.view');
 
-var Marionette = require('marionette');
-var template = require('./query-status.hbs');
-var CustomElements = require('js/CustomElements');
-var store = require('js/store');
-var TableView = require('component/table/query-status/table-query-status.view');
-
-module.exports = Marionette.LayoutView.extend({
-    template: template,
-    tagName: CustomElements.register('query-status'),
-    regions: {
-        table: '.table-container'
+module.exports = TableView.extend({
+    className: 'is-results',
+    getHeaderView: function(){
+        return new HeaderView({
+            selectionInterface: this.options.selectionInterface
+        });
     },
-    initialize: function () {
-        this.model = store.getQueryById(this.model.id);
-    },
-    onBeforeShow: function(){
-        this.table.show(new TableView({
-            model: this.model
-        }));
+    getBodyView: function(){
+        return new BodyView({
+            selectionInterface: this.options.selectionInterface,
+            collection: this.options.selectionInterface.getActiveSearchResults()
+        });
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.hbs
@@ -11,6 +11,7 @@
  *
  **/
  --}}
-<div class="table-container">
-
-</div>
+<table>
+    <thead></thead>
+    <tbody></tbody>
+</table>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
@@ -1,0 +1,57 @@
+@{customElementNamespace}table {
+  .customElement;
+  position: relative;
+  overflow: auto;
+  background: inherit;
+
+  table {
+    width: 100%;
+    border-collapse: separate !important;
+  }
+
+  .is-thead,
+  .is-thead > th {
+    background: inherit;
+    position: relative;
+  }
+
+  .is-thead > th {
+    padding: 10px 20px;
+  }
+
+  .is-thead > th > .column-absolute {
+    padding: 10px 20px;
+    left: 0px;
+    top: 0px;
+    position: absolute;
+    z-index: 1;
+    background: inherit;
+    width: 100%;
+    height: 100%;
+    background: inherit;
+    border-bottom: 1px solid @heavily-lighten-inherited-background-color;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  td {
+    padding: @minimumSpacing @mediumSpacing;
+  }
+
+  th + th {
+    border-left: 1px solid @lighten-inherited-background-color;
+  }
+
+  td + td {
+    border-left: 1px solid @lighten-inherited-background-color;
+  }
+
+  .table-header > .is-tbody {
+    visibility: hidden;
+  }
+
+  .table-body > .is-thead {
+    visibility: hidden;
+  }
+
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
@@ -12,26 +12,11 @@
   .is-thead,
   .is-thead > th {
     background: inherit;
-    position: relative;
   }
 
   .is-thead > th {
-    padding: 10px 20px;
-  }
-
-  .is-thead > th > .column-absolute {
-    padding: 10px 20px;
-    left: 0px;
-    top: 0px;
-    position: absolute;
-    z-index: 1;
-    background: inherit;
-    width: 100%;
-    height: 100%;
-    background: inherit;
+    padding: @minimumSpacing @mediumSpacing;
     border-bottom: 1px solid @heavily-lighten-inherited-background-color;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   td {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.less
@@ -17,6 +17,7 @@
   .is-thead > th {
     padding: @minimumSpacing @mediumSpacing;
     border-bottom: 1px solid @heavily-lighten-inherited-background-color;
+    z-index: 1;
   }
 
   td {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+var template = require('./table.hbs');
+var Marionette = require('marionette');
+var MarionetteRegion = require('js/Marionette.Region');
+var CustomElements = require('js/CustomElements');
+
+function moveHeaders(elementToUpdate, elementToMatch) {
+    this.$el.find('.column-absolute').css('transform', 'translate3d(0, '+ this.el.scrollTop+'px, 0)').attr('data-help-translateY', this.el.scrollTop);
+}
+
+module.exports = Marionette.LayoutView.extend({
+    tagName: CustomElements.register('table'),
+    template: template,
+    regions: {
+        bodyThead: {
+            selector: 'thead',
+            replaceElement: true
+        },
+        bodyTbody: {
+            selector: 'tbody',
+            replaceElement: true
+        }
+    },
+    headerAnimationFrameId: undefined,
+    getHeaderView: function(){
+        console.log('You need to overwrite this function and provide the constructed HeaderView');
+        // return new ExampleHeaderView({...})
+    },
+    getBodyView: function(){
+        console.log('You need to overwrite this function and provide the constructed BodyView');
+        // return new ExampleBodyView({...})
+    },
+    onRender: function() {
+        this.bodyTbody.show(this.getBodyView(), {
+            replaceElement: true
+        });
+        this.bodyThead.show(this.getHeaderView(), {
+            replaceElement: true
+        });
+        this.onDestroy();
+        this.startUpdatingHeaders();
+    },
+    startUpdatingHeaders: function(){
+        window.requestAnimationFrame(function(){
+            moveHeaders.call(this);
+            this.startUpdatingHeaders();
+        }.bind(this));
+    },
+    onDestroy: function(){
+        window.cancelAnimationFrame(this.headerAnimationFrameId);
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
@@ -19,7 +19,7 @@ var MarionetteRegion = require('js/Marionette.Region');
 var CustomElements = require('js/CustomElements');
 
 function moveHeaders(elementToUpdate, elementToMatch) {
-    this.$el.find('.column-absolute').css('transform', 'translate3d(0, '+ this.el.scrollTop+'px, 0)').attr('data-help-translateY', this.el.scrollTop);
+    this.$el.find('th').css('transform', 'translate3d(0, '+ this.el.scrollTop+'px, 0)');
 }
 
 module.exports = Marionette.LayoutView.extend({

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
@@ -38,11 +38,9 @@ module.exports = Marionette.LayoutView.extend({
     headerAnimationFrameId: undefined,
     getHeaderView: function(){
         console.log('You need to overwrite this function and provide the constructed HeaderView');
-        // return new ExampleHeaderView({...})
     },
     getBodyView: function(){
         console.log('You need to overwrite this function and provide the constructed BodyView');
-        // return new ExampleBodyView({...})
     },
     onRender: function() {
         this.bodyTbody.show(this.getBodyView(), {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.less
@@ -1,7 +1,9 @@
 @{customElementNamespace}tabs {
 
   .customElement;
+  background: inherit;
   .tabs-list {
+    background: inherit;
     .inlineFix;
 
     z-index: @zIndexContent;
@@ -122,8 +124,14 @@
   }
 
   .tabs-content {
+    margin-top: 1px;
     height: ~"calc(100% - @{minimumButtonSize})";
     .boxShadowTop;
+    background: inherit;
+
+    > * {
+      margin-top: 1px;
+    }
   }
 
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.less
@@ -3,6 +3,7 @@
   .customElement;
   background: inherit;
   .tabs-list {
+    border-bottom: 1px solid rgba(255, 255, 255, .10);
     background: inherit;
     .inlineFix;
 
@@ -33,7 +34,7 @@
         display: block;
         width: 100%;
         text-align: center;
-        .boxShadow;
+        border: 1px solid @heavily-lighten-inherited-background-color;
 
         > div.is-merged {
           display: block;
@@ -126,7 +127,6 @@
   .tabs-content {
     margin-top: 1px;
     height: ~"calc(100% - @{minimumButtonSize})";
-    .boxShadowTop;
     background: inherit;
 
     > * {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/value/value.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/value/value.less
@@ -29,7 +29,7 @@
 }
 
 @{customElementNamespace}value-collection {
-  @{customElementNamespace}value {
+  @{customElementNamespace}value + @{customElementNamespace}value {
     margin-top: @minimumSpacing;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.less
@@ -1,5 +1,4 @@
 @{customElementNamespace}result-row {
-  display: table-row;
 
   td {
     padding: @minimumSpacing @mediumSpacing;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -26,6 +26,7 @@ var user = require('component/singletons/user-instance');
 var properties = require('properties');
 
 module.exports = Marionette.ItemView.extend({
+    className: 'is-tr',
     tagName: CustomElements.register('result-row'),
     attributes: function() {
         return {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.hbs
@@ -29,16 +29,4 @@
         </button>
     </div>
 <div class="tables-container">
-    <div class="container-header">
-        <table class="table-header">
-            <thead></thead>
-            <tbody></tbody>
-        </table>
-    </div>
-    <div class="container-body">
-        <table class="table-body">
-            <thead></thead>
-            <tbody></tbody>
-        </table>
-    </div>
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.less
@@ -1,4 +1,4 @@
-@{customElementNamespace}table {
+@{customElementNamespace}table-viz {
   .customElement;
   background: inherit;
 
@@ -10,11 +10,6 @@
     height: ~'calc(100% - @{minimumButtonSize})';
     position: relative;
     overflow: hidden;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: separate !important;
   }
 
   > .tables-container,
@@ -29,44 +24,6 @@
   > .table-empty {
     text-align: center;
     display: none;
-  }
-
-  .table-body {
-    @{customElementNamespace}result-thead {
-        visibility: hidden;
-    }
-  }
-
-  .container-header {
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    height: 100%;
-    overflow-x: hidden;
-    overflow-y: hidden;
-    width: 100%;
-    background: inherit;
-  }
-
-  .container-body {
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    height: 100%;
-    overflow: auto;
-    width: 100%;
-  }
-
-  .table-header {
-    @{customElementNamespace}result-tbody {
-      visibility: hidden;
-    }
-  }
-
-  .table-body {
-    @{customElementNamespace}result-thead {
-      visibility: hidden;
-    }
   }
 
   > .table-options {
@@ -92,7 +49,7 @@
 
 }
 
-@{customElementNamespace}table.is-empty {
+@{customElementNamespace}table-viz.is-empty {
 
   > .table-empty {
     display: block;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.view.js
@@ -15,7 +15,7 @@
 /*global require*/
 var wreqr = require('wreqr');
 var _ = require('underscore');
-var template = require('./table.hbs');
+var template = require('./table-viz.hbs');
 var Marionette = require('marionette');
 var MarionetteRegion = require('js/Marionette.Region');
 var CustomElements = require('js/CustomElements');
@@ -28,34 +28,18 @@ var HeaderView = require('./thead.view');
 var BodyView = require('./tbody.view');
 var TableVisibility = require('./table-visibility.view');
 var TableRearrange = require('./table-rearrange.view');
-
-function syncScrollbars(elementToUpdate, elementToMatch) {
-    elementToUpdate.scrollLeft = elementToMatch.scrollLeft;
-}
+var ResultsTableView = require('component/table/results/table-results.view');
 
 module.exports = Marionette.LayoutView.extend({
-    tagName: CustomElements.register('table'),
+    tagName: CustomElements.register('table-viz'),
     template: template,
     events: {
         'click .options-rearrange': 'startRearrange',
         'click .options-visibility': 'startVisibility'
     },
     regions: {
-        bodyThead: {
-            selector: '.table-body thead',
-            replaceElement: true
-        },
-        bodyTbody: {
-            selector: '.table-body tbody',
-            replaceElement: true
-        },
-        headerThead: {
-            selector: '.table-header thead',
-            replaceElement: true
-        },
-        headerTbody: {
-            selector: '.table-header tbody',
-            replaceElement: true
+        table: {
+            selector: '.tables-container'
         },
         tableVisibility: {
             selector: '.table-visibility',
@@ -77,32 +61,9 @@ module.exports = Marionette.LayoutView.extend({
     },
     onRender: function() {
         this.handleEmpty();
-        this.headerTbody.show(new BodyView({
-            selectionInterface: this.options.selectionInterface,
-            collection: this.options.selectionInterface.getActiveSearchResults()
-        }), {
-            replaceElement: true
-        });
-        this.headerThead.show(new HeaderView({
+        this.table.show(new ResultsTableView({
             selectionInterface: this.options.selectionInterface
-        }), {
-            replaceElement: true
-        });
-        this.bodyTbody.show(new BodyView({
-            selectionInterface: this.options.selectionInterface,
-            collection: this.options.selectionInterface.getActiveSearchResults()
-        }), {
-            replaceElement: true
-        });
-        this.bodyThead.show(new HeaderView({
-            selectionInterface: this.options.selectionInterface
-        }), {
-            replaceElement: true
-        });
-        this.syncScrollbars();
-    },
-    syncScrollbars: function() {
-        this.$el.find('.container-body').on('scroll', syncScrollbars.bind(this, this.$el.find('.container-header')[0], this.$el.find('.container-body')[0]));
+        }));
     },
     startRearrange: function() {
         this.$el.toggleClass('is-rearranging');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.less
@@ -1,4 +1,3 @@
 @{customElementNamespace}result-tbody {
-    display: table-row-group;
     position: relative;
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.view.js
@@ -23,7 +23,7 @@ var RowView = require('./row.view');
 
 module.exports = Marionette.CollectionView.extend({
     tagName: CustomElements.register('result-tbody'),
-    className: 'is-list has-list-highlighting',
+    className: 'is-tbody is-list has-list-highlighting',
     events: {
         'click > *': 'handleClick',
         'mousedown > *': 'handleMouseDown',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.hbs
@@ -13,7 +13,7 @@
  --}}
 {{#each this}}
     <th class="{{#if hidden}}is-hidden-column{{/if}} {{#if sortable}}is-sortable{{/if}}" data-propertyid="{{id}}" data-propertytext="{{label}}{{#unless label}}{{id}}{{/unless}}">
-        <span class="column-text">
+        <span class="column-text" title="{{label}}{{#unless label}}{{id}}{{/unless}}">
             {{label}}
             {{#unless label}}
                 {{id}}
@@ -21,15 +21,5 @@
         </span>
         <span class="fa fa-sort-asc"></span>
         <span class="fa fa-sort-desc"></span>
-        <div class="column-absolute">
-            <span class="column-text" title="{{label}}{{#unless label}}{{id}}{{/unless}}">
-                {{label}}
-                {{#unless label}}
-                    {{id}}
-                {{/unless}}
-            </span>
-            <span class="fa fa-sort-asc"></span>
-            <span class="fa fa-sort-desc"></span>
-        </div>
     </th>
 {{/each}}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.less
@@ -1,5 +1,4 @@
 @{customElementNamespace}result-thead {
-    display: table-header-group;
     background: inherit;
 
     th {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.less
@@ -27,21 +27,6 @@
       text-overflow: ellipsis;
     }
 
-    th .column-absolute {
-      left: 0px;
-      top: 0px;
-      position: absolute;
-      padding: 10px 20px;
-      z-index: 1;
-      background: inherit;
-      width: 100%;
-      height: 100%;
-      background: inherit;
-      border-bottom: 1px solid @heavily-lighten-inherited-background-color;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
     th.is-hidden-column {
       display: none;
     }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/thead.view.js
@@ -26,6 +26,7 @@ var metacardDefinitions = require('component/singletons/metacard-definitions');
 
 module.exports = Marionette.ItemView.extend({
     template: template,
+    className: 'is-thead',
     tagName: CustomElements.register('result-thead'),
     events: {
         'click th.is-sortable': 'updateSorting'

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/visualization.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/visualization.view.js
@@ -21,7 +21,7 @@ define([
     'component/visualization/maps/cesium/cesium.view',
     'component/visualization/maps/openlayers/openlayers.view',
     'component/visualization/histogram/histogram.view',
-    'component/visualization/table/table.view',
+    'component/visualization/table/table-viz.view',
     'component/singletons/user-instance',
     'maptype'
 ], function (wreqr, Marionette, CustomElements, template, CesiumView, OpenlayersView, HistogramView,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-explore/workspace-explore.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-explore/workspace-explore.less
@@ -2,9 +2,9 @@
 
   .customElement;
 
-    .workspaceExplore-queries {
-        height: 100%;
-    }
+  .workspaceExplore-queries {
+      height: 100%;
+  }
 
 }
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-explore/workspace-explore.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-explore/workspace-explore.view.js
@@ -21,10 +21,9 @@ define([
     'js/CustomElements',
     'component/query-selector/query-selector.view',
     'js/store',
-    'component/lightbox/lightbox.view.instance',
-    'component/queries/queries.view'
+    'component/lightbox/lightbox.view.instance'
 ], function (Marionette, _, $, workspaceExploreTemplate, CustomElements, QuerySelectorView,
-             store, lightboxViewInstance, QueriesView) {
+             store, lightboxViewInstance) {
 
     var WorkspaceExplore = Marionette.LayoutView.extend({
         setDefaultModel: function(){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
@@ -63,6 +63,7 @@ define([
             this.model.save();
         },
         handleRun: function(){
+            store.clearOtherWorkspaces(this.model.id);
             this.model.get('queries').forEach(function(query){
                 query.startSearch();
             });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -321,8 +321,8 @@ define([
                     result.setColor(this.getColor());
                     result.setQueryId(this.getId());
                     result.set('merged', true);
-                    result.get('mergedResults').fullCollection.reset();
-                    result.get('mergedResults').reset();
+                    result.get('queuedResults').fullCollection.reset();
+                    result.get('queuedResults').reset();
                     result.get('results').fullCollection.reset();
                     result.get('results').reset();
                     result.get('status').reset(initialStatus);
@@ -429,9 +429,14 @@ define([
 
             cancelCurrentSearches: function(){
                 this.currentSearches.forEach(function(request){
-                    request.abort();
+                    request.abort('Canceled');
                 });
                 this.currentSearches = [];
+            },
+
+            clearResults: function(){
+                this.cancelCurrentSearches();
+                this.set({result: undefined});
             },
 
             setSources: function (sources) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -82,12 +82,10 @@ define([
                 this.set('saved', false);
             },
             handleChange: function(model){
-                if (model !== undefined && 
-                    model.changedAttributes().result === undefined && 
-                    model.changedAttributes().saved === undefined &&
-                    model.changedAttributes()['metacard.modified'] === undefined &&
-                    model.changedAttributes().id === undefined &&
-                    model.changedAttributes().subscribed === undefined){
+                if (model !==undefined &&
+                     _.intersection(Object.keys(model.changedAttributes()), [
+                         'result', 'saved', 'metacard.modified', 'id', 'subscribed'
+                     ]).length === 0){
                     this.set('saved', false);
                 }
             },
@@ -144,6 +142,11 @@ define([
                 }).then(function () {
                     this.set('subscribed', false);
                 }.bind(this));
+            },
+            clearResults: function(){
+                this.get('queries').forEach(function(queryModel){
+                    queryModel.clearResults();
+                });
             }
         });
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
@@ -48,6 +48,22 @@ define([
                     this.get('content').set('currentWorkspace', undefined);
                 }
             });
+            this.listenTo(this.get('content'), 'change:currentWorkspace', this.handleWorkspaceChange);
+        },
+        clearOtherWorkspaces: function(workspaceId){
+            this.get('workspaces').forEach(function(workspaceModel){
+                if (workspaceId !== workspaceModel.id){
+                    workspaceModel.clearResults();
+                }
+            });
+        },
+        handleWorkspaceChange: function(){
+            if (this.get('content').changedAttributes().currentWorkspace){
+                var previousWorkspace = this.get('content').previousAttributes().currentWorkspace;
+                if (previousWorkspace && previousWorkspace.id !== this.get('content').get('currentWorkspace').id){
+                    previousWorkspace.clearResults();
+                }
+            }
         },
         getWorkspaceById: function(workspaceId){
             return this.get('workspaces').get(workspaceId);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/styles/components/table.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/styles/components/table.less
@@ -28,3 +28,15 @@ table.table {
   }
 
 }
+
+.is-tbody {
+  display: table-row-group;
+}
+
+.is-thead {
+  display: table-header-group;
+}
+
+.is-tr {
+  display: table-row;
+}


### PR DESCRIPTION
#### What does this PR do?
 - Updates Intrigue to forget results upon workspace changes.
 - Updates Intrigue to clear other workspace results upon running the workspace interaction to run all searches.
 - Refactors the table view a bit to be less dom heavy, while also making it reusable.
 - Adds messages to the status that gets returned with searches, so if something goes wrong the user can now get a better understanding of what it might be.
 - Updates the status model to track searches a little better.
 - Updates how searches work to make them only keep the top X number of results for the entire search rather than per source.  Each time a new source returns with results, the results are reranked (upon merge) and only the top X number are kept.  Keep in mind that X is the number initially set by an Admin, and can be later tweaked by the user in the Search settings.
 - Updates the help view to be a bit more performant.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@jlcsmith
@bdeining 
@rzwiefel 

#### How should this be tested? (List steps with links to updated documentation)
Go to a workspace and run a query (with multiple sources).  Verify that only the top is only kept per query rather than per source now (so if you say 250 per search, that's all you get no matter what).  

Go to the status page for the query and run the query.  Verify that it updates appropriately.

After running a query, go to a different workspace and then return.  Verify that the query has no longer been run.

Execute a long running query and go to a different workspace.  Verify that it gets canceled.

Execute run all queries from the workspaces home page on two different workspaces.  Verify that it only keeps the results on the latest run action.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2963
