### PR TITLE
DDF-2977 SolrCloud system properties are not properly processed

### DIFF
--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/SolrCloudClientFactory.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/SolrCloudClientFactory.java
@@ -52,14 +52,14 @@ public class SolrCloudClientFactory implements SolrClientFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SolrCloudClientFactory.class);
 
-    private static final int SHARD_COUNT = NumberUtils.toInt("solr.cloud.shardCount", 2);
+    private static final int SHARD_COUNT = NumberUtils.toInt(System.getProperty(
+            "solr.cloud.shardCount"), 2);
 
-    private static final int REPLICATION_FACTOR = NumberUtils.toInt("solr.cloud.replicationFactor",
-            2);
+    private static final int REPLICATION_FACTOR = NumberUtils.toInt(System.getProperty(
+            "solr.cloud.replicationFactor"), 2);
 
-    private static final int MAXIMUM_SHARDS_PER_NODE = NumberUtils.toInt(
-            "solr.cloud.maxShardPerNode",
-            2);
+    private static final int MAXIMUM_SHARDS_PER_NODE = NumberUtils.toInt(System.getProperty(
+            "solr.cloud.maxShardPerNode"), 2);
 
     private static final int THREAD_POOL_DEFAULT_SIZE = 128;
 
@@ -112,8 +112,8 @@ public class SolrCloudClientFactory implements SolrClientFactory {
     }
 
     private static ScheduledExecutorService createExecutorService() throws NumberFormatException {
-        Integer threadPoolSize = NumberUtils.toInt("org.codice.ddf.system.threadPoolSize",
-                THREAD_POOL_DEFAULT_SIZE);
+        Integer threadPoolSize = NumberUtils.toInt(System.getProperty(
+                "org.codice.ddf.system.threadPoolSize"), THREAD_POOL_DEFAULT_SIZE);
         return Executors.newScheduledThreadPool(threadPoolSize);
     }
 


### PR DESCRIPTION
#### What does this PR do?
Added missing System.getProperty() calls.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@pklinef 
@brjeter 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@millerw8
@figliold 

#### How should this be tested? (List steps with links to updated documentation)
Configure DDF to use SolrCloud and verify that the `solr.cloud.shardCount`, `solr.cloud.replicationFactor`, `solr.cloud.maxShardPerNode` and `org.codice.ddf.system.threadPoolSize` system properties can be used to change how SolrCloud gets configured at startup.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2977](https://codice.atlassian.net/browse/DDF-02977)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
