### PR TITLE
DDF-2927 Started the subscription service by adding a persistor and its data model

### DIFF
--- a/catalog/core/catalog-core-subscriptionstore/pom.xml
+++ b/catalog/core/catalog-core-subscriptionstore/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>core</artifactId>
+        <groupId>ddf.catalog.core</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>DDF :: Catalog :: Core :: Subscription Store</name>
+    <artifactId>catalog-core-subscriptionstore</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>subscriptionstore-internal-api</module>
+        <module>subscriptionstore-impl</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/pom.xml
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>catalog-core-subscriptionstore</artifactId>
+        <groupId>ddf.catalog.core</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>DDF :: Catalog :: Core :: Subscription Store Impl</name>
+    <artifactId>subscriptionstore-impl</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.persistence.core</groupId>
+            <artifactId>persistence-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>subscriptionstore-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.88</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionMetadata.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionMetadata.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.common;
+
+import java.util.UUID;
+
+import org.codice.ddf.catalog.subscriptionstore.internal.MarshalledSubscription;
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An immutable data object for storing subscriptions in the {@link org.codice.ddf.persistence.PersistentStore}.
+ * <p>
+ * {@link SubscriptionMetadata} wraps a serialized {@link ddf.catalog.event.Subscription} with no assumption as
+ * to the specific serialization format, only the guarantee that metadata objects with the same <i>type</i> are
+ * the same format. That means metadata objects with the same <i>type</i> can be serialized and deserialized the
+ * same way, using the same instance of {@link org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionFactory}.
+ */
+public class SubscriptionMetadata implements SubscriptionIdentifier, MarshalledSubscription {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionMetadata.class);
+
+    private static final String URN_UUID = "urn:uuid:";
+
+    private final String id;
+
+    private final String type;
+
+    private final String filter;
+
+    private final String callbackAddress;
+
+    public SubscriptionMetadata(String type, String filter, String callbackAddress) {
+        this(type,
+                filter, callbackAddress,
+                URN_UUID + UUID.randomUUID()
+                        .toString());
+    }
+
+    public SubscriptionMetadata(String type, String filter, String callbackAddress, String id) {
+        this.type = type;
+        this.filter = filter;
+        this.callbackAddress = callbackAddress;
+        this.id = id;
+
+        LOGGER.trace("Created subscription metadata object: {} | {} | {}", id, type,
+                callbackAddress);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getTypeName() {
+        return type;
+    }
+
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public String getCallbackAddress() {
+        return callbackAddress;
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistor.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistor.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.common;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.Validate.notEmpty;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionStoreException;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.persistence.PersistentItem;
+import org.codice.ddf.persistence.PersistentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A common persistence layer for all subscriptions targeting the {@link PersistentStore}.
+ * <p>
+ * The {@link SubscriptionPersistor} serves as the data-access object for all {@link ddf.catalog.event.Subscription}s
+ * across any endpoint. The object that actually gets stored is a {@link SubscriptionMetadata}, but combined
+ * with a {@link org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionFactory}, the
+ * original {@code Subscription} object can be re-created and registered with the OSGi framework.
+ * <p>
+ * {@code SubscriptionPersistor} knows how to marshall and unmarshall between {@code SubscriptionMetadata}
+ * and {@link PersistentItem}, effectively hiding the persistence details of subscriptions from the rest
+ * of the service.
+ */
+public class SubscriptionPersistor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionPersistor.class);
+
+    private static final String ECQL_FORMAT = "\"%s_txt\" LIKE '%s'";
+
+    private static final String VERSION_LABEL = "version";
+
+    private static final String VERSION = "1.0";
+
+    private static final String SUBSCRIPTION_ID_SOLR = "id";
+
+    private static final String SUBSCRIPTION_TYPE = "type";
+
+    private static final String SUBSCRIPTION_FILTER = "filter";
+
+    private static final String SUBSCRIPTION_CALLBACK = "callback";
+
+    private final PersistentStore persistentStore;
+
+    public SubscriptionPersistor(PersistentStore persistentStore) {
+        this.persistentStore = persistentStore;
+    }
+
+    /**
+     * Get all the subscription metadata objects in the persistent store, regardless of type.
+     *
+     * @return a map of subscription ids to their accompanying metadata.
+     * @throws SubscriptionStoreException if a problem occurs during the read.
+     */
+    public Map<String, SubscriptionMetadata> getSubscriptions() {
+        List<Map<String, Object>> results;
+        try {
+            results = persistentStore.get(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE);
+        } catch (PersistenceException e) {
+            throw new SubscriptionStoreException("Exception while reading subscriptions from Solr: ",
+                    e);
+        }
+
+        return results.stream()
+                .map(this::formatIfPersistentItem)
+                .map(this::mapToMetadata)
+                .collect(Collectors.toMap(SubscriptionMetadata::getId, Function.identity()));
+    }
+
+    /**
+     * Add the subscription metadata to the persistent store using its id for the document key.
+     * <p>
+     * Insertion operations with the same key overwrite the previous value, which means a duplicate
+     * being added is a no-op, minus the network overhead.
+     *
+     * @param metadata the subscription metadata to add to the persistent store.
+     * @throws SubscriptionStoreException if a problem occurs during insert.
+     */
+    public void insert(SubscriptionMetadata metadata) {
+        LOGGER.debug("Adding [{}] to persistence store. ", metadata.getId());
+        PersistentItem persistentSubscription = metadataToPersistentItem(metadata);
+        try {
+            persistentStore.add(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE, persistentSubscription);
+        } catch (PersistenceException e) {
+            throw new SubscriptionStoreException("Exception while persisting subscription: ", e);
+        }
+    }
+
+    /**
+     * Remove the subscription metadata from the persistent store that corresponds to the given id.
+     * <p>
+     * Redundant deletes are valid as a no-op to support javax.cache events propogating write-through
+     * processing to other cache nodes.
+     *
+     * @param subscriptionId the unique id of the subscription to delete.
+     * @throws SubscriptionStoreException if a problem occurs during delete.
+     */
+    public void delete(String subscriptionId) {
+        LOGGER.debug("Deleting [{}] from persistence store. ", subscriptionId);
+        try {
+            persistentStore.delete(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE,
+                    getEcqlStringForId(subscriptionId));
+        } catch (PersistenceException e) {
+            throw new SubscriptionStoreException("Exception while deleting subscription: ", e);
+        }
+    }
+
+    /**
+     * Given subscription metadata, transform it into a persistent item for storage.
+     */
+    private PersistentItem metadataToPersistentItem(SubscriptionMetadata metadata) {
+        notNull(metadata, "subscription metadata cannot be null");
+
+        PersistentItem persistentItem = new PersistentItem();
+        persistentItem.addProperty(VERSION_LABEL, VERSION);
+        persistentItem.addProperty(SUBSCRIPTION_ID_SOLR, metadata.getId());
+        persistentItem.addProperty(SUBSCRIPTION_TYPE, metadata.getTypeName());
+        persistentItem.addProperty(SUBSCRIPTION_FILTER, metadata.getFilter());
+        persistentItem.addProperty(SUBSCRIPTION_CALLBACK, metadata.getCallbackAddress());
+
+        return persistentItem;
+    }
+
+    /**
+     * Given a result from the persistent store, transform the map back into valid subscription
+     * metadata.
+     */
+    private SubscriptionMetadata mapToMetadata(Map<String, Object> map) {
+        notEmpty(map, "map cannot be null or empty");
+
+        String id = (String) map.get(SUBSCRIPTION_ID_SOLR);
+        String type = (String) map.get(SUBSCRIPTION_TYPE);
+        String serializedSubscription = (String) map.get(SUBSCRIPTION_FILTER);
+        String callback = (String) map.get(SUBSCRIPTION_CALLBACK);
+
+        return new SubscriptionMetadata(type, serializedSubscription, callback, id);
+    }
+
+    /**
+     * There may be {@link PersistentStore} implementations that do not use suffix-based key labeling.
+     * This pass-through method allows conditional formating of the retrieved results and tries to
+     * reduce the implementation-dependence of the solution.
+     */
+    private Map<String, Object> formatIfPersistentItem(Map<String, Object> map) {
+        if (map instanceof PersistentItem) {
+            return PersistentItem.stripSuffixes(map);
+        }
+        return map;
+    }
+
+    /**
+     * Generate the ECQL string used for deletes. It will select the entity with the provided
+     * {@code subscriptionId}.
+     */
+    private String getEcqlStringForId(String subscriptionId) {
+        return format(ECQL_FORMAT, SUBSCRIPTION_ID_SOLR, subscriptionId);
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistorTest.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistorTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionStoreException;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.persistence.PersistentStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriptionPersistorTest {
+
+    private static final String ECQL_FOR_ID = "\"id_txt\" LIKE 'df-87-6g-11'";
+
+    private static final String SUBSCRIPTION_ID = "df-87-6g-11";
+
+    private static final String SUBSCRIPTION_TYPE = "csw";
+
+    private static final String SUBSCRIPTION_CALLBACK = "https://localhost:8993/test";
+
+    private static final String SUBSCRIPTION_FILTER = "<xml>filter here</xml>";
+
+    @Mock
+    private PersistentStore mockPersistentStore;
+
+    private SubscriptionPersistor persistor;
+
+    private SubscriptionMetadata metadata;
+
+    private Map<String, Object> nonPersistentItemResponse;
+
+    @Before
+    public void setup() throws Exception {
+        metadata = new SubscriptionMetadata(SUBSCRIPTION_TYPE,
+                SUBSCRIPTION_FILTER,
+                SUBSCRIPTION_CALLBACK,
+                SUBSCRIPTION_ID);
+
+        nonPersistentItemResponse = new HashMap<>();
+        nonPersistentItemResponse.put("id", SUBSCRIPTION_ID);
+        nonPersistentItemResponse.put("type", SUBSCRIPTION_TYPE);
+        nonPersistentItemResponse.put("callback", SUBSCRIPTION_CALLBACK);
+        nonPersistentItemResponse.put("filter", SUBSCRIPTION_FILTER);
+
+        persistor = new SubscriptionPersistor(mockPersistentStore);
+    }
+
+    @Test
+    public void testValidInsert() throws Exception {
+        persistor.insert(metadata);
+        verify(mockPersistentStore).add(eq(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE), anyMap());
+        verifyNoMoreInteractions(mockPersistentStore);
+    }
+
+    @Test(expected = SubscriptionStoreException.class)
+    public void testInsertThrowsException() throws Exception {
+        doThrow(PersistenceException.class).when(mockPersistentStore)
+                .add(anyString(), anyObject());
+        persistor.insert(metadata);
+    }
+
+    @Test
+    public void testValidDelete() throws Exception {
+        persistor.delete(SUBSCRIPTION_ID);
+        verify(mockPersistentStore).delete(eq(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE),
+                eq(ECQL_FOR_ID));
+        verifyNoMoreInteractions(mockPersistentStore);
+    }
+
+    @Test(expected = SubscriptionStoreException.class)
+    public void testDeleteThrowsException() throws Exception {
+        doThrow(PersistenceException.class).when(mockPersistentStore)
+                .delete(anyString(), anyString());
+        persistor.delete(SUBSCRIPTION_ID);
+    }
+
+    @Test
+    public void testInsertAndGetForPersistentItemRoundTrip() {
+        persistor = new SubscriptionPersistor(new SingleItemPersistentStore());
+        persistor.insert(metadata);
+
+        Map<String, SubscriptionMetadata> results = persistor.getSubscriptions();
+        SubscriptionMetadata resultMetadata = results.get(SUBSCRIPTION_ID);
+        verifyIfMetadataIsCorrect(resultMetadata);
+    }
+
+    @Test
+    public void testGetWhenResultIsNotPersistentItem() throws Exception {
+        when(mockPersistentStore.get(eq(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE))).thenReturn(
+                Collections.singletonList(nonPersistentItemResponse));
+        Map<String, SubscriptionMetadata> results = persistor.getSubscriptions();
+        SubscriptionMetadata resultMetadata = results.get(SUBSCRIPTION_ID);
+        verifyIfMetadataIsCorrect(resultMetadata);
+    }
+
+    @Test(expected = SubscriptionStoreException.class)
+    public void testGetThrowsException() throws Exception {
+        doThrow(PersistenceException.class).when(mockPersistentStore)
+                .get(anyString());
+        persistor.getSubscriptions();
+    }
+
+    private void verifyIfMetadataIsCorrect(SubscriptionMetadata resultMetadata) {
+        assertThat("Metadata should not be null. ", resultMetadata != null);
+
+        assertThat("Metadata IDs should match. ",
+                metadata.getId()
+                        .equals(resultMetadata.getId()));
+        assertThat("Metadata types should match. ",
+                metadata.getTypeName()
+                        .equals(resultMetadata.getTypeName()));
+        assertThat("Metadata callbacks should match. ",
+                metadata.getCallbackAddress()
+                        .equals(resultMetadata.getCallbackAddress()));
+        assertThat("Metadata filters should match. ",
+                metadata.getFilter()
+                        .equals(resultMetadata.getFilter()));
+    }
+
+    /**
+     * Keep a reference to the last item added to the persistent store.
+     */
+    private static class SingleItemPersistentStore implements PersistentStore {
+        private Map<String, Object> data;
+
+        public SingleItemPersistentStore() {
+        }
+
+        @Override
+        public void add(String type, Map<String, Object> properties) throws PersistenceException {
+            assertThat("Version should be present",
+                    properties.containsKey("version_txt"),
+                    is(true));
+            data = properties;
+        }
+
+        @Override
+        public List<Map<String, Object>> get(String type) throws PersistenceException {
+            if (data == null) {
+                return Collections.emptyList();
+            }
+            return Collections.singletonList(data);
+        }
+
+        @Override
+        public List<Map<String, Object>> get(String type, String ecql) throws PersistenceException {
+            if (data == null) {
+                return Collections.emptyList();
+            }
+            return Collections.singletonList(data);
+        }
+
+        @Override
+        public int delete(String type, String ecql) throws PersistenceException {
+            if (data == null) {
+                return 0;
+            }
+            data = null;
+            return 1;
+        }
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/pom.xml
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>catalog-core-subscriptionstore</artifactId>
+        <groupId>ddf.catalog.core</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>DDF :: Catalog :: Core :: Subscription Store API</name>
+    <artifactId>subscriptionstore-internal-api</artifactId>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            org.codice.ddf.catalog.subscriptionstore.internal.*
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/MarshalledSubscription.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/MarshalledSubscription.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.internal;
+
+/**
+ * Describes the pieces of a {@link ddf.catalog.event.Subscription} that can be immediately serialized
+ * without any special factory logic.
+ * <p>
+ * <b>This interface is for internal use only and should not be implemented by a third party. </b>
+ * <i>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</i>
+ */
+public interface MarshalledSubscription {
+
+    /**
+     * Get the subscription filter as a marshalled string. This can be JSON, XML with any schema, etc.
+     * No guarantees are made to the format of this String, only that providing it to the correct
+     * {@link SubscriptionFactory} will yield a valid instance of {@code Subscription}.
+     *
+     * @return the marshalled subscription filter.
+     */
+    String getFilter();
+
+    /**
+     * Get the subscription callback address. While current endpoints conform to using a {@link java.net.URL}
+     * for their {@link ddf.catalog.event.DeliveryMethod}, this is not a guarantee.
+     *
+     * @return the callback address to send events to for this {@code Subscription}.
+     */
+    String getCallbackAddress();
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionIdentifier.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionIdentifier.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.internal;
+
+/**
+ * Encapsulates all necessary information to identify a single subscription within the
+ * {@link SubscriptionContainer}.
+ * <p>
+ * <b>This interface is for internal use only and should not be implemented by a third party. </b>
+ * <i>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</i>
+ */
+public interface SubscriptionIdentifier extends SubscriptionType {
+
+    /**
+     * Uniquely identifies a single subscription for a given type in the {@link SubscriptionContainer}.
+     *
+     * @return a subscription's unique key.
+     */
+    String getId();
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionStoreException.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionStoreException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.internal;
+
+/**
+ * Exception specific to the subscription store, where the process of saving and loading subscriptions
+ * has failed.
+ * <p>
+ * <b>This interface is for internal use only and should not be implemented by a third party. </b>
+ * <i>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</i>
+ */
+public class SubscriptionStoreException extends RuntimeException {
+    public SubscriptionStoreException() {
+    }
+
+    public SubscriptionStoreException(String message) {
+        super(message);
+    }
+
+    public SubscriptionStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SubscriptionStoreException(Throwable cause) {
+        super(cause);
+    }
+
+    public SubscriptionStoreException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionType.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionType.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.internal;
+
+/**
+ * Uniquely identifies a consumer of subscription services. There should be a 1-to-1 correspondence
+ * between a type and a consumer's {@link SubscriptionFactory} that gets registered with OSGi. Consumers
+ * must ensure the value for {@link SubscriptionType#getTypeName()} is always:
+ * <ol>
+ * <li>Unique across all API consumers</li>
+ * <li>Consistent across all {@link SubscriptionType}s, including {@link SubscriptionIdentifier}
+ * and {@link SubscriptionFactory} implementations</li>
+ * </ol>
+ * <p>
+ * <b>This interface is for internal use only and should not be implemented by a third party. </b>
+ * <i>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</i>
+ *
+ * @see SubscriptionIdentifier
+ */
+public interface SubscriptionType {
+
+    /**
+     * Retrieve a unique type.
+     *
+     * @return the type identifier.
+     */
+    String getTypeName();
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -122,5 +122,6 @@
         <module>catalog-core-tagsfilterplugin</module>
         <module>catalog-core-downloadaction</module>
         <module>catalog-core-metacardtype</module>
+        <module>catalog-core-subscriptionstore</module>
     </modules>
 </project>

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
@@ -21,25 +21,25 @@ import java.util.Set;
 
 public interface PersistentStore {
 
-    public static final String METACARD_TYPE = "metacard";
-    public static final String SAVED_QUERY_TYPE = "saved_query";
-    public static final String NOTIFICATION_TYPE = "notification";
-    public static final String ACTIVITY_TYPE = "activity";
-    public static final String WORKSPACE_TYPE = "workspace";
-    public static final String PREFERENCES_TYPE = "preferences";
-    public static final String USER_ATTRIBUTE_TYPE = "attributes";
-    public static final String SUBSCRIPTION_TYPE = "subscriptions";
+    String METACARD_TYPE = "metacard";
+    String SAVED_QUERY_TYPE = "saved_query";
+    String NOTIFICATION_TYPE = "notification";
+    String ACTIVITY_TYPE = "activity";
+    String WORKSPACE_TYPE = "workspace";
+    String PREFERENCES_TYPE = "preferences";
+    String USER_ATTRIBUTE_TYPE = "attributes";
+    String SUBSCRIPTION_TYPE = "subscriptions";
+    String EVENT_SUBSCRIPTIONS_TYPE = "event_subscriptions";
 
-
-    public static final Set<String> PERSISTENCE_TYPES = new HashSet<String>(Arrays.asList(
-            METACARD_TYPE,
+    Set<String> PERSISTENCE_TYPES = new HashSet<String>(Arrays.asList(METACARD_TYPE,
             SAVED_QUERY_TYPE,
             NOTIFICATION_TYPE,
             ACTIVITY_TYPE,
             WORKSPACE_TYPE,
             PREFERENCES_TYPE,
             USER_ATTRIBUTE_TYPE,
-            SUBSCRIPTION_TYPE));
+            SUBSCRIPTION_TYPE,
+            EVENT_SUBSCRIPTIONS_TYPE));
 
     /**
      * Adds item of specified type with the specified properties.


### PR DESCRIPTION
#### What does this PR do?
_DDF-2927 PR 1 out of 4._ 
The SubscriptionPersistor will be used within the cache loader and writer. It talks to the Persistent Store, specifically the `event_subscriptions` core. It operates on SubscriptionMetadata, which contains the serializable parts of a complete Subscription object. 

#### Who is reviewing it?
@brjeter 
@paouelle 
@lessarderic 
@shaundmorris 
@ryeats 
@rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Solr](https://github.com/orgs/codice/teams/solr)
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR.
@figliold 
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Part 1 of 4 is not testable by the end user, as it exposes no functionality. Please refer to the unit tests. 

#### Any background context you want to provide?
This is part of an effort to centralize durable subscriptions to Solr. Later on, there are high availability implications and benefits. 

#### What are the relevant tickets?
[DDF-2927](https://codice.atlassian.net/browse/DDF-2927)

#### Checklist:
- [x] Documentation Updated - N/A
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests - N/A
