### PR TITLE
DDF-2997 Remove implicit globals

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/behaviors/button.behavior.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/behaviors/button.behavior.js
@@ -25,7 +25,7 @@ Behaviors.addBehavior('button', Marionette.Behavior.extend({
         'click': 'blur'
     },
     emulateClick: function(e) {
-        if (e.target === this.el && (e.keyCode === 13 || event.keyCode === 32)) {
+        if (e.target === this.el && (e.keyCode === 13 || e.keyCode === 32)) {
             e.preventDefault();
             e.stopPropagation();
             this.$el.click();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/announcement/actions.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/announcement/actions.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+/*global require, setTimeout*/
 var uuid = require('uuid');
 var _ = require('underscore');
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/associations-graph/associations-graph.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/associations-graph/associations-graph.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, setTimeout*/
 var Backbone = require('backbone');
 var Marionette = require('marionette');
 var wreqr = require('wreqr');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/alert/content.alert.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/alert/content.alert.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'wreqr',
     'marionette',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'wreqr',
     'marionette',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/upload/content.upload.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/upload/content.upload.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'wreqr',
     'marionette',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/dropdown.companion.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/dropdown.companion.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/result-filter/dropdown.companion.result-filter.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/result-filter/dropdown.companion.result-filter.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, HTMLCanvasElement*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-advanced/metacard-advanced.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-advanced/metacard-advanced.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, setTimeout*/
 define([
     'marionette',
     'backbone',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/help/help.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, window*/
+/*global define, window, document*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/ingest-details/ingest-details.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/ingest-details/ingest-details.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, window, setTimeout*/
 var wreqr = require('wreqr');
 var Marionette = require('marionette');
 var _ = require('underscore');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, window*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/input.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/input.less
@@ -14,6 +14,7 @@
   }
 
   > .if-viewing label {
+    display: block;
     cursor: text;
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/thumbnail/input-thumbnail.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, window, FileReader*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/loading-companion/loading-companion.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/loading-companion/loading-companion.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, window*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -113,7 +113,7 @@ define([
                         if (CQLUtils.isPointRadiusFilter(filter)){
                             var pointText = filter.value.value.substring(6);
                             pointText = pointText.substring(0, pointText.length - 1);
-                            latLon = pointText.split(' ');
+                            var latLon = pointText.split(' ');
                             this.model.set({
                                 lat: latLon[1],
                                 lon: latLon[0],

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-associations/metacard-associations.view.js
@@ -62,7 +62,7 @@ module.exports = Marionette.LayoutView.extend({
         this.clearAssociations();
         LoadingCompanionView.beginLoading(this);
         $.get('/search/catalog/internal/associations/' + this.model.get('metacard').get('id')).then(function(response) {
-            if (!self.isDestroyed && this.associationsMenu !== undefined){
+            if (!this.isDestroyed && this.associationsMenu !== undefined){
                 this._originalAssociations = JSON.parse(JSON.stringify(response));
                 this._associations = response;
                 this.parseAssociations();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-interactions/metacard-interactions.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'wreqr',
     'marionette',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/notification-group/notification-group.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/notification-group/notification-group.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require, window*/
+/*global require, window, setTimeout*/
 var Marionette = require('marionette');
 var CustomElements = require('js/CustomElements');
 var template = require('./notification-group.hbs');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, setTimeout*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/slideout.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/slideout/slideout.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, window, setTimeout*/
 var Marionette = require('marionette');
 var template = require('./slideout.hbs');
 var CustomElements = require('js/CustomElements');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, document*/
 var Marionette = require('marionette');
 var template = require('./system-usage.hbs');
 var CustomElements = require('js/CustomElements');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/table/table.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, window*/
 var template = require('./table.hbs');
 var Marionette = require('marionette');
 var MarionetteRegion = require('js/Marionette.Region');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/tabs.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, alert*/
+/*global define, alert, window*/
 define([
     'marionette',
     'underscore',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/upload-item/upload-item.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/upload-item/upload-item.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, setTimeout*/
 var wreqr = require('wreqr');
 var Marionette = require('marionette');
 var _ = require('underscore');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'wreqr',
     'jquery',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/DrawingUtility.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/DrawingUtility.js
@@ -9,7 +9,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, document*/
 //allows us to get around svg security restrictions in IE11 (see using svg in opengl)
 //make our own image and manually set dimensions because of IE: https://github.com/openlayers/openlayers/issues/3939
 var _ = require('underscore');
@@ -47,7 +47,7 @@ module.exports = {
             textColor: 'white'
         });
         var canvas = this.getCircle(options);
-        ctx = canvas.getContext("2d");
+        var ctx = canvas.getContext("2d");
         ctx.font = '16pt Helvetica';
         ctx.fillStyle = options.textColor;
         ctx.textAlign = 'center';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, setTimeout*/
 var MapView = require('../map.view');
 var template = require('./cesium.hbs');
 var $ = require('jquery');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global require*/
+/*global require, setTimeout*/
 var wreqr = require('wreqr');
 var template = require('./map.hbs');
 var Marionette = require('marionette');
@@ -150,7 +150,7 @@ module.exports = Marionette.LayoutView.extend({
                     if (CQLUtils.isPointRadiusFilter(filter)) {
                         pointText = filter.value.value.substring(6);
                         pointText = pointText.substring(0, pointText.length - 1);
-                        latLon = pointText.split(' ');
+                        var latLon = pointText.split(' ');
                         locationModel = new LocationModel({
                             lat: latLon[1],
                             lon: latLon[0],

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -24,7 +24,7 @@ var DrawLine = require('js/widgets/openlayers.line');
 
 var properties = require('properties');
 var Openlayers = require('openlayers');
-var geocoder = require('js/view/openlayers.geocoder');
+var Geocoder = require('js/view/openlayers.geocoder');
 var LayerCollectionController = require('js/controllers/ol.layerCollection.controller');
 var user = require('component/singletons/user-instance');
 var User = require('js/model/User');
@@ -49,8 +49,8 @@ function createMap(insertionElement) {
     });
 
     if (properties.gazetteer) {
-        geoCoder = new geocoder.View({ el: $(insertionElement).siblings('#mapTools') });
-        geoCoder.render();
+        var geocoder = new Geocoder.View({ el: $(insertionElement).siblings('#mapTools') });
+        geocoder.render();
     }
     return map;
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 
 define([
     'wreqr',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.view.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, window*/
 define([
     'backbone',
     'marionette',


### PR DESCRIPTION
#### What does this PR do?
 - Babel will cause the app to crash at the first implicit global it encounters, so this removes all of them.
 - Changes the label on inputs to be display block to avoid issue with whitespace between the label and the validation div (this would show up on invalid enums that were multivalued).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 
@rzwiefel 
@andrewkfiedler
@pklinef 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2997
