### PR TITLE
DDF-3004 Moved Default Tag behavior to JSON

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -15,13 +15,11 @@ package ddf.catalog.plugin.groomer.metacard;
 
 import java.io.Serializable;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,11 +66,6 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
 
         if (aMetacard.getEffectiveDate() == null) {
             aMetacard.setAttribute(new AttributeImpl(Metacard.EFFECTIVE, now));
-        }
-
-        if (CollectionUtils.isEmpty(aMetacard.getTags())) {
-            aMetacard.setAttribute(new AttributeImpl(Metacard.TAGS,
-                    Collections.singletonList(Metacard.DEFAULT_TAG)));
         }
 
         if (isDateAttributeEmpty(aMetacard, Core.METACARD_CREATED)) {
@@ -133,11 +126,6 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
 
         if (aMetacard.getEffectiveDate() == null) {
             aMetacard.setAttribute(new AttributeImpl(Metacard.EFFECTIVE, now));
-        }
-
-        if (CollectionUtils.isEmpty(aMetacard.getTags())) {
-            aMetacard.setAttribute(new AttributeImpl(Metacard.TAGS,
-                    Collections.singletonList(Metacard.DEFAULT_TAG)));
         }
 
         // upon an update operation, the metacard modified time should be updated

--- a/distribution/ddf-common/src/main/resources/etc/definitions/core-attribute-injectors.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/core-attribute-injectors.json
@@ -3,5 +3,11 @@
     {
       "attribute": "point-of-contact"
     }
+  ],
+  "defaults": [
+    {
+      "attribute": "metacard-tags",
+      "value": "resource"
+    }
   ]
 }

--- a/distribution/test/itests/test-itests-common/src/main/resources/modified-metacard-2.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/modified-metacard-2.xml
@@ -40,10 +40,9 @@
     <string name="metadata-content-type">
         <value>myContentType</value>
     </string>
-    <string name="metacard-tags">
-        <value>GAMMA</value>
-        <value>DELTA</value>
-        <value>FOXTROT</value>
-        <value>resource</value>
+    <string name="resource.derived-download-url">
+        <value>http://example.com/1</value>
+        <value>http://example.com/2</value>
+        <value>http://example.com/3</value>
     </string>
 </metacard>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -1307,16 +1307,14 @@ public class TestCatalog extends AbstractIntegrationTest {
         Used for validation */
         final Matcher<Node> hasInitialDescription = hasMetacardAttributeXPath("description",
                 "Lombardi");
-        final Matcher<Node> hasInitialMetacardTags = hasMetacardAttributeXPath("metacard-tags",
-                "GAMMA",
-                "DELTA",
-                "FOXTROT",
-                "resource");
+        final Matcher<Node> hasInitialDerivedUrls = hasMetacardAttributeXPath("resource.derived-download-url",
+                "http://example.com/1",
+                "http://example.com/2",
+                "http://example.com/3");
         final Matcher<Node> hasNewDescription = hasMetacardAttributeXPath("description", "None");
-        final Matcher<Node> hasNewMetacardTags = hasMetacardAttributeXPath("metacard-tags",
-                "ALPHA",
-                "BRAVO",
-                "resource");
+        final Matcher<Node> hasNewDerivedUrls = hasMetacardAttributeXPath("resource.derived-download-url",
+                "http://example.com/4",
+                "http://example.com/5");
         final Matcher<Node> hasNewSecurityAccessGroups = hasMetacardAttributeXPath(
                 "security.access-groups",
                 "FIFA",
@@ -1338,7 +1336,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "security.access-groups = FIFA, NFL");
 
         List<Object> attributeAdjustmentsForRule2 = ImmutableList.of("description = None",
-                "metacard-tags = ALPHA, BRAVO, resource");
+                "resource.derived-download-url = http://example.com/4, http://example.com/5");
 
         networkRule1Properties.put("criteriaKey", "remoteAddr");
         networkRule1Properties.put("expectedValue", clientIP);
@@ -1368,14 +1366,14 @@ public class TestCatalog extends AbstractIntegrationTest {
             Note only the first validation gets security since it's parsed by tika */
             getMetacardValidatableResponse(simpleProductId).assertThat()
                     .body(hasNewDescription)
-                    .body(hasNewMetacardTags)
+                    .body(hasNewDerivedUrls)
                     .body(hasNewSecurityAccessGroups);
             getMetacardValidatableResponse(card1Id).assertThat()
                     .body(hasInitialDescription)
-                    .body(hasNewMetacardTags);
+                    .body(hasNewDerivedUrls);
             getMetacardValidatableResponse(card2Id).assertThat()
                     .body(hasNewDescription)
-                    .body(hasInitialMetacardTags);
+                    .body(hasInitialDerivedUrls);
 
         } finally {
 


### PR DESCRIPTION
#### What does this PR do?
This PR removes the logic to set default tags from the StandardMetacardGroomerPlugin and adds a JSON configuration instead.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @troymohl 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@clockard 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Ingest and verify tags are set
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3004](https://codice.atlassian.net/browse/DDF-3004)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
