### PR TITLE
DDF-2987 Remove duplicate call to doPostIngest

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/DeleteOperations.java
@@ -117,9 +117,7 @@ public class DeleteOperations {
     //
     public DeleteResponse delete(DeleteRequest deleteRequest, List<String> fanoutTagBlacklist)
             throws IngestException, SourceUnavailableException {
-        DeleteResponse deleteResponse = doDelete(deleteRequest, fanoutTagBlacklist);
-        deleteResponse = doPostIngest(deleteResponse);
-        return deleteResponse;
+        return doDelete(deleteRequest, fanoutTagBlacklist);
     }
 
     private List<Metacard> getDeleteMetacards(DeleteRequest deleteRequest) {


### PR DESCRIPTION
Removing the call to doPostIngest in DeleteOperations delete method. It was removed here because delete calls doDelete which is calling doPostIngest.

#### What does this PR do?
This PR removes the duplicate processing of post ingest plugins on a delete operation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @dcruver 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2987
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
