### PR TITLE
DDF-2978 Fixed bug in commitUpdates

### DIFF
--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -369,12 +369,13 @@ public class FileSystemStorageProvider implements StorageProvider {
                     try {
                         Path createdTarget = Files.createDirectories(target);
                         List<Path> files = listPaths(contentIdDir);
-                        Files.copy(files.get(0),
-                                Paths.get(createdTarget.toAbsolutePath()
-                                                .toString(),
-                                        files.get(0)
-                                                .getFileName()
-                                                .toString()));
+                        for (Path path : files) {
+                            Path newTarget = Paths.get(createdTarget.toAbsolutePath().toString(), path.getFileName().toString());
+                            Path source = path;
+                            if (!Files.exists(newTarget)) {
+                                Files.copy(source, newTarget);
+                            }
+                        }
                     } catch (IOException e1) {
                         throw new StorageException(
                                 "Unable to commit changes for request: " + request.getId(), e1);
@@ -475,7 +476,7 @@ public class FileSystemStorageProvider implements StorageProvider {
                     result.add(entry);
                 }
             } catch (DirectoryIteratorException ex) {
-                // I/O error encounted during the iteration, the cause is an IOException
+                // I/O error encountered during the iteration, the cause is an IOException
                 throw ex.getCause();
             }
         }

--- a/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
@@ -15,13 +15,11 @@ package org.codice.ddf.catalog.content.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -176,9 +174,6 @@ public class FileSystemStorageProviderTest {
                 Collections.singletonMap(Constants.STORE_REFERENCE_KEY,
                         tempFile.toFile()
                                 .getAbsolutePath()));
-        URI uri = new URI(createResponse.getCreatedContentItems()
-                .get(0)
-                .getUri());
 
         ReadStorageResponse read =
                 provider.read(new ReadStorageRequestImpl(new URI(createResponse.getCreatedContentItems()
@@ -235,7 +230,7 @@ public class FileSystemStorageProviderTest {
         ContentItem item = items.get(0);
 
         LOGGER.debug("Item retrieved: {}", item);
-        assertEquals(id, item.getId());
+        assertThat(id, is(item.getId()));
         assertThat(item.getFilename(), isEmptyString());
     }
 
@@ -308,13 +303,7 @@ public class FileSystemStorageProviderTest {
 
         Metacard metacard = mock(Metacard.class);
         when(metacard.getId()).thenReturn(uuid);
-        ContentItem contentItem = new ContentItemImpl(uuid,
-                null,
-                null,
-                "application/text",
-                "datadatadata",
-                0,
-                metacard);
+
         DeleteStorageRequest deleteRequest = new DeleteStorageRequestImpl(Lists.newArrayList(
                 metacard), null);
         DeleteStorageResponse deleteResponse = provider.delete(deleteRequest);
@@ -387,7 +376,7 @@ public class FileSystemStorageProviderTest {
         ContentItem item = items.get(0);
 
         LOGGER.debug("Item retrieved: {}", item);
-        assertEquals(id, item.getId());
+        assertThat(id, is(item.getId()));
         assertThat(item.getFilename(), is(""));
     }
 
@@ -434,9 +423,6 @@ public class FileSystemStorageProviderTest {
         CreateStorageResponse createResponse = assertContentItem(TEST_INPUT_CONTENTS,
                 NITF_MIME_TYPE,
                 TEST_INPUT_FILENAME);
-        URI unqualifiedUri = new URI(createResponse.getCreatedContentItems()
-                .get(0)
-                .getUri());
 
         createResponse = assertContentItemWithQualifier(TEST_INPUT_CONTENTS,
                 NITF_MIME_TYPE,
@@ -463,15 +449,14 @@ public class FileSystemStorageProviderTest {
                 byteSource,
                 NITF_MIME_TYPE,
                 mock(Metacard.class));
-        submitAndVerifySuccessfulUpdateStorageRequest(updateItem);
 
-        updateItem = new ContentItemImpl(id,
+        ContentItem updateItem2 = new ContentItemImpl(id,
                 qualifiedUri.getFragment(),
                 byteSource,
                 NITF_MIME_TYPE,
                 mock(Metacard.class));
-        submitAndVerifySuccessfulUpdateStorageRequest(updateItem);
 
+        submitAndVerifySuccessfulUpdateStorageRequest(updateItem, updateItem2);
     }
 
     @Test
@@ -574,12 +559,12 @@ public class FileSystemStorageProviderTest {
         CreateStorageRequest createRequest = new CreateStorageRequestImpl(Collections.singletonList(
                 contentItem), null);
 
-        CreateStorageResponse createStorageResponse = provider.create(createRequest);
+        provider.create(createRequest);
         provider.rollback(createRequest);
 
         ReadStorageRequest readStorageRequest = new ReadStorageRequestImpl(new URI("content:" + id),
                 null);
-        ReadStorageResponse read = provider.read(readStorageRequest);
+        provider.read(readStorageRequest);
     }
 
     @Test
@@ -596,7 +581,7 @@ public class FileSystemStorageProviderTest {
         String badId = id.substring(0, 6) + uuid.substring(6, uuid.length() - 1);
         boolean hadError = false;
         try {
-            CreateStorageResponse badCreateResponse = assertContentItemWithQualifier(
+            assertContentItemWithQualifier(
                     TEST_INPUT_CONTENTS,
                     NITF_MIME_TYPE,
                     TEST_INPUT_FILENAME,
@@ -626,7 +611,7 @@ public class FileSystemStorageProviderTest {
         ContentItem item = items.get(0);
 
         LOGGER.debug("Item retrieved: {}", item);
-        assertEquals(id, item.getId());
+        assertThat(id, is(item.getId()));
         assertThat(item.getFilename(), is(""));
         provider.commit(deleteRequest);
 
@@ -674,10 +659,9 @@ public class FileSystemStorageProviderTest {
         ContentItem item = items.get(0);
 
         LOGGER.debug("Item retrieved: {}", item);
-        assertEquals(id, item.getId());
+        assertThat(id, is(item.getId()));
         assertThat(item.getFilename(), isEmptyString());
-
-        assertTrue(new File(path).exists());
+        assertThat(new File(path).exists(), is(true));
     }
 
     @Test
@@ -747,21 +731,21 @@ public class FileSystemStorageProviderTest {
         ContentItem createdContentItem =
                 createdContentItems.isEmpty() ? null : createdContentItems.get(0);
 
-        assertNotNull(createdContentItem);
+        assertThat(createdContentItem, notNullValue());
         String createdId = createdContentItem.getId();
-        assertNotNull(createdId);
+        assertThat(createdId, notNullValue());
         assertThat(createdId, equalTo(uuid));
 
         String contentUri = createdContentItem.getUri();
         LOGGER.debug("contentUri = {}", contentUri);
-        assertNotNull(contentUri);
+        assertThat(contentUri, notNullValue());
         String expectedContentUri =
                 ContentItem.CONTENT_SCHEME + ":" + uuid + ((StringUtils.isNotBlank(qualifier)) ?
                         "#" + qualifier :
                         "");
         assertThat(contentUri, equalTo(expectedContentUri));
 
-        assertTrue(createdContentItem.getSize() > 0);
+        assertThat(createdContentItem.getSize(), greaterThan(0L));
         String createdMimeType = createdContentItem.getMimeTypeRawData()
                 .replace(";", "");
         List<String> createdMimeTypeArr =
@@ -769,7 +753,7 @@ public class FileSystemStorageProviderTest {
         List<String> givenMimeTypeArr = new ArrayList<>(Arrays.asList(mimeTypeRawData.replace(";",
                 "")
                 .split(" ")));
-        assertEquals(createdMimeTypeArr.size(), givenMimeTypeArr.size());
+        assertThat(createdMimeTypeArr, hasSize(givenMimeTypeArr.size()));
         givenMimeTypeArr.removeAll(createdMimeTypeArr);
         assertThat(givenMimeTypeArr.size(), is(0));
         provider.commit(createRequest);
@@ -815,7 +799,7 @@ public class FileSystemStorageProviderTest {
             expectedFilePath = expectedFilePath + "." + FileSystemStorageProvider.REF_EXT;
         }
         assertThat(Files.exists(Paths.get(expectedFilePath)), is(true));
-        assertTrue(item.getSize() > 0);
+        assertThat(item.getSize(), greaterThan(0L));
     }
 
     private void submitAndVerifySuccessfulUpdateStorageRequest(ContentItem... requestContentItems)


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug in commitUpdates where not all derived resources were copied on an updateRequest, which resulted in a loss of data.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Best to test with Alliance, as NITF ingest creates derived resources.  Build / Install / Ingest NITF and verify all content exists.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2978](https://codice.atlassian.net/browse/DDF-2978)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
