### PR TITLE
DDF-2968 Allow associations view for remote results

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/association/association.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/association/association.view.js
@@ -37,7 +37,7 @@ function determineChoices(view) {
     var choices = view.options.selectionInterface.getCurrentQuery().get('result').get('results').fullCollection.filter(function(result) {
         return result.get('metacard').id !== currentMetacard.get('metacard').id;
     }).filter(function(result){
-        return !(result.isWorkspace() || result.isRevision() || result.isRemote() || result.isDeleted());
+        return !(result.isWorkspace() || result.isRevision() || result.isUnwritable() || result.isDeleted());
     }).reduce(function(options, result) {
         options.push({
             label: result.get('metacard').get('properties').get('title'),

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.less
@@ -214,7 +214,7 @@
 .is-editing-restricted @{customElementNamespace}metacard-associations,
 @{customElementNamespace}metacard-associations.is-deleted,
 @{customElementNamespace}metacard-associations.is-revision,
-@{customElementNamespace}metacard-associations.is-remote {
+@{customElementNamespace}metacard-associations.is-unwritable {
   > .editor-footer {
     display: none;
   }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.view.js
@@ -196,5 +196,6 @@ module.exports = Marionette.LayoutView.extend({
         this.$el.toggleClass('is-revision', this.model.isRevision());
         this.$el.toggleClass('is-deleted', this.model.isDeleted());
         this.$el.toggleClass('is-remote', this.model.isRemote());
+        this.$el.toggleClass('is-unwritable', this.model.isUnwritable());
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.less
@@ -42,7 +42,6 @@
         [data-id=History],
         [data-id=Overwrite],
         [data-id=Archive],
-        [data-id=Associations],
         [data-id=Quality] {
             display: none !important;
         }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
@@ -59,7 +59,7 @@ define([
             } else if (result.isWorkspace() && ['History', 'Actions', 'Overwrite', 'Archive'].indexOf(activeTabName) >= 0){
                 this.model.set('activeTab', 'Summary');
             }
-            if (result.isRemote() && ['History', 'Associations', 'Quality', 'Archive', 'Overwrite'].indexOf(activeTabName) >=0){
+            if (result.isRemote() && ['History', 'Quality', 'Archive', 'Overwrite'].indexOf(activeTabName) >=0){
                 this.model.set('activeTab', 'Summary');
             }
             if (properties.isEditingRestricted() && ['Archive', 'Overwrite'].indexOf(activeTabName) >=0){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -547,6 +547,13 @@ define([
             isDeleted: function(){
                 return this.get('metacard').get('properties').get('metacard-tags').indexOf('deleted') >= 0;
             },
+            isUnwritable: function(){
+                return !this.isWritable();
+            },
+            isWritable: function(){
+                var originatingSource = Sources.get(this.get('metacard').get('properties').get('source-id'));
+                return originatingSource && originatingSource.get('writable') === true;
+            },
             isRemote: function(){
                 return this.get('metacard').get('properties').get('source-id') !== Sources.localCatalog;
             },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Sources.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Sources.js
@@ -59,7 +59,8 @@ define([
         url: "/services/catalog/sources",
         useAjaxSync: true,
         initialize: function () {
-          this._types = new Types();
+            this.listenTo(this, 'update add', _.debounce(this.determineWritableSources, 60));
+            this._types = new Types();
             poller.get(this, {
                 delay: properties.sourcePollInterval,
                 delayed: properties.sourcePollInterval,
@@ -75,6 +76,13 @@ define([
             this._types.set(computeTypes(response));
             return response;
         },
+        determineWritableSources: function(){
+            $.get('/search/catalog/internal/writablesources').then(function(writableSources){
+                this.forEach(function(sourceModel){
+                    sourceModel.set('writable', writableSources.indexOf(sourceModel.id) >= 0);
+                }.bind(this));
+            }.bind(this));
+        },  
         determineLocalCatalog: function(){
             $.get('/search/catalog/internal/localcatalogid').then(function(data){
                 this.localCatalog = data['local-catalog-id'];


### PR DESCRIPTION
#### What does this PR do?
 - Now that associations can be fetched for remote results, the associations view is allowed for them.
 - If the source for a result is writable, associations are editable for that source.
 - Updates the Sources model to determine writability whenever new sources are found.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@bdeining 
@rzwiefel 
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
Add a new csw transactional profile federated source.  Add a normal source of any other kind.
Verify that results from any source have the associations view.
Verify that only results that are local or from the new csw transactional profile federated source are editable on the associations view.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2968
