### PR TITLE
DDF-3024 CSV Query Response Transformer

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -614,5 +614,10 @@
             <artifactId>catalog-plugin-security-audit</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>csv-queryresponse-transformer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -269,6 +269,12 @@
         <bundle>mvn:ddf.catalog.transformer/service-atom-transformer/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-transformer-csv" install="auto" version="${project.version}"
+             description="CSV Query Response Transformer converts query results to CSV format.">
+        <feature prerequisite="true">catalog-app</feature>
+        <bundle>mvn:ddf.catalog.transformer/csv-queryresponse-transformer/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-transformer-geoformatter" install="manual" version="${project.version}"
              description="Geo library to help with conversion of geometry objects into various formats such GeoJson, GeoRSS, etc.">
         <feature prerequisite="true">abdera</feature>

--- a/catalog/transformer/catalog-transformer-csv/pom.xml
+++ b/catalog/transformer/catalog-transformer-csv/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.catalog.transformer</groupId>
+        <artifactId>transformer</artifactId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <packaging>bundle</packaging>
+    <artifactId>csv-queryresponse-transformer</artifactId>
+    <name>DDF :: Catalog :: Transformer :: QueryResponse :: CSV</name>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons-csv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            commons-csv,
+                            commons-lang3,
+                            platform-util
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/ColumnHeaderIterator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/ColumnHeaderIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import ddf.catalog.data.AttributeDescriptor;
+
+/**
+ * An implementation of java.util.Iterator that iterates over the supplied list of
+ * AttributeDescriptors returning either the attribute name or (if provided) an alias
+ * for the attribute.
+ *
+ * @see java.util.Iterator
+ */
+class ColumnHeaderIterator implements Iterator<String> {
+    private Map<String, String> columnAliasMap;
+
+    private List<AttributeDescriptor> attributeDescriptorList;
+
+    private int index;
+
+    /**
+     * @param attributeDescriptorList an ordered list of the AttributeDescriptors to iterate over
+     * @param columnAliasMap          a map of Strings from attribute name to column name (alias).
+     */
+    ColumnHeaderIterator(final List<AttributeDescriptor> attributeDescriptorList,
+            final Map<String, String> columnAliasMap) {
+        this.attributeDescriptorList = Collections.unmodifiableList(attributeDescriptorList);
+        this.columnAliasMap = Collections.unmodifiableMap(columnAliasMap);
+        index = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        return this.attributeDescriptorList.size() > index;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String next() {
+        if (!this.hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        AttributeDescriptor attributeDescriptor = attributeDescriptorList.get(index);
+        String attributeDescriptorName = attributeDescriptor.getName();
+        String columnAlias = Optional.ofNullable(columnAliasMap.get(attributeDescriptorName))
+                .orElse(attributeDescriptorName);
+
+        index++;
+        return columnAlias;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvAttributeDescriptorComparator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvAttributeDescriptorComparator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.CompareToBuilder;
+
+import ddf.catalog.data.AttributeDescriptor;
+
+/**
+ * An implementation of java.util.Comparator that sorts AttributeDescriptors according to the
+ * provided list of attribute names. This allows us to put the output csv columns in any order
+ * as specified by the user.
+ *
+ * @see java.util.Comparator
+ */
+class CsvAttributeDescriptorComparator implements Comparator<AttributeDescriptor>, Serializable {
+    private static final int EQUAL = 0;
+
+    private static final int LESSER = -1;
+
+    private static final int GREATER = 1;
+
+    private List<String> attributeOrder;
+
+    /**
+     * @param attributeOrder the order in which the attributes should be output.
+     */
+    CsvAttributeDescriptorComparator(List<String> attributeOrder) {
+        this.attributeOrder = Collections.unmodifiableList(attributeOrder);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int compare(AttributeDescriptor descriptor1, AttributeDescriptor descriptor2) {
+        if (descriptor1 == null && descriptor2 == null) {
+            return EQUAL;
+        }
+
+        if (descriptor1 == null) {
+            return LESSER;
+        }
+
+        if (descriptor2 == null) {
+            return GREATER;
+        }
+
+        String descriptorName1 = descriptor1.getName();
+        String descriptorName2 = descriptor2.getName();
+
+        return new CompareToBuilder().append(getAttributeIndex(descriptorName1),
+                getAttributeIndex(descriptorName2))
+                .toComparison();
+    }
+
+    /**
+     * @param attributeName the name of the attribute that we need to find the index of.
+     * @return the index of the attribute in the 'attributeOrder' list whose name is 'attributeName'
+     */
+    private int getAttributeIndex(String attributeName) {
+        int descriptorIndex = attributeOrder.indexOf(attributeName);
+
+        if (descriptorIndex == -1) {
+            return attributeOrder.size();
+        }
+
+        return descriptorIndex;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.QueryResponseTransformer;
+
+/**
+ * An implementation of QueryResponseTransformer that produces CSV output.
+ *
+ * @see ddf.catalog.transform.QueryResponseTransformer
+ */
+
+public class CsvQueryResponseTransformer implements QueryResponseTransformer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvQueryResponseTransformer.class);
+
+    private static final String HIDDEN_FIELDS_KEY = "hiddenFields";
+
+    private static final String COLUMN_ORDER_KEY = "columnOrder";
+
+    private static final String COLUMN_ALIAS_KEY = "aliases";
+
+    /**
+     * @param upstreamResponse the SourceResponse to be converted.
+     * @param arguments        this transformer accepts 3 parameters in the 'arguments' map.
+     *                         1) key: 'hiddenFields'
+     *                         value: a java.util.Set containing Attribute names (as Strings) to be
+     *                         excluded from the output.
+     *                         2) key: 'attributeOrder'
+     *                         value: a java.utilList containing Attribute name (as Strings) to identify
+     *                         the order that the columns will appear in the output.
+     *                         3) key: 'aliases'
+     *                         value: a java.util.Map whose keys are attribute names and values are
+     *                         the how that attribute column should be aliased in the output.
+     *                         For example, if the key is 'title' and the value is 'Product'
+     *                         then the resulting CSV will have a column name of 'Product'
+     *                         instead of 'title'.
+     * @return a BinaryContent object that contains an InputStream with the CSV content.
+     * @throws CatalogTransformerException during processing, the CSV output is written to an
+     *         Appendable, whose 'append()' method signature declares that it throws IOException.
+     *         When that Appendable throws IOException, this class will theoretically convert that
+     *         into a CatalogTransformerException and raise that. Because this implementation uses a
+     *         StringBuilder which doesn't throw IOException, this will never occur.
+     */
+    @Override
+    public BinaryContent transform(SourceResponse upstreamResponse,
+            Map<String, Serializable> arguments) throws CatalogTransformerException {
+
+        Set<String> hiddenFields =
+                Optional.ofNullable((Set<String>) arguments.get(HIDDEN_FIELDS_KEY))
+                        .orElse(Collections.emptySet());
+
+        List<String> attributeOrder = Optional.ofNullable((List<String>) arguments.get(
+                COLUMN_ORDER_KEY))
+                .orElse(Collections.emptyList());
+
+        Map<String, String> columnAliasMap =
+                Optional.ofNullable((Map<String, String>) arguments.get(COLUMN_ALIAS_KEY))
+                        .orElse(Collections.emptyMap());
+
+        Set<AttributeDescriptor> allAttributeDescriptors = getAllRequestedAttributes(
+                upstreamResponse.getResults(),
+                hiddenFields);
+
+        List<AttributeDescriptor> sortedAttributeDescriptors = sortAttributes(
+                allAttributeDescriptors,
+                attributeOrder);
+
+        Appendable csv = writeSearchResultsToCsv(upstreamResponse,
+                columnAliasMap,
+                sortedAttributeDescriptors);
+
+        return createResponse(csv);
+    }
+
+    private BinaryContent createResponse(final Appendable csv) {
+        InputStream inputStream = new ByteArrayInputStream(csv.toString()
+                .getBytes(Charset.defaultCharset()));
+        BinaryContent binaryContent = new BinaryContentImpl(inputStream);
+        return binaryContent;
+    }
+
+    private Appendable writeSearchResultsToCsv(final SourceResponse upstreamResponse,
+            Map<String, String> columnAliasMap,
+            List<AttributeDescriptor> sortedAttributeDescriptors)
+            throws CatalogTransformerException {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        try {
+            CSVPrinter csvPrinter = new CSVPrinter(stringBuilder, CSVFormat.RFC4180);
+            printColumnHeaders(csvPrinter, sortedAttributeDescriptors, columnAliasMap);
+
+            upstreamResponse.getResults()
+                    .stream()
+                    .map(Result::getMetacard)
+                    .forEach(mc -> printMetacard(csvPrinter, mc, sortedAttributeDescriptors));
+
+            return csvPrinter.getOut();
+        } catch (IOException ioe) {
+            throw new CatalogTransformerException(ioe.getMessage(), ioe);
+        }
+    }
+
+    private void printMetacard(final CSVPrinter csvPrinter, final Metacard metacard,
+            final List<AttributeDescriptor> attributeDescriptors) {
+
+        Iterator<Serializable> metacardIterator = new MetacardIterator(metacard,
+                attributeDescriptors);
+
+        printData(csvPrinter, metacardIterator);
+    }
+
+    private void printColumnHeaders(final CSVPrinter csvPrinter,
+            final List<AttributeDescriptor> attributeDescriptors, Map<String, String> aliasMap) {
+        Iterator<String> columnHeaderIterator = new ColumnHeaderIterator(attributeDescriptors,
+                aliasMap);
+
+        printData(csvPrinter, columnHeaderIterator);
+    }
+
+    private void printData(final CSVPrinter csvPrinter, final Iterator iterator) {
+        try {
+            csvPrinter.printRecord(() -> iterator);
+        } catch (IOException ioe) {
+            LOGGER.error(ioe.getMessage(), ioe);
+        }
+    }
+
+    private List<AttributeDescriptor> sortAttributes(final Set<AttributeDescriptor> attributeSet,
+            final List<String> attributeOrder) {
+        CsvAttributeDescriptorComparator attributeComparator = new CsvAttributeDescriptorComparator(
+                attributeOrder);
+
+        return attributeSet.stream()
+                .sorted(attributeComparator)
+                .collect(Collectors.toList());
+    }
+
+    private Set<AttributeDescriptor> getAllRequestedAttributes(final List<Result> results,
+            final Set<String> hiddenFields) {
+
+        Set<AttributeDescriptor> allAttributes = new HashSet<>();
+
+        results.stream()
+                .map(Result::getMetacard)
+                .map(Metacard::getMetacardType)
+                .map(MetacardType::getAttributeDescriptors)
+                .forEach(descriptorSet -> descriptorSet.stream()
+                        .filter(desc -> !AttributeType.AttributeFormat.BINARY.equals(desc.getType()
+                                .getAttributeFormat()))
+                        .filter(desc -> !AttributeType.AttributeFormat.OBJECT.equals(desc.getType()
+                                .getAttributeFormat()))
+                        .filter(desc -> !hiddenFields.contains(desc.getName()))
+                        .forEach(allAttributes::add));
+
+        return allAttributes;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+
+/**
+ * An implementation of java.util.Iterator which iterates over Metacard attribute values.
+ *
+ * @see java.util.Iterator
+ */
+class MetacardIterator implements Iterator<Serializable> {
+    private List<AttributeDescriptor> attributeDescriptorList;
+
+    private Metacard metacard;
+
+    private int index;
+
+    /**
+     * @param metacard                the metacard to be iterated over.
+     * @param attributeDescriptorList the list of attributeDescriptors used to determine which
+     *                                metacard attributes to return.
+     */
+    MetacardIterator(final Metacard metacard,
+            final List<AttributeDescriptor> attributeDescriptorList) {
+        this.metacard = metacard;
+        this.attributeDescriptorList = Collections.unmodifiableList(attributeDescriptorList);
+        this.index = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        return this.attributeDescriptorList.size() > index;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Serializable next() {
+        if (!this.hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        AttributeDescriptor attributeDescriptor = this.attributeDescriptorList.get(index);
+        Attribute attribute = metacard.getAttribute(attributeDescriptor.getName());
+        index++;
+
+        if (attribute != null) {
+            return attribute.getValue();
+        }
+
+        return "";
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-csv/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <service ref="CsvQueryResponseTransformer"
+             interface="ddf.catalog.transform.QueryResponseTransformer">
+        <service-properties>
+            <entry key="id" value="csv"/>
+            <entry key="mime-type" >
+                <list>
+                    <value>text/csv</value>
+                </list>
+            </entry>
+        </service-properties>
+    </service>
+
+    <bean id="CsvQueryResponseTransformer"
+          class="ddf.catalog.transformer.csv.CsvQueryResponseTransformer">
+    </bean>
+
+</blueprint>

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/ColumnHeaderIteratorTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/ColumnHeaderIteratorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.AttributeDescriptor;
+
+public class ColumnHeaderIteratorTest {
+    private static final String[][] TEST_DATA =
+            {{"attribute1", "column1"},
+             {"attribute2", "column2"},
+             {"attribute3"}};
+
+    private List<AttributeDescriptor> attributeDescriptorList;
+
+    private Map<String, String> aliasMap;
+
+    @Before
+    public void setUp() {
+        this.attributeDescriptorList = new ArrayList<AttributeDescriptor>();
+        this.aliasMap = new HashMap<>();
+
+        for (String[] data : TEST_DATA) {
+            AttributeDescriptor descriptor = buildAttribute(data[0]);
+            attributeDescriptorList.add(descriptor);
+
+            if (data.length == 2) {
+                aliasMap.put(data[0], data[1]);
+            }
+        }
+    }
+
+    @Test
+    public void testColumnHeaderIterator() {
+        Iterator<String> iterator = new ColumnHeaderIterator(attributeDescriptorList, aliasMap);
+
+        for (int i = 0; i < TEST_DATA.length - 1; i++) {
+            assertThat(iterator.hasNext(), is(true));
+            assertThat(iterator.next(), is(TEST_DATA[i][1]));
+        }
+
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next(), is(TEST_DATA[2][0]));
+        assertThat(iterator.hasNext(), is(false));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testHasNext() {
+        Iterator<String> iterator = new ColumnHeaderIterator(attributeDescriptorList, aliasMap);
+
+        while (iterator.hasNext()) {
+            iterator.next();
+        }
+
+        iterator.next();
+    }
+
+    private AttributeDescriptor buildAttribute(String name) {
+        AttributeDescriptor attribute = mock(AttributeDescriptor.class);
+        when(attribute.getName()).thenReturn(name);
+        return attribute;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvAttributeDescriptorComparatorTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvAttributeDescriptorComparatorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.AttributeDescriptor;
+
+public class CsvAttributeDescriptorComparatorTest {
+    private CsvAttributeDescriptorComparator comparator;
+
+    private AttributeDescriptor attribute1;
+
+    private AttributeDescriptor attribute2;
+
+    private AttributeDescriptor nonExistendAttribute1;
+
+    private AttributeDescriptor nonExistendAttribute2;
+
+    @Before
+    public void setUp() {
+        String[] columnNames = {"columnC", "columnB", "columnA", "columnD"};
+        this.attribute1 = buildAttribute(columnNames[0]);
+        this.attribute2 = buildAttribute(columnNames[2]);
+        this.nonExistendAttribute1 = buildAttribute("columnE");
+        this.nonExistendAttribute2 = buildAttribute("columnF");
+        this.comparator = new CsvAttributeDescriptorComparator(Arrays.asList(columnNames));
+    }
+
+    @Test
+    public void testDescriptorComparator() {
+        int comparison = comparator.compare(attribute1, attribute2);
+        assertThat(comparison, is(-1));
+
+        comparison = comparator.compare(attribute2, attribute1);
+        assertThat(comparison, is(1));
+
+        comparison = comparator.compare(attribute1, attribute1);
+        assertThat(comparison, is(0));
+
+        comparison = comparator.compare(attribute1, nonExistendAttribute1);
+        assertThat(comparison, is(-1));
+
+        comparison = comparator.compare(nonExistendAttribute1, attribute1);
+        assertThat(comparison, is(1));
+
+        comparison = comparator.compare(nonExistendAttribute1, nonExistendAttribute2);
+        assertThat(comparison, is(0));
+
+        comparison = comparator.compare(nonExistendAttribute1, null);
+        assertThat(comparison, is(1));
+
+        comparison = comparator.compare(null, nonExistendAttribute2);
+        assertThat(comparison, is(-1));
+
+        comparison = comparator.compare(null, null);
+        assertThat(comparison, is(0));
+    }
+
+    private AttributeDescriptor buildAttribute(String name) {
+        AttributeDescriptor attribute = mock(AttributeDescriptor.class);
+        when(attribute.getName()).thenReturn(name);
+        return attribute;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.transform.CatalogTransformerException;
+
+public class CsvQueryResponseTransformerTest {
+
+    private static final Object[][] ATTRIBUTE_DATA = {{"attribute1", "value1", BasicTypes.STRING_TYPE},
+            {"attribute2", new Integer(101), BasicTypes.INTEGER_TYPE},
+            {"attribute3", new Double(3.14159), BasicTypes.DOUBLE_TYPE},
+            {"attribute4", "value,4", BasicTypes.STRING_TYPE},
+            {"attribute5", "value5", BasicTypes.STRING_TYPE},
+            {"attribute6", "OBJECT", BasicTypes.OBJECT_TYPE},
+            {"attribute7", "BINARY", BasicTypes.BINARY_TYPE}};
+
+    private static final Map<String, Serializable> METACARD_DATA_MAP = new HashMap<>();
+
+    private static final List<AttributeDescriptor> ATTRIBUTE_DESCRIPTOR_LIST = new ArrayList<>();
+
+    private static final List<Result> RESULT_LIST = new ArrayList<>();
+
+    public static final int METACARD_COUNT = 10;
+
+    private SourceResponse sourceResponse;
+
+    private CsvQueryResponseTransformer transformer;
+
+    @Before
+    public void setUp() {
+        RESULT_LIST.clear();
+        ATTRIBUTE_DESCRIPTOR_LIST.clear();
+        METACARD_DATA_MAP.clear();
+
+        this.transformer = new CsvQueryResponseTransformer();
+        buildMetacardDataMap();
+        this.sourceResponse = buildSourceResponse();
+        buildResultList();
+    }
+
+    @Test
+    public void testCsvQueryResponseTransformer() throws CatalogTransformerException, IOException {
+        Map<String, Serializable> argumentsMap = new HashMap<>();
+
+        String[] hiddenFieldsArray = {"attribute3", "attribute5"};
+        argumentsMap.put("hiddenFields", buildSet(hiddenFieldsArray));
+
+        String[] columnOrderArray = {"attribute4", "attribute2"};
+        argumentsMap.put("columnOrder", buildList(columnOrderArray));
+
+        String[][] aliases = {{"attribute1", "column1"}, {"attribute2", "column2"}};
+        argumentsMap.put("aliases", buildMap(aliases));
+
+        assertThat(ATTRIBUTE_DESCRIPTOR_LIST.size(), is(ATTRIBUTE_DATA.length));
+
+        BinaryContent bc = transformer.transform(sourceResponse, argumentsMap);
+        Scanner scanner = new Scanner(bc.getInputStream());
+        scanner.useDelimiter("\\n|\\r|,");
+
+        //OBJECT types, BINARY types and hidden attributes will be filtered out
+        String[] expectedHeaders = {"attribute4", "column2", "column1"};
+        validate(scanner, expectedHeaders);
+
+        //The scanner will split "value,4" into two tokens even though the CSVPrinter will
+        //handle it correctly.
+        String[] expectedValues = {"", "\"value", "4\"", "101", "value1"};
+
+        for (int i = 0; i < METACARD_COUNT; i++) {
+            validate(scanner, expectedValues);
+        }
+
+        //final new line causes an extra "" value at end of file
+        assertThat(scanner.hasNext(), is(true));
+        assertThat(scanner.next(), is(""));
+        assertThat(scanner.hasNext(), is(false));
+    }
+
+    private void validate(Scanner scanner, String[] expectedValues) {
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertThat(scanner.hasNext(), is(true));
+            assertThat(scanner.next(), is(expectedValues[i]));
+        }
+    }
+
+    private ArrayList<String> buildList(String[] entries) {
+        ArrayList<String> arrayList = new ArrayList<>();
+        arrayList.addAll(Arrays.asList(entries));
+        return arrayList;
+    }
+
+    private HashMap<String, String> buildMap(String[][] entries) {
+        HashMap<String, String> hashMap = new HashMap<>();
+
+        for (String[] entry : entries) {
+            hashMap.put(entry[0], entry[1]);
+        }
+
+        return hashMap;
+    }
+
+    private HashSet<String> buildSet(String[] attributes) {
+        HashSet<String> hashSet = new HashSet<>();
+        hashSet.addAll(Arrays.asList(attributes));
+        return hashSet;
+    }
+
+    private void buildMetacardDataMap() {
+        for (Object[] entry : ATTRIBUTE_DATA) {
+            String attributeName = entry[0].toString();
+            AttributeType attributeType = (AttributeType) entry[2];
+            Serializable attributeValue = (Serializable) entry[1];
+            Attribute attribute = buildAttribute(attributeName, attributeValue);
+            METACARD_DATA_MAP.put(attributeName, attribute);
+            ATTRIBUTE_DESCRIPTOR_LIST.add(buildAttributeDescriptor(attributeName, attributeType));
+        }
+    }
+
+    private SourceResponse buildSourceResponse() {
+        SourceResponse sourceResponse = mock(SourceResponse.class);
+        when(sourceResponse.getResults()).thenReturn(RESULT_LIST);
+        return sourceResponse;
+    }
+
+    private void buildResultList() {
+        RESULT_LIST.clear();
+
+        for (int i = 0; i < METACARD_COUNT; i++) {
+            Result result = mock(Result.class);
+            Metacard metacard = buildMetacard();
+            when(result.getMetacard()).thenReturn(metacard);
+            RESULT_LIST.add(result);
+        }
+    }
+
+    private Metacard buildMetacard() {
+        Metacard metacard = mock(Metacard.class);
+
+        Answer<Serializable> answer = invocation -> {
+            String key = invocation.getArgumentAt(0, String.class);
+            return METACARD_DATA_MAP.get(key);
+        };
+
+        when(metacard.getAttribute(anyString())).thenAnswer(answer);
+        MetacardType metacardType = buildMetacardType();
+        when(metacard.getMetacardType()).thenReturn(metacardType);
+        return metacard;
+    }
+
+    private MetacardType buildMetacardType() {
+        MetacardType metacardType = mock(MetacardType.class);
+        when(metacardType.getAttributeDescriptors()).thenReturn(new HashSet<>(ATTRIBUTE_DESCRIPTOR_LIST));
+        return metacardType;
+    }
+
+    private AttributeDescriptor buildAttributeDescriptor(String name, AttributeType type) {
+        AttributeDescriptor attributeDescriptor = mock(AttributeDescriptor.class);
+        when(attributeDescriptor.getName()).thenReturn(name);
+        when(attributeDescriptor.getType()).thenReturn(type);
+        return attributeDescriptor;
+    }
+
+    private Attribute buildAttribute(String name, Serializable value) {
+        Attribute attribute = mock(Attribute.class);
+        when(attribute.getName()).thenReturn(name);
+        when(attribute.getValue()).thenReturn(value);
+        return attribute;
+    }
+}

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.csv;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+
+public class MetacardIteratorTest {
+    private static final Object[][] ATTRIBUTE_DATA = {{"attribute1", "value1"},
+            {"attribute2", new Integer(101)},
+            {"attribute3", new Double(3.14159)}};
+
+    private static final Map<String, Serializable> METACARD_DATA_MAP = new HashMap<>();
+
+    private static final List<AttributeDescriptor> ATTRIBUTE_DESCRIPTOR_LIST = new ArrayList<>();
+
+    @Before
+    public void setUp() {
+        ATTRIBUTE_DESCRIPTOR_LIST.clear();
+        METACARD_DATA_MAP.clear();
+
+        for (Object[] entry : ATTRIBUTE_DATA) {
+            String attributeName = entry[0].toString();
+            Serializable attributeValue = (Serializable) entry[1];
+            Attribute attribute = buildAttribute(attributeName, attributeValue);
+            METACARD_DATA_MAP.put(attributeName, attribute);
+            ATTRIBUTE_DESCRIPTOR_LIST.add(buildAttribute(attributeName));
+        }
+
+        Attribute attribute = buildAttribute("skipMe", "value");
+        METACARD_DATA_MAP.put("skipMe", attribute);
+    }
+
+    @Test
+    public void testColumnHeaderIterator() {
+        Metacard metacard = buildMetacard();
+        Iterator<Serializable> iterator = new MetacardIterator(metacard, ATTRIBUTE_DESCRIPTOR_LIST);
+
+        for (int i = 0; i < ATTRIBUTE_DATA.length; i++) {
+            assertThat(iterator.hasNext(), is(true));
+            assertThat(iterator.next(), is(ATTRIBUTE_DATA[i][1]));
+        }
+
+        assertThat(iterator.hasNext(), is(false));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testHasNext() {
+        Metacard metacard = buildMetacard();
+        Iterator<Serializable> iterator = new MetacardIterator(metacard, ATTRIBUTE_DESCRIPTOR_LIST);
+
+        while (iterator.hasNext()) {
+            iterator.next();
+        }
+
+        iterator.next();
+    }
+
+    private Metacard buildMetacard() {
+        Metacard metacard = mock(Metacard.class);
+
+        Answer<Serializable> answer = invocation -> {
+            String key = invocation.getArgumentAt(0, String.class);
+            return METACARD_DATA_MAP.get(key);
+        };
+
+        when(metacard.getAttribute(anyString())).thenAnswer(answer);
+        return metacard;
+    }
+
+    private AttributeDescriptor buildAttribute(String name) {
+        AttributeDescriptor attribute = mock(AttributeDescriptor.class);
+        when(attribute.getName()).thenReturn(name);
+        return attribute;
+    }
+
+    private Attribute buildAttribute(String name, Serializable value) {
+        Attribute attribute = mock(Attribute.class);
+        when(attribute.getName()).thenReturn(name);
+        when(attribute.getValue()).thenReturn(value);
+        return attribute;
+    }
+}

--- a/catalog/transformer/pom.xml
+++ b/catalog/transformer/pom.xml
@@ -81,6 +81,7 @@
         </dependencies>
     </dependencyManagement>
     <modules>
+        <module>catalog-transformer-csv</module>
         <module>catalog-transformer-attribute</module>
         <module>catalog-transformer-service-xslt</module>
         <module>catalog-transformer-resource</module>

--- a/distribution/docs/src/main/resources/_contents/_transformers/csv-query-response-transformer-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_transformers/csv-query-response-transformer-contents.adoc
@@ -1,0 +1,91 @@
+==== CSV Query Response Transformer
+
+The CSV Query Response Transformer is responsible for translating a query response into a CSV formatted response.
+The CSV format is generally an initial line containing the headers (Name of each column) separated by commas. Each line after is one set of data (a metacard) with the absense of a value represented by no characters between the commas for that column.
+
+===== Installing the CSV Query Response Transformer
+
+This transformer is installed by default with a standard installation in the ${ddf-catalog} application.
+To uninstall, uninstall the `catalog-transformer-csv` feature.
+
+===== Configuring the CSV Query Response Transformer
+
+The CSV Query Response Transformer has three main configurable properties.
+
+[cols="1,1m,1,3,1,1" options="header"]
+|===
+
+|Name
+|Id
+|Type
+|Description
+|Default Value
+|Required
+
+|Hidden Fields
+|hiddenFields
+|Set of attribute names (Set<String>)
+|Specifies the names of attributes to be excluded from the export
+|empty
+|false
+
+|Column Order
+|columnOrder
+|List of attribute names (List<String>)
+|Specifies the order that columns will be presented in. Any columns not specified that are also not hidden will appear after the columns specified in columnOrder
+|empty
+|false
+
+|Aliases
+|aliases
+|Map of Attribute name to Alias (Map<String, String)
+|Specifies that the  given Attribute name should appear as the given alias name. E.g. (id -> Metacard ID) means that the column header will say "Metacard ID" instead of id.
+|empty
+|false
+
+|===
+
+===== Using the CSV Query Response Transformer
+
+Using the OpenSearch Endpoint, for example, query with the format option set to the CSV shortname `csv`.
+
+.CSV Query Response Transformer Query Example
+[source,http]
+----
+${public_url}/services/catalog/query?q=input?format=csv
+----
+
+.CSV Query Response Transformer Example Output
+[source,csv,linenums]
+----
+title,created,modified,checksum,checksum-algorithm,effective,expiration,resource-size,id,Location,metacard-tags,metadata-content-type,metadata-content-type-version,point-of-contact,resource-download-url,resource-size,resource-uri,source-id,metacard.associations.derived,description,validation-warnings,metacard.associations.related,failed-validators-warnings,validation-errors,failed-validators-errors
+Albury,2016-03-15T23:22:44.438+0000,2016-03-05T05:04:33.000+0000,fb1653b9,Adler32,2017-06-15T20:52:49.735+0000,2017-12-12T20:52:49.735+0000,79872,855937ac4adc42b1ae317e2abdb0e20a,POINT (146.91583333 -36.08055556),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/855937ac4adc42b1ae317e2abdb0e20a?transform=resource,79872,content:855937ac4adc42b1ae317e2abdb0e20a,ddf.distribution,,,,,,,
+"Allegany County, New York",2016-03-15T23:22:44.438+0000,2016-03-05T04:45:39.000+0000,9d1891e9,Adler32,2017-06-15T20:53:10.858+0000,2017-12-12T20:53:10.858+0000,22925,c7753469d1aa4ac1baee6a12d4caf721,POINT (-78.02 42.25),resource,adm2nd,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/c7753469d1aa4ac1baee6a12d4caf721?transform=resource,22925,content:c7753469d1aa4ac1baee6a12d4caf721,ddf.distribution,,,,,,,
+"Annapolis, Maryland",2016-03-15T23:22:44.438+0000,2016-03-02T01:52:04.000+0000,b1fdd6c6,Adler32,2017-06-15T20:54:23.687+0000,2017-12-12T20:54:23.687+0000,74459,3310642f451f45598319ac384b9f90c2,POINT (-76.50115833 38.97294444),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/3310642f451f45598319ac384b9f90c2?transform=resource,74459,content:3310642f451f45598319ac384b9f90c2,ddf.distribution,,,,,,,
+"Alsip, Illinois",2016-03-16T17:00:29.614+0000,2016-03-02T00:25:00.000+0000,ef9447a,Adler32,2017-06-15T20:53:34.574+0000,2017-12-12T20:53:34.574+0000,38044,1fe96bac7cae4b92a0ad5cf4bdfc94a8,POINT (-87.73222222 41.67055556),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/1fe96bac7cae4b92a0ad5cf4bdfc94a8?transform=resource,38044,content:1fe96bac7cae4b92a0ad5cf4bdfc94a8,ddf.distribution,,,,,,,
+Ambleside,2016-03-16T17:00:29.614+0000,2016-02-12T02:54:21.000+0000,e6a10881,Adler32,2017-06-15T20:53:51.937+0000,2017-12-12T20:53:51.937+0000,30523,a493e2b2565e4ed4a4f609f08d86d553,POINT (-2.9626 54.4251),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/a493e2b2565e4ed4a4f609f08d86d553?transform=resource,30523,content:a493e2b2565e4ed4a4f609f08d86d553,ddf.distribution,,,,,,,
+"Ambler, Pennsylvania",2016-03-16T17:00:29.614+0000,2016-02-12T01:57:20.000+0000,d8cf7521,Adler32,2017-06-15T20:53:51.782+0000,2017-12-12T20:53:51.782+0000,69420,a156eb46643f47b0b486df40286a9bad,POINT (-75.22027778 40.155),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/a156eb46643f47b0b486df40286a9bad?transform=resource,69420,content:a156eb46643f47b0b486df40286a9bad,ddf.distribution,,,,,,,
+"Alcona County, Michigan",2016-03-16T17:00:29.614+0000,2016-02-12T01:07:41.000+0000,69b499cf,Adler32,2017-06-15T20:52:50.651+0000,2017-12-12T20:52:50.651+0000,26493,23bd9b2bf23447e0a7f3f694cf953fa8,POINT (-83.27 44.71),resource,adm2nd,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/23bd9b2bf23447e0a7f3f694cf953fa8?transform=resource,26493,content:23bd9b2bf23447e0a7f3f694cf953fa8,ddf.distribution,,,,,,,
+"Alexandria, Indiana",2016-03-15T22:51:11.622+0000,2016-02-11T17:26:15.000+0000,fb06a965,Adler32,2017-06-15T20:52:57.321+0000,2017-12-12T20:52:57.321+0000,13892,20fddbe7c2004799bf8e8d7dfd267b81,POINT (-85.67638889 40.26305556),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/20fddbe7c2004799bf8e8d7dfd267b81?transform=resource,13892,content:20fddbe7c2004799bf8e8d7dfd267b81,ddf.distribution,,,,,,,
+"Annsville, New York",2016-03-16T17:00:29.614+0000,2016-02-11T10:52:26.000+0000,2946b099,Adler32,2017-06-15T20:54:27.038+0000,2017-12-12T20:54:27.038+0000,14662,dad6b940b96c48d28ba00d9646d37993,POINT (-75.61583333 43.33972222),resource,city,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/dad6b940b96c48d28ba00d9646d37993?transform=resource,14662,content:dad6b940b96c48d28ba00d9646d37993,ddf.distribution,,,,,,,
+Akeldama,2016-03-15T23:22:44.438+0000,2016-02-11T06:24:27.000+0000,5ab03eb6,Adler32,2017-06-15T20:52:24.163+0000,2017-12-12T20:52:24.163+0000,19237,9fac266ac7e84ba280febc89c6c04cd2,POINT (35.23288 31.76841),resource,unknown,20160305,admin@localhost,https://localhost:8993/services/catalog/sources/ddf.distribution/9fac266ac7e84ba280febc89c6c04cd2?transform=resource,19237,content:9fac266ac7e84ba280febc89c6c04cd2,ddf.distribution,,,,,,,
+----
+
+.CSV Query Response Transformer Implementation Details
+[cols="3" options="header"]
+|===
+
+|Registered Interface
+|Service Property
+|Value
+
+1.3+^|`ddf.catalog.transform.QueryResponseTransformer`
+
+|`shortname` / `id`
+|`csv`
+
+|`mimetype`
+|`text/csv`
+
+|===
+

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -511,6 +511,8 @@ include::{adoc-include}/_transformers/searchui-transformer-contents.adoc[]
 
 include::{adoc-include}/_transformers/xml-query-response-transformer-contents.adoc[]
 
+include::{adoc-include}/_transformers/csv-query-response-transformer-contents.adoc[]
+
 include::{adoc-include}/_transformers/mime-type-mapper-intro-contents.adoc[]
 
 include::{adoc-include}/_transformers/mime-type-mappers-contents.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <jodatime2-bundle.version>2.9.9</jodatime2-bundle.version>
         <aws-java-sdk-bundle.version>1.11.125_1</aws-java-sdk-bundle.version>
         <javax-mail.version>1.4.7</javax-mail.version>
-        <!--START If these bundles are used elsewhere in DDF, the versions MUST exactly match the versions used by the CXF and Camel features.-->
+        <!--START If these bundles are used elsewhere in DDF, the versions MUSco exactly match the versions used by the CXF and Camel features.-->
         <woodstox.core.version>4.4.1</woodstox.core.version>
         <woodstox.stax2-api.version>3.1.4</woodstox.stax2-api.version>
         <xpp3.bundle.version>1.1.4c_6</xpp3.bundle.version>
@@ -205,6 +205,7 @@
         <gib.baseBranch>HEAD</gib.baseBranch>
         <gib.enabled>false</gib.enabled>
         <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-csv.version>1.4</commons-csv.version>
         <xerces.version>2.11.0</xerces.version>
     </properties>
     <!--


### PR DESCRIPTION
#### What does this PR do?
This change creates an implementation of QueryResponseTransformer that translates the results from metacards to CSV format. Front-end support for this
will be added in a separate story.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@gordocanchola (hero)
@brianfelix 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui) (@andrewfielder)
[Data](https://github.com/orgs/codice/teams/data) (@brianfelix)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
1) ingest some number of products.
2) perform an OpenSearch query and specify 'csv' as the output format 
     Example: curl --basic --user admin:admin --insecure "https://localhost:8993/services/catalog/query?q=*&format=csv"

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3024](https://codice.atlassian.net/browse/DDF-3024)
#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
