### PR TITLE
DDF-3026: Registy unit tests failing for locales outside of 'en-US'

### DIFF
--- a/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/InternationalStringTypeHelper.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/helper/InternationalStringTypeHelper.java
@@ -32,6 +32,7 @@ import oasis.names.tc.ebxml_regrep.xsd.rim._3.LocalizedStringType;
  */
 public class InternationalStringTypeHelper {
     private Locale locale;
+
     private static final String DEFAULT_LANG = "en-US";
 
     public InternationalStringTypeHelper() {
@@ -73,7 +74,8 @@ public class InternationalStringTypeHelper {
             LocalizedStringType lst = RIM_FACTORY.createLocalizedStringType();
             lst.setValue(internationalizeThis);
             // The LocalizedStringType handles the default languageTag so don't need to set it
-            if (!locale.toLanguageTag().equals(DEFAULT_LANG)) {
+            if (!locale.toLanguageTag()
+                    .equals(DEFAULT_LANG)) {
                 lst.setLang(locale.toLanguageTag());
             }
             ist.setLocalizedString(Collections.singletonList(lst));
@@ -92,6 +94,14 @@ public class InternationalStringTypeHelper {
                         .equals(localizedString.getLang()))
                 .findFirst()
                 .map(LocalizedStringType::getValue);
+
+        // Default to the the first string in the list if one matching the locale wasn't found
+        if (!optionalLocalString.isPresent()) {
+            optionalLocalString = localizedStrings.stream()
+                    .findFirst()
+                    .map(LocalizedStringType::getValue);
+        }
+
         return optionalLocalString;
     }
 }

--- a/catalog/spatial/registry/registry-schema-bindings/src/test/java/org/codice/ddf/registry/schemabindings/helper/InternationalStringTypeHelperTest.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/test/java/org/codice/ddf/registry/schemabindings/helper/InternationalStringTypeHelperTest.java
@@ -51,7 +51,7 @@ public class InternationalStringTypeHelperTest {
                     ITALY);
 
     private static final String DEF_LOCALE_NAME = "deflocale";
-    
+
     private static final String TAIWAN = "taiwan";
 
     private static final String EMPTY_STRING = "";
@@ -107,7 +107,8 @@ public class InternationalStringTypeHelperTest {
         }
 
         String istString = istHelper.getString(ist);
-        assertThat(istString, is(equalTo(EMPTY_STRING)));
+        // If unknown locale isn't matched, the first in the list of localized strings will be returned. US, in this case.
+        assertThat(istString, is(equalTo(US)));
     }
 
     @Test
@@ -161,32 +162,34 @@ public class InternationalStringTypeHelperTest {
 
     private InternationalStringType getTestInternationalStringType() {
         InternationalStringType ist = RIM_FACTORY.createInternationalStringType();
-        
+
         for (Map.Entry<String, String> row : LOCALE_MAP.entrySet()) {
             LocalizedStringType localizedStringType = RIM_FACTORY.createLocalizedStringType();
             localizedStringType.setLang(row.getKey());
             localizedStringType.setValue(row.getValue());
-            ist.getLocalizedString().add(localizedStringType);
+            ist.getLocalizedString()
+                    .add(localizedStringType);
         }
 
         return ist;
     }
-    
-    private InternationalStringType getTestInternationalStringWithDefault(){
+
+    private InternationalStringType getTestInternationalStringWithDefault() {
         InternationalStringType ist = RIM_FACTORY.createInternationalStringType();
-        
+
         LocalizedStringType lstLocale = RIM_FACTORY.createLocalizedStringType();
-        lstLocale.setLang(Locale.getDefault().toLanguageTag());
+        lstLocale.setLang(Locale.getDefault()
+                .toLanguageTag());
         lstLocale.setValue(DEF_LOCALE_NAME);
         ist.getLocalizedString()
                 .add(lstLocale);
-        
-        LocalizedStringType lstTaiwan = RIM_FACTORY.createLocalizedStringType(); 
-        lstTaiwan.setLang(Locale.TAIWAN.toLanguageTag()); 
-        lstTaiwan.setValue(TAIWAN); 
+
+        LocalizedStringType lstTaiwan = RIM_FACTORY.createLocalizedStringType();
+        lstTaiwan.setLang(Locale.TAIWAN.toLanguageTag());
+        lstTaiwan.setValue(TAIWAN);
         ist.getLocalizedString()
-            .add(lstTaiwan);
-        
+                .add(lstTaiwan);
+
         return ist;
     }
 


### PR DESCRIPTION
The InternationalStringTypeHelper class has a method to get a string from the InternationStringType. In this method, the list of LocalizedStringTypes is iterated until one with a language matching the default locale's is found.
  Adding a check so if a match isn't found it will default to the first string in the list.
  Updating itest

#### What does this PR do?
This PR fixes the build errors seen by systems whose locale's language is not 'en-US'

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @vinamartin 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)
[Test](https://github.com/orgs/codice/teams/test)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Set machine's region to something other than US.
Build ddf/catalog/spatial/registy
Verify tests pass
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3026](https://codice.atlassian.net/browse/DDF-3026)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
