### PR TITLE
DDF-2992 Security utility class contains static methods which cannot mocked

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
-import static org.codice.ddf.security.common.Security.runAsAdmin;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,12 +35,11 @@ import org.apache.camel.model.RouteDefinition;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.util.ThreadContext;
+import org.codice.ddf.security.common.Security;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.Constants;
-import ddf.security.common.util.Security;
-
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 
@@ -67,6 +64,8 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
     private static final int MIN_THREAD_SIZE = 1;
 
     private static final int MIN_READLOCK_INTERVAL_MILLISECONDS = 100;
+
+    private static final Security SECURITY = Security.getInstance();
 
     private final int maxRetries;
 
@@ -130,9 +129,8 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
     private void setBlacklist() {
         String badFileProperty = System.getProperty("bad.files");
         String badFileExtensionProperty = System.getProperty("bad.file.extensions");
-        badFiles = StringUtils.isNotEmpty(badFileProperty) ?
-                Arrays.asList(badFileProperty.split("\\s*,\\s*")) :
-                null;
+        badFiles = StringUtils.isNotEmpty(badFileProperty) ? Arrays.asList(badFileProperty.split(
+                "\\s*,\\s*")) : null;
         badFileExtensions = StringUtils.isNotEmpty(badFileExtensionProperty) ? Arrays.asList(
                 badFileExtensionProperty.split(",")) : null;
     }
@@ -188,7 +186,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
             LOGGER.trace("No routes to remove before configuring a new route");
         }
 
-        runAsAdmin(this::configure);
+        SECURITY.runAsAdmin(this::configure);
     }
 
     private Object configure() {
@@ -412,8 +410,9 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
                             .constant(attributeOverrides);
                 }
                 if (IN_PLACE.equals(processingMechanism)) {
-                    routeDefinition.setHeader(Constants.STORE_REFERENCE_KEY, simple(String.valueOf(
-                            IN_PLACE.equals(processingMechanism)), Boolean.class));
+                    routeDefinition.setHeader(Constants.STORE_REFERENCE_KEY,
+                            simple(String.valueOf(IN_PLACE.equals(processingMechanism)),
+                                    Boolean.class));
                 }
 
                 LOGGER.trace("About to process scheme content:framework");
@@ -461,7 +460,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
          */
         @Override
         public void process(Exchange exchange) {
-            ThreadContext.bind(Security.getSystemSubject());
+            ThreadContext.bind(SECURITY.getSystemSubject());
         }
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -451,10 +451,12 @@ public class Historian {
             security = Security.getInstance();
         }
 
-        Subject systemSubject = Security.runAsAdmin(() -> security.getSystemSubject());
+        Subject systemSubject = security.runAsAdmin(() -> security.getSystemSubject());
+
         if (systemSubject == null) {
             throw new RuntimeException("Could not get systemSubject to version metacards.");
         }
+
         return systemSubject.execute(func);
     }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -116,7 +117,7 @@ public class HistorianTest {
         Security security = mock(Security.class);
         Subject subject = mock(MockSubject.class);
         when(subject.execute(any(Callable.class))).thenCallRealMethod();
-        when(security.getSystemSubject()).thenReturn(subject);
+        when(security.runAsAdmin(any(PrivilegedAction.class))).thenReturn(subject);
         historian.setSecurity(security);
     }
 

--- a/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
+++ b/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
@@ -23,6 +23,7 @@ import java.util.StringJoiner;
 import java.util.TreeMap;
 
 import org.apache.shiro.subject.Subject;
+import org.codice.ddf.security.common.Security;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -51,7 +52,6 @@ import ddf.catalog.util.impl.ServiceComparator;
 import ddf.security.SecurityConstants;
 import ddf.security.SubjectUtils;
 import ddf.security.common.audit.SecurityLogger;
-import ddf.security.common.util.Security;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.permission.KeyValueCollectionPermission;
 
@@ -65,6 +65,8 @@ public class FilterPlugin implements AccessPlugin {
 
     private Map<ServiceReference, FilterStrategy> filterStrategies =
             Collections.synchronizedMap(new TreeMap<>(new ServiceComparator()));
+
+    private static final Security SECURITY = Security.getInstance();
 
     public void addStrategy(ServiceReference<FilterStrategy> filterStrategyRef) {
         Bundle bundle = FrameworkUtil.getBundle(FilterPlugin.class);
@@ -80,7 +82,7 @@ public class FilterPlugin implements AccessPlugin {
     }
 
     protected Subject getSystemSubject() {
-        return org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
+        return SECURITY.runAsAdmin(SECURITY::getSystemSubject);
     }
 
     @Override

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -54,6 +54,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.common.util.CollectionUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.cxf.SecureCxfClientFactory;
+import org.codice.ddf.security.common.Security;
 import org.codice.ddf.spatial.ogc.catalog.MetadataTransformer;
 import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityCommand;
 import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityTask;
@@ -216,6 +217,8 @@ public abstract class AbstractCswSource extends MaskableImpl
             "http://www.iana.org/assignments/media-types/application/octet-stream";
 
     private static final String ERROR_ID_PRODUCT_RETRIEVAL = "Error retrieving resource for ID: %s";
+
+    private static final Security SECURITY = Security.getInstance();
 
     private EncryptionService encryptionService;
 
@@ -1367,9 +1370,7 @@ public abstract class AbstractCswSource extends MaskableImpl
     }
 
     protected Subject getSystemSubject() {
-        org.codice.ddf.security.common.Security security =
-                org.codice.ddf.security.common.Security.getInstance();
-        return org.codice.ddf.security.common.Security.runAsAdmin(security::getSystemSubject);
+        return SECURITY.runAsAdmin(SECURITY::getSystemSubject);
     }
 
     public void configureCswSource() {

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryMetacardHandler.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryMetacardHandler.java
@@ -72,7 +72,9 @@ public class RegistryMetacardHandler implements EventHandler {
 
     private void processEvent(Metacard mcard, String topic) {
         try {
-            Security.runAsAdminWithException(() -> {
+            Security security = Security.getInstance();
+
+            security.runAsAdminWithException(() -> {
                 if (topic.equals(EventProcessor.EVENTS_TOPIC_DELETED)) {
                     processMetacardDelete(mcard);
                 } else if (topic.equals(EventProcessor.EVENTS_TOPIC_CREATED) || topic.equals(

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStoreCleanupHandler.java
@@ -94,14 +94,16 @@ public class RegistryStoreCleanupHandler implements EventHandler {
         executor.execute(() -> {
             String registryId = service.getRegistryId();
             try {
+                Security security = Security.getInstance();
+
                 List<Metacard> metacards =
-                        Security.runAsAdminWithException(() -> federationAdminService.getInternalRegistryMetacardsByRegistryId(
+                        security.runAsAdminWithException(() -> federationAdminService.getInternalRegistryMetacardsByRegistryId(
                                 registryId));
                 List<String> idsToDelete = metacards.stream()
                         .map(Metacard::getId)
                         .collect(Collectors.toList());
                 if (!idsToDelete.isEmpty()) {
-                    Security.runAsAdminWithException(() -> {
+                    security.runAsAdminWithException(() -> {
                         federationAdminService.deleteRegistryEntriesByMetacardIds(idsToDelete);
                         return null;
                     });

--- a/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStorePublisher.java
+++ b/catalog/spatial/registry/registry-api-impl/src/main/java/org/codice/ddf/registry/api/impl/RegistryStorePublisher.java
@@ -145,8 +145,10 @@ public class RegistryStorePublisher implements EventHandler {
 
         executor.schedule(() -> {
             try {
+                Security security = Security.getInstance();
+
                 Optional<Metacard> registryIdentityMetacardOpt =
-                        Security.runAsAdminWithException(() -> federationAdminService.getLocalRegistryIdentityMetacard());
+                        security.runAsAdminWithException(() -> federationAdminService.getLocalRegistryIdentityMetacard());
 
                 if (registryIdentityMetacardOpt.isPresent()) {
                     Metacard registryIdentityMetacard = registryIdentityMetacardOpt.get();
@@ -155,7 +157,7 @@ public class RegistryStorePublisher implements EventHandler {
                     if (localRegistryId == null) {
                         throw new EventException();
                     }
-                    Security.runAsAdminWithException(() -> {
+                    security.runAsAdminWithException(() -> {
                         if (publish.equals(PUBLISH)) {
                             registryPublicationService.publish(localRegistryId,
                                     registryStore.getRegistryId());

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
@@ -84,7 +84,9 @@ public class IdentityNodeInitialization {
 
     public void init() {
         try {
-            Security.runAsAdminWithException(() -> {
+            Security security = Security.getInstance();
+
+            security.runAsAdminWithException(() -> {
                 Optional<Metacard> optional =
                         federationAdminService.getLocalRegistryIdentityMetacard();
                 if (optional.isPresent()) {

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/RefreshRegistryEntries.java
@@ -66,6 +66,8 @@ public class RefreshRegistryEntries {
 
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 60;
 
+    private static final Security SECURITY = Security.getInstance();
+
     private List<RegistryStore> registryStores;
 
     private FederationAdminService federationAdminService;
@@ -199,7 +201,7 @@ public class RefreshRegistryEntries {
     private Map<String, Metacard> getRegistryMetacardsMap() throws FederationAdminException {
         try {
             List<Metacard> registryMetacards =
-                    Security.runAsAdminWithException(() -> federationAdminService.getInternalRegistryMetacards());
+                    SECURITY.runAsAdminWithException(() -> federationAdminService.getInternalRegistryMetacards());
 
             return registryMetacards.stream()
                     .collect(Collectors.toMap(e -> RegistryUtility.getStringAttribute(e,
@@ -269,7 +271,7 @@ public class RefreshRegistryEntries {
     private List<String> getLocalRegistryIds() throws FederationAdminException {
         try {
             List<Metacard> localMetacards =
-                    Security.runAsAdminWithException(() -> federationAdminService.getLocalRegistryMetacards());
+                    SECURITY.runAsAdminWithException(() -> federationAdminService.getLocalRegistryMetacards());
             return localMetacards.stream()
                     .map(e -> RegistryUtility.getRegistryId(e))
                     .collect(Collectors.toList());
@@ -281,7 +283,7 @@ public class RefreshRegistryEntries {
     private void writeRemoteUpdates(List<Metacard> remoteMetacardsToUpdate)
             throws FederationAdminException {
         try {
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
                 for (Metacard m : remoteMetacardsToUpdate) {
                     federationAdminService.updateRegistryEntry(m);
                 }
@@ -297,7 +299,7 @@ public class RefreshRegistryEntries {
     private void createRemoteEntries(List<Metacard> remoteMetacardsToCreate)
             throws FederationAdminException {
         try {
-            Security.runAsAdminWithException(() -> federationAdminService.addRegistryEntries(
+            SECURITY.runAsAdminWithException(() -> federationAdminService.addRegistryEntries(
                     remoteMetacardsToCreate,
                     null));
         } catch (PrivilegedActionException e) {
@@ -308,7 +310,7 @@ public class RefreshRegistryEntries {
     private void deleteRemoteEntries(List<Metacard> remoteMetacardsToDelete)
             throws FederationAdminException {
         try {
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
                 federationAdminService.deleteRegistryEntriesByMetacardIds(remoteMetacardsToDelete.stream()
                         .map(Metacard::getId)
                         .collect(Collectors.toList()));

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/RegistryIdPostIngestPlugin.java
@@ -80,7 +80,7 @@ public class RegistryIdPostIngestPlugin implements PostIngestPlugin {
         security = Security.getInstance();
     }
 
-    public RegistryIdPostIngestPlugin(Security security){
+    public RegistryIdPostIngestPlugin(Security security) {
         this.security = security;
     }
 
@@ -138,8 +138,9 @@ public class RegistryIdPostIngestPlugin implements PostIngestPlugin {
             query.setPageSize(PAGE_SIZE);
             QueryRequest request = new QueryRequestImpl(query);
 
-            QueryResponse response = Security.runAsAdminWithException(() -> security
-                    .runWithSubjectOrElevate(() -> catalogFramework.query(request)));
+            QueryResponse response =
+                    security.runAsAdminWithException(() -> security.runWithSubjectOrElevate(() -> catalogFramework.query(
+                            request)));
 
             if (response == null) {
                 throw new PluginExecutionException(

--- a/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
+++ b/catalog/spatial/registry/registry-publication-action-provider/src/main/java/org/codice/ddf/registry/publication/manager/RegistryPublicationManager.java
@@ -78,8 +78,8 @@ public class RegistryPublicationManager implements EventHandler {
     public void init() {
 
         try {
-            List<Metacard> metacards =
-                    Security.runAsAdminWithException(() -> federationAdminService.getRegistryMetacards());
+            List<Metacard> metacards = Security.getInstance()
+                    .runAsAdminWithException(() -> federationAdminService.getRegistryMetacards());
 
             for (Metacard metacard : metacards) {
                 String registryId = RegistryUtility.getRegistryId(metacard);

--- a/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
@@ -96,7 +96,9 @@ public class RegistryPublicationHandler implements EventHandler {
         //since the last time we published send an update to the remote location
         if ((datePublished == null || datePublished.before(mcard.getModifiedDate()))) {
             try {
-                Security.runAsAdminWithException(() -> {
+                Security security = Security.getInstance();
+
+                security.runAsAdminWithException(() -> {
                     registryPublicationService.update(mcard);
                     return null;
                 });

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -200,14 +200,14 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
      * @throws InvalidSyntaxException
      * @throws ParserException
      */
-    private synchronized void updateRegistryConfigurations(Metacard metacard, boolean activationHint)
-            throws IOException, InvalidSyntaxException, ParserException {
-        if(RegistryUtility.isIdentityNode(metacard)){
+    private synchronized void updateRegistryConfigurations(Metacard metacard,
+            boolean activationHint) throws IOException, InvalidSyntaxException, ParserException {
+        if (RegistryUtility.isIdentityNode(metacard)) {
             return;
         }
 
-        boolean autoActivateConfigurations = activateConfigurations && (activationHint
-                || !preserveActiveConfigurations);
+        boolean autoActivateConfigurations =
+                activateConfigurations && (activationHint || !preserveActiveConfigurations);
 
         List<ServiceBindingType> bindingTypes = registryTypeHelper.getBindingTypes(
                 metacardMarshaller.getRegistryPackageFromMetacard(metacard));
@@ -684,8 +684,8 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
 
     private void updateRegistrySourceConfigurations(boolean deleteOldConfig) {
         try {
-            List<Metacard> metacards =
-                    Security.runAsAdminWithException(() -> federationAdminService.getRegistryMetacards());
+            List<Metacard> metacards = Security.getInstance()
+                    .runAsAdminWithException(() -> federationAdminService.getRegistryMetacards());
 
             for (Metacard metacard : metacards) {
                 try {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -117,6 +117,8 @@ public class MetacardApplication implements SparkApplication {
     private static final Set<Action> DELETE_ACTIONS = ImmutableSet.of(Action.DELETED,
             Action.DELETED_CONTENT);
 
+    private static final Security SECURITY = Security.getInstance();
+
     private final CatalogFramework catalogFramework;
 
     private final FilterBuilder filterBuilder;
@@ -576,8 +578,7 @@ public class MetacardApplication implements SparkApplication {
      * @return result of the callable func
      */
     private <T> T executeAsSystem(Callable<T> func) {
-        Subject systemSubject = Security.runAsAdmin(() -> Security.getInstance()
-                .getSystemSubject());
+        Subject systemSubject = SECURITY.runAsAdmin(SECURITY::getSystemSubject);
         if (systemSubject == null) {
             throw new RuntimeException("Could not get systemSubject to version metacards.");
         }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerProxy.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerProxy.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ServiceManagerProxy implements InvocationHandler {
 
+    private static final Security SECURITY = Security.getInstance();
+
     private ServiceManager serviceManager;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceManagerProxy.class);
@@ -37,11 +39,7 @@ public class ServiceManagerProxy implements InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 
-        Subject subject =
-                org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getInstance()
-                        .getSystemSubject());
-        return subject.execute(() -> {
-            return method.invoke(serviceManager, args);
-        });
+        Subject subject = SECURITY.runAsAdmin(SECURITY::getSystemSubject);
+        return subject.execute(() -> method.invoke(serviceManager, args));
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -90,6 +90,8 @@ public class TestRegistry extends AbstractIntegrationTest {
 
     private static final long SLEEP_TIME = 2000;
 
+    private static final Security SECURITY = Security.getInstance();
+
     private static String storeId;
 
     private static FederatedCswMockServer cswServer;
@@ -337,7 +339,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                                 "2016-01-26T17:16:34.996Z").getBytes()));
 
         try {
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
                 String id = createRegistryStoreEntry(METACARD_ID, regID, regID);
                 LOGGER.info("Created remote metacard with ID: {}", id);
                 assertThat(id, is(regID));
@@ -373,7 +375,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                                 "NodeName",
                                 "2016-01-26T17:16:34.996Z").getBytes()));
         try {
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
                 String id = createRegistryStoreEntry(METACARD_ID, regID, regID);
                 assertThat(id, is(regID));
                 cswServer.verifyHttp()
@@ -430,7 +432,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                         contentType("text/xml"),
                         bytesContent(remoteUpdatedMetacardResponse.getBytes()));
         try {
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
 
                 FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
                         FederationAdminService.class);
@@ -483,7 +485,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                             contentType("text/xml"),
                             bytesContent(remoteMetacardResponse.getBytes()));
 
-            Security.runAsAdminWithException(() -> {
+            SECURITY.runAsAdminWithException(() -> {
 
                 FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
                         FederationAdminService.class);
@@ -564,7 +566,7 @@ public class TestRegistry extends AbstractIntegrationTest {
         long metacardLookupTimeout = TimeUnit.MINUTES.toMillis(20);
         while (!foundMetacard) {
             LOGGER.info("Waiting for metacard to be created");
-            List entries = Security.runAsAdminWithException(() -> {
+            List entries = SECURITY.runAsAdminWithException(() -> {
 
                 FederationAdminService federationAdminServiceImpl = getServiceManager().getService(
                         FederationAdminService.class);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestApplicationService.java
@@ -39,6 +39,7 @@ import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.annotations.ConditionalIgnoreRule;
 import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
+import org.codice.ddf.security.common.Security;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,8 +50,6 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import ddf.security.common.util.Security;
 
 /**
  * Note: Tests prefixed with aRunFirst NEED to run before any other tests.  For this reason, we
@@ -102,8 +101,8 @@ public class TestApplicationService extends AbstractIntegrationTest {
     public void beforeExam() throws Exception {
         try {
             waitForSystemReady();
-            systemSubject =
-                    org.codice.ddf.security.common.Security.runAsAdmin(() -> Security.getSystemSubject());
+            Security security = Security.getInstance();
+            systemSubject = security.runAsAdmin(security::getSystemSubject);
         } catch (Exception e) {
             LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
         }

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationConfigInstaller.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationConfigInstaller.java
@@ -43,6 +43,8 @@ public class ApplicationConfigInstaller extends Thread {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationConfigInstaller.class);
 
+    private static final Security SECURITY = Security.getInstance();
+
     private ApplicationService appService;
 
     private FeaturesService featuresService;
@@ -151,8 +153,7 @@ public class ApplicationConfigInstaller extends Thread {
     }
 
     Subject getSystemSubject() {
-        return Security.runAsAdmin(() -> Security.getInstance()
-                .getSystemSubject());
+        return SECURITY.runAsAdmin(SECURITY::getSystemSubject);
     }
 
 }

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
@@ -47,15 +47,16 @@ public class CommandJob implements Job {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandJob.class);
 
+    private static final Security SECURITY = Security.getInstance();
+
     public Subject getSystemSubject() {
-        return Security.getInstance()
-                .getSystemSubject();
+        return SECURITY.getSystemSubject();
     }
 
     @Override
     public void execute(final JobExecutionContext context) throws JobExecutionException {
 
-        Security.runAsAdmin(() -> {
+        SECURITY.runAsAdmin(() -> {
             Subject subject = getSystemSubject();
 
             if (subject != null) {

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
@@ -65,7 +65,11 @@ import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
 
 /**
- * Singleton class that provides common security related utility functions.
+ * Singleton class that provides common security related utility functions. To use, get the
+ * instance of the class using {@link #getInstance()} and call the desired method, or inject as
+ * a dependency.
+ *
+ * IMPORTANT: New methods added to this class should be non-static.
  */
 public class Security {
 
@@ -304,11 +308,11 @@ public class Security {
         return null;
     }
 
-    public static <T> T runAsAdmin(PrivilegedAction<T> action) {
+    public <T> T runAsAdmin(PrivilegedAction<T> action) {
         return javax.security.auth.Subject.doAs(JAVA_ADMIN_SUBJECT, action);
     }
 
-    public static <T> T runAsAdminWithException(PrivilegedExceptionAction<T> action)
+    public <T> T runAsAdminWithException(PrivilegedExceptionAction<T> action)
             throws PrivilegedActionException {
         return javax.security.auth.Subject.doAs(JAVA_ADMIN_SUBJECT, action);
     }

--- a/platform/security/common/src/test/java/org/codice/ddf/security/SecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/SecurityTest.java
@@ -160,7 +160,7 @@ public class SecurityTest {
 
     @Test
     public void testJavaSubjectHasAdminRole() throws Exception {
-        Security.runAsAdmin(() -> {
+        security.runAsAdmin(() -> {
             assertThat(security.javaSubjectHasAdminRole(), equalTo(true));
             return null;
         });
@@ -170,7 +170,7 @@ public class SecurityTest {
     public void testGetSystemSubject() throws Exception {
         configureMocksForBundleContext("server");
 
-        Security.runAsAdmin(() -> {
+        security.runAsAdmin(() -> {
             assertThat(security.getSystemSubject(), not(equalTo(null)));
             return null;
         });
@@ -199,9 +199,8 @@ public class SecurityTest {
         when(systemSubject.execute(callable)).thenReturn("Success!");
         configureMocksForBundleContext("server");
 
-        String result =
-                Security.runAsAdminWithException(() -> security.runWithSubjectOrElevate(
-                        callable));
+        String result = security.runAsAdminWithException(() -> security.runWithSubjectOrElevate(
+                callable));
 
         assertThat(result, is("Success!"));
         verifyStatic();
@@ -231,7 +230,7 @@ public class SecurityTest {
         when(SecurityUtils.getSubject()).thenThrow(new IllegalStateException());
         configureMocksForBundleContext("bad-alias");
 
-        boolean securityExceptionThrown = Security.runAsAdmin(() -> {
+        boolean securityExceptionThrown = security.runAsAdmin(() -> {
 
             try {
                 return security.runWithSubjectOrElevate(() -> false);
@@ -271,7 +270,7 @@ public class SecurityTest {
         when(systemSubject.execute(callable)).thenThrow(new ExecutionException(new UnsupportedOperationException()));
         configureMocksForBundleContext("server");
 
-        Exception exception = Security.runAsAdmin(() -> {
+        Exception exception = security.runAsAdmin(() -> {
 
             try {
                 security.runWithSubjectOrElevate(callable);


### PR DESCRIPTION
#### What does this PR do?
Changes the `Security.runAsAdmin()` and `Security.runAsAdminWithException()` to be non-static
and updates all the usages of those methods in the code.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@brendan-hofmann 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full build, install and make sure the following areas are working properly:
* Directory monitor
* Historian
* Redaction and filtering
* Registry
* Catalog UI workspaces
* Command scheduler

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2992](https://codice.atlassian.net/browse/DDF-2992)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
