### PR TITLE
DDF-2990 Protects against NPE in ReliableResourceDownloader

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -183,6 +183,14 @@ public class ReliableResourceDownloader implements Runnable {
                 // <INSTALL-DIR>/data/product-cache/<source-id>-<metacard-id>
                 // <INSTALL-DIR>/data/product-cache/ddf.distribution-abc123
                 filePath = FilenameUtils.concat(resourceCache.getProductCacheDirectory(), key);
+                if (filePath == null) {
+                    LOGGER.info(
+                            "Unable to create cache for cache directory {} and key {} - no caching will be done.",
+                            resourceCache.getProductCacheDirectory(),
+                            key);
+                    return resourceResponse;
+                }
+
                 reliableResource = new ReliableResource(key,
                         filePath,
                         mimeType,


### PR DESCRIPTION
#### What does this PR do?
Protects against an unlikely but possible NPE. From a Coverity finding, CID-108051.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@Lambeaux @rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full build/test should be sufficient.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2990](https://codice.atlassian.net/browse/DDF-2990)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
