### PR TITLE
DDF-2981 Update System Usage view to take cache busting into account

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
@@ -23,7 +23,7 @@ var $ = require('jquery');
 
 function getSrc() {
     return '<html class="is-iframe" style="font-size: '+preferences.get('fontSize')+'px">' +
-    '<link href="css/index.css" rel="stylesheet">' +
+    '<link href="css/styles.' + document.querySelector('link[href*="css/styles."]').href.split('css/styles.')[1] + '" rel="stylesheet">' +
     properties.ui.systemUsageMessage +
     '</html>';
 }


### PR DESCRIPTION
#### What does this PR do?
 - The url for the css is a moving target with the new cache busting, so this updates the system usage view to get whatever the latest style sheet is dynamically rather than statically.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@andrewkfiedler
@clockard
@djblue 
@Lambeaux 

#### How should this be tested? (List steps with links to updated documentation)
Add a system usage message.  Verify the correct css is fetched for the view.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2981#### Screenshots (if appropriate)
