### PR TITLE
DDF-2872 Enforce maximum pageSize for queries in the Catalog Framework

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/operation/Query.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/operation/Query.java
@@ -45,8 +45,8 @@ public interface Query extends Filter {
 
     /**
      * The page size represents the maximum amount of results the query will return. Page sizes of
-     * less than 1 (0 or a negative number) should return the maximum number of results for each
-     * {@link ddf.catalog.source.Source}.
+     * less than 1 (0 or a negative number) should return the maximum number of results supported by
+     * the catalog or the maximum supported by each {@link ddf.catalog.source.Source}, whichever is smaller.
      *
      * @return the page size - the maximum result size
      */

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/QueryOperationsTest.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/QueryOperationsTest.groovy
@@ -670,6 +670,7 @@ class QueryOperationsTest extends Specification {
         def response = Mock(QueryResponse)
 
         query.getTimeoutMillis() >> { 100 }
+        query.getPageSize() >> { 100 }
         request.query >> { query }
         request.getQuery() >> { query }
         request.getProperties() >> [:]


### PR DESCRIPTION
#### What does this PR do?
- Enforces a maximum pageSize that defaults to `1000`, but can be overridden with a system property. This protects against overloading the system with too many records.
- With the current implementation, NegativeArraySizeExceptions occur in Solr Cloud. In order to avoid defaulting the number of rows for a query to a large number that could cause OutOfMemory errors in Solr Cloud, it will instead do a query for the number of records then set the number of rows for the actual query to that number.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @figliold 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
- Full build
- Run DDF while connected to Solr Cloud.
- Ensure basic functionality of the Intrigue UI (i.e. workspaces get saved, are preserved between accounts, etc).
- Hit CSW Endpoint with `maxRecords=1001`. Verify `numberOfRecordsReturned=1000` in the response.
- Restart DDF after setting `catalog.maxPageSize = 900` in `system.properties`, and run above query. Verify `numberOfRecordsReturned=900` in the response.
- Check the logs and verify there are no Solr-related exceptions
#### Any background context you want to provide?
See https://github.com/codice/ddf/pull/1832#issuecomment-295301634
#### What are the relevant tickets?
[DDF-2872](https://codice.atlassian.net/browse/DDF-2872)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
