### PR TITLE
Ddf 2880 add Introductory sections to templated docs

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -24,6 +24,8 @@
     <properties>
         <skipTests>true</skipTests>
         <ddf.version>${project.version}</ddf.version>
+        <timestamp>${maven.build.timestamp}</timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <packaging>pom</packaging>
         <module>docs</module>
         <skipTests>false</skipTests>

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/catalog-framework-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/catalog-framework-intro-contents.adoc
@@ -1,6 +1,7 @@
 :type: coreConcept
 :status: published
 :title: Introduction to the Catalog Framework
+:order: 05
 
 The Catalog Framework wires all the Catalog components together.
 

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/catalog-framework-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/catalog-framework-intro-contents.adoc
@@ -1,0 +1,12 @@
+:type: coreConcept
+:status: published
+:title: Introduction to the Catalog Framework
+
+The Catalog Framework wires all the Catalog components together.
+
+It is responsible for routing Catalog requests and responses to the appropriate source, destination, federated system, etc. 
+
+<<_endpoints,Endpoints>> send Catalog requests to the Catalog Framework.
+The Catalog Framework then invokes <<_plugins,Catalog Plugins>>, <<_transformers,Transformers>>, and <<_resources,Resource Components>> as needed before sending requests to the intended destination, such as one or more <<_sources,Sources>>. 
+
+The Catalog Framework decouples clients from service implementations and provides integration points for Catalog Plugins and convenience methods for Endpoint developers.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/content-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/content-intro-contents.adoc
@@ -1,0 +1,12 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Content
+
+The Catalog Framework can interface with <<_storage_providers,Storage Providers>> to provide storage of resources to specific types of storage, e.g., file system, relational database, XML database.
+A default file system implementation is provided by default.
+
+Storage providers act as a proxy between the Catalog Framework and the mechanism storing the content.
+Storage providers expose the storage mechanism to the Catalog Framework.
+Storage plugins provide pluggable functionality that can be executed either immediately before or immediately after content has been stored or updated.
+
+Storage providers provide the capability to the Catalog Framework to create, read, update, and delete content in the content repository.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/endpoints-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/endpoints-intro-contents.adoc
@@ -1,0 +1,20 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Endpoints
+
+Endpoints expose the Catalog Framework to clients using protocols and formats that the clients understand.
+
+Endpoint interface formats encompass a variety of protocols, including (but not limited to):
+
+* SOAP Web services
+* RESTful services
+* JMS
+* JSON
+* OpenSearch
+
+The endpoint may transform a client request into a compatible Catalog format and then transform the response into a compatible client format.
+Endpoints may use <<_transformers,Transformers>> to perform these transformations.
+This allows an endpoint to interact with Source(s) that have different interfaces.
+For example, an OpenSearch Endpoint can send a query to the Catalog Framework, which could then query a federated source that has no OpenSearch interface.
+
+Endpoints are meant to be the only client-accessible components in the Catalog.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/endpoints-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/endpoints-intro-contents.adoc
@@ -1,6 +1,7 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Endpoints
+:order: 09
 
 Endpoints expose the Catalog Framework to clients using protocols and formats that the clients understand.
 

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/events-subscriptions-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/events-subscriptions-intro-contents.adoc
@@ -1,0 +1,8 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Events and Subscriptions
+
+${branding} can be configured to receive metacards whenever metadata is created, updated, or deleted in any federated sources.
+Creations, updates, and deletions are collectively called *Events*, and the process of registering to recieve them is called *Subscription*.
+
+The behavior of these subscriptions is consistent, but the method of configuring them is specific to the <<_endpoints,Endpoint>> used.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/events-subscriptions-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/events-subscriptions-intro-contents.adoc
@@ -1,8 +1,9 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Events and Subscriptions
+:order: 07
 
-${branding} can be configured to receive metacards whenever metadata is created, updated, or deleted in any federated sources.
+${branding} can be configured to receive notifications whenever metadata is created, updated, or deleted in any federated sources.
 Creations, updates, and deletions are collectively called *Events*, and the process of registering to recieve them is called *Subscription*.
 
 The behavior of these subscriptions is consistent, but the method of configuring them is specific to the <<_endpoints,Endpoint>> used.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/federation-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/federation-intro-contents.adoc
@@ -1,18 +1,19 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Federation
+:order: 06
 
 Federation is the ability of the ${branding} to query other data sources, including other ${branding}s.
 By default, the ${branding} is able to federate using http://www.opensearch.org/Home[OpenSearch] and http://www.opengeospatial.org/standards/cat[CSW] protocols.
-The minimum configuration necessary to configure those federations is to supply a query address.
+The minimum configuration necessary to configure those federations is a query address.
 
 Federation enables constructing dynamic networks of data sources that can be queried individually, or aggregated into specific configuration to enable a wider range of accessibility for data and data products.
 
 Federation provides the capability to extend the ${branding} enterprise to include <<_sources,Remote Sources>>, which may include other instances of ${branding}. 
 The Catalog handles all aspects of federated queries as they are sent to the Catalog Provider and Remote Sources, as they are processed, and as the query results are returned.
 Queries can be scoped to include only the local Catalog Provider (and any Connected Sources), only specific Federated Sources, or the entire enterprise (which includes all local and Remote Sources).
-If the query is supposed to be federated, the Catalog Framework passes the query to a Federation Strategy, which is responsible for querying each federated source that is specified.
+If the query is federated, the Catalog Framework passes the query to a Federation Strategy, which is responsible for querying each federated source that is specified.
 The Catalog Framework is also responsible for receiving the query results from each federated source and returning them to the client in the order specified by the particular federation strategy used.
 After the federation strategy handles the results, the Catalog returns them to the client through the Endpoint.
-Query results returned from a federated query are a list of metacards.
+Query results are returned from a federated query as a list of metacards.
 The source ID in each metacard identifies the Source from which the metacard originated.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/federation-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/federation-intro-contents.adoc
@@ -1,0 +1,18 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Federation
+
+Federation is the ability of the ${branding} to query other data sources, including other ${branding}s.
+By default, the ${branding} is able to federate using http://www.opensearch.org/Home[OpenSearch] and http://www.opengeospatial.org/standards/cat[CSW] protocols.
+The minimum configuration necessary to configure those federations is to supply a query address.
+
+Federation enables constructing dynamic networks of data sources that can be queried individually, or aggregated into specific configuration to enable a wider range of accessibility for data and data products.
+
+Federation provides the capability to extend the ${branding} enterprise to include <<_sources,Remote Sources>>, which may include other instances of ${branding}. 
+The Catalog handles all aspects of federated queries as they are sent to the Catalog Provider and Remote Sources, as they are processed, and as the query results are returned.
+Queries can be scoped to include only the local Catalog Provider (and any Connected Sources), only specific Federated Sources, or the entire enterprise (which includes all local and Remote Sources).
+If the query is supposed to be federated, the Catalog Framework passes the query to a Federation Strategy, which is responsible for querying each federated source that is specified.
+The Catalog Framework is also responsible for receiving the query results from each federated source and returning them to the client in the order specified by the particular federation strategy used.
+After the federation strategy handles the results, the Catalog returns them to the client through the Endpoint.
+Query results returned from a federated query are a list of metacards.
+The source ID in each metacard identifies the Source from which the metacard originated.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/ingest-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/ingest-intro-contents.adoc
@@ -1,0 +1,12 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Ingest
+
+Ingest is the process of bringing data products, metadata, or both into the catalog to enable search, sharing, and discovery.
+Ingested files are <<_transformers,transformed>> into a neutral format that can be searched against as well as migrated to other formats and systems.
+See <<_ingesting_data, Ingesting Data>> for the various methods of ingesting data.
+
+==== Populating Metacards During Ingest
+
+Upon ingest, a transformer will read the metadata from the ingested file and populate the fields of a metacard.
+Exactly how this is accomplished depends on the origin of the data, but most fields (except id) are imported directly.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/ingest-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/ingest-intro-contents.adoc
@@ -1,12 +1,11 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Ingest
+:order: 03
 
 Ingest is the process of bringing data products, metadata, or both into the catalog to enable search, sharing, and discovery.
 Ingested files are <<_transformers,transformed>> into a neutral format that can be searched against as well as migrated to other formats and systems.
 See <<_ingesting_data, Ingesting Data>> for the various methods of ingesting data.
-
-==== Populating Metacards During Ingest
 
 Upon ingest, a transformer will read the metadata from the ingested file and populate the fields of a metacard.
 Exactly how this is accomplished depends on the origin of the data, but most fields (except id) are imported directly.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/metadata-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/metadata-intro-contents.adoc
@@ -1,0 +1,11 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Metadata
+
+In ${branding}, <<_resources,resources>> are the data products, files, reports, or documents of interest to users of the system.
+
+Metadata is information about those resources, organized into a schema to make search possible.
+The ${ddf-catalog} stores this metadata and allows access to it.
+Metacards are single instances of metadata, representing a single resource, in the Catalog.
+Metacards follow one of several schemas to ensure reliable, accurate, and complete metadata.
+Essentially, Metacards function as containers of metadata.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/metadata-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/metadata-intro-contents.adoc
@@ -1,8 +1,9 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Metadata
+:order: 02
 
-In ${branding}, <<_resources,resources>> are the data products, files, reports, or documents of interest to users of the system.
+In ${branding}, <<_introduction_to_resources,resources>> are the data products, files, reports, or documents of interest to users of the system.
 
 Metadata is information about those resources, organized into a schema to make search possible.
 The ${ddf-catalog} stores this metadata and allows access to it.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/registry-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/registry-intro-contents.adoc
@@ -1,0 +1,17 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Registries
+
+The Registry Application serves as an index of registry nodes and their information, including service bindings, configurations and supplemental details.
+
+Each registry has the capability to serve as an index of information about a network of registries which, in turn, can be used to connect across a network of ${branding}s and other data sources.
+Registries communicate with each other through the CSW endpoint and each registry node is converted into a registry metacard to be stored in the catalog.
+When a registry is subscribed to or published from, it sends the details of one or more nodes to another registry.
+
+Identity Node:: The ${ddf-registry} is initially comprised of a single registry node, refered to as the *identity*, which represents the registry's primary configuration.
+
+Subscription:: *Subscribing* to a registry is the act of retreiving its information, specifically its identity information and any other registries it knows about.
+By default, subscriptions are configured to check for updates every 30 seconds.
+
+Publication:: *Publishing* is the act of sending a registry's information to another registry.
+Once publication has occurred, any updates to the local registry will be pushed out to the registries that have been published to.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/registry-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/registry-intro-contents.adoc
@@ -1,6 +1,7 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Registries
+:order: 08
 
 The Registry Application serves as an index of registry nodes and their information, including service bindings, configurations and supplemental details.
 

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/resources-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/resources-intro-contents.adoc
@@ -1,6 +1,7 @@
 :type: coreConcept
 :status: published
-:title: Introduction to Content
+:title: Introduction to Resources
+:order: 04
 
 The Catalog Framework can interface with <<_storage_providers,Storage Providers>> to provide storage of resources to specific types of storage, e.g., file system, relational database, XML database.
 A default file system implementation is provided by default.
@@ -9,4 +10,6 @@ Storage providers act as a proxy between the Catalog Framework and the mechanis
 Storage providers expose the storage mechanism to the Catalog Framework.
 Storage plugins provide pluggable functionality that can be executed either immediately before or immediately after content has been stored or updated.
 
-Storage providers provide the capability to the Catalog Framework to create, read, update, and delete content in the content repository.
+Storage providers provide the capability to the Catalog Framework to create, read, update, and delete resources in the content repository.
+
+See <<_data_management,Data Management>> for more information on specific file types supported by ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/search-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/search-intro-contents.adoc
@@ -1,0 +1,30 @@
+:type: coreConcept
+:status: published
+:title: Introduction to Search
+
+${branding} provides the capability to search the Catalog for metadata.
+There are a number of different types of searches that can be performed on the Catalog, and these searches are accessed using one of several interfaces.
+This section provides a very high level overview of introductory concepts of searching with ${branding}.
+These concepts are expanded upon in later sections.
+
+===== Search Types
+
+There are four basic types of metadata search.
+Additionally, any of the types can be combined to create a compound search.
+
+Text Search:: A text search is used when searching for textual information.
+It searches all textual fields by default, although it is possible to refine searches to a text search on a single metadata attribute.
+Text searches may use wildcards, logical operators, and approximate matches.
+
+Spatial Search:: A spatial search is used for Area of Interest (AOI) searches.
+Polygon and point radius searches are supported.
+
+Temporal Search:: A temporal search finds information from a specific time range.
+Two types of temporal searches are supported: _relative_ and _absolute_.
+Relative searches contain an offset from the current time, while absolute searches contain a start and an end timestamp.
+Temporal searches can use the `created` or `modified` date attributes.
+
+Datatype Search:: A datatype search is used to search for metadata based on the datatype of the resource.
+Wildcards (*) can be used in both the datatype and version fields.
+Metadata that matches any of the datatypes (and associated versions if specified) will be returned.
+If a version is not specified, then all metadata records for the specified datatype(s) regardless of version will be returned.

--- a/distribution/docs/src/main/jdocs/content/_core-concepts/search-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_core-concepts/search-intro-contents.adoc
@@ -1,6 +1,7 @@
 :type: coreConcept
 :status: published
 :title: Introduction to Search
+:order: 00
 
 ${branding} provides the capability to search the Catalog for metadata.
 There are a number of different types of searches that can be performed on the Catalog, and these searches are accessed using one of several interfaces.

--- a/distribution/docs/src/main/jdocs/content/_introduction/applications-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/applications-contents.adoc
@@ -1,6 +1,7 @@
 :type: introduction
 :status: published
 :title: Applications
+:priority: 1
 
 ${branding} is comprised of several modular applications, to be installed or uninstalled as needed.
 
@@ -14,7 +15,7 @@ At the core of the Catalog functionality is the *Catalog Framework*, which rout
 
 ${ddf-platform} Application::
 The Core application of the distribution.
-The Platform application has fundamental building blocks that the distribution needs to run.
+The Platform application contains the fundamental building blocks to run the distribution.
 
 ${ddf-security} Application::
 Provides authentication, authorization, and auditing services for the ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/applications-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/applications-contents.adoc
@@ -1,0 +1,31 @@
+:type: introduction
+:status: published
+:title: Applications
+
+${branding} is comprised of several modular applications, to be installed or uninstalled as needed.
+
+${ddf-admin} Application::
+Enhances administrative capabilities when installing and managing ${branding}. It contains various services and interfaces that allow administrators more control over their systems.
+
+${ddf-catalog} Application::
+Provides a framework for storing, searching, processing, and transforming information.
+Clients typically perform local and/or federated query, create, read, update, and delete (QCRUD) operations against the Catalog.
+At the core of the Catalog functionality is the *Catalog Framework*, which routes all requests and responses through the system, invoking additional processing per the system configuration.
+
+${ddf-platform} Application::
+The Core application of the distribution.
+The Platform application has fundamental building blocks that the distribution needs to run.
+
+${ddf-security} Application::
+Provides authentication, authorization, and auditing services for the ${branding}.
+It is both a framework that developers and integrators can extend and a reference implementation that meets security requirements.
+
+${ddf-solr} Application::
+Includes the Solr Catalog Provider, an implementation of the Catalog Provider using http://lucene.apache.org/solr/[Apache Solr] as a data store.
+
+${ddf-spatial} Application::
+Provides OGC services, such as http://www.opengeospatial.org/standards/cat[CSW], http://www.opengeospatial.org/standards/wcs[WCS], http://www.opengeospatial.org/standards/wfs[WFS], and http://www.opengeospatial.org/standards/kml[KML].
+
+${ddf-ui}::
+Allows a user to search for records in the local Catalog (provider) and federated sources.
+Results of the search are returned and displayed on a globe or map, providing a visual representation of where the records were found.

--- a/distribution/docs/src/main/jdocs/content/_introduction/core-concepts-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/core-concepts-intro-contents.adoc
@@ -1,0 +1,6 @@
+:type: documentation
+:status: published
+:filename: core-concepts-intro-contents.adoc
+:projectpath: {adoc-include}
+
+This introduction section is intended to give a high level overview of the concepts and capabilities of ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/core-concepts-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/core-concepts-intro-contents.adoc
@@ -1,6 +1,6 @@
-:type: documentation
+:type: introduction
 :status: published
-:filename: core-concepts-intro-contents.adoc
-:projectpath: {adoc-include}
+:title: Core Concepts Introduction
+:priority: 1
 
 This introduction section is intended to give a high level overview of the concepts and capabilities of ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/developing-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/developing-intro-contents.adoc
@@ -1,6 +1,6 @@
+:title: Developing Intro
 :type: documentation
 :status: published
-:filename: developing-intro-contents.adoc
-:projectpath: {adoc-include}
+:priority: 1
 
 Developers will build or extend the functionality of the applications. 

--- a/distribution/docs/src/main/jdocs/content/_introduction/developing-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/developing-intro-contents.adoc
@@ -1,0 +1,6 @@
+:type: documentation
+:status: published
+:filename: developing-intro-contents.adoc
+:projectpath: {adoc-include}
+
+Developers will build or extend the functionality of the applications. 

--- a/distribution/docs/src/main/jdocs/content/_introduction/documentation-notes-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/documentation-notes-contents.adoc
@@ -1,0 +1,53 @@
+:type: introduction
+:status: published
+:title: Documentation Guide
+
+The ${branding} documentation is organized by audience.
+
+<<_core_concepts,Core Concepts>>::
+This introduction section is intended to give a high level overview of the concepts and capabilities of ${branding}.
+
+Administrators::
+<<_managing,Managing>> |
+Administrators will be installing, maintaining, and supporting existing applications.
+Use this section to <<_installation_prerequisites,prepare>>, <<_installing,install>>, <<_configuring,configure>>, <<_running,run>>, and <<_monitoring,monitor>> a ${branding}.
+
+Users::
+<<_using,Using>> |
+Users interact with the system to search data stores.
+Use this section to navigate the various user interfaces available in ${branding}.
+
+Integrators::
+<<_integrating,Integrating>> |
+Integrators will use the existing applications to support their external frameworks. This section will provide details for finding, accessing and using the components of ${branding}.
+
+Developers::
+<<_developing,Developing>> |
+Developers will build or extend the functionality of the applications. 
+
+==== Documentation Conventions
+
+The following conventions are used within this documentation:
+
+===== Customizable Values
+
+Many values used in descriptions are customizable and should be changed for specific use cases.
+These values are denoted by `< >`, and by `[[ ]]` when within XML syntax. When using a real value, the placeholder characters should be omitted.
+
+===== Code Values
+
+Java objects, lines of code, or file properties are denoted with the `Monospace` font style.
+Example: `ddf.catalog.CatalogFramework`
+
+===== Hyperlinks
+
+Some hyperlinks (e.g., `/admin`) within the documentation assume a locally running installation of ${ddf-branding}. 
+Simply change the hostname if accessing a remote host.
+
+==== Support
+
+Questions about ${ddf-branding} should be posted to the https://groups.google.com/d/forum/ddf-users[ddf-users forum] or https://groups.google.com/d/forum/ddf-developers[ddf-developers forum], where they will be responded to quickly by a member of the ${ddf-branding} team.
+
+=====  Documentation Updates
+
+The most current ${ddf-branding} documentation is available at http://codice.org/ddf/Documentation-versions.html[${ddf-branding} Documentation].

--- a/distribution/docs/src/main/jdocs/content/_introduction/documentation-notes-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/documentation-notes-contents.adoc
@@ -1,6 +1,7 @@
 :type: introduction
 :status: published
 :title: Documentation Guide
+:priority: 1
 
 The ${branding} documentation is organized by audience.
 

--- a/distribution/docs/src/main/jdocs/content/_introduction/integrating-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/integrating-intro-contents.adoc
@@ -1,0 +1,6 @@
+:type: documentation
+:status: published
+:filename: integrating-intro-contents.adoc
+:projectpath: {adoc-include}
+
+Integrators will use the existing applications to support their external frameworks. This section will provide details for finding, accessing and using the components of ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/integrating-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/integrating-intro-contents.adoc
@@ -1,6 +1,6 @@
+:title: Integrating Intro
 :type: documentation
 :status: published
-:filename: integrating-intro-contents.adoc
-:projectpath: {adoc-include}
+:priority: 1
 
 Integrators will use the existing applications to support their external frameworks. This section will provide details for finding, accessing and using the components of ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/introduction-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/introduction-contents.adoc
@@ -1,0 +1,14 @@
+:type: introduction
+:status: published
+:title: Introduction
+
+${ddf-branding-expanded} (${ddf-branding}) is a free and open-source common data layer that abstracts services and business logic from the underlying data structures to enable rapid integration of new data sources.
+
+Licensed under http://www.gnu.org/licenses/gpl.html[LGPL], ${ddf-branding} is an interoperability platform that provides secure and scalable discovery and retrieval from a wide array of disparate sources.
+
+${ddf-branding} is:
+
+* a flexible and modular integration framework.
+* built to "unzip and run" while having the ability to scale to large enterprise systems.
+* primarily focused on data integration, enabling clients to insert, query, and transform information from disparate data sources via the ${ddf-branding} Catalog.
+

--- a/distribution/docs/src/main/jdocs/content/_introduction/introduction-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/introduction-contents.adoc
@@ -1,14 +1,17 @@
 :type: introduction
 :status: published
 :title: Introduction
+:priority: 1
 
-${ddf-branding-expanded} (${ddf-branding}) is a free and open-source common data layer that abstracts services and business logic from the underlying data structures to enable rapid integration of new data sources.
+=== Introducing ${ddf-branding}
+
+*${ddf-branding-expanded}* (*${ddf-branding}*) is a free and open-source common data layer that abstracts services and business logic from underlying data structures to enable rapid integration of new data sources.
 
 Licensed under http://www.gnu.org/licenses/gpl.html[LGPL], ${ddf-branding} is an interoperability platform that provides secure and scalable discovery and retrieval from a wide array of disparate sources.
 
 ${ddf-branding} is:
 
 * a flexible and modular integration framework.
-* built to "unzip and run" while having the ability to scale to large enterprise systems.
+* built to "unzip and run" even when scaled to large enterprise systems.
 * primarily focused on data integration, enabling clients to insert, query, and transform information from disparate data sources via the ${ddf-branding} Catalog.
 

--- a/distribution/docs/src/main/jdocs/content/_introduction/managing-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/managing-intro-contents.adoc
@@ -1,7 +1,7 @@
+:title: Managing Intro
 :type: documentation
 :status: published
-:filename: managing-intro-contents.adoc
-:projectpath: {adoc-include}
+:priority: 1
 
 Administrators will be installing, maintaining, and supporting existing applications.
 Use this section to prepare, install, configure, run, and monitor a ${branding}.

--- a/distribution/docs/src/main/jdocs/content/_introduction/managing-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_introduction/managing-intro-contents.adoc
@@ -1,0 +1,7 @@
+:type: documentation
+:status: published
+:filename: managing-intro-contents.adoc
+:projectpath: {adoc-include}
+
+Administrators will be installing, maintaining, and supporting existing applications.
+Use this section to prepare, install, configure, run, and monitor a ${branding}.

--- a/distribution/docs/src/main/jdocs/jbake.properties
+++ b/distribution/docs/src/main/jdocs/jbake.properties
@@ -18,5 +18,5 @@ template.transformerIntro.file=transformers.ftl
 template.mimeTypeMapper.file=transformers.ftl
 template.mimeTypeResolver.file=transformers.ftl
 template.developingComponent.file=developing-components.ftl
-render.endpoint=false
-render.source=false
+template.introduction.file=introduction.ftl
+template.coreConcept.file=introduction.ftl

--- a/distribution/docs/src/main/jdocs/templates/documentation.ftl
+++ b/distribution/docs/src/main/jdocs/templates/documentation.ftl
@@ -1,5 +1,9 @@
 = ${branding-expanded} Documentation
-include::${project.build.directory}/doc-contents/_contents/jconfig.adoc[]
+include::${project.build.directory}/doc-contents/_contents/config.adoc[]
+
+== Introduction
+
+<#include "introduction.ftl">
 
 :sectnums!:
 == Integrating

--- a/distribution/docs/src/main/jdocs/templates/documentation.ftl
+++ b/distribution/docs/src/main/jdocs/templates/documentation.ftl
@@ -1,7 +1,9 @@
 = ${branding-expanded} Documentation
 include::${project.build.directory}/doc-contents/_contents/config.adoc[]
 
+:sectnums!:
 == Introduction
+:sectnums:
 
 <#include "introduction.ftl">
 

--- a/distribution/docs/src/main/jdocs/templates/eventing.ftl
+++ b/distribution/docs/src/main/jdocs/templates/eventing.ftl
@@ -5,7 +5,7 @@
 === ${ev.title}
 
 include::${ev.file}[]
-<#else> icon::[star]
+
 </#if>
 
 <#if (ev.title == "Subscriptions")>
@@ -13,6 +13,6 @@ include::${ev.file}[]
 === ${ev.title}
 
 include::${ev.file}[]
-<#else> icon[heart]
+
 </#if>
 </#list>

--- a/distribution/docs/src/main/jdocs/templates/introduction.ftl
+++ b/distribution/docs/src/main/jdocs/templates/introduction.ftl
@@ -1,14 +1,17 @@
-<#list introductions as intro>
+== About ${branding}
+<#list introductions?sort_by("priority") as intro>
 <#if (intro.title == "Introduction")>
 include::${intro.file}[]
+
 </#if>
 </#list>
 
-=== Applications
+=== Component Applications
 
 <#list introductions as intro>
 <#if (intro.title == "Applications")>
 include::${intro.file}[]
+
 </#if>
 </#list>
 
@@ -17,17 +20,20 @@ include::${intro.file}[]
 <#list introductions as intro>
 <#if (intro.title == "Documentation Guide")>
 include::${intro.file}[]
+
 </#if>
 </#list>
 
 === Core Concepts
 
 <#assign count=0>
-<#list coreConcepts as coreConcept>
+<#list coreConcepts?sort_by("order") as coreConcept>
 <#if (coreConcept.status == "published")>
 <#assign count++>
 
+<#if (coreConcept.title?contains("Introduction"))>
 ==== ${coreConcept.title}
+</#if>
 
 include::${coreConcept.file}[]
 

--- a/distribution/docs/src/main/jdocs/templates/introduction.ftl
+++ b/distribution/docs/src/main/jdocs/templates/introduction.ftl
@@ -1,0 +1,38 @@
+<#list introductions as intro>
+<#if (intro.title == "Introduction")>
+include::${intro.file}[]
+</#if>
+</#list>
+
+=== Applications
+
+<#list introductions as intro>
+<#if (intro.title == "Applications")>
+include::${intro.file}[]
+</#if>
+</#list>
+
+=== Documentation Guide
+
+<#list introductions as intro>
+<#if (intro.title == "Documentation Guide")>
+include::${intro.file}[]
+</#if>
+</#list>
+
+=== Core Concepts
+
+<#assign count=0>
+<#list coreConcepts as coreConcept>
+<#if (coreConcept.status == "published")>
+<#assign count++>
+
+==== ${coreConcept.title}
+
+include::${coreConcept.file}[]
+
+</#if>
+</#list>
+<#if (count == 0)>
+None.
+</#if>

--- a/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.transformer.input.pdf.PdfInputTransformer-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.transformer.input.pdf.PdfInputTransformer-table-contents.adoc
@@ -1,0 +1,21 @@
+:type: documentation
+:status: published
+
+.[[ddf.catalog.transformer.input.pdf.PdfInputTransformer]]PDF Input Transformer
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+|Name
+|Property
+|Type
+|Description
+|Default Value
+|Required
+
+|Use PDF Title
+|usePdfTitleAsTitle
+|Boolean
+|Use the PDF's metadata to determine the metacard title. If this is not enabled, the metacard title will be the file name.
+|false
+|true
+
+|===

--- a/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.transformer.input.pptx.PptxInputTransformer-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.transformer.input.pptx.PptxInputTransformer-table-contents.adoc
@@ -1,0 +1,22 @@
+:type: documentation
+:status: published
+
+.[[ddf.catalog.transformer.input.pptx.PptxInputTransformer]]PowerPoint Input Transformer
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Use PPTX Title
+|usePptTitleAsTitle
+|Boolean
+|Use the PowerPoint document's metadata to determine the metacard title. If this is not enabled, the metacard title will be the file name.
+|false
+|true
+
+|===

--- a/distribution/docs/src/main/resources/_contents/config.adoc
+++ b/distribution/docs/src/main/resources/_contents/config.adoc
@@ -24,7 +24,8 @@ ifdef::backend-pdf[]
 :sectnums:
 Copyright (c) Codice Foundation. +
 This work is licensed under a http://creativecommons.org/licenses/by/4.0[Creative Commons Attribution 4.0 International License].
-This page last updated:
+
+This document last updated: ${timestamp}.
 
 <<<
 endif::[]

--- a/distribution/docs/src/main/resources/_contents/config.adoc
+++ b/distribution/docs/src/main/resources/_contents/config.adoc
@@ -1,6 +1,7 @@
 Version ${project.version}. Copyright (c) Codice Foundation
 :imagesdir: ${project.build.directory}/doc-contents/images
 :toc: left
+:toclevels: 6
 :example-caption:
 :source-highlighter: coderay
 :sectlinks:
@@ -18,7 +19,9 @@ This page last updated:
 
 ifdef::backend-pdf[]
 [colophon]
+:sectnums!:
 == License
+:sectnums:
 Copyright (c) Codice Foundation. +
 This work is licensed under a http://creativecommons.org/licenses/by/4.0[Creative Commons Attribution 4.0 International License].
 This page last updated:


### PR DESCRIPTION
#### What does this PR do?

- Adds the introduction and core-concepts sections of the documentation to the jbake templates. 
- Simplified/reduced the outline/TOC for these sections

#### Who is reviewing it?

@mcalcote @vinamartin @Lambeaux @jrnorth 

#### Select at least one member from relevant component team(s) from below.

[Docs](https://github.com/orgs/codice/teams/docs)

#### Choose 2 committers to review/merge the PR.

@clockard
@coyotesqrl
@lessarderic
@pklinef
@shaundmorris

#### How should this be tested?

Verify sections are being included from old format.

#### Any background context you want to provide?

`-contents.adoc` files unchanged except for adding headers. Content review optional.

#### What are the relevant tickets?
[DDF-2880](https://codice.atlassian.net/browse/DDF-2880)
#### Screenshots (if appropriate)

[jdocumentation.pdf](https://github.com/codice/ddf/files/1006135/jdocumentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
