### PR TITLE
DDF-2867 removed skipDocs profile from distribution/ddf pom

### DIFF
--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -116,59 +116,46 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-docs</id>
+                        <!--
+                        The unpack needs to run in an earlier phase than the copy,
+                        due to a recurring bug in maven that causes plugins in the
+                        same lifecycle phase to run in orders other than that which
+                        they were declared in.
+
+                        See https://issues.apache.org/jira/browse/MNG-5799 as well
+                        as the related tickets for more details.
+                        -->
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>ddf</groupId>
+                                    <artifactId>docs</artifactId>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>${setup.folder}/docs
+                                    </outputDirectory>
+                                    <overWrite>true</overWrite>
+                                    <classifier>docs-export</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
-        <profile>
-            <id>documentation</id>
-            <activation>
-                <property>
-                    <name>skipDocs</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-docs</id>
-                                <!--
-                                The unpack needs to run in an earlier phase than the copy,
-                                due to a recurring bug in maven that causes plugins in the
-                                same lifecycle phase to run in orders other than that which
-                                they were declared in.
-
-                                See https://issues.apache.org/jira/browse/MNG-5799 as well
-                                as the related tickets for more details.
-                                -->
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>ddf</groupId>
-                                            <artifactId>docs</artifactId>
-                                            <version>${project.version}</version>
-                                            <outputDirectory>${setup.folder}/docs
-                                            </outputDirectory>
-                                            <overWrite>true</overWrite>
-                                            <classifier>docs-export</classifier>
-                                            <type>zip</type>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <overWriteSnapshots>true</overWriteSnapshots>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release</id>
             <dependencies>
@@ -268,7 +255,6 @@
         </profile>
     </profiles>
     <dependencies>
-
         <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>kernel</artifactId>


### PR DESCRIPTION
#### What does this PR do?

removed documentation profile from distribution/ddf module.
#### Who is reviewing it?

@mcalcote @vinamartin @Lambeaux @jrnorth 

#### Select at least one member from relevant component team(s) from below.
[Build](https://github.com/orgs/codice/teams/build)
[Docs](https://github.com/orgs/codice/teams/docs)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@lessarderic
@pklinef
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

builds successfully

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2867](https://codice.atlassian.net/browse/DDF-2867)
#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
