### PR TITLE
DDF-2875 Unit tests for LdapClaimsHandler

### DIFF
--- a/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
@@ -178,7 +178,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
@@ -178,17 +178,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -101,72 +101,6 @@ public class ClaimsHandlerManager {
         this.encryptService = encryptService;
     }
 
-    public static KeyManagerFactory createKeyManagerFactory(String keyStoreLoc, String keyStorePass)
-            throws IOException {
-        KeyManagerFactory kmf;
-        try {
-            // keystore stuff
-            KeyStore keyStore =
-                    KeyStore.getInstance(System.getProperty("javax.net.ssl.keyStoreType"));
-            LOGGER.debug("keyStoreLoc = {}", keyStoreLoc);
-            FileInputStream keyFIS = new FileInputStream(keyStoreLoc);
-            try {
-                LOGGER.debug("Loading keyStore");
-                keyStore.load(keyFIS, keyStorePass.toCharArray());
-            } catch (CertificateException e) {
-                throw new IOException("Unable to load certificates from keystore. " + keyStoreLoc,
-                        e);
-            } finally {
-                IOUtils.closeQuietly(keyFIS);
-            }
-            kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(keyStore, keyStorePass.toCharArray());
-            LOGGER.debug("key manager factory initialized");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException("Problems creating SSL socket. Usually this is "
-                    + "referring to the certificate sent by the server not being trusted by the client.",
-                    e);
-        } catch (UnrecoverableKeyException e) {
-            throw new IOException("Unable to load keystore. " + keyStoreLoc, e);
-        } catch (KeyStoreException e) {
-            throw new IOException("Unable to read keystore. " + keyStoreLoc, e);
-        }
-
-        return kmf;
-    }
-
-    public static TrustManagerFactory createTrustManagerFactory(String trustStoreLoc,
-            String trustStorePass) throws IOException {
-        TrustManagerFactory tmf;
-        try {
-            // truststore stuff
-            KeyStore trustStore = KeyStore.getInstance(System.getProperty(
-                    "javax.net.ssl.keyStoreType"));
-            LOGGER.debug("trustStoreLoc = {}", trustStoreLoc);
-            FileInputStream trustFIS = new FileInputStream(trustStoreLoc);
-            try {
-                LOGGER.debug("Loading trustStore");
-                trustStore.load(trustFIS, trustStorePass.toCharArray());
-            } catch (CertificateException e) {
-                throw new IOException(
-                        "Unable to load certificates from truststore. " + trustStoreLoc, e);
-            } finally {
-                IOUtils.closeQuietly(trustFIS);
-            }
-
-            tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
-            LOGGER.debug("trust manager factory initialized");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException("Problems creating SSL socket. Usually this is "
-                    + "referring to the certificate sent by the server not being trusted by the client.",
-                    e);
-        } catch (KeyStoreException e) {
-            throw new IOException("Unable to read keystore. " + trustStoreLoc, e);
-        }
-        return tmf;
-    }
-
     /**
      * Callback method that is called when configuration is updated. Also called by the
      * blueprint init-method when all properties have been set.
@@ -476,5 +410,71 @@ public class ClaimsHandlerManager {
     public void configure() {
         LOGGER.trace("configure method called - calling update");
         update(ldapProperties);
+    }
+
+    public static KeyManagerFactory createKeyManagerFactory(String keyStoreLoc, String keyStorePass)
+            throws IOException {
+        KeyManagerFactory kmf;
+        try {
+            // keystore stuff
+            KeyStore keyStore = KeyStore.getInstance(
+                    System.getProperty("javax.net.ssl.keyStoreType"));
+            LOGGER.debug("keyStoreLoc = {}", keyStoreLoc);
+            FileInputStream keyFIS = new FileInputStream(keyStoreLoc);
+            try {
+                LOGGER.debug("Loading keyStore");
+                keyStore.load(keyFIS, keyStorePass.toCharArray());
+            } catch (CertificateException e) {
+                throw new IOException("Unable to load certificates from keystore. " + keyStoreLoc,
+                        e);
+            } finally {
+                IOUtils.closeQuietly(keyFIS);
+            }
+            kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(keyStore, keyStorePass.toCharArray());
+            LOGGER.debug("key manager factory initialized");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Problems creating SSL socket. Usually this is "
+                    + "referring to the certificate sent by the server not being trusted by the client.",
+                    e);
+        } catch (UnrecoverableKeyException e) {
+            throw new IOException("Unable to load keystore. " + keyStoreLoc, e);
+        } catch (KeyStoreException e) {
+            throw new IOException("Unable to read keystore. " + keyStoreLoc, e);
+        }
+
+        return kmf;
+    }
+
+    public static TrustManagerFactory createTrustManagerFactory(String trustStoreLoc,
+            String trustStorePass) throws IOException {
+        TrustManagerFactory tmf;
+        try {
+            // truststore stuff
+            KeyStore trustStore = KeyStore.getInstance(
+                    System.getProperty("javax.net.ssl.keyStoreType"));
+            LOGGER.debug("trustStoreLoc = {}", trustStoreLoc);
+            FileInputStream trustFIS = new FileInputStream(trustStoreLoc);
+            try {
+                LOGGER.debug("Loading trustStore");
+                trustStore.load(trustFIS, trustStorePass.toCharArray());
+            } catch (CertificateException e) {
+                throw new IOException(
+                        "Unable to load certificates from truststore. " + trustStoreLoc, e);
+            } finally {
+                IOUtils.closeQuietly(trustFIS);
+            }
+
+            tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+            LOGGER.debug("trust manager factory initialized");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Problems creating SSL socket. Usually this is "
+                    + "referring to the certificate sent by the server not being trusted by the client.",
+                    e);
+        } catch (KeyStoreException e) {
+            throw new IOException("Unable to read keystore. " + trustStoreLoc, e);
+        }
+        return tmf;
     }
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static ddf.security.SubjectUtils.NAME_IDENTIFIER_CLAIM_URI;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -39,9 +40,7 @@ import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
-import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.LinkedAttribute;
-import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.requests.BindRequest;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
@@ -53,8 +52,6 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import ddf.security.SubjectUtils;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({LDAPConnectionFactory.class, AttributeMapLoader.class, BindMethodChooser.class})
@@ -101,7 +98,7 @@ public class LdapClaimsHandlerTest {
     ClaimsParameters claimsParameters;
 
     @Before
-    public void setup() throws LdapException, URISyntaxException, SearchResultReferenceIOException {
+    public void setup() throws Exception {
         claimsParameters = mock(ClaimsParameters.class);
         when(claimsParameters.getPrincipal()).thenReturn(new UserPrincipal(USER_DN));
         mockEntry = mock(SearchResultEntry.class);
@@ -116,8 +113,7 @@ public class LdapClaimsHandlerTest {
                 eq(REALM),
                 eq(KCD))).thenReturn(mockBindRequest);
         Map<String, String> map = new HashMap<>();
-        map.put("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
-                ATTRIBUTE_NAME);
+        map.put(NAME_IDENTIFIER_CLAIM_URI, ATTRIBUTE_NAME);
         PowerMockito.mockStatic(AttributeMapLoader.class);
         when(AttributeMapLoader.buildClaimsMapFile(anyString())).thenReturn(map);
         when(AttributeMapLoader.getUser(any(Principal.class))).then(i -> i.getArgumentAt(0,
@@ -147,7 +143,7 @@ public class LdapClaimsHandlerTest {
         claimsHandler.setUserBaseDN(USER_BASE_DN);
         claims = new ClaimCollection();
         Claim claim = new Claim();
-        claim.setClaimType(new URI(SubjectUtils.NAME_IDENTIFIER_CLAIM_URI));
+        claim.setClaimType(new URI(NAME_IDENTIFIER_CLAIM_URI));
         claims.add(claim);
     }
 

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -18,19 +18,29 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cxf.rt.security.claims.Claim;
 import org.apache.cxf.rt.security.claims.ClaimCollection;
 import org.apache.cxf.sts.claims.ClaimsParameters;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
+import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
+import org.forgerock.opendj.ldap.requests.BindRequest;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -39,44 +49,94 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ddf.security.SubjectUtils;
+
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(LDAPConnectionFactory.class)
+@PrepareForTest({LDAPConnectionFactory.class, AttributeMapLoader.class, BindMethodChooser.class})
 
 public class LdapClaimsHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapClaimsHandlerTest.class);
 
+    private static final String USER_NAME = "USER_NAME";
+
+    LdapClaimsHandler claimsHandler;
+
+    LDAPConnectionFactory mockConnectionFactory;
+
+    BindResult mockBindResult;
+
+    BindRequest mockBindRequest;
+
+    Connection mockConnection;
+
+    ClaimCollection claims;
+
+    @Before
+    public void setup() throws LdapException, URISyntaxException {
+
+        mockBindRequest = mock(BindRequest.class);
+        PowerMockito.mockStatic(BindMethodChooser.class);
+        when(BindMethodChooser.selectBindMethod(eq("Simple"),
+                eq("cn=admin"),
+                eq("test"),
+                eq("kualdgalain"),
+                eq("Kerberos Constrained Delegation"))).thenReturn(mockBindRequest);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+                "emailaddress");
+        PowerMockito.mockStatic(AttributeMapLoader.class);
+        when(AttributeMapLoader.buildClaimsMapFile(anyString())).thenReturn(map);
+        when(AttributeMapLoader.getUser(anyObject())).thenReturn(USER_NAME);
+        claimsHandler = new LdapClaimsHandler();
+        mockBindResult = mock(BindResult.class);
+        mockConnection = mock(Connection.class);
+        mockConnectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
+        when(mockConnectionFactory.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.bind(anyString(), any(char[].class))).thenReturn(mockBindResult);
+        when(mockConnection.bind(any(BindRequest.class))).thenReturn(mockBindResult);
+        claimsHandler.setLdapConnectionFactory(mockConnectionFactory);
+        claimsHandler.setPropertyFileLocation("thisstringisnotempty");
+        claimsHandler.setBindMethod("Simple");
+        claimsHandler.setBindUserCredentials("cn=admin");
+        claimsHandler.setBindUserCredentials("test");
+        claimsHandler.setRealm("kualdgalain");
+        claimsHandler.setKdcAddress("Kerberos Constrained Delegation");
+        claims = new ClaimCollection();
+        Claim claim = new Claim();
+        claim.setClaimType(new URI(SubjectUtils.EMAIL_ADDRESS_CLAIM_URI));
+        claims.add(claim);
+    }
+
     @Test
     public void testUnsuccessfulConnectionBind() {
-        LDAPConnectionFactory mockedConnectionFactory =
-                PowerMockito.mock(LDAPConnectionFactory.class);
-        BindResult mockedBindResult = mock(BindResult.class);
-        when(mockedBindResult.isSuccess()).thenReturn(false);
-        Connection mockedConnection = mock(Connection.class);
-        try {
-            when(mockedConnectionFactory.getConnection()).thenReturn(mockedConnection);
-            when(mockedConnection.bind(anyString(),
-                    any(char[].class))).thenReturn(mockedBindResult);
-        } catch (LdapException e) {
-            LOGGER.error("LDAP Exception", e);
-        }
-        LdapClaimsHandler ldapClaimsHandler = new LdapClaimsHandler();
-        ldapClaimsHandler.setLdapConnectionFactory(mockedConnectionFactory);
+        when(mockBindResult.isSuccess()).thenReturn(false);
 
         ProcessedClaimCollection testClaimCollection =
-                ldapClaimsHandler.retrieveClaimValues(new ClaimCollection(),
-                        new ClaimsParameters());
+                claimsHandler.retrieveClaimValues(new ClaimCollection(), new ClaimsParameters());
         assertThat(testClaimCollection.isEmpty(), is(true));
     }
 
     @Test
     public void testRetrieveClaimsValuesNullPrincipal() {
-        LdapClaimsHandler claimsHandler = new LdapClaimsHandler();
-        ClaimsParameters claimsParameters = new ClaimsParameters();
-        ClaimCollection claimCollection = new ClaimCollection();
-        ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(
-                claimCollection, claimsParameters);
+        when(mockBindResult.isSuccess()).thenReturn(false);
 
-        Assert.assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
+        ProcessedClaimCollection processedClaims =
+                claimsHandler.retrieveClaimValues(new ClaimCollection(), new ClaimsParameters());
+        assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
     }
+
+    @Test
+    public void testRetrieveClaimsValues() throws URISyntaxException {
+        when(mockBindResult.isSuccess()).thenReturn(true);
+        ClaimsParameters claimsParameters = mock(ClaimsParameters.class);
+        when(claimsParameters.getPrincipal()).thenReturn(new UserPrincipal(USER_NAME));
+
+        ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(claims,
+                claimsParameters);
+
+        assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
+    }
+
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -77,7 +77,9 @@ public class LdapClaimsHandlerTest {
 
     public static final String DUMMY_VALUE = "Tony Stark";
 
-    public static final String USER_DN = String.format("%s=%s,%s", ATTRIBUTE_NAME, DUMMY_VALUE,
+    public static final String USER_DN = String.format("%s=%s,%s",
+            ATTRIBUTE_NAME,
+            DUMMY_VALUE,
             USER_BASE_DN);
 
     LdapClaimsHandler claimsHandler;
@@ -121,12 +123,9 @@ public class LdapClaimsHandlerTest {
         when(AttributeMapLoader.getUser(any(Principal.class))).then(i -> i.getArgumentAt(0,
                 Principal.class)
                 .getName());
-
-        //TODO: Test the path where the method getUserBaseDN() returns null.
         when(AttributeMapLoader.getBaseDN(any(Principal.class),
                 anyString(),
                 eq(false))).then(i -> i.getArgumentAt(1, String.class));
-
         claimsHandler = new LdapClaimsHandler();
         mockBindResult = mock(BindResult.class);
         mockConnection = mock(Connection.class);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -155,7 +155,6 @@ public class LdapClaimsHandlerTest {
     @Test
     public void testUnsuccessfulConnectionBind() {
         when(mockBindResult.isSuccess()).thenReturn(false);
-
         ProcessedClaimCollection testClaimCollection =
                 claimsHandler.retrieveClaimValues(new ClaimCollection(), claimsParameters);
         assertThat(testClaimCollection.isEmpty(), is(true));
@@ -164,7 +163,6 @@ public class LdapClaimsHandlerTest {
     @Test
     public void testRetrieveClaimsValuesNullPrincipal() {
         when(mockBindResult.isSuccess()).thenReturn(false);
-
         ProcessedClaimCollection processedClaims =
                 claimsHandler.retrieveClaimValues(new ClaimCollection(), claimsParameters);
         assertThat(processedClaims.size(), CoreMatchers.is(equalTo(0)));
@@ -173,7 +171,6 @@ public class LdapClaimsHandlerTest {
     @Test
     public void testRetrieveClaimsValues() throws URISyntaxException {
         when(mockBindResult.isSuccess()).thenReturn(true);
-
         ProcessedClaimCollection processedClaims = claimsHandler.retrieveClaimValues(claims,
                 claimsParameters);
 


### PR DESCRIPTION
#### What does this PR do?
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
1. Improves unit coverage of LdapClaimsHandler from 28% method coverage to 57% method coverage.
2.Improves unit coverage of LdapClaimsHandler from 11% line coverage to 77% line coverage.
3. Cleans up checkstyle warnings about ClaimsHandlerManager

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@clockard

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)
Full build of DDF w/ integration tests
#### Any background context you want to provide?
Part of red team's "war on test coverage"
#### What are the relevant tickets?
[DDF-2875](https://codice.atlassian.net/browse/DDF-2875)
#### Screenshots (if appropriate)
#### Checklist:
- [ N/A] Documentation Updated
- [ N/A] Change Log Updated
- [X ] Update / Add Unit Tests
- [ N/A] Update / Add Integration Tests
