### PR TITLE
DDF-3025 Upgrade to Pax Exam 4.11.0

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -55,28 +55,33 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-federationstrategy/${project.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/lucene-core/3.0.2_1</bundle>
         <bundle>mvn:ddf.catalog.core/ddf-pubsub/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-eventcommands/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/ddf-pubsub-tracker/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-urlresourcereader/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/filter-proxy/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-commands/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-solrcommands/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-metacardgroomerplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/metacard-type-registry/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-attributeregistry/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-injectattribute/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-localstorageprovider/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-standardframework/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-resourcestatusplugin/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.core/catalog-core-tagsfilterplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.security/catalog-security-logging/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-attribute/${project.version}
         </bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-defaultvalues/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-metacardtype/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/versioning-api/${project.version}</bundle>
+    </feature>
+
+    <feature name="catalog-core-plugins" install="auto" version="${project.version}"
+             description="Catalog core plugins">
+        <feature prerequisite="true">catalog-app</feature>
+        <bundle>mvn:ddf.catalog.core/catalog-core-resourcesizeplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-resourcestatusplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-tagsfilterplugin/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-camelcomponent/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-commands/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-solrcommands/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-eventcommands/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.core/catalog-core-metacardgroomerplugin/${project.version}</bundle>
     </feature>
 
     <feature name="catalog-core-content" install="auto" version="${project.version}"
@@ -186,9 +191,11 @@
         <bundle>
             mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.abdera-parser/${abdera.osgi.version}
         </bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${dom4j.bundle.version}
+        <bundle>
+            mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${dom4j.bundle.version}
         </bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/${jdom.bundle.version}
+        <bundle>
+            mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/${jdom.bundle.version}
         </bundle>
         <bundle>mvn:org.codice.thirdparty/commons-httpclient/3.1.0_1</bundle>
     </feature>
@@ -324,15 +331,20 @@
         <bundle>mvn:ddf.catalog.security/catalog-security-policyplugin/${project.version}</bundle>
     </feature>
 
-    <feature name="catalog-security-pointofcontact-readonly" install="auto" version="${project.version}"
+    <feature name="catalog-security-pointofcontact-readonly" install="auto"
+             version="${project.version}"
              description="DDF Point of Contact Read Only">
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">security-pdp-authz</feature>
-        <bundle>mvn:ddf.catalog.security/catalog-security-pointofcontact-policyplugin/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-pointofcontactupdate/${project.version}</bundle>
+        <bundle>
+            mvn:ddf.catalog.security/catalog-security-pointofcontact-policyplugin/${project.version}
+        </bundle>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-pointofcontactupdate/${project.version}
+        </bundle>
     </feature>
 
-    <feature name="catalog-security-metacardattributeplugin" install="auto" version="${project.version}"
+    <feature name="catalog-security-metacardattributeplugin" install="auto"
+             version="${project.version}"
              description="DDF Catalog Metacard Attribute Policy Plugin">
         <feature prerequisite="true">security-pdp-authz</feature>
         <bundle>
@@ -478,7 +490,8 @@
         <feature prerequisite="true">catalog-app</feature>
         <bundle>mvn:ddf.catalog.async/catalog-async-data-api/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.async/catalog-async-plugin-api/${project.version}</bundle>
-        <bundle>mvn:ddf.catalog.async/catalog-async-processingframework-api/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.async/catalog-async-processingframework-api/${project.version}
+        </bundle>
         <bundle>mvn:ddf.catalog.async/catalog-async-postingestplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.async/catalog-async-processingframework/${project.version}</bundle>
     </feature>

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -31,9 +31,12 @@
         <module>test-itests-dependencies-app</module>
     </modules>
     <properties>
-        <pax.exam.version>4.9.2</pax.exam.version>
+        <!-- Copied from ops4j/org.ops4j.pax.exam2/4.11.0/pom/pom.xml
+        Do not change these unless upgrading pax exam-->
+        <pax.exam.version>4.11.0</pax.exam.version>
         <pax.tinybundles.version>2.1.1</pax.tinybundles.version>
         <pax.url.version>2.4.5</pax.url.version>
+        <!-- End pax exam properties -->
         <cometd.version>3.0.9</cometd.version>
     </properties>
     <dependencyManagement>

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -495,8 +495,7 @@ public abstract class AbstractIntegrationTest {
                 KarafDistributionOption.editConfigurationFilePut(
                         "etc/ddf.security.sts.client.configuration.config",
                         "address",
-                        "\"" + SECURE_ROOT + HTTPS_PORT.getPort()
-                                + "/services/SecurityTokenService?wsdl" + "\""),
+                        SECURE_ROOT + HTTPS_PORT.getPort() + "/services/SecurityTokenService?wsdl"),
                 installStartupFile(getClass().getClassLoader()
                                 .getResourceAsStream(
                                         "ddf.catalog.solr.external.SolrHttpCatalogProvider.config"),


### PR DESCRIPTION
#### What does this PR do?
Pax Exam 4.11.0 Release notes: https://ops4j1.jira.com/wiki/display/PAXEXAM4/2017/05/16/Pax+Exam+4.11.0+released

Changes by file: 

_catalog-app/src/main/resources/features.xml_
Rearranges bundles in catalog-core to prevent a timing issue

_distribution/test/itests/pom.xml_
Updates the pax exam version to 4.11.0, added a comment

_test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java_
Fixes an issue with a configuration that gets set using pax exam that used to be in quotations but no longer needs to be.

_test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerProxy.java_
Creates a retry for getting the SecurityManager in the ServiceManagerProxy to prevent a potential timing issue that was occurring in the itests. This issue currently exists in master, but was happening more frequently with the upgrade. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk @kcwire @lessarderic 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Run the integration tests and make sure nothing fails

#### What are the relevant tickets?
[DDF-3025](https://codice.atlassian.net/browse/DDF-3025)
