### PR TITLE
DDF-3000 Added itest for GeoCoderPlugin

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,6 +37,7 @@
                 <bean class="ddf.catalog.data.impl.types.TopicAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
             </list>
         </argument>

--- a/distribution/test/itests/test-itests-common/src/main/resources/csw/record/CswRecord2
+++ b/distribution/test/itests/test-itests-common/src/main/resources/csw/record/CswRecord2
@@ -1,0 +1,20 @@
+        <csw:Record
+            xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:dct="http://purl.org/dc/terms/"
+            xmlns:ows="http://www.opengis.net/ows">
+            <dc:identifier>fc3f1798fe17466fbbcc39dcfcb232e6</dc:identifier>
+            <dct:bibliographicCitation>fc3f1798fe17466fbbcc39dcfcb232e6</dct:bibliographicCitation>
+            <dc:title>A record in the UK</dc:title>
+            <dct:alternative>5710818352_8f794bd7b9_o.jpg</dct:alternative>
+            <dc:date>2011-05-08T08:51:25.000-06:00</dc:date>
+            <dct:modified>2011-05-08T08:51:25.000-06:00</dct:modified>
+            <dct:created>2011-05-08T08:51:25.000-06:00</dct:created>
+            <dct:dateSubmitted>2011-05-08T08:51:25.000-06:00</dct:dateSubmitted>
+            <dct:issued>2011-05-08T08:51:25.000-06:00</dct:issued>
+            <dct:abstract>A record in the UK</dct:abstract>
+            <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+                <ows:LowerCorner>-0.360823 51.241903</ows:LowerCorner>
+                <ows:UpperCorner>-0.360823 51.241903</ows:UpperCorner>
+            </ows:BoundingBox>
+        </csw:Record>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
@@ -28,7 +28,6 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -356,12 +355,7 @@ public class TestSpatial extends AbstractIntegrationTest {
 
     @Test
     public void testGeoCoderPlugin() throws Exception {
-        String uuid = UUID.randomUUID()
-                .toString()
-                .replaceAll("-", "");
-
-        ingestCswRecord(getFileContent(CSW_RECORD_RESOURCE_PATH + "/CswRecord2",
-                ImmutableMap.of("id", uuid)));
+        ingestCswRecord(getFileContent(CSW_RECORD_RESOURCE_PATH + "/CswRecord2"));
 
         StringBuilder buffer = new StringBuilder(OPENSEARCH_PATH.getUrl()).append("?")
                 .append("format=")


### PR DESCRIPTION
#### What does this PR do?
This PR adds an integration test for the GeoCoderPlugin and asserts that a metacard's location.country-code is correctly derived from its location attribute.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@adimka @glenhein 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Build DDF
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3000](https://codice.atlassian.net/browse/DDF-3000)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
