### PR TITLE
DDF-2967 Fixed cache queries when source is unavailable

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -40,6 +40,7 @@ import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.delegate.TagsFilterDelegate;
 import ddf.catalog.impl.FrameworkProperties;
+import ddf.catalog.operation.Operation;
 import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
@@ -659,7 +660,8 @@ public class QueryOperations extends DescribableImpl {
                     if (!canAccessSource) {
                         notPermittedSources.add(source.getId());
                     }
-                    if (queryOps.sourceOperations.isSourceAvailable(source) && canAccessSource) {
+                    if (canAccessSource && (queryOps.sourceOperations.isSourceAvailable(source)
+                            || isCacheQuery(queryRequest))) {
                         sourcesToQuery.add(source);
                     } else {
                         exceptions.add(queryOps.createUnavailableProcessingDetails(source));
@@ -761,6 +763,10 @@ public class QueryOperations extends DescribableImpl {
 
         boolean isEmpty() {
             return sourcesToQuery.isEmpty();
+        }
+
+        boolean isCacheQuery(Operation operation) {
+            return "cache".equals(operation.getPropertyValue("mode"));
         }
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes cache queries when a source is unavailable
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler 
@bdeining 
@jlcsmith 
@kcwire 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### How should this be tested? (List steps with links to updated documentation)
Setup Source, Query and ensure cache is primed. Take down source, wait for sources to show source as unavailable. Run query and ensure cache results are still returned

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2967
#### Checklist:
- [ ] Update / Add Unit Tests (still need to do this, likely separate PR from this)

