### PR TITLE
DDF-2936 Windows build fix for separating Metacard backup storage from backup configuration

### DIFF
--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/filestorage/MetacardBackupFileStorageTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +31,7 @@ public class MetacardBackupFileStorageTest {
 
     private static final String PLUGIN_ID = "PluginId";
 
-    private static final String OUTPUT_DIRECTORY = "test-output/";
+    private static final String OUTPUT_DIRECTORY = "test-output" + File.separator;
 
     private static final String TEST_ID = "TestId";
 
@@ -67,7 +68,7 @@ public class MetacardBackupFileStorageTest {
 
     @Test
     public void testRefresh() {
-        String newBackupDir = "target/temp";
+        String newBackupDir = "target" + File.separator + "temp";
         String newId = "test2";
         Map<String, Object> properties = new HashMap<>();
         properties.put("outputDirectory", newBackupDir);
@@ -116,7 +117,8 @@ public class MetacardBackupFileStorageTest {
     public void testPath() throws Exception {
         fileStorageProvider.setOutputDirectory(OUTPUT_DIRECTORY);
         Path path = fileStorageProvider.getMetacardDirectory(TEST_ID);
-        assertThat(path.toString(), is(OUTPUT_DIRECTORY + "Tes/tId/TestId"));
+        String testPath = "Tes" + File.separator + "tId" + File.separator + "TestId";
+        assertThat(path.toString(), is(OUTPUT_DIRECTORY + testPath));
     }
 
     @Test

--- a/catalog/plugin/catalog-plugin-metacardbackup/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/MetacardBackupPluginTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -80,7 +81,7 @@ public class MetacardBackupPluginTest {
                     + "                <ows:UpperCorner>51.126 -2.228</ows:UpperCorner>\n"
                     + "            </ows:BoundingBox>\n" + "        </csw:Record>";
 
-    private static final String OUTPUT_DIRECTORY = "target/";
+    private static final String OUTPUT_DIRECTORY = "target" + File.separator;
 
     private static final String FILE_STORAGE_PROVIDER_ID = "TestFileStorageProvider";
 


### PR DESCRIPTION
#### What does this PR do?
Fixes Windows build errors caused by the DDF-2936 changes.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote 
@bdeining 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build on Windows.

#### Any background context you want to provide?
Unit tests for Metacard Backup Plugin and Metacard Backup File Storage were coded for unix pathing instead of using File.separator. 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2936

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
