### PR TITLE
(2.10.x) DDF-2978 Fixed bug in commitUpdates

### DIFF
--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -369,12 +369,13 @@ public class FileSystemStorageProvider implements StorageProvider {
                     try {
                         Path createdTarget = Files.createDirectories(target);
                         List<Path> files = listPaths(contentIdDir);
-                        Files.copy(files.get(0),
-                                Paths.get(createdTarget.toAbsolutePath()
-                                                .toString(),
-                                        files.get(0)
-                                                .getFileName()
-                                                .toString()));
+                        for (Path path : files) {
+                            Path newTarget = Paths.get(createdTarget.toAbsolutePath().toString(), path.getFileName().toString());
+                            Path source = path;
+                            if (!Files.exists(newTarget)) {
+                                Files.copy(source, newTarget);
+                            }
+                        }
                     } catch (IOException e1) {
                         throw new StorageException(
                                 "Unable to commit changes for request: " + request.getId(), e1);
@@ -475,7 +476,7 @@ public class FileSystemStorageProvider implements StorageProvider {
                     result.add(entry);
                 }
             } catch (DirectoryIteratorException ex) {
-                // I/O error encounted during the iteration, the cause is an IOException
+                // I/O error encountered during the iteration, the cause is an IOException
                 throw ex.getCause();
             }
         }

--- a/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
@@ -457,42 +457,11 @@ public class FileSystemStorageProviderTest {
                 NITF_MIME_TYPE,
                 mock(Metacard.class));
 
-        UpdateStorageRequest updateRequest = new UpdateStorageRequestImpl(Arrays.asList(updateItem, updateItem2), null);
+        UpdateStorageRequest updateRequest = new UpdateStorageRequestImpl(Arrays.asList(updateItem, updateItem2),
+                null);
 
         assertUpdateRequest(updateRequest);
 
-    }
-
-    @Test
-    public void testUpdateMultipleQualifiedItemsInTheSameRequest() throws Exception {
-        CreateStorageResponse createResponse = assertContentItem(TEST_INPUT_CONTENTS,
-                NITF_MIME_TYPE,
-                TEST_INPUT_FILENAME);
-
-        createResponse = assertContentItemWithQualifier(TEST_INPUT_CONTENTS,
-                NITF_MIME_TYPE,
-                TEST_INPUT_FILENAME,
-                createResponse.getCreatedContentItems()
-                        .get(0)
-                        .getId(),
-                QUALIFIER);
-
-        String id = createResponse.getCreatedContentItems()
-                .get(0)
-                .getId();
-        ByteSource byteSource = new ByteSource() {
-            @Override
-            public InputStream openStream() throws IOException {
-                return IOUtils.toInputStream("Updated NITF");
-            }
-        };
-        ContentItem updateItem = new ContentItemImpl(id,
-                byteSource,
-                NITF_MIME_TYPE,
-                mock(Metacard.class));
-
-        UpdateStorageRequest updateRequest = new UpdateStorageRequestImpl(Collections.singletonList(updateItem), null);
-        assertUpdateRequest(updateRequest);
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug in commitUpdates where not all derived resources were copied on an updateRequest, which resulted in a loss of data.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Best to test with Alliance, as NITF ingest creates derived resources.  Build / Install / Ingest NITF and verify all content exists.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2978](https://codice.atlassian.net/browse/DDF-2978)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
