### PR TITLE
DDF-2698 Remove -d alias from Export Command

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -207,17 +207,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.33</minimum>
+                                            <minimum>0.38</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.25</minimum>
+                                            <minimum>0.28</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.24</minimum>
+                                            <minimum>0.28</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -135,6 +135,12 @@
             <artifactId>catalog-transformer-zip</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
@@ -72,19 +72,19 @@ public abstract class CatalogCommands extends SubjectCommands {
     @Option(name = "--provider", required = false, aliases = {"-p",
             "-provider"}, multiValued = false, description = "Interacts with the Provider directly "
             + "instead of the framework. NOTE: This option picks the first Provider.")
-    boolean isProvider = false;
+    protected boolean isProvider = false;
 
     @Reference
-    CatalogProvider catalogProvider;
+    protected CatalogProvider catalogProvider;
 
     @Reference
-    CatalogFramework catalogFramework;
+    protected CatalogFramework catalogFramework;
 
     @Reference
-    BundleContext bundleContext;
+    protected BundleContext bundleContext;
 
     @Reference
-    FilterBuilder filterBuilder;
+    protected FilterBuilder filterBuilder;
 
     protected SolrCacheMBean getCacheProxy()
             throws IOException, MalformedObjectNameException, InstanceNotFoundException {

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -146,20 +146,20 @@ public class ExportCommand extends CqlCommands {
         final File outputFile = initOutputFile(output);
         if (outputFile.exists()) {
             printErrorMessage(String.format("File [%s] already exists!", outputFile.getPath()));
-            return null;
+            throw new IllegalStateException("File already exists!");
         }
 
         final File parentDirectory = outputFile.getParentFile();
         if (parentDirectory == null || !parentDirectory.isDirectory()) {
             printErrorMessage(String.format("Directory [%s] must exist.", output));
             console.println("If the directory does indeed exist, try putting the path in quotes.");
-            return null;
+            throw new IllegalStateException("Must be inside of a directory!");
         }
 
         String filename = FilenameUtils.getName(outputFile.getPath());
         if (StringUtils.isBlank(filename) || !filename.endsWith(".zip")) {
             console.println("Filename must end with '.zip' and not be blank");
-            return null;
+            throw new IllegalStateException("Must not be blank and end with '.zip'!");
         }
 
         if (delete && !force) {
@@ -570,4 +570,11 @@ public class ExportCommand extends CqlCommands {
                 TimeUnit.MINUTES.toMillis(1)), new HashMap<>());
     }
 
+    public void setStorageProvider(StorageProvider storageProvider) {
+        this.storageProvider = storageProvider;
+    }
+
+    public void setJarSigner(JarSigner jarSigner) {
+        this.jarSigner = jarSigner;
+    }
 }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -117,8 +117,7 @@ public class ExportCommand extends CqlCommands {
     String output = Paths.get(System.getProperty("ddf.home"), FILE_NAMER.get())
             .toString();
 
-    @Option(name = "--delete", required = true, aliases = {
-            "-d"}, multiValued = false, description = "Delete Metacards and content after export. EG: --delete=true or --delete=false")
+    @Option(name = "--delete", required = true, multiValued = false, description = "Delete Metacards and content after export. EG: --delete=true or --delete=false")
     boolean delete = false;
 
     @Option(name = "--archived", required = false, aliases = {"-a",

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -38,7 +38,9 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
@@ -177,10 +179,16 @@ public class ExportCommand extends CqlCommands {
         console.println("Starting metacard export...");
         Instant start = Instant.now();
         List<ExportItem> exportedItems = doMetacardExport(zipFile, filter);
-        console.println("Metacards exported in: " + getFormattedDuration(start));
+        if (exportedItems.isEmpty()) {
+            console.println("No metacards found to export, exiting.");
+            FileUtils.deleteQuietly(zipFile.getFile());
+            return null;
+        }
 
+        console.println("Metacards exported in: " + getFormattedDuration(start));
         console.println("Number of metacards exported: " + exportedItems.size());
         console.println();
+
 
         SecurityLogger.audit("Ids of exported metacards and content:\n{}",
                 exportedItems.stream()

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -15,6 +15,7 @@ package org.codice.ddf.commands.catalog;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -40,7 +41,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
@@ -112,14 +112,14 @@ public class ExportCommand extends CqlCommands {
     private JarSigner jarSigner = new JarSigner();
 
     @Reference
-    private StorageProvider storageProvider;
+    protected StorageProvider storageProvider;
 
     @Option(name = "--output", description = "Output file to export Metacards and contents into. Paths are absolute and must be in quotes. Will default to auto generated name inside of ddf.home", multiValued = false, required = false, aliases = {
             "-o"})
     String output = Paths.get(System.getProperty("ddf.home"), FILE_NAMER.get())
             .toString();
 
-    @Option(name = "--delete", required = true, multiValued = false, description = "Delete Metacards and content after export. EG: --delete=true or --delete=false")
+    @Option(name = "--delete", required = true, multiValued = false, description = "Delete Metacards and content after export. E.g., --delete=true or --delete=false")
     boolean delete = false;
 
     @Option(name = "--archived", required = false, aliases = {"-a",
@@ -146,20 +146,20 @@ public class ExportCommand extends CqlCommands {
         final File outputFile = initOutputFile(output);
         if (outputFile.exists()) {
             printErrorMessage(String.format("File [%s] already exists!", outputFile.getPath()));
-            throw new IllegalStateException("File already exists!");
+            throw new IllegalStateException("File already exists");
         }
 
         final File parentDirectory = outputFile.getParentFile();
         if (parentDirectory == null || !parentDirectory.isDirectory()) {
             printErrorMessage(String.format("Directory [%s] must exist.", output));
             console.println("If the directory does indeed exist, try putting the path in quotes.");
-            throw new IllegalStateException("Must be inside of a directory!");
+            throw new IllegalStateException("Must be inside of a directory");
         }
 
         String filename = FilenameUtils.getName(outputFile.getPath());
         if (StringUtils.isBlank(filename) || !filename.endsWith(".zip")) {
             console.println("Filename must end with '.zip' and not be blank");
-            throw new IllegalStateException("Must not be blank and end with '.zip'!");
+            throw new IllegalStateException("Filename must not be blank and must end with '.zip'");
         }
 
         if (delete && !force) {
@@ -188,7 +188,6 @@ public class ExportCommand extends CqlCommands {
         console.println("Metacards exported in: " + getFormattedDuration(start));
         console.println("Number of metacards exported: " + exportedItems.size());
         console.println();
-
 
         SecurityLogger.audit("Ids of exported metacards and content:\n{}",
                 exportedItems.stream()
@@ -222,6 +221,7 @@ public class ExportCommand extends CqlCommands {
                     System.getProperty("javax.net.ssl.keyStorePassword"));
             console.println("zip file signed in: " + getFormattedDuration(start));
         }
+
         console.println("Export complete.");
         console.println("Exported to: " + zipFile.getFile()
                 .getCanonicalPath());
@@ -427,8 +427,23 @@ public class ExportCommand extends CqlCommands {
         String id = exportItem.getId();
         String path = getContentPath(id, resource);
         parameters.setFileNameInZip(path);
-        zipFile.addStream(resource.getResource()
-                .getInputStream(), parameters);
+        try (InputStream resourceStream = resource.getResource()
+                .getInputStream()) {
+            zipFile.addStream(resourceStream, parameters);
+        } catch (IOException e) {
+            LOGGER.warn("Could not get content. Content will not be included in export [{}]",
+                    exportItem.getId());
+            console.printf(
+                    "%sCould not get Content. Content will not be included in export. %s (%s)%s%n",
+                    Ansi.ansi()
+                            .fg(Ansi.Color.RED)
+                            .toString(),
+                    exportItem.getId(),
+                    exportItem.getResourceUri(),
+                    Ansi.ansi()
+                            .reset()
+                            .toString());
+        }
     }
 
     private String getContentPath(String id, ResourceResponse resource) {
@@ -469,11 +484,13 @@ public class ExportCommand extends CqlCommands {
         try {
             BinaryContent binaryMetacard = transformer.transform(result.getMetacard(),
                     Collections.emptyMap());
-            zipFile.addStream(binaryMetacard.getInputStream(), parameters);
+            try (InputStream metacard = binaryMetacard.getInputStream()) {
+                zipFile.addStream(metacard, parameters);
+            }
         } catch (ZipException e) {
             LOGGER.error("Error processing result and adding to ZIP", e);
             throw new CatalogCommandRuntimeException(e);
-        } catch (CatalogTransformerException e) {
+        } catch (CatalogTransformerException | IOException e) {
             LOGGER.warn("Could not transform metacard. Metacard will not be added to zip [{}]",
                     result.getMetacard()
                             .getId());
@@ -570,11 +587,4 @@ public class ExportCommand extends CqlCommands {
                 TimeUnit.MINUTES.toMillis(1)), new HashMap<>());
     }
 
-    public void setStorageProvider(StorageProvider storageProvider) {
-        this.storageProvider = storageProvider;
-    }
-
-    public void setJarSigner(JarSigner jarSigner) {
-        this.jarSigner = jarSigner;
-    }
 }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
@@ -45,7 +45,7 @@ public abstract class SubjectCommands extends CommandSupport {
     protected String user = null;
 
     @Reference
-    Session session;
+    protected Session session;
 
     protected SubjectCommands() {
         this(Security.getInstance());

--- a/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
+++ b/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
@@ -96,23 +96,6 @@ class ExportCommandSpec extends spock.lang.Specification {
         thrown(IllegalStateException)
     }
 
-    def "Test bad parent file"() {
-        setup:
-        def file = Mock(File) { // This is really dirty and regardless that it works its bad
-            getParentFile() >> null // and I should feel bad and delete this.
-        }
-        exportCommand.with {
-            delete = false
-            output = file // <- setting a String field to a File Mock object that just happens to
-        }                   // get passed to the new File() constructor and so actually passes mock
-        // object on to the actual class to be used.
-        when:
-        exportCommand.executeWithSubject()
-
-        then:
-        thrown(IllegalStateException)
-    }
-
     def "Test bad file name"() {
         setup:
         def file = Paths.get(System.getProperty('ddf.home'), 'badFilename.notazip')
@@ -225,7 +208,7 @@ class ExportCommandSpec extends spock.lang.Specification {
             files.any { it.contains(id) }
         }
         assert [resourceName].every { name ->
-            files.any {it.contains(name)}
+            files.any { it.contains(name) }
         }
 
     }
@@ -298,10 +281,3 @@ class ExportCommandSpec extends spock.lang.Specification {
     }
 
 }
-
-
-
-
-
-
-

--- a/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
+++ b/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
@@ -1,0 +1,307 @@
+package org.codice.ddf.commands.catalog
+
+import ddf.catalog.CatalogFramework
+import ddf.catalog.data.BinaryContent
+import ddf.catalog.data.Metacard
+import ddf.catalog.data.impl.AttributeImpl
+import ddf.catalog.data.impl.MetacardImpl
+import ddf.catalog.data.impl.ResultImpl
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder
+import ddf.catalog.operation.QueryRequest
+import ddf.catalog.operation.ResourceRequest
+import ddf.catalog.operation.impl.QueryResponseImpl
+import ddf.catalog.operation.impl.ResourceResponseImpl
+import ddf.catalog.resource.ResourceNotFoundException
+import ddf.catalog.resource.impl.ResourceImpl
+import ddf.catalog.transform.MetacardTransformer
+import groovy.xml.MarkupBuilder
+import org.apache.karaf.shell.api.console.Session
+import org.osgi.framework.BundleContext
+import org.osgi.framework.ServiceReference
+
+import javax.activation.MimeType
+import java.nio.file.Paths
+import java.util.zip.ZipFile
+
+class ExportCommandSpec extends spock.lang.Specification {
+
+    ExportCommand exportCommand
+
+    CatalogFramework catalogFramework
+
+    MetacardTransformer xmlTransformer
+
+    File tmpHomeDir
+
+    void setup() {
+        tmpHomeDir = File.createTempDir()
+        System.setProperty("ddf.home", tmpHomeDir.canonicalPath)
+
+        ServiceReference xmlTransformerReference = Mock(ServiceReference)
+
+        xmlTransformer = Mock(MetacardTransformer)
+
+        xmlTransformer.transform(_ as Metacard, _ as Map) >> { metacard, map ->
+            metacardToXmlTransformer(metacard, map)
+        }
+
+        BundleContext bundleContext = Mock(BundleContext) {
+            getServiceReferences(MetacardTransformer, '(id=xml)') >> [xmlTransformerReference]
+            getService(xmlTransformerReference) >> xmlTransformer
+        }
+
+        catalogFramework = Mock(CatalogFramework)
+        catalogFramework.query(_ as QueryRequest) >> { QueryRequest req ->
+            new QueryResponseImpl(req, [], 0)
+        }
+        catalogFramework.getLocalResource(_ as ResourceRequest) >> {
+            throw new ResourceNotFoundException('Could not find exception')
+        }
+
+        exportCommand = new ExportCommand(filterBuilder: new GeotoolsFilterBuilder(),
+                bundleContext: bundleContext, catalogFramework: catalogFramework)
+
+    }
+
+    void cleanup() {
+        assert tmpHomeDir?.deleteDir()
+    }
+
+    def "Test export no items"() {
+        setup:
+        exportCommand.with {
+            delete = false
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        notThrown(Exception)
+    }
+
+    def "Test filename that already exists"() {
+        setup:
+        def file = Paths.get(System.getProperty('ddf.home'), 'filealreadyexists').toFile()
+        file.createNewFile()
+        exportCommand.with {
+            delete = false
+            output = file.canonicalPath
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "Test bad parent file"() {
+        setup:
+        def file = Mock(File) { // This is really dirty and regardless that it works its bad
+            getParentFile() >> null // and I should feel bad and delete this.
+        }
+        exportCommand.with {
+            delete = false
+            output = file // <- setting a String field to a File Mock object that just happens to
+        }                   // get passed to the new File() constructor and so actually passes mock
+        // object on to the actual class to be used.
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "Test bad file name"() {
+        setup:
+        def file = Paths.get(System.getProperty('ddf.home'), 'badFilename.notazip')
+        exportCommand.with {
+            delete = false
+            output = file
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "Test abort command"() {
+        setup:
+        InputStream keyboardInput = new ByteArrayInputStream("n\r".getBytes('utf-8'))
+        Session session = Mock(Session) {
+            getKeyboard() >> keyboardInput
+        }
+        exportCommand.with {
+            it.delete = true
+            it.session = session
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        notThrown(Exception)
+        tmpHomeDir.list() == [] // dir is empty
+    }
+
+    def "Test single metacard no content export"() {
+        setup:
+        exportCommand.with {
+            it.delete = false
+        }
+
+        def attributes = simpleAttributes()
+        attributes.remove(Metacard.RESOURCE_URI) // removed Resource URI simulates no content
+        def result = new ResultImpl(simpleMetacard(attributes))
+        exportCommand.catalogFramework = Mock(CatalogFramework) {
+            query(_ as QueryRequest) >> { QueryRequest req ->
+                new QueryResponseImpl(req, [result], 1)
+            }
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        notThrown(Exception)
+        tmpHomeDir.list().size() == 1
+
+        String zip = tmpHomeDir.listFiles().find()?.canonicalPath
+        assert zip?.trim() as boolean // null or empty
+        assert zip.endsWith('.zip')
+
+        def files = new ZipFile(zip).entries()
+                .collect { it.isDirectory() ? null : it.name }
+                .findAll { it != null }
+
+        assert [result.metacard.id].every { id ->
+            files.any { it.contains(id) }
+        }
+
+
+    }
+
+    def "Test single metacard with content export"() {
+        setup:
+        exportCommand.with {
+            it.delete = false
+        }
+
+        def result = new ResultImpl(simpleMetacard(simpleAttributes() + [(Metacard.TAGS): [Metacard.DEFAULT_TAG]]))
+        def resourceName = "contentfor-${result.metacard.id}.xml" as String
+        exportCommand.catalogFramework = Mock(CatalogFramework) {
+            query(_ as QueryRequest) >> { QueryRequest req ->
+                new QueryResponseImpl(req, [result], 1)
+            }
+            getLocalResource(_ as ResourceRequest) >> { ResourceRequest req ->
+                BinaryContent xmlContent = getMetacardToXmlTransformer()(result.metacard, [:])
+
+                return new ResourceResponseImpl(req, [:], new ResourceImpl(xmlContent.inputStream,
+                        new MimeType('text/xml'),
+                        resourceName))
+            }
+        }
+
+        when:
+        exportCommand.executeWithSubject()
+
+        then:
+        notThrown(Exception)
+        tmpHomeDir.list().size() == 1
+        tmpHomeDir.list().find()?.endsWith('.zip')
+
+        String zip = tmpHomeDir.listFiles().find()?.canonicalPath
+        assert zip?.trim() as boolean // null or empty
+        assert zip.endsWith('.zip')
+
+        def files = new ZipFile(zip).entries()
+                .collect { it.isDirectory() ? null : it.name }
+                .findAll { it != null }
+        println(files)
+        assert [result.metacard.id].every { id ->
+            files.any { it.contains(id) }
+        }
+        assert [resourceName].every { name ->
+            files.any {it.contains(name)}
+        }
+
+    }
+
+/**************************************************************************
+ *
+ * Utility Methods
+ *
+ *************************************************************************/
+
+    Metacard simpleMetacard(Map kwargs) {
+        Metacard metacard = new MetacardImpl()
+        kwargs.forEach({ key, val ->
+            if (key != null && val != null) {
+                metacard.setAttribute(new AttributeImpl(key, val))
+            }
+        })
+        return metacard
+    }
+
+    Map simpleAttributes() {
+        String id = randomUUID()
+        [
+                (Metacard.ID)          : id,
+                (Metacard.TITLE)       : 'Metacard Title',
+                (Metacard.RESOURCE_URI): "content:$id".toString(),
+        ]
+    }
+
+    String randomUUID() {
+        UUID.randomUUID().toString().replaceAll('-', '')
+    }
+
+    Map namespaces = ['xmlns'         : 'urn:catalog:metacard',
+                      'xmlns:gml'     : 'http://www.opengis.net/gml',
+                      'xmlns:xlink'   : 'http://www.w3.org/1999/xlink',
+                      'xmlns:smil'    : 'http://www.w3.org/2001/SMIL20/',
+                      'xmlns:smillang': 'http://www.w3.org/2001/SMIL20/Language']
+
+    Closure metacardToXmlTransformer = {
+            //    BiFunction<Metacard, Map, BinaryContent> metacardToXmlTransformer = {
+        Metacard metacard, Map properties ->
+            def sw = new StringWriter()
+            def xml = new MarkupBuilder(sw)
+            xml.metacard(namespaces) {
+                type("${metacard.metacardType.name}")
+                if (metacard.sourceId) {
+                    source("${metacard.sourceId}")
+                }
+                metacard.metacardType.attributeDescriptors.each { ad ->
+                    if (metacard.getAttribute(ad.name) != null) {
+                        "${ad.type.attributeFormat.toString().toLowerCase()}"('name': "${ad.name}") {
+                            metacard.getAttribute(ad.name).values.each {
+                                'value'(it)
+                            }
+                        }
+                    }
+                }
+            }
+
+            final String data = sw.toString()
+
+            return [
+                    getInputStream  : { -> new ByteArrayInputStream(data.bytes) },
+                    getMimeType     : { -> new MimeType('text/xml') },
+                    getMimeTypeValue: { -> 'text/xml' },
+                    getSize         : data.&length,
+                    getByteArray    : data.&getBytes
+            ] as BinaryContent
+    }
+
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
#### What does this PR do?
 - Removes `-d` delete alias from export command
 - Short circuits trying to sign zip if nothing was exported
 - Added unit tests for Export Command
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@adimka @bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
1. Ensure -d command has no conflicts
2. Ensure on an export with no metacards or content there are no errors in the log
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2698

#### Checklist:
- [x] Update / Add Unit Tests
