### PR TITLE
[WIP] DDF-2979 ContentProducerDataAccessObject is not accessing existing metacard on an update. Without the metacard attribute overrides set during the create step will be lost.

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/pom.xml
+++ b/catalog/core/catalog-core-camelcomponent/pom.xml
@@ -104,6 +104,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponent.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponent.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.CatalogFramework;
+import ddf.catalog.filter.FilterBuilder;
 import ddf.mime.MimeTypeMapper;
 
 public class ContentComponent extends DefaultComponent {
@@ -37,6 +38,8 @@ public class ContentComponent extends DefaultComponent {
     private CatalogFramework catalogFramework;
 
     private MimeTypeMapper mimeTypeMapper;
+
+    private FilterBuilder filterBuilder;
 
     public ContentComponent() {
         super();
@@ -83,6 +86,14 @@ public class ContentComponent extends DefaultComponent {
 
     public void setMimeTypeMapper(MimeTypeMapper mimeTypeMapper) {
         this.mimeTypeMapper = mimeTypeMapper;
+    }
+
+    public FilterBuilder getFilterBuilder() {
+        return filterBuilder;
+    }
+
+    public void setFilterBuilder(FilterBuilder filterBuilder) {
+        this.filterBuilder = filterBuilder;
     }
 
 }

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
@@ -27,8 +27,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.Constants;
+import ddf.catalog.federation.FederationException;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
 
 public class ContentProducer extends DefaultProducer {
     public static final int KB = 1024;
@@ -62,7 +64,8 @@ public class ContentProducer extends DefaultProducer {
 
     @Override
     public void process(Exchange exchange)
-            throws ContentComponentException, SourceUnavailableException, IngestException {
+            throws ContentComponentException, SourceUnavailableException, IngestException,
+            UnsupportedQueryException, FederationException {
         LOGGER.trace("ENTERING: process");
 
         if (!exchange.getPattern()

--- a/catalog/core/catalog-core-camelcomponent/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-camelcomponent/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,6 +23,8 @@
 
     <reference id="framework" interface="ddf.catalog.CatalogFramework"/>
 
+    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+
     <!--
     Instantiate our custom Camel CatalogComponent and inject this bundle context into it.  
     -->
@@ -58,6 +60,7 @@
     <bean id="contentComponent" class="ddf.camel.component.catalog.content.ContentComponent">
         <property name="catalogFramework" ref="framework"/>
         <property name="mimeTypeMapper" ref="mimeTypeMapper"/>
+        <property name="filterBuilder" ref="filterBuilder"/>
     </bean>
 
     <!--

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
@@ -48,6 +48,8 @@ import ddf.catalog.Constants;
 import ddf.catalog.content.operation.CreateStorageRequest;
 import ddf.catalog.content.operation.StorageRequest;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.DeleteResponse;
@@ -60,6 +62,8 @@ public class ContentProducerDataAccessObjectTest {
 
     ContentProducerDataAccessObject contentProducerDataAccessObject =
             new ContentProducerDataAccessObject();
+
+    private FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
 
     @Test
     public void testGetFileUsingRefKey() throws Exception {
@@ -199,6 +203,7 @@ public class ContentProducerDataAccessObjectTest {
         ContentComponent mockComponent = mock(ContentComponent.class);
         doReturn(mockCatalogFramework).when(mockComponent)
                 .getCatalogFramework();
+        doReturn(filterBuilder).when(mockComponent).getFilterBuilder();
 
         //setup mockEndpoint
         ContentEndpoint mockEndpoint = mock(ContentEndpoint.class);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -1537,6 +1537,61 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testAttributeOverridesOnUpdate() throws Exception {
+        final String TMP_PREFIX = "tcdm_";
+        final String attribute = "title";
+        final String value = "someTitleIMadeUp";
+
+        Path tmpDir = Files.createTempDirectory(TMP_PREFIX);
+        tmpDir.toFile()
+                .deleteOnExit();
+        Path tmpFile = Files.createTempFile(tmpDir, TMP_PREFIX, "_tmp.xml");
+        tmpFile.toFile()
+                .deleteOnExit();
+        Files.copy(getFileContentAsStream("metacard5.xml"),
+                tmpFile,
+                StandardCopyOption.REPLACE_EXISTING);
+
+        Map<String, Object> cdmProperties = new HashMap<>();
+        cdmProperties.putAll(getServiceManager().getMetatypeDefaults("content-core-directorymonitor",
+                "org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor"));
+        cdmProperties.put("monitoredDirectoryPath", tmpDir.toString() + "/");
+        cdmProperties.put("processingMechanism", ContentDirectoryMonitor.IN_PLACE);
+        cdmProperties.put("attributeOverrides", format("%s=%s", attribute, value));
+        Configuration managedService = getServiceManager().createManagedService(
+                "org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor",
+                cdmProperties);
+
+        //assert that the file was ingested
+        ValidatableResponse response = assertIngestedDirectoryMonitor("SysAdmin", 1);
+
+        //assert that the metacard contains the overridden attribute
+        assertStringMetacardAttribute(response, attribute, value);
+
+        //edit the file
+        Files.copy(getFileContentAsStream("metacard4.xml"),
+                tmpFile,
+                StandardCopyOption.REPLACE_EXISTING);
+
+        //assert updated
+        // onlyFillNull = true so the metadata won't contain the new stuff
+        // should this be?
+        response = assertIngestedDirectoryMonitor("Space", 1);
+
+        //assert that the metacard still contains the overridden attribute
+        assertStringMetacardAttribute(response, attribute, value);
+
+        //delete the file
+        tmpFile.toFile()
+                .delete();
+
+        //assert deleted
+        assertIngestedDirectoryMonitor("SysAdmin", 0);
+
+        getServiceManager().stopManagedService(managedService.getPid());
+    }
+
+    @Test
     public void testInPlaceDirectoryMonitorPersistence() throws Exception {
         final String TMP_PREFIX = "tcdm_";
         Path tmpDir = Files.createTempDirectory(TMP_PREFIX);
@@ -1625,6 +1680,12 @@ public class TestCatalog extends AbstractIntegrationTest {
         } while (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
                 < TimeUnit.MINUTES.toMillis(1));
         response.body("metacards.metacard.size()", equalTo(numResults));
+        return response;
+    }
+
+    private ValidatableResponse assertStringMetacardAttribute(ValidatableResponse response, String attribute, String value) {
+        String attributeValueXpath = format("/metacards/metacard/string[@name='%s']/value", attribute);
+        response.body(hasXPath(attributeValueXpath, is(value)));
         return response;
     }
 


### PR DESCRIPTION
Adding and exposing filter builder to ContentComponent

Updating ContentProducer's thrown exceptions

Updating ContentProducerDataAccessObject's createContentItem.
  On ENTRY_MODIFY get the existing metacard for the file being updated/ingested. This metacard will be set in the UpdateStorageRequest instead of null.

#### What does this PR do?
  This PR changes the content component to retrieve and use the metacard associated to the file being updated.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann @dcruver 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison
@clockard 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2979
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
