### PR TITLE
[2.10.x] DDF-2976 corrected catalog-core-camelcomponent startup order 

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -65,7 +65,6 @@
         <bundle>mvn:ddf.catalog.core/metacard-type-registry/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-attributeregistry/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-injectattribute/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-localstorageprovider/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-standardframework/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
@@ -426,6 +425,13 @@
         <feature prerequisite="true">admin-app</feature>
         <feature>catalog-core-api</feature>
         <feature>catalog-core</feature>
+        <feature>catalog-camel-component</feature>
+    </feature>
+
+    <feature name="catalog-camel-component" install="auto" version="${project.version}"
+             description="Camel compoenent for catalog framework operations">
+        <feature prerequisite="true">catalog-core</feature>
+        <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
     </feature>
 
     <feature name="catalog-client-info" install="auto" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
catalog-core-camelcomponent depends on the framework being available but wasn't explicitly ordered accordingly in the catalog app features file.  This can cause this bundle to intermittently fail during startup.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining @rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2976](https://codice.atlassian.net/browse/DDF-2976)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
