### PR TITLE
DDF-2698 Now remove exported items from cache

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -199,6 +199,7 @@ public class ExportCommand extends CqlCommands {
 
         if (delete) {
             doDelete(exportedItems, exportedContentItems);
+
         }
 
         if (!unsafe) {
@@ -385,6 +386,7 @@ public class ExportCommand extends CqlCommands {
                 printErrorMessage(
                         "Could not delete content for metacard: " + exportedContentItem.toString());
             }
+
         }
         for (ExportItem exported : exportedItems) {
             try {
@@ -392,6 +394,18 @@ public class ExportCommand extends CqlCommands {
             } catch (IngestException e) {
                 printErrorMessage("Could not delete metacard: " + exported.toString());
             }
+        }
+
+        // delete items from cache
+        try {
+            getCacheProxy().removeById(exportedItems.stream()
+                    .map(ExportItem::getId)
+                    .collect(Collectors.toList())
+                    .toArray(new String[exportedItems.size()]));
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Could not delete all exported items from cache (Results will eventually expire)",
+                    e);
         }
 
         console.println("Metacards and Content deleted in: " + getFormattedDuration(start));


### PR DESCRIPTION
#### What does this PR do?
 - When delete is enabled, we now remove items from the cache so cached items don't get returned in results

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@vinamartin @peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested? (List steps with links to updated documentation)
Run search of archived items to populate cache, Export with delete enabled `--delete=true`, ensure that no items get returned from UI search.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2698
