### PR TITLE
DDF-2991 Updated registry delete operation to removes backing registry-remote metacards.

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/FederationAdmin.java
@@ -297,13 +297,14 @@ public class FederationAdmin implements FederationAdminMBean, EventHandler {
         }
 
         List<Metacard> localMetacards =
-                federationAdminService.getRegistryMetacardsByRegistryIds(ids);
+                federationAdminService.getRegistryMetacardsByRegistryIds(ids, true);
+
         List<String> metacardIds = new ArrayList<>();
 
         metacardIds.addAll(localMetacards.stream()
                 .map(Metacard::getId)
                 .collect(Collectors.toList()));
-        if (ids.size() != metacardIds.size()) {
+        if (ids.size() > metacardIds.size()) {
             String message = "Error deleting local registry entries. ";
             LOGGER.debug("{} Registry Ids provided: {}. Registry metacard ids found: {}",
                     message,

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/test/java/org/codice/ddf/registry/federationadmin/impl/FederationAdminTest.java
@@ -455,12 +455,12 @@ public class FederationAdminTest {
                 .map(Metacard::getId)
                 .collect(Collectors.toList()));
 
-        when(federationAdminService.getRegistryMetacardsByRegistryIds(ids)).thenReturn(
+        when(federationAdminService.getRegistryMetacardsByRegistryIds(ids, true)).thenReturn(
                 matchingMetacards);
 
         federationAdmin.deleteLocalEntry(ids);
 
-        verify(federationAdminService).getRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService).getRegistryMetacardsByRegistryIds(ids, true);
         verify(federationAdminService).deleteRegistryEntriesByMetacardIds(metacardIds);
     }
 

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -424,6 +424,12 @@ public class FederationAdminServiceImpl implements FederationAdminService {
     @Override
     public List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
             throws FederationAdminException {
+        return getRegistryMetacardsByRegistryIds(ids, false);
+    }
+
+    @Override
+    public List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids,
+            boolean includeInternal) throws FederationAdminException {
         if (CollectionUtils.isEmpty(ids)) {
             throw new FederationAdminException(
                     "Error getting registry metacards by registry ids. Null list of Ids provided.");
@@ -437,6 +443,10 @@ public class FederationAdminServiceImpl implements FederationAdminService {
                 .collect(Collectors.toList());
         List<Filter> filters = getBasicFilter();
         Filter filter = filterBuilder.allOf(filters);
+        if (includeInternal) {
+            filter = filterBuilder.anyOf(filter,
+                    filterBuilder.allOf(getBasicFilter(RegistryConstants.REGISTRY_TAG_INTERNAL)));
+        }
         filter = filterBuilder.allOf(filter, filterBuilder.anyOf(idFilters));
         return getRegistryMetacardsByFilter(filter);
     }

--- a/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/internal/FederationAdminService.java
+++ b/catalog/spatial/registry/registry-federation-admin-service/src/main/java/org/codice/ddf/registry/federationadmin/service/internal/FederationAdminService.java
@@ -225,6 +225,21 @@ public interface FederationAdminService {
     List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
             throws FederationAdminException;
 
+
+    /**
+     * Get a list of registry metacards with the provided registry ids. It won't run the query
+     * if the list provided is empty.
+     *
+     * @param ids List of IDs to to get metacards for
+     * @param includeInternal boolean indicating whether the internal representation metacards should be included
+     * @return List<Metacard>
+     * @throws FederationAdminException If empty list of registry ids is provided
+     *                                  If the list of id filters isn't created
+     *                                  If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids, boolean includeInternal)
+            throws FederationAdminException;
+
     /**
      * Get a list of local registry metacards with the provided registry ids. It won't run the query
      * if the list provided is empty.


### PR DESCRIPTION
#### What does this PR do?
Updates the registry delete logic so that the internal remote-registry metacards can be removed.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Install two instances and have registry 1 publish to registry 2. 
From the Node Information tab on registry 2 delete registry 1.
Go to solr on registry 2 and verify that there is only one entry that matches metacar-tags_txt:registry*
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2991](https://codice.atlassian.net/browse/DDF-2991)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
