### PR TITLE
DDF-2961 Add option to skip invalid metacards when backing up.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,7 +67,8 @@ _This is a preview of a pending release and is subject to change._
     </li>
 	<li><a href='https://codice.atlassian.net/browse/DDF-2820'>DDF-2820</a> - As a user, I would like the ability to provide feedback on DDF.
 	</li>
-
+	<li><a href='https://codice.atlassian.net/browse/DDF-2961'>DDF-2961</a> - As an administrator I would like to set the transformer backup plugin to have an option to skip any metacards that has warnings or errors on it so that a non-conformant metadata card is not backed up
+    </li>
 </ul>
     
 <h3>New Feature</h3>

--- a/catalog/plugin/catalog-plugin-metacardbackup/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/pom.xml
@@ -105,7 +105,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPlugin.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.plugin.metacard.backup;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,8 +42,10 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
@@ -63,11 +66,17 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
 
     private static final String OUTPUT_PROVIDER_PROPERTY = "metacardOutputProviderIds";
 
+    private static final String BACKUP_INVALID_METACARDS_PROPERTY = "backupInvalidMetacards";
+
+    private static final String INVALID_TAG = "INVALID";
+
     private Boolean keepDeletedMetacards = false;
 
     private String metacardTransformerId;
 
     private MetacardTransformer metacardTransformer;
+
+    private Boolean backupInvalidMetacards = true;
 
     private List<String> metacardOutputProviderIds = new ArrayList<>();
 
@@ -159,6 +168,14 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
         this.metacardOutputProviderIds = metacardOutputProviderIds;
     }
 
+    public Boolean getBackupInvalidMetacards() {
+        return backupInvalidMetacards;
+    }
+
+    public void setBackupInvalidMetacards(Boolean backupInvalidMetacards) {
+        this.backupInvalidMetacards = backupInvalidMetacards;
+    }
+
     public void refresh(Map<String, Object> properties) {
         Object metacardTransformerProperty = properties.get(METACARD_TRANSFORMER_ID_PROPERTY);
         if (metacardTransformerProperty instanceof String
@@ -174,6 +191,11 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
         Object metacardOutputProviderIds = properties.get(OUTPUT_PROVIDER_PROPERTY);
         if (metacardOutputProviderIds instanceof String[]) {
             this.metacardOutputProviderIds = Arrays.asList((String[]) metacardOutputProviderIds);
+        }
+
+        Object backupInvalidMetacards = properties.get(BACKUP_INVALID_METACARDS_PROPERTY);
+        if (backupInvalidMetacards instanceof Boolean) {
+            this.backupInvalidMetacards = (Boolean) backupInvalidMetacards;
         }
     }
 
@@ -192,16 +214,18 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
         List<? extends ProcessResourceItem> processResourceItems = processRequest.getProcessItems();
         for (ProcessResourceItem processResourceItem : processResourceItems) {
             Metacard metacard = processResourceItem.getMetacard();
-            try {
-                LOGGER.trace("Backing up metacard : {}", metacard.getId());
-                BinaryContent binaryContent = metacardTransformer.transform(metacard,
-                        Collections.emptyMap());
-                backupData(binaryContent, metacard.getId());
-            } catch (CatalogTransformerException e) {
-                LOGGER.debug("Unable to transform metacard with id {}.", metacard.getId(), e);
-                throw new PluginExecutionException(String.format(
-                        "Unable to transform metacard with id %s.",
-                        metacard.getId()));
+            if (shouldBackupMetacard(metacard)) {
+                try {
+                    LOGGER.trace("Backing up metacard : {}", metacard.getId());
+                    BinaryContent binaryContent = metacardTransformer.transform(metacard,
+                            Collections.emptyMap());
+                    backupData(binaryContent, metacard.getId());
+                } catch (CatalogTransformerException e) {
+                    LOGGER.debug("Unable to transform metacard with id {}.", metacard.getId(), e);
+                    throw new PluginExecutionException(String.format(
+                            "Unable to transform metacard with id %s.",
+                            metacard.getId()));
+                }
             }
         }
     }
@@ -260,5 +284,25 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
             }
         }
         return null;
+    }
+
+    private boolean shouldBackupMetacard(Metacard metacard) {
+        if (backupInvalidMetacards) {
+            return true;
+        } else {
+            Attribute metacardTagsAttr = metacard.getAttribute(Core.METACARD_TAGS);
+            if (metacardTagsAttr != null) {
+                List<Serializable> metacardTags = metacardTagsAttr.getValues();
+                for (Serializable metacardTag : metacardTags) {
+                    if (metacardTag instanceof String) {
+                        String metacardTagStr = (String) metacardTag;
+                        if (metacardTagStr.equalsIgnoreCase(INVALID_TAG)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
     }
 }

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPlugin.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.catalog.plugin.metacard.backup;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -173,7 +172,11 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
     }
 
     public void setBackupInvalidMetacards(Boolean backupInvalidMetacards) {
-        this.backupInvalidMetacards = backupInvalidMetacards;
+        if (backupInvalidMetacards != null) {
+            this.backupInvalidMetacards = backupInvalidMetacards;
+        } else {
+            this.backupInvalidMetacards = false;
+        }
     }
 
     public void refresh(Map<String, Object> properties) {
@@ -292,15 +295,11 @@ public class MetacardBackupPlugin implements PostProcessPlugin {
         } else {
             Attribute metacardTagsAttr = metacard.getAttribute(Core.METACARD_TAGS);
             if (metacardTagsAttr != null) {
-                List<Serializable> metacardTags = metacardTagsAttr.getValues();
-                for (Serializable metacardTag : metacardTags) {
-                    if (metacardTag instanceof String) {
-                        String metacardTagStr = (String) metacardTag;
-                        if (metacardTagStr.equalsIgnoreCase(INVALID_TAG)) {
-                            return false;
-                        }
-                    }
-                }
+                return metacardTagsAttr.getValues()
+                        .stream()
+                        .filter(String.class::isInstance)
+                        .map(String.class::cast)
+                        .noneMatch(INVALID_TAG::equalsIgnoreCase);
             }
             return true;
         }

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,6 +36,7 @@
                                    update-method="refresh"/>
             <property name="metacardTransformerId" value="metadata"/>
             <property name="keepDeletedMetacards" value="false"/>
+            <property name="backupInvalidMetacards" value="true" />
             <property name="storageBackupPlugins" ref="metacardBackupStorageSortedList"/>
             <property name="metacardOutputProviderIds">
                 <list>

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,6 +27,11 @@
             type="String"
             default="metadata"/>
 
+        <AD description="Keep backups for metacards that fail validation with warnings or errors."
+            name="Backup Invalid Metacards" id="backupInvalidMetacards" required="true"
+            type="Boolean"
+            default="true"/>
+
         <AD description="Metacard Backup Provider IDs to use for this backup plugin"
             cardinality="100"
             name="Metacard Backup Output Provider(s)" id="metacardOutputProviderIds"

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.metacard-backup-table-contents.adoc
@@ -9,6 +9,13 @@
 |Default Value
 |Required
 
+|Keep Deleted Metacard
+|keepDeletedMetacards
+|Boolean
+|Should backups for deleted metacards be kept or removed.
+|false
+|true
+
 |Metacard Transformer Id
 |metacardTransformerId
 |String
@@ -16,12 +23,12 @@
 |metacard
 |true
 
-| Keep Deleted Metacard
-| keepDeletedMetacards
-| Boolean
-| Should backups for deleted metacards be kept or removed.
-| false
-| true
+|Backup Invalid Metacards
+|keepDeletedMetacards
+|Boolean
+|Keep backups for metacards that fail validation with warnings or errors.
+|true
+|true
 
 | Metacard Backup Output Provider(s)
 | metacardOutputProviderIds


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to disable the backup of invalid metacards, such that only metacards that pass validation are backed up. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@glenhein 
@ricklarsen 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
**Automated Tests:**
Run full build with Unit Tests.

**Manual Testing:**
1. Install DDF. Go into the Admin UI -> Catalog -> Features
	a. Install catalog-metacard-backup-filestorage
	b. Install catalog-metacard-backup
2. Refresh Admin UI
3. Go into Admin UI -> Catalog -> Configuration
	a. Select Metacard Backup File Storage Provider and Save Changes for the default configuration
	b. Select Metacard Backup Plugin and Save Changes for default configuration with the `Backup Invalid Metacards` option selected
4. Upload anything into DDF (e.g. .png image)
5. Click the Green checkbox on the upload page or search for the content.
6. Verify that the Output Directory in the Metacard Backup File Storage Provider (e.g. data/backup/metacard) contains a backup file for that metacard.
7. Delete that backup file (or everything in the backup directory)
8. In the UI, edit the metacard. Remove the datatype attribute and then add one back but don’t select any valid value. Save the metacard. You should see a warning that the value is invalid.
9. Verify that the output directory contains a backup for that metacard.
10. Edit the metacard and change the datatype value to something valid (e.g. Image).
11. Delete that backup file (or everything in the backup directory)
12. In the Admin UI, change the Metacard Backup Plugin such that `Backup Invalid Metacards` is deselected and `Save Changes`
13. Update the metacard in the UI changing the datatype to an invalid option (same as in Step 8).
14. Verify that no backup file exists in the back directory. 

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2961

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated
- [X] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
