### PR TITLE
DDF-3009 Added service to generate Metacard UUIDs

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/data/impl/ContentItemImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/data/impl/ContentItemImpl.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.UUID;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
@@ -52,22 +51,6 @@ public class ContentItemImpl implements ContentItem {
     private Metacard metacard;
 
     protected String qualifier;
-
-    /**
-     * An incoming content item whose ID will initially be
-     * <code>null</code> because the {@link ddf.catalog.CatalogFramework} will assign its GUID.
-     *
-     * @param byteSource      the {@link ContentItem}'s input stream containing its actual data
-     * @param mimeTypeRawData the {@link ContentItem}'s mime type
-     * @param filename        the {@link ContentItem}'s file name - can be null
-     * @param metacard        the {@link ContentItem}'s associated metacard
-     */
-    public ContentItemImpl(ByteSource byteSource, String mimeTypeRawData, String filename,
-            Metacard metacard) {
-        this(UUID.randomUUID()
-                .toString()
-                .replaceAll("-", ""), byteSource, mimeTypeRawData, filename, 0, metacard);
-    }
 
     /**
      * An incoming content item where the item's GUID should be known.

--- a/catalog/core/catalog-core-camelcomponent/pom.xml
+++ b/catalog/core/catalog-core-camelcomponent/pom.xml
@@ -104,6 +104,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponent.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentComponent.java
@@ -17,7 +17,8 @@ import java.util.Map;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.impl.DefaultComponent;
-import org.osgi.framework.BundleContext;
+
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +33,11 @@ public class ContentComponent extends DefaultComponent {
 
     private static final transient Logger LOGGER = LoggerFactory.getLogger(ContentComponent.class);
 
-    private BundleContext bundleContext;
-
     private CatalogFramework catalogFramework;
 
     private MimeTypeMapper mimeTypeMapper;
+
+    private UuidGenerator uuidGenerator;
 
     public ContentComponent() {
         super();
@@ -83,6 +84,14 @@ public class ContentComponent extends DefaultComponent {
 
     public void setMimeTypeMapper(MimeTypeMapper mimeTypeMapper) {
         this.mimeTypeMapper = mimeTypeMapper;
+    }
+
+    public void setUuidGenerator(UuidGenerator uuidGenerator) {
+        this.uuidGenerator = uuidGenerator;
+    }
+
+    public UuidGenerator getUuidGenerator() {
+        return uuidGenerator;
     }
 
 }

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
@@ -23,6 +23,7 @@ import org.apache.camel.ExchangePattern;
 import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultProducer;
 import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +45,7 @@ public class ContentProducer extends DefaultProducer {
 
     private ContentEndpoint endpoint;
 
-    ContentProducerDataAccessObject contentProducerDataAccessObject =
-            new ContentProducerDataAccessObject();
+    ContentProducerDataAccessObject contentProducerDataAccessObject;
 
     /**
      * Constructs the {@link org.apache.camel.Producer} for the custom Camel ContentComponent. This producer would
@@ -56,7 +56,12 @@ public class ContentProducer extends DefaultProducer {
     public ContentProducer(ContentEndpoint endpoint) {
         super(endpoint);
         this.endpoint = endpoint;
-
+        ContentComponent contentComponent = endpoint.getComponent();
+        UuidGenerator uuidGenerator = null;
+        if (contentComponent != null) {
+            uuidGenerator = contentComponent.getUuidGenerator();
+        }
+        this.contentProducerDataAccessObject = new ContentProducerDataAccessObject(uuidGenerator);
         LOGGER.trace("INSIDE: ContentProducer constructor");
     }
 

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObject.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObject.java
@@ -29,6 +29,7 @@ import org.apache.camel.Message;
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileMessage;
 import org.apache.commons.io.FilenameUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,12 @@ import ddf.mime.MimeTypeMapper;
 import ddf.mime.MimeTypeResolutionException;
 
 public class ContentProducerDataAccessObject {
+
+    private UuidGenerator uuidGenerator;
+
+    public ContentProducerDataAccessObject(UuidGenerator uuidGenerator) {
+        this.uuidGenerator = uuidGenerator;
+    }
 
     private static final transient Logger LOGGER = LoggerFactory.getLogger(
             ContentProducerDataAccessObject.class);
@@ -131,8 +138,13 @@ public class ContentProducerDataAccessObject {
 
         if (StandardWatchEventKinds.ENTRY_CREATE.equals(eventType)) {
             CreateStorageRequest createRequest =
-                    new CreateStorageRequestImpl(Collections.singletonList(new ContentItemImpl(Files.asByteSource(
-                            ingestedFile), mimeType, ingestedFile.getName(), null)), null);
+                    new CreateStorageRequestImpl(Collections.singletonList(new ContentItemImpl(
+                            uuidGenerator.generateUuid(),
+                            Files.asByteSource(ingestedFile),
+                            mimeType,
+                            ingestedFile.getName(),
+                            0L,
+                            null)), null);
 
             processHeaders(headers, createRequest, ingestedFile);
 

--- a/catalog/core/catalog-core-camelcomponent/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-camelcomponent/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,6 +23,8 @@
 
     <reference id="framework" interface="ddf.catalog.CatalogFramework"/>
 
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
+
     <!--
     Instantiate our custom Camel CatalogComponent and inject this bundle context into it.  
     -->
@@ -58,6 +60,7 @@
     <bean id="contentComponent" class="ddf.camel.component.catalog.content.ContentComponent">
         <property name="catalogFramework" ref="framework"/>
         <property name="mimeTypeMapper" ref="mimeTypeMapper"/>
+        <property name="uuidGenerator" ref="uuidGenerator"/>
     </bean>
 
     <!--

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,10 +32,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.camel.component.file.GenericFile;
 import org.apache.camel.component.file.GenericFileMessage;
 import org.apache.commons.collections.map.HashedMap;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -58,8 +62,15 @@ public class ContentProducerDataAccessObjectTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    ContentProducerDataAccessObject contentProducerDataAccessObject =
-            new ContentProducerDataAccessObject();
+    ContentProducerDataAccessObject contentProducerDataAccessObject;
+
+    @Before
+    public void setUp() {
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        when((uuidGenerator.generateUuid())).thenReturn(UUID.randomUUID()
+                .toString());
+        contentProducerDataAccessObject = new ContentProducerDataAccessObject(uuidGenerator);
+    }
 
     @Test
     public void testGetFileUsingRefKey() throws Exception {

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerTest.java
@@ -17,12 +17,16 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.UUID;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Message;
+
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -47,6 +51,12 @@ public class ContentProducerTest {
         File testFile = testDir.newFile();
 
         mockEndpoint = mock(ContentEndpoint.class);
+
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        ContentComponent contentComponent = mock(ContentComponent.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+        when(mockEndpoint.getComponent()).thenReturn(contentComponent);
 
         Message mockMessage = mock(Message.class);
         doReturn(ImmutableMap.of(Constants.STORE_REFERENCE_KEY, true)).when(mockMessage)

--- a/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
+++ b/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
@@ -32,10 +32,12 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.geotools.filter.FilterFactoryImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -133,6 +135,10 @@ public class FederationStrategyTest {
     public void testQueryTimeout() throws Exception {
         long queryDelay = 100;
 
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         MockDelayProvider provider = new MockDelayProvider("Provider",
                 "Provider",
                 "v1.0",
@@ -162,7 +168,7 @@ public class FederationStrategyTest {
 
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(props.getMimeTypeToTransformerMapper());
+                new MetacardFactory(props.getMimeTypeToTransformerMapper(), uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(props,
                 metacardFactory);
 

--- a/catalog/core/catalog-core-metacardgroomerplugin/pom.xml
+++ b/catalog/core/catalog-core-metacardgroomerplugin/pom.xml
@@ -39,6 +39,11 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -47,8 +52,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Private-Package>ddf.catalog.plugin.groomer.metacard
-                        </Private-Package>
+                        <Private-Package>ddf.catalog.plugin.groomer.metacard</Private-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             catalog-core-api-impl;scope=!test,

--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -17,10 +17,8 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Date;
 import java.util.Map.Entry;
-import java.util.UUID;
-import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,18 +40,19 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
     private static final Logger LOGGER =
             LoggerFactory.getLogger(StandardMetacardGroomerPlugin.class);
 
-    private Pattern hexPattern = Pattern.compile("^[0-9A-Fa-f]+$");
+    private UuidGenerator uuidGenerator;
+
+    public void setUuidGenerator(UuidGenerator uuidGenerator) {
+        this.uuidGenerator = uuidGenerator;
+    }
 
     protected void applyCreatedOperationRules(CreateRequest createRequest, Metacard aMetacard,
             Date now) {
         LOGGER.debug("Applying standard rules on CreateRequest");
         if ((aMetacard.getResourceURI() != null
-                && !isCatalogResourceUri(aMetacard.getResourceURI())) || !isCorrectFormatId(
+                && !isCatalogResourceUri(aMetacard.getResourceURI())) || !uuidGenerator.validateUuid(
                 aMetacard.getId())) {
-            aMetacard.setAttribute(new AttributeImpl(Metacard.ID,
-                    UUID.randomUUID()
-                            .toString()
-                            .replaceAll("-", "")));
+            aMetacard.setAttribute(new AttributeImpl(Metacard.ID, uuidGenerator.generateUuid()));
         }
 
         if (aMetacard.getCreatedDate() == null) {
@@ -80,11 +79,6 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
 
     private boolean isCatalogResourceUri(URI uri) {
         return uri != null && ContentItem.CONTENT_SCHEME.equals(uri.getScheme());
-    }
-
-    private boolean isCorrectFormatId(String id) {
-        return !StringUtils.isEmpty(id) && id.length() == 32 && hexPattern.matcher(id)
-                .matches();
     }
 
     protected void applyUpdateOperationRules(UpdateRequest updateRequest,

--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,11 +11,14 @@
  *
  **/
 -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-        >
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
 
 	<!-- PreIngest Plugin -->
-    <bean id="plugin" class="ddf.catalog.plugin.groomer.metacard.StandardMetacardGroomerPlugin"/>
+    <bean id="plugin" class="ddf.catalog.plugin.groomer.metacard.StandardMetacardGroomerPlugin">
+        <property name="uuidGenerator" ref="uuidGenerator" />
+    </bean>
 
     <!-- Register in the OSGi Service Registry -->
     <service ref="plugin" interface="ddf.catalog.plugin.PreIngestPlugin" ranking="1000"/>

--- a/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/TestMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/TestMetacardGroomerPlugin.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +40,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.UUID;
 
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Test;
 
 import ddf.catalog.content.data.ContentItem;
@@ -81,11 +84,22 @@ public class TestMetacardGroomerPlugin {
 
     private static final String DEFAULT_METADATA = "<sample>sample</sample>";
 
+    private UuidGenerator uuidGenerator;
+
+    private StandardMetacardGroomerPlugin plugin;
+
+    @Before
+    public void setUp() {
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+        plugin = new StandardMetacardGroomerPlugin();
+        plugin.setUuidGenerator(uuidGenerator);
+    }
+
     @Test
     public void testCreateWithNullRequest()
         throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         CreateRequest returnedRequest = plugin.process((CreateRequest) null);
 
@@ -96,8 +110,6 @@ public class TestMetacardGroomerPlugin {
     @Test
     public void testCreateWithNullRecords()
         throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         CreateRequest request = mock(CreateRequest.class);
 
@@ -113,8 +125,6 @@ public class TestMetacardGroomerPlugin {
 
     @Test
     public void testCreateWithNoRecords() throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         CreateRequest request = mock(CreateRequest.class);
 
@@ -168,8 +178,8 @@ public class TestMetacardGroomerPlugin {
 
         Date snapshotOfNow = new Date();
 
-        String id = UUID.randomUUID().toString().replaceAll("-", "");
-
+        String id = UUID.randomUUID().toString();
+        when(uuidGenerator.validateUuid(anyString())).thenReturn(true);
         Metacard inputMetacard = getStandardMetacard(id);
         inputMetacard.setAttribute(
                 new AttributeImpl(Metacard.RESOURCE_URI, ContentItem.CONTENT_SCHEME + ":" + id));
@@ -242,7 +252,8 @@ public class TestMetacardGroomerPlugin {
 
         Date snapshotOfNow = new Date();
 
-        String id = UUID.randomUUID().toString().replaceAll("-", "");
+        String id = UUID.randomUUID().toString();
+        when(uuidGenerator.validateUuid(anyString())).thenReturn(true);
 
         Metacard inputMetacard = getStandardMetacard(id);
 
@@ -445,8 +456,6 @@ public class TestMetacardGroomerPlugin {
 
         DeleteRequest inputRequest = new DeleteRequestImpl(SAMPLE_ID);
 
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
-
         DeleteRequest returnedRequest = plugin.process(inputRequest);
 
         assertNotNull(returnedRequest);
@@ -533,8 +542,6 @@ public class TestMetacardGroomerPlugin {
         uris[0] = new URI(SAMPLE_ID);
         UpdateRequestImpl inputRequest = new UpdateRequestImpl(uris,
                 Arrays.asList(copy(inputMetacard)));
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         UpdateRequest returnedRequest = plugin.process(inputRequest);
 
@@ -624,8 +631,6 @@ public class TestMetacardGroomerPlugin {
     public void testUpdateWithNullRequest()
         throws PluginExecutionException, StopProcessingException {
 
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
-
         UpdateRequest returnedRequest = plugin.process((UpdateRequest) null);
 
         assertThat(returnedRequest, nullValue());
@@ -635,8 +640,6 @@ public class TestMetacardGroomerPlugin {
     @Test
     public void testUpdateWithNullRecords()
         throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         UpdateRequest request = mock(UpdateRequest.class);
 
@@ -652,8 +655,6 @@ public class TestMetacardGroomerPlugin {
 
     @Test
     public void testUpdateWithNoRecords() throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         UpdateRequest request = mock(UpdateRequest.class);
 
@@ -673,8 +674,6 @@ public class TestMetacardGroomerPlugin {
     public void testUpdateSingleUpdateNull()
         throws PluginExecutionException, StopProcessingException {
 
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
-
         UpdateRequest request = mock(UpdateRequest.class);
 
         List<Entry<Serializable, Metacard>> updates = new ArrayList<>();
@@ -691,8 +690,6 @@ public class TestMetacardGroomerPlugin {
     @Test
     public void testUpdateSingleUpdateKeyNull()
         throws PluginExecutionException, StopProcessingException {
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         UpdateRequest request = mock(UpdateRequest.class);
 
@@ -727,8 +724,6 @@ public class TestMetacardGroomerPlugin {
     public void testUpdateSingleUpdateValueNull()
         throws PluginExecutionException, StopProcessingException {
 
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
-
         UpdateRequest request = mock(UpdateRequest.class);
 
         List<Entry<Serializable, Metacard>> updates = new ArrayList<>();
@@ -762,8 +757,6 @@ public class TestMetacardGroomerPlugin {
         throws PluginExecutionException, StopProcessingException {
         CreateRequestImpl inputRequest = new CreateRequestImpl(copy(inputMetacard));
 
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
-
         CreateRequest returnedRequest = plugin.process(inputRequest);
 
         assertNotNull(returnedRequest);
@@ -776,8 +769,6 @@ public class TestMetacardGroomerPlugin {
     private Metacard processUpdate(Metacard inputMetacard)
         throws PluginExecutionException, StopProcessingException {
         UpdateRequestImpl inputRequest = new UpdateRequestImpl(SAMPLE_ID, copy(inputMetacard));
-
-        StandardMetacardGroomerPlugin plugin = new StandardMetacardGroomerPlugin();
 
         UpdateRequest returnedRequest = plugin.process(inputRequest);
 

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -261,6 +261,11 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.mime.core</groupId>
             <artifactId>mime-core-impl</artifactId>
             <scope>test</scope>
@@ -460,6 +465,7 @@
                             org.apache.xml.resolver,
                             org.apache.xml.resolver.helpers,
                             org.codice.ddf.security.handler.api,
+                            org.codice.ddf.platform.util.uuidgenerator,
                             org.geotools.filter.visitor,
                             org.geotools.geometry.jts.spatialschema,
                             org.geotools.geometry.jts.spatialschema.geometry.aggregate,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
@@ -19,13 +19,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +51,12 @@ public class MetacardFactory {
     //
     private final MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
 
-    public MetacardFactory(MimeTypeToTransformerMapper mimeTypeToTransformerMapper) {
+    private UuidGenerator uuidGenerator;
+
+    public MetacardFactory(MimeTypeToTransformerMapper mimeTypeToTransformerMapper,
+            UuidGenerator uuidGenerator) {
         this.mimeTypeToTransformerMapper = mimeTypeToTransformerMapper;
+        this.uuidGenerator = uuidGenerator;
     }
 
     Metacard generateMetacard(String mimeTypeRaw, String id, String fileName, Path tmpContentPath)
@@ -97,9 +101,7 @@ public class MetacardFactory {
             generatedMetacard.setAttribute(new AttributeImpl(Metacard.ID, id));
         } else {
             generatedMetacard.setAttribute(new AttributeImpl(Metacard.ID,
-                    UUID.randomUUID()
-                            .toString()
-                            .replaceAll("-", "")));
+                    uuidGenerator.generateUuid()));
         }
 
         if (StringUtils.isBlank(generatedMetacard.getTitle())) {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,6 +32,8 @@
 
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
 
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
+
     <reference id="defaultAttributeValueRegistry"
                interface="ddf.catalog.data.DefaultAttributeValueRegistry"/>
 

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -19,6 +19,7 @@
     <bean id="historian" class="ddf.catalog.history.Historian" init-method="init">
         <cm:managed-properties persistent-id="ddf.catalog.history.Historian"
                                update-strategy="container-managed"/>
+        <property name="uuidGenerator" ref="uuidGenerator"/>
         <property name="catalogProviders" ref="catalogProviderSortedList"/>
         <property name="storageProviders" ref="storageProviderSortedList"/>
         <property name="filterBuilder" ref="filterBuilder"/>
@@ -31,6 +32,7 @@
 
     <bean id="cfMetafactory" class="ddf.catalog.impl.operations.MetacardFactory">
         <argument ref="transformerMapper"/>
+        <argument ref="uuidGenerator"/>
     </bean>
 
     <bean id="cfOpsMetacard" class="ddf.catalog.impl.operations.OperationsMetacardSupport">

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportSpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportSpec.groovy
@@ -20,6 +20,7 @@ import ddf.catalog.source.IngestException
 import ddf.catalog.transform.InputTransformer
 import ddf.mime.MimeTypeMapper
 import ddf.mime.MimeTypeToTransformerMapper
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -32,6 +33,7 @@ class OperationsMetacardSupportTest extends Specification {
     private MimeTypeToTransformerMapper mimeTransMapper
     private DefaultAttributeValueRegistry defaultAttributeValueRegistry
     private Metacard generatedMetacard
+    private UuidGenerator uuidGenerator
     private InputTransformer transformer
 
     def setup() {
@@ -41,6 +43,7 @@ class OperationsMetacardSupportTest extends Specification {
 
         mimeTypeMapper = Mock(MimeTypeMapper)
         mimeTransMapper = Mock(MimeTypeToTransformerMapper)
+        uuidGenerator = Mock(UuidGenerator)
         defaultAttributeValueRegistry = Mock(DefaultAttributeValueRegistry)
 
         transformer = Mock(InputTransformer)
@@ -56,7 +59,7 @@ class OperationsMetacardSupportTest extends Specification {
             defaultAttributeValueRegistry = this.defaultAttributeValueRegistry
         }
 
-        def metacardFactory = new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper())
+        def metacardFactory = new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper(), uuidGenerator)
         opsMetacard = new OperationsMetacardSupport(frameworkProperties, metacardFactory)
     }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
@@ -37,9 +37,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import org.apache.shiro.subject.ExecutionException;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.security.common.Security;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,9 +102,16 @@ public class HistorianTest {
 
     private Historian historian;
 
+    private UuidGenerator uuidGenerator;
+
     @Before
     public void setup() {
         historian = new Historian();
+
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+        historian.setUuidGenerator(uuidGenerator);
 
         catalogProvider = mock(CatalogProvider.class);
         historian.setCatalogProviders(Collections.singletonList(catalogProvider));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -68,6 +68,7 @@ import javax.activation.MimeType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.util.ThreadContext;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.geotools.filter.FilterFactoryImpl;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -238,6 +239,8 @@ public class CatalogFrameworkImplTest {
 
     RemoteDeleteOperations mockRemoteDeleteOperations;
 
+    UuidGenerator uuidGenerator;
+
     @Rule
     public MethodRule watchman = new TestWatchman() {
         public void starting(FrameworkMethod method) {
@@ -394,8 +397,13 @@ public class CatalogFrameworkImplTest {
         attributeInjector = spy(new AttributeInjectorImpl(new AttributeRegistryImpl()));
         frameworkProperties.setAttributeInjectors(Collections.singletonList(attributeInjector));
 
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
-        MetacardFactory metacardFactory = new MetacardFactory(mimeTypeToTransformerMapper);
+        MetacardFactory metacardFactory = new MetacardFactory(mimeTypeToTransformerMapper,
+                uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
@@ -653,9 +661,12 @@ public class CatalogFrameworkImplTest {
                 return new ByteArrayInputStream("blah".getBytes());
             }
         };
-        ContentItemImpl newItem = new ContentItemImpl(byteSource,
+        ContentItemImpl newItem = new ContentItemImpl(
+                uuidGenerator.generateUuid(),
+                byteSource,
                 "application/octet-stream",
                 "blah",
+                0L,
                 newCard);
         contentItems.add(newItem);
 
@@ -728,9 +739,11 @@ public class CatalogFrameworkImplTest {
                 return new ByteArrayInputStream("blah".getBytes());
             }
         };
-        ContentItemImpl newItem = new ContentItemImpl(byteSource,
+        ContentItemImpl newItem = new ContentItemImpl(uuidGenerator.generateUuid(),
+                byteSource,
                 "application/octet-stream",
                 "blah",
+                0L,
                 newCard);
         contentItems.add(newItem);
 
@@ -799,9 +812,11 @@ public class CatalogFrameworkImplTest {
                 return new ByteArrayInputStream("blah".getBytes());
             }
         };
-        ContentItemImpl newItem = new ContentItemImpl(byteSource,
+        ContentItemImpl newItem = new ContentItemImpl(uuidGenerator.generateUuid(),
+                byteSource,
                 "application/octet-stream",
                 "blah",
+                0L,
                 newCard);
         contentItems.add(newItem);
 
@@ -988,9 +1003,11 @@ public class CatalogFrameworkImplTest {
                 return new ByteArrayInputStream("blah".getBytes());
             }
         };
-        ContentItemImpl contentItem = new ContentItemImpl(byteSource,
+        ContentItemImpl contentItem = new ContentItemImpl(uuidGenerator.generateUuid(),
+                byteSource,
                 "application/octet-stream",
                 "blah",
+                0L,
                 metacard);
         contentItems.add(contentItem);
 
@@ -1050,9 +1067,11 @@ public class CatalogFrameworkImplTest {
                 return new ByteArrayInputStream("blah".getBytes());
             }
         };
-        ContentItemImpl contentItem = new ContentItemImpl(byteSource,
+        ContentItemImpl contentItem = new ContentItemImpl(uuidGenerator.generateUuid(),
+                byteSource,
                 "application/octet-stream",
                 "blah",
+                0L,
                 metacard);
         CreateResponse response =
                 framework.create(new CreateStorageRequestImpl(Collections.singletonList(contentItem),
@@ -1386,7 +1405,8 @@ public class CatalogFrameworkImplTest {
     private CatalogFrameworkImpl createFramework(FrameworkProperties frameworkProperties) {
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper());
+                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper(),
+                        uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
@@ -26,7 +26,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.geotools.filter.FilterFactoryImpl;
 import org.geotools.temporal.object.DefaultInstant;
 import org.geotools.temporal.object.DefaultPeriod;
@@ -103,9 +105,13 @@ public class CatalogFrameworkQueryTest {
         props.setFilterBuilder(new GeotoolsFilterBuilder());
         props.setDefaultAttributeValueRegistry(new DefaultAttributeValueRegistryImpl());
 
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(props.getMimeTypeToTransformerMapper());
+                new MetacardFactory(props.getMimeTypeToTransformerMapper(), uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(props,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(props);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
@@ -30,9 +30,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.activation.MimeType;
 
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -107,6 +109,8 @@ public class FanoutCatalogFrameworkTest {
 
     private FrameworkProperties frameworkProperties;
 
+    private UuidGenerator uuidGenerator;
+
     @Before
     public void initFramework() {
 
@@ -119,13 +123,18 @@ public class FanoutCatalogFrameworkTest {
         frameworkProperties.setFederationStrategy(new MockFederationStrategy());
         frameworkProperties.setPostIngest(postIngestPlugins);
 
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         framework = createCatalogFramework(frameworkProperties);
     }
 
     private CatalogFrameworkImpl createCatalogFramework(FrameworkProperties frameworkProperties) {
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper());
+                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper(),
+                        uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
@@ -435,7 +444,8 @@ public class FanoutCatalogFrameworkTest {
 
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper());
+                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper(),
+                        uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
@@ -505,7 +515,8 @@ public class FanoutCatalogFrameworkTest {
 
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
         MetacardFactory metacardFactory =
-                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper());
+                new MetacardFactory(frameworkProperties.getMimeTypeToTransformerMapper(),
+                        uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
@@ -554,9 +565,11 @@ public class FanoutCatalogFrameworkTest {
         framework.setFanoutEnabled(true);
         framework.setFanoutTagBlacklist(Collections.singletonList("blacklisted"));
 
-        ContentItem item = new ContentItemImpl(ByteSource.empty(),
+        ContentItem item = new ContentItemImpl(uuidGenerator.generateUuid(),
+                ByteSource.empty(),
                 "text/xml",
                 "filename.xml",
+                0L,
                 metacard);
         CreateStorageRequest request = new CreateStorageRequestImpl(Collections.singletonList(item),
                 new HashMap<>());
@@ -570,9 +583,11 @@ public class FanoutCatalogFrameworkTest {
         metacard.setAttribute(new AttributeImpl(Metacard.ID, "metacardId"));
         metacard.setAttribute(new AttributeImpl(Metacard.TAGS, "blacklisted"));
 
-        ContentItem item = new ContentItemImpl(ByteSource.empty(),
+        ContentItem item = new ContentItemImpl(uuidGenerator.generateUuid(),
+                ByteSource.empty(),
                 "text/xml",
                 "filename.xml",
+                0L,
                 metacard);
         UpdateStorageRequest request = new UpdateStorageRequestImpl(Collections.singletonList(item),
                 new HashMap<>());

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -30,10 +30,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.activation.MimeType;
 
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,6 +104,8 @@ public class RemoteDeleteOperationsTest {
     PostResourcePlugin mockPostResourcePlugin;
 
     List<PostResourcePlugin> mockPostResourcePlugins;
+
+    UuidGenerator uuidGenerator;
 
     @Before
     public void setUp() throws Exception {
@@ -320,6 +324,10 @@ public class RemoteDeleteOperationsTest {
 
         mimeTypeToTransformerMapper = mock(MimeTypeToTransformerMapper.class);
 
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         inputTransformer = mock(InputTransformer.class);
         when(inputTransformer.transform(any(InputStream.class))).thenReturn(new MetacardImpl());
         when(mimeTypeToTransformerMapper.findMatches(any(Class.class),
@@ -361,7 +369,8 @@ public class RemoteDeleteOperationsTest {
     private void setUpDeleteOperations() {
         SourceOperations sourceOperations = new SourceOperations(frameworkProperties);
         OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
-        MetacardFactory metacardFactory = new MetacardFactory(mimeTypeToTransformerMapper);
+        MetacardFactory metacardFactory = new MetacardFactory(mimeTypeToTransformerMapper,
+                uuidGenerator);
         OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(frameworkProperties,
                 metacardFactory);
 

--- a/catalog/core/catalog-core-versioning/versioning-api/pom.xml
+++ b/catalog/core/catalog-core-versioning/versioning-api/pom.xml
@@ -25,6 +25,7 @@
 
     <packaging>bundle</packaging>
     <artifactId>versioning-api</artifactId>
+    <name>DDF :: Catalog :: Core :: Versioning :: API</name>
 
     <dependencies>
         <dependency>

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
@@ -16,12 +16,8 @@ package ddf.catalog.core.versioning.impl;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -40,8 +36,6 @@ import ddf.catalog.data.impl.MetacardTypeImpl;
  * Represents a currently soft deleted metacard.
  */
 public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeletedMetacardImpl.class);
-
     private static final MetacardType METACARD_TYPE;
 
     private static final Set<AttributeDescriptor> DESCRIPTORS =
@@ -54,7 +48,6 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
                 false,
                 false,
                 BasicTypes.STRING_TYPE));
-
         DESCRIPTORS.add(new AttributeDescriptorImpl(DELETION_OF_ID,
                 true,
                 true,
@@ -70,20 +63,18 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
         METACARD_TYPE = new MetacardTypeImpl(PREFIX, DESCRIPTORS);
     }
 
-    public DeletedMetacardImpl(String deletionOfId, String deletedBy, String lastVersionId,
-            Metacard metacardBeingDeleted) {
+    public DeletedMetacardImpl(String id, String deletionOfId, String deletedBy,
+            String lastVersionId, Metacard metacardBeingDeleted) {
         super(metacardBeingDeleted,
                 new MetacardTypeImpl(PREFIX,
-                        getDeletedMetacardType(),
-                        metacardBeingDeleted.getMetacardType()
-                                .getAttributeDescriptors()));
+                    getDeletedMetacardType(),
+                    metacardBeingDeleted.getMetacardType()
+                        .getAttributeDescriptors()));
         this.setDeletionOfId(deletionOfId);
         this.setDeletedBy(deletedBy);
         this.setLastVersionId(lastVersionId);
         this.setTags(ImmutableSet.of(DELETED_TAG));
-        this.setId(UUID.randomUUID()
-                .toString()
-                .replace("-", ""));
+        this.setId(id);
     }
 
     public static boolean isNotDeleted(@Nullable Metacard metacard) {

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -131,8 +130,8 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
      * @param action         Which action was done to modify the metacard
      * @throws IllegalArgumentException
      */
-    public MetacardVersionImpl(Metacard sourceMetacard, Action action, Subject subject) {
-        this(sourceMetacard, action, subject, Collections.singletonList(BasicTypes.BASIC_METACARD));
+    public MetacardVersionImpl(String id, Metacard sourceMetacard, Action action, Subject subject) {
+        this(id, sourceMetacard, action, subject, Collections.singletonList(BasicTypes.BASIC_METACARD));
     }
 
     /**
@@ -148,7 +147,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
      * @param types          A list of currently defined types in the system
      * @throws IllegalArgumentException
      */
-    public MetacardVersionImpl(Metacard sourceMetacard, Action action, Subject subject,
+    public MetacardVersionImpl(String id, Metacard sourceMetacard, Action action, Subject subject,
             List<MetacardType> types) {
         super(sourceMetacard,
                 new MetacardTypeImpl(PREFIX,
@@ -179,9 +178,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
         this.setEditedBy(editedBy);
 
         this.setVersionedOn(Date.from(Instant.now()));
-        this.setId(UUID.randomUUID()
-                .toString()
-                .replace("-", ""));
+        this.setId(id);
         this.setVersionResourceUri(sourceMetacard.getResourceURI());
         this.setTags(Collections.singleton(VERSION_TAG));
     }

--- a/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/MetacardVersionImplSpec.groovy
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/MetacardVersionImplSpec.groovy
@@ -47,7 +47,7 @@ class MetacardVersionImplSpec extends Specification {
         Instant start = Instant.now()
 
         when:
-        MetacardVersionImpl history = new MetacardVersionImpl(
+        MetacardVersionImpl history = new MetacardVersionImpl("anId",
                 meta.metacard,
                 action,
                 SecurityUtils.subject)
@@ -76,7 +76,7 @@ class MetacardVersionImplSpec extends Specification {
         setup:
         def meta = defaultMetacard()
         Action action = Action.VERSIONED
-        MetacardVersionImpl history = new MetacardVersionImpl(
+        MetacardVersionImpl history = new MetacardVersionImpl("anId",
                 meta.metacard as Metacard,
                 action,
                 SecurityUtils.subject)
@@ -98,7 +98,7 @@ class MetacardVersionImplSpec extends Specification {
         Action action = Action.VERSIONED
 
         when: "History items are created from non basic metacard types"
-        MetacardVersionImpl history = new MetacardVersionImpl(
+        MetacardVersionImpl history = new MetacardVersionImpl("anId",
                 meta.metacard as Metacard,
                 action,
                 SecurityUtils.subject,
@@ -129,7 +129,7 @@ class MetacardVersionImplSpec extends Specification {
         Action action = Action.VERSIONED
 
         when: "History items are created from non basic metacard types"
-        MetacardVersionImpl history = new MetacardVersionImpl(
+        MetacardVersionImpl history = new MetacardVersionImpl("anId",
                 meta.metacard as Metacard,
                 action,
                 SecurityUtils.subject)

--- a/catalog/ftp/pom.xml
+++ b/catalog/ftp/pom.xml
@@ -106,6 +106,11 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,6 +42,7 @@
     <bean id="ftplet" class="ddf.catalog.ftp.ftplets.FtpRequestHandler">
         <argument ref="catalogFramework"/>
         <argument ref="mimeTypeMapper"/>
+        <argument ref="uuidGenerator"/>
     </bean>
     <bean id="userManager" class="ddf.catalog.ftp.UserManagerImpl">
         <property name="uploadDirectory" value="${ddf.home}/data/products"/>
@@ -56,4 +57,5 @@
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
     <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
 </blueprint>

--- a/catalog/ftp/src/test/java/ddf/catalog/ftp/ftplets/FtpRequestHandlerTest.java
+++ b/catalog/ftp/src/test/java/ddf/catalog/ftp/ftplets/FtpRequestHandlerTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ import org.apache.ftpserver.ftplet.FtpSession;
 import org.apache.ftpserver.ftplet.FtpletResult;
 import org.apache.ftpserver.impl.IODataConnectionFactory;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -75,6 +77,8 @@ public class FtpRequestHandlerTest {
 
     private MimeTypeMapper mimeTypeMapper;
 
+    private UuidGenerator uuidGenerator;
+
     @Before
     public void setUp() {
         session = mock(FtpSession.class, RETURNS_DEEP_STUBS);
@@ -82,8 +86,10 @@ public class FtpRequestHandlerTest {
 
         catalogFramework = mock(CatalogFramework.class);
         mimeTypeMapper = mock(MimeTypeMapper.class);
-
-        ftplet = new FtpRequestHandler(catalogFramework, mimeTypeMapper);
+        uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+        ftplet = new FtpRequestHandler(catalogFramework, mimeTypeMapper, uuidGenerator);
     }
 
     @Test(expected = FtpException.class)
@@ -184,7 +190,7 @@ public class FtpRequestHandlerTest {
         String mimeType;
         catalogFramework = mock(CatalogFramework.class);
 
-        FtpRequestHandler ftplett = new FtpRequestHandler(catalogFramework, null);
+        FtpRequestHandler ftplett = new FtpRequestHandler(catalogFramework, null, uuidGenerator);
 
         mimeType = ftplett.getMimeType("xml", new TemporaryFileBackedOutputStream());
         assertEquals("", mimeType);

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -182,7 +187,6 @@
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.35</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -64,6 +64,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.opengis.filter.Filter;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -121,6 +122,7 @@ import ddf.mime.MimeTypeMapper;
 import ddf.mime.MimeTypeResolutionException;
 import ddf.mime.MimeTypeResolver;
 import ddf.mime.MimeTypeToTransformerMapper;
+
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
@@ -160,6 +162,8 @@ public class RESTEndpoint implements RESTService {
     private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
 
     private static final String DEFAULT_FILE_NAME = "file";
+
+    private UuidGenerator uuidGenerator;
 
     /**
      * Basic mime types that will be attempted to refine to a more accurate mime type
@@ -722,15 +726,21 @@ public class RESTEndpoint implements RESTService {
                 }
 
                 if (createInfo == null) {
-                    UpdateRequest updateRequest = new UpdateRequestImpl(id,
-                            generateMetacard(mimeType, id, message, transformerParam));
+                    UpdateRequest updateRequest = new UpdateRequestImpl(id, generateMetacard(
+                            mimeType,
+                            id,
+                            message,
+                            transformerParam));
                     catalogFramework.update(updateRequest);
                 } else {
                     UpdateStorageRequest streamUpdateRequest = new UpdateStorageRequestImpl(
-                            Collections.singletonList(
-                                    new IncomingContentItem(id, createInfo.getStream(),
-                                            createInfo.getContentType(), createInfo.getFilename(),
-                                            0, createInfo.getMetacard())), null);
+                            Collections.singletonList(new IncomingContentItem(id,
+                                            createInfo.getStream(),
+                                            createInfo.getContentType(),
+                                            createInfo.getFilename(),
+                                            0,
+                                            createInfo.getMetacard())),
+                            null);
                     catalogFramework.update(streamUpdateRequest);
                 }
 
@@ -796,15 +806,19 @@ public class RESTEndpoint implements RESTService {
 
                 CreateResponse createResponse;
                 if (createInfo == null) {
-                    CreateRequest createRequest = new CreateRequestImpl(
-                            generateMetacard(mimeType, null, message, transformerParam));
+                    CreateRequest createRequest = new CreateRequestImpl(generateMetacard(mimeType,
+                            null,
+                            message,
+                            transformerParam));
                     createResponse = catalogFramework.create(createRequest);
                 } else {
                     CreateStorageRequest streamCreateRequest = new CreateStorageRequestImpl(
-                            Collections.singletonList(
-                                    new IncomingContentItem(createInfo.getStream(),
-                                            createInfo.getContentType(), createInfo.getFilename(),
-                                            createInfo.getMetacard())), null);
+                            Collections.singletonList(new IncomingContentItem(uuidGenerator,
+                                            createInfo.getStream(),
+                                            createInfo.getContentType(),
+                                            createInfo.getFilename(),
+                                            createInfo.getMetacard())),
+                            null);
                     createResponse = catalogFramework.create(streamCreateRequest);
                 }
 
@@ -833,8 +847,7 @@ public class RESTEndpoint implements RESTService {
                 throw new ServerErrorException(errorMessage, Status.BAD_REQUEST);
             }
         } catch (SourceUnavailableException e) {
-            String exceptionMessage =
-                    "Cannot create catalog entry because source is unavailable: ";
+            String exceptionMessage = "Cannot create catalog entry because source is unavailable: ";
             LOGGER.info(exceptionMessage, e);
             // Catalog framework logs these exceptions to the ingest logger so we don't have to.
             throw new ServerErrorException(exceptionMessage, Status.INTERNAL_SERVER_ERROR);
@@ -882,7 +895,8 @@ public class RESTEndpoint implements RESTService {
             } catch (IOException e) {
                 LOGGER.debug(
                         "Unable to get input stream for mime attachment. Ignoring override attribute: {}",
-                        name, e);
+                        name,
+                        e);
             }
 
         }
@@ -914,32 +928,31 @@ public class RESTEndpoint implements RESTService {
                 case XML:
                 case GEOMETRY:
                 case STRING:
-                    attributes.add(new AttributeImpl(parsedName,
-                            IOUtils.toString(inputStream)));
+                    attributes.add(new AttributeImpl(parsedName, IOUtils.toString(inputStream)));
                     break;
                 case BOOLEAN:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Boolean.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Boolean.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case SHORT:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Short.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Short.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case LONG:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Long.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Long.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case INTEGER:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Integer.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Integer.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case FLOAT:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Float.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Float.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case DOUBLE:
-                    attributes.add(new AttributeImpl(parsedName,
-                            Double.valueOf(IOUtils.toString(inputStream))));
+                    attributes.add(new AttributeImpl(parsedName, Double.valueOf(IOUtils.toString(
+                            inputStream))));
                     break;
                 case DATE:
                     Instant instant = Instant.parse(IOUtils.toString(inputStream));
@@ -949,8 +962,7 @@ public class RESTEndpoint implements RESTService {
                     attributes.add(new AttributeImpl(parsedName, Date.from(instant)));
                     break;
                 case BINARY:
-                    attributes.add(new AttributeImpl(parsedName,
-                            IOUtils.toByteArray(inputStream)));
+                    attributes.add(new AttributeImpl(parsedName, IOUtils.toByteArray(inputStream)));
                     break;
                 case OBJECT:
                     LOGGER.debug("Object type not supported for override");
@@ -975,7 +987,9 @@ public class RESTEndpoint implements RESTService {
             MimeType mimeType = new MimeType(attachment.getContentType()
                     .toString());
             metacard = generateMetacard(mimeType,
-                    "assigned-when-ingested", inputStream, transformer);
+                    "assigned-when-ingested",
+                    inputStream,
+                    transformer);
         } catch (MimeTypeParseException | MetacardCreationException e) {
             LOGGER.debug("Unable to parse metadata {}",
                     attachment.getContentType()
@@ -1031,8 +1045,7 @@ public class RESTEndpoint implements RESTService {
                     fileExtension = DEFAULT_FILE_EXTENSION;
                 }
             } catch (MimeTypeResolutionException e) {
-                LOGGER.debug("Exception getting file extension for contentType = {}",
-                        contentType);
+                LOGGER.debug("Exception getting file extension for contentType = {}", contentType);
             }
             filename = DEFAULT_FILE_NAME + "." + fileExtension; // DDF-2263
             LOGGER.debug("No filename parameter provided - default to {}", filename);
@@ -1045,13 +1058,14 @@ public class RESTEndpoint implements RESTService {
             if (StringUtils.isEmpty(contentType) || REFINEABLE_MIME_TYPES.contains(contentType)) {
                 String fileExtension = FilenameUtils.getExtension(filename);
                 LOGGER.debug("fileExtension = {}, contentType before refinement = {}",
-                        fileExtension, contentType);
+                        fileExtension,
+                        contentType);
                 try {
                     contentType = mimeTypeMapper.getMimeTypeForFileExtension(fileExtension);
                 } catch (MimeTypeResolutionException e) {
-                    LOGGER.debug(
-                            "Unable to refine contentType {} based on filename extension {}",
-                            contentType, fileExtension);
+                    LOGGER.debug("Unable to refine contentType {} based on filename extension {}",
+                            contentType,
+                            fileExtension);
                 }
                 LOGGER.debug("Refined contentType = {}", contentType);
             }
@@ -1153,8 +1167,9 @@ public class RESTEndpoint implements RESTService {
             Iterator<InputTransformer> it = listOfCandidates.iterator();
             if (StringUtils.isNotEmpty(transformerId)) {
                 BundleContext bundleContext = getBundleContext();
-                Collection<ServiceReference<InputTransformer>> serviceReferences = bundleContext.getServiceReferences(
-                        InputTransformer.class, "(id=" + transformerId + ")");
+                Collection<ServiceReference<InputTransformer>> serviceReferences =
+                        bundleContext.getServiceReferences(InputTransformer.class,
+                                "(id=" + transformerId + ")");
                 it = serviceReferences.stream()
                         .map(bundleContext::getService)
                         .iterator();
@@ -1166,7 +1181,8 @@ public class RESTEndpoint implements RESTService {
                         .openStream()) {
                     generatedMetacard = transformer.transform(inputStreamMessageCopy);
                 } catch (CatalogTransformerException | IOException e) {
-                    List<String> stackTraces = Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
+                    List<String> stackTraces =
+                            Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
                     stackTraceList.add(String.format("Transformer [%s] could not create metacard.",
                             transformer));
                     stackTraceList.addAll(stackTraces);
@@ -1264,8 +1280,8 @@ public class RESTEndpoint implements RESTService {
             if (rangeHeader.startsWith(BYTES_EQUAL)) {
                 String tempString = rangeHeader.substring(BYTES_EQUAL.length());
                 if (tempString.contains("-")) {
-                    response = rangeHeader.substring(BYTES_EQUAL.length(),
-                            rangeHeader.lastIndexOf("-"));
+                    response = rangeHeader.substring(BYTES_EQUAL.length(), rangeHeader.lastIndexOf(
+                            "-"));
                 } else {
                     response = rangeHeader.substring(BYTES_EQUAL.length());
                 }
@@ -1304,6 +1320,10 @@ public class RESTEndpoint implements RESTService {
 
     public void setMetacardTypes(List<MetacardType> metacardTypes) {
         this.metacardTypes = metacardTypes;
+    }
+
+    public void setUuidGenerator(UuidGenerator uuidGenerator) {
+        this.uuidGenerator = uuidGenerator;
     }
 
     protected static class CreateInfo {
@@ -1352,14 +1372,19 @@ public class RESTEndpoint implements RESTService {
 
         private InputStream inputStream;
 
-        public IncomingContentItem(ByteSource byteSource, String mimeTypeRawData, String filename,
-                Metacard metacard) {
-            super(byteSource, mimeTypeRawData, filename, metacard);
+        public IncomingContentItem(UuidGenerator uuidGenerator, ByteSource byteSource,
+                String mimeTypeRawData, String filename, Metacard metacard) {
+            super(uuidGenerator.generateUuid(),
+                    byteSource,
+                    mimeTypeRawData,
+                    filename,
+                    0L,
+                    metacard);
         }
 
-        public IncomingContentItem(InputStream inputStream, String mimeTypeRawData, String filename,
-                Metacard metacard) {
-            super(null, mimeTypeRawData, filename, metacard);
+        public IncomingContentItem(UuidGenerator uuidGenerator, InputStream inputStream,
+                String mimeTypeRawData, String filename, Metacard metacard) {
+            super(uuidGenerator.generateUuid(), null, mimeTypeRawData, filename, 0L, metacard);
             this.inputStream = inputStream;
         }
 

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,6 +21,7 @@
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="tikaMimeTypeResolver" filter="(name=tikaMimeTypeResolver)" interface="ddf.mime.MimeTypeResolver"/>
     <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
 
     <bean id="actionFactory"
           class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory"/>
@@ -44,6 +45,7 @@
         <property name="metacardTypes">
             <reference-list interface="ddf.catalog.data.MetacardType" availability="optional"/>
         </property>
+        <property name="uuidGenerator" ref="uuidGenerator" />
     </bean>
 
     <jaxrs:server id="restService" address="/catalog">

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.activation.MimeType;
 import javax.servlet.http.HttpServletRequest;
@@ -56,6 +57,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 import org.apache.tika.io.IOUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -177,7 +179,7 @@ public class TestRestEndpoint {
 
     }
 
-    @Test()
+    @Test
     public void testAddDocumentFrameworkIngestException()
             throws IngestException, SourceUnavailableException, URISyntaxException {
 
@@ -185,7 +187,7 @@ public class TestRestEndpoint {
 
     }
 
-    @Test()
+    @Test
     public void testAddDocumentFrameworkSourceUnavailableException()
             throws IngestException, SourceUnavailableException, URISyntaxException {
 
@@ -193,7 +195,7 @@ public class TestRestEndpoint {
 
     }
 
-    @Test()
+    @Test
     public void testAddDocumentPositiveCase()
             throws IOException, CatalogTransformerException, IngestException,
             SourceUnavailableException, URISyntaxException {
@@ -223,7 +225,7 @@ public class TestRestEndpoint {
                 .toString(), equalTo(SAMPLE_ID));
     }
 
-    @Test()
+    @Test
     public void testAddDocumentWithMetadataPositiveCase()
             throws IOException, CatalogTransformerException, IngestException,
             SourceUnavailableException, URISyntaxException, InvalidSyntaxException,
@@ -247,6 +249,11 @@ public class TestRestEndpoint {
                 return bundleContext;
             }
         };
+
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+        rest.setUuidGenerator(uuidGenerator);
         rest.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
         MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
         when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");

--- a/catalog/spatial/registry/registry-identification-plugin/pom.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>ddf-security-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>filter-proxy</artifactId>
             <scope>test</scope>

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
@@ -17,11 +17,11 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.common.metacard.RegistryUtility;
@@ -52,6 +52,12 @@ public class IdentificationPlugin implements PreIngestPlugin {
     private MetacardMarshaller metacardMarshaller;
 
     private RegistryIdPostIngestPlugin registryIdPostIngestPlugin;
+
+    private UuidGenerator uuidGenerator;
+
+    public IdentificationPlugin(UuidGenerator uuidGenerator) {
+        this.uuidGenerator = uuidGenerator;
+    }
 
     /**
      * For registry metacards updates the tags and identifiers
@@ -90,10 +96,7 @@ public class IdentificationPlugin implements PreIngestPlugin {
                                 ""))) {
                     throw new StopProcessingException("Can't create duplicate registry entries.");
                 }
-                metacard.setAttribute(new AttributeImpl(Metacard.ID,
-                        UUID.randomUUID()
-                                .toString()
-                                .replaceAll("-", "")));
+                metacard.setAttribute(new AttributeImpl(Metacard.ID, uuidGenerator.generateUuid()));
                 updateTags(metacard);
                 updateIdentifiers(metacard, true);
 

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,9 +16,9 @@
 
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
-
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator"/>
 
     <bean id="metacardMarshaller"
           class="org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller">
@@ -38,6 +38,7 @@
 
     <bean id="identificationPlugin"
           class="org.codice.ddf.registry.identification.IdentificationPlugin">
+        <argument ref="uuidGenerator"/>
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryIdPostIngestPlugin" ref="registryPostIngestPlugin"/>
     </bean>

--- a/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/test/java/org/codice/ddf/registry/identification/IdentificationPluginTest.java
@@ -16,6 +16,8 @@ package org.codice.ddf.registry.identification;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -33,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBElement;
@@ -40,6 +43,7 @@ import javax.xml.bind.JAXBElement;
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.EbrimConstants;
@@ -59,6 +63,7 @@ import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.impl.CreateRequestImpl;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
+
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
 
@@ -74,8 +79,12 @@ public class IdentificationPluginTest {
 
     @Before
     public void setUp() {
+        UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+        when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID()
+                .toString());
+
         parser = new XmlParser();
-        identificationPlugin = new IdentificationPlugin();
+        identificationPlugin = new IdentificationPlugin(uuidGenerator);
         identificationPlugin.setMetacardMarshaller(new MetacardMarshaller(parser));
         identificationPlugin.setRegistryIdPostIngestPlugin(new RegistryIdPostIngestPlugin());
         setParser(parser);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -69,8 +69,8 @@ public class QueryApplication implements SparkApplication {
             CqlRequest cqlRequest = mapper.readValue(req.body(), CqlRequest.class);
 
             CqlQueryResponse cqlQueryResponse = executeCqlQuery(cqlRequest);
-
-            return mapper.toJson(cqlQueryResponse);
+            String result = mapper.toJson(cqlQueryResponse);
+            return result;
         });
 
         after("/cql", (req, res) -> {

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -317,6 +317,16 @@
             <artifactId>platform-email-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <!-- CXF Properties used in platform-app's features.xml -->

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -760,6 +760,17 @@
         <bundle>mvn:ddf.platform.migration/platform-migration/${project.version}</bundle>
     </feature>
 
+    <feature name="util-uuidgenerator-api" install="manual" version="${project.version}"
+             description="UUID Generator API">
+        <feature prerequisite="true">platform-dependencies</feature>
+        <bundle>mvn:ddf.platform.util/util-uuidgenerator-api/${project.version}</bundle>
+    </feature>
+
+    <feature name="util-uuidgenerator" install="manual" version="${project.version}" description="A UUID generator service">
+        <feature>util-uuidgenerator-api</feature>
+        <bundle>mvn:ddf.platform.util/util-uuidgenerator-impl/${project.version}</bundle>
+    </feature>
+
     <feature name="platform-scheduler" install="manual" version="${project.version}"
              description="Schedules tasks">
         <feature prerequisite="true">commons</feature>
@@ -1046,6 +1057,7 @@
         <feature>landing-page</feature>
         <feature>platform-filter-response</feature>
         <feature>platform-email</feature>
+        <feature>util-uuidgenerator</feature>
     </feature>
 
     <feature name="clientinfo-filter" install="auto" version="${project.version}"

--- a/platform/util/platform-util-uuidgenerator/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform.util</groupId>
+        <artifactId>util</artifactId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>uuidgenerator</artifactId>
+    <name>DDF :: Platform :: Util :: UUID Generator</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>util-uuidgenerator-api</module>
+        <module>util-uuidgenerator-impl</module>
+    </modules>
+</project>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform.util</groupId>
+        <artifactId>uuidgenerator</artifactId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>util-uuidgenerator-api</artifactId>
+    <name>DDF :: Platform :: Util :: UUID Generator API</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                    <Export-Package>
+                        org.codice.ddf.platform.util.uuidgenerator
+                    </Export-Package>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/src/main/java/org/codice/ddf/platform/util/uuidgenerator/UuidGenerator.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/src/main/java/org/codice/ddf/platform/util/uuidgenerator/UuidGenerator.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util.uuidgenerator;
+
+/**
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ * </p>
+ *
+ * The {@code UuidGenerator} generates {@link java.util.UUID}s
+ */
+public interface UuidGenerator {
+
+    /**
+     * Returns a generated uuid for a Metacard
+     *
+     * @return
+     */
+    String generateUuid();
+
+    /**
+     * Returns true if the UUID format is correct
+     *
+     * @param uuid - the given UUID
+     * @return
+     */
+    boolean validateUuid(String uuid);
+}

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform.util</groupId>
+        <artifactId>uuidgenerator</artifactId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>util-uuidgenerator-impl</artifactId>
+    <name>DDF :: Platform :: Util :: UUID Generator Impl</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.93</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.91</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImpl.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util.uuidgenerator.impl;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+
+public class UuidGeneratorImpl implements UuidGenerator {
+
+    private Pattern hexPattern = Pattern.compile("^[0-9A-Fa-f]+$");
+
+    private Pattern hexPatternWithHypens = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    private Boolean removeHyphens = true;
+
+    public void setRemoveHyphens(Boolean removeHyphens) {
+        this.removeHyphens = removeHyphens;
+    }
+
+    @Override
+    public String generateUuid() {
+        String uuid = UUID.randomUUID()
+                .toString();
+        if (removeHyphens) {
+            uuid = uuid.replaceAll("-", "");
+        }
+        return uuid;
+    }
+
+    @Override
+    public boolean validateUuid(String uuid) {
+        if (StringUtils.isEmpty(uuid)) {
+            return false;
+        }
+
+        if (removeHyphens && uuid.length() == 32) {
+            return hexPattern.matcher(uuid)
+                    .matches();
+        } else if (!removeHyphens && uuid.length() == 36) {
+            return hexPatternWithHypens.matcher(uuid)
+                    .matches();
+        }
+        return false;
+    }
+}

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <bean id="uuidGenerator" class="org.codice.ddf.platform.util.uuidgenerator.impl.UuidGeneratorImpl">
+        <cm:managed-properties persistent-id="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator"
+                               update-strategy="container-managed" />
+        <property name="removeHyphens" value="true"/>
+    </bean>
+
+    <service ref="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator">
+        <service-properties>
+            <entry key="id" value="uuidGenerator"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Metacard UUID Generator Service" id="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator"
+         description="The Metacard UUID Generator Service generates UUIDs for Metacards.">
+
+        <AD description="Remove hyphens from the Metacard UUID during generation" name="Remove Hyphens"
+            id="removeHyphens" required="true" type="Boolean" default="true"/>
+
+    </OCD>
+
+    <Designate pid="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator">
+        <Object ocdref="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/test/java/org/codice/ddf/platform/util/uuidgenerator/impl/TestUuidGeneratorImpl.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/test/java/org/codice/ddf/platform/util/uuidgenerator/impl/TestUuidGeneratorImpl.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.platform.util.uuidgenerator.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestUuidGeneratorImpl {
+
+    private UuidGeneratorImpl uuidGenerator;
+
+    private static final List<String> INVALID_ID_LIST_NO_HYPHENS = Arrays.asList(null,
+            "",
+            " ",
+            "1234",
+            "fc3f1798fe17_66fbbcc39dcfcb232e6",
+            "fc3f1798fe17166fbbcc39dcfcb2232e6");
+
+    private static final List<String> INVALID_ID_LIST_HYPHENS = Arrays.asList(
+            "fc3f1798fe17166fbbcc39dcfcb2232e6----",
+            "fc3f1798fe1766fbbcc39dcfcb232e6---1",
+            "fc3f1798fe17166fbbcc39dcfcb2232e61234");
+
+    @Before
+    public void setUp() {
+        uuidGenerator = new UuidGeneratorImpl();
+    }
+
+    @Test
+    public void testGenerateIdRemoveHyphens() {
+        String uuid = uuidGenerator.generateUuid();
+        assertThat(uuid.length(), is(32));
+        assertThat(uuidGenerator.validateUuid(uuid), is(true));
+    }
+
+    @Test
+    public void testGenerateIdHyphens() {
+        uuidGenerator.setRemoveHyphens(false);
+        String uuid = uuidGenerator.generateUuid();
+        assertThat(uuid.length(), is(36));
+        assertThat(uuidGenerator.validateUuid(uuid), is(true));
+    }
+
+    @Test
+    public void testValidateUuidNoHyphens() {
+        for (String id : INVALID_ID_LIST_NO_HYPHENS) {
+            assertThat(uuidGenerator.validateUuid(id), is(false));
+        }
+    }
+
+    @Test
+    public void testValidateUuid() {
+        uuidGenerator.setRemoveHyphens(false);
+        for (String id : INVALID_ID_LIST_HYPHENS) {
+            assertThat(uuidGenerator.validateUuid(id), is(false));
+        }
+    }
+
+    @Test
+    public void testValidateUuidBothFormats() {
+        uuidGenerator.setRemoveHyphens(false);
+        assertThat(uuidGenerator.validateUuid(UUID.randomUUID()
+                .toString()), is(true));
+        uuidGenerator.setRemoveHyphens(true);
+        assertThat(uuidGenerator.validateUuid(UUID.randomUUID()
+                .toString()), is(false));
+    }
+}

--- a/platform/util/pom.xml
+++ b/platform/util/pom.xml
@@ -26,5 +26,6 @@
     <modules>
         <module>platform-util</module>
         <module>platform-util-unavailableurls</module>
+        <module>platform-util-uuidgenerator</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
This PR creates a configurable service to create Metacard UUIDs and extracts the use of UUID.randomUUID from areas in DDF.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @adimka 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brianfelix @troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
- Build 
- Install 
- Ingest some data and verify IDs are still set properly
- Verify Archive / Restore / Caching has not regressed
- Configure Metacard UUID Generator (remove hyphens)
- Ingest some data and verify IDs are set properly
- Verify Archive / Restore / Caching has not regressed
- Configure a Content Directory Monitor and verify ingest works properly
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3009](https://codice.atlassian.net/browse/DDF-3009)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
