### PR TITLE
DDF-2927 Added a self-registering cached subscription, cache loader, and cache writer

### DIFF
--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/pom.xml
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>subscriptionstore-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -68,7 +73,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -78,7 +83,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheLoader.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheLoader.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+
+import org.codice.ddf.catalog.subscriptionstore.common.CachedSubscription;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionMetadata;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionPersistor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link CacheLoader} implementation for the {@link javax.cache.Cache} in
+ * {@link SubscriptionContainerImpl}. All inner exceptions will be handled by the cache
+ * implementation, or rethrown as a {@link javax.cache.CacheException}.
+ */
+public class SubscriptionCacheLoader implements CacheLoader<String, CachedSubscription> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionCacheLoader.class);
+
+    private final SubscriptionPersistor persistor;
+
+    public SubscriptionCacheLoader(SubscriptionPersistor persistor) {
+        this.persistor = persistor;
+    }
+
+    @Override
+    public CachedSubscription load(String key) throws CacheLoaderException {
+        LOGGER.debug("Populating cache with entity for key [{}]", key);
+        Map<String, SubscriptionMetadata> subscriptions = persistor.getSubscriptions();
+        return loadFromMap(subscriptions, key);
+    }
+
+    /**
+     * Implementation detail. We need to ignore the keys because we don't know them at load time.
+     * If we want to honor the keys, and know them at load time, we will need to ping the persistent
+     * store twice.
+     * But there's no point to doing that (for the sake of an API). The keys don't matter - we're
+     * loading everything that we can load regardless of the keys provided.
+     */
+    @Override
+    public Map<String, CachedSubscription> loadAll(Iterable<? extends String> keys)
+            throws CacheLoaderException {
+        LOGGER.debug("Populating cache with all entries from the backing store");
+        return persistor.getSubscriptions()
+                .values()
+                .stream()
+                .map(CachedSubscription::new)
+                .collect(Collectors.toMap(sub -> sub.getMetadata()
+                        .getId(), Function.identity()));
+    }
+
+    /**
+     * Subscription loading boilerplate.
+     */
+    private CachedSubscription loadFromMap(Map<String, SubscriptionMetadata> map, String key) {
+        SubscriptionMetadata metadata = map.get(key);
+        if (metadata == null) {
+            return null;
+        }
+        return new CachedSubscription(metadata);
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheWriter.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheWriter.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore;
+
+import java.util.Collection;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+
+import org.codice.ddf.catalog.subscriptionstore.common.CachedSubscription;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionPersistor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link CacheWriter} implementation for the {@link Cache} in {@link SubscriptionContainerImpl}. All
+ * inner exceptions will be handled by the cache implementation, or rethrown as a
+ * {@link javax.cache.CacheException}.
+ */
+public class SubscriptionCacheWriter implements CacheWriter<String, CachedSubscription> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionCacheWriter.class);
+
+    private final SubscriptionPersistor persistor;
+
+    public SubscriptionCacheWriter(SubscriptionPersistor persistor) {
+        this.persistor = persistor;
+    }
+
+    @Override
+    public void write(Cache.Entry<? extends String, ? extends CachedSubscription> entry)
+            throws CacheWriterException {
+        LOGGER.debug("Writing through cache for key [{}]", entry.getKey());
+        CachedSubscription cachedSubscription = entry.getValue();
+        persistor.insert(cachedSubscription.getMetadata());
+    }
+
+    @Override
+    public void writeAll(
+            Collection<Cache.Entry<? extends String, ? extends CachedSubscription>> entries)
+            throws CacheWriterException {
+        entries.forEach(this::write);
+    }
+
+    @Override
+    public void delete(Object obj) throws CacheWriterException {
+        LOGGER.debug("Deleting through cache for key [{}]", obj);
+        verifyString(obj);
+        String key = (String) obj;
+        persistor.delete(key);
+    }
+
+    @Override
+    public void deleteAll(Collection<?> keys) throws CacheWriterException {
+        keys.forEach(this::verifyString);
+        keys.stream()
+                .map(String.class::cast)
+                .forEach(persistor::delete);
+    }
+
+    private void verifyString(Object obj) {
+        if (!(obj instanceof String)) {
+            throw new CacheWriterException("Subscription keys are expected to be of type String");
+        }
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/CachedSubscription.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/CachedSubscription.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.common;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Optional;
+
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionFactory;
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionRegistrationException;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.event.Subscription;
+
+/**
+ * A data object for storing subscription information in a cache.
+ * <p>
+ * The data stored is a mix of persisted and locally cached information. This includes the
+ * original {@link Subscription} either passed from the client or deserialized from stored data,
+ * and the relevant {@link SubscriptionMetadata}.
+ * <p>
+ * The existence of a {@link CachedSubscription} object <i>between</i> subscription CRUD operations implies
+ * that:
+ * <ol>
+ * <li>
+ * The {@code SubscriptionMetadata} in this object is also in the {@code PersistentStore}.
+ * </li>
+ * <li>
+ * The {@code Subscription} in this object is registered as a service with OSGi <b>only if</b>
+ * {@link #isNotRegistered()} is false.
+ * </li>
+ * </ol>
+ * {@code CachedSubscription} objects are not meant to be reused. They have a 1-to-1 correspondence with
+ * a {@code SubscriptionMetadata} object in the backing store and are used to track that subscription's
+ * lifecycle in OSGi.
+ * <p>
+ * Given the dynamic nature of Karaf and the need to handle {@link javax.cache.event.CacheEntryEvent}s,
+ * there may be a brief period during system startup where cached subscriptions exist in the cache but
+ * are not registered. This problem should rectify itself as additional {@link SubscriptionFactory}
+ * instances are registered by subscription endpoints.
+ * <p>
+ * Currently, no guarantees are made regarding the state of this object <i>during</i> a subscription CRUD
+ * operation. Only one container operation may be active at a time.
+ *
+ * @see org.codice.ddf.catalog.subscriptionstore.SubscriptionContainerImpl
+ */
+public class CachedSubscription {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachedSubscription.class);
+
+    private static final String SUBSCRIPTION_ID_OSGI = "subscription-id";
+
+    private static final String EVENT_ENDPOINT = "event-endpoint";
+
+    private static final Integer INITIAL_CAPACITY = 4;
+
+    private final SubscriptionMetadata metadata;
+
+    private transient Subscription subscription;
+
+    private transient ServiceRegistration registration;
+
+    public CachedSubscription(SubscriptionMetadata metadata) {
+        notNull(metadata, "Subscription metadata cannot be null");
+        this.metadata = metadata;
+
+        this.subscription = null;
+        this.registration = null;
+    }
+
+    public SubscriptionMetadata getMetadata() {
+        return metadata;
+    }
+
+    public Optional<Subscription> getSubscription() {
+        return Optional.ofNullable(subscription);
+    }
+
+    public boolean isType(String type) {
+        return metadata.getTypeName()
+                .equals(type);
+    }
+
+    public boolean isNotType(String type) {
+        return !isType(type);
+    }
+
+    public synchronized boolean isNotRegistered() {
+        return registration == null;
+    }
+
+    /**
+     * Attempt to construct a {@link Subscription} using the provided factory. If the resultant
+     * subscription is valid, register it as this cached subscription's OSGi service.
+     *
+     * @param factory subscription factory corresponding to this cached subscription's type.
+     * @throws SubscriptionRegistrationException if the factory can't operate on this cached subscription.
+     */
+    public void registerSubscription(SubscriptionFactory factory) {
+        if (isNotType(factory.getTypeName())) {
+            throw new SubscriptionRegistrationException(format(
+                    "Factory type mismatch for subscription type [%s]",
+                    metadata.getTypeName()));
+        }
+
+        LOGGER.debug("Regenerating subscription [ {} | {} | {} ]",
+                metadata.getId(),
+                metadata.getTypeName(),
+                metadata.getCallbackAddress());
+
+        Subscription sub = factory.createSubscription(metadata);
+        if (sub == null) {
+            throw new SubscriptionRegistrationException("Unable to regenerate subscription");
+        }
+        registerSubscription(sub);
+    }
+
+    /**
+     * Register the provided {@link Subscription} as this cached subscription's OSGi service.
+     *
+     * @param sub the subscription to register.
+     * @throws SubscriptionRegistrationException if registration failed.
+     */
+    public synchronized void registerSubscription(Subscription sub) {
+        if (registration != null) {
+            throw new SubscriptionRegistrationException("Subscription already registered");
+        }
+
+        LOGGER.debug("Registering service [{}]", metadata.getId());
+
+        Dictionary<String, String> properties = new Hashtable<>(INITIAL_CAPACITY);
+        properties.put(SUBSCRIPTION_ID_OSGI, metadata.getId());
+        properties.put(EVENT_ENDPOINT, metadata.getCallbackAddress());
+
+        registration = getBundleContext().registerService(Subscription.class.getName(),
+                sub,
+                properties);
+
+        if (registration != null) {
+            LOGGER.debug("Subscription [ {} | {} | {} ] registered with bundle ID = {}",
+                    metadata.getId(),
+                    metadata.getTypeName(),
+                    metadata.getCallbackAddress(),
+                    registration.getReference()
+                            .getBundle()
+                            .getBundleId());
+            subscription = sub;
+        } else {
+            throw new SubscriptionRegistrationException(format(
+                    "Subscription registration attempt for id [%s] of type [%s] failed",
+                    metadata.getId(),
+                    metadata.getTypeName()));
+        }
+    }
+
+    /**
+     * Removes this cached subscriptions OSGi service from the service registry. Calling this method
+     * on a cached subscription that {@link #isNotRegistered()} will throw an exception.
+     *
+     * @throws SubscriptionRegistrationException if this cached subscription did not have a service
+     *                                           registered.
+     */
+    public synchronized void unregisterSubscription() {
+        LOGGER.debug("Removing service [{}]", metadata.getId());
+        if (registration == null) {
+            throw new SubscriptionRegistrationException(format(
+                    "Subscription [%s] had no registration and could not be unregistered",
+                    metadata.getId()));
+        }
+        registration.unregister();
+        registration = null;
+    }
+
+    protected BundleContext getBundleContext() {
+        return FrameworkUtil.getBundle(CachedSubscription.class)
+                .getBundleContext();
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionMetadata.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionMetadata.java
@@ -35,26 +35,29 @@ public class SubscriptionMetadata implements SubscriptionIdentifier, MarshalledS
 
     private final String id;
 
-    private final String type;
+    private final String typeName;
 
     private final String filter;
 
     private final String callbackAddress;
 
-    public SubscriptionMetadata(String type, String filter, String callbackAddress) {
-        this(type,
-                filter, callbackAddress,
+    public SubscriptionMetadata(String typeName, String filter, String callbackAddress) {
+        this(typeName,
+                filter,
+                callbackAddress,
                 URN_UUID + UUID.randomUUID()
                         .toString());
     }
 
-    public SubscriptionMetadata(String type, String filter, String callbackAddress, String id) {
-        this.type = type;
+    public SubscriptionMetadata(String typeName, String filter, String callbackAddress, String id) {
+        this.typeName = typeName;
         this.filter = filter;
         this.callbackAddress = callbackAddress;
         this.id = id;
 
-        LOGGER.trace("Created subscription metadata object: {} | {} | {}", id, type,
+        LOGGER.trace("Created subscription metadata object: {} | {} | {}",
+                id,
+                typeName,
                 callbackAddress);
     }
 
@@ -65,7 +68,7 @@ public class SubscriptionMetadata implements SubscriptionIdentifier, MarshalledS
 
     @Override
     public String getTypeName() {
-        return type;
+        return typeName;
     }
 
     @Override

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistor.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/main/java/org/codice/ddf/catalog/subscriptionstore/common/SubscriptionPersistor.java
@@ -114,7 +114,7 @@ public class SubscriptionPersistor {
      * @throws SubscriptionStoreException if a problem occurs during delete.
      */
     public void delete(String subscriptionId) {
-        LOGGER.debug("Deleting [{}] from persistence store. ", subscriptionId);
+        LOGGER.debug("Deleting [{}] from persistence store", subscriptionId);
         try {
             persistentStore.delete(PersistentStore.EVENT_SUBSCRIPTIONS_TYPE,
                     getEcqlStringForId(subscriptionId));

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/CacheEntryTestImpl.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/CacheEntryTestImpl.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore;
+
+import javax.cache.Cache;
+
+import org.codice.ddf.catalog.subscriptionstore.common.CachedSubscription;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionMetadata;
+
+public class CacheEntryTestImpl implements Cache.Entry<String, CachedSubscription> {
+
+    private final String key;
+
+    private final CachedSubscription subscription;
+
+    public CacheEntryTestImpl(SubscriptionMetadata metadata) {
+        this.key = metadata.getId();
+        this.subscription = new CachedSubscription(metadata);
+    }
+
+    public CacheEntryTestImpl(CachedSubscription cachedSubscription) {
+        this.key = cachedSubscription.getMetadata()
+                .getId();
+        this.subscription = cachedSubscription;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public CachedSubscription getValue() {
+        return subscription;
+    }
+
+    @Override
+    public Object unwrap(Class aClass) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheLoaderTest.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheLoaderTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.Validate.notNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.codice.ddf.catalog.subscriptionstore.common.CachedSubscription;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionMetadata;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionPersistor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Tests for the cache loader. Note that for {@link SubscriptionCacheLoader#loadAll(Iterable)}, the
+ * set of keys does not matter. The backing store is the single source of truth. And the tests reflect
+ * this.
+ *
+ * @see SubscriptionCacheLoader#loadAll(Iterable)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriptionCacheLoaderTest {
+
+    @Mock
+    private SubscriptionPersistor mockPersistor;
+
+    @Mock
+    private SubscriptionMetadata mockMetadata;
+
+    private SubscriptionCacheLoader cacheLoader;
+
+    @Before
+    public void setup() {
+        cacheLoader = new SubscriptionCacheLoader(mockPersistor);
+    }
+
+    @Test
+    public void testLoad() {
+        Map<String, SubscriptionMetadata> results = ImmutableMap.of("id", mockMetadata);
+        when(mockPersistor.getSubscriptions()).thenReturn(results);
+        CachedSubscription cachedSubscription = cacheLoader.load("id");
+        assertThat(cachedSubscription.getMetadata(), is(mockMetadata));
+    }
+
+    @Test
+    public void testLoadReturnsNull() {
+        Map<String, SubscriptionMetadata> results = ImmutableMap.of("id", mockMetadata);
+        when(mockPersistor.getSubscriptions()).thenReturn(results);
+        CachedSubscription cachedSubscription = cacheLoader.load("not_id");
+        assertThat(cachedSubscription, is(nullValue()));
+    }
+
+    @Test
+    public void testLoadAll() {
+        Map<String, SubscriptionMetadata> results = generatePersistorLoadAllMap();
+        when(mockPersistor.getSubscriptions()).thenReturn(results);
+        Map<String, CachedSubscription> map = cacheLoader.loadAll(Collections.emptySet());
+        validateLoadAllResults(map);
+    }
+
+    @Test
+    public void testLoadAllWithNonEmptyKeySet() {
+        Map<String, SubscriptionMetadata> results = generatePersistorLoadAllMap();
+        when(mockPersistor.getSubscriptions()).thenReturn(results);
+        Map<String, CachedSubscription> map = cacheLoader.loadAll(ImmutableSet.of("id1", "id2"));
+        validateLoadAllResults(map);
+    }
+
+    private Map generatePersistorLoadAllMap() {
+        return ImmutableMap.builder()
+                .put("id1", new SubscriptionMetadata("t1", "f1", asValidUrl("cb1"), "id1"))
+                .put("id2", new SubscriptionMetadata("t2", "f2", asValidUrl("cb2"), "id2"))
+                .put("id3", new SubscriptionMetadata("t3", "f3", asValidUrl("cb3"), "id3"))
+                .build();
+    }
+
+    private void validateLoadAllResults(Map<String, CachedSubscription> map) {
+        validateSubscriptionMetadata(map.get("id1")
+                .getMetadata(), "t1", "f1", asValidUrl("cb1"), "id1");
+        validateSubscriptionMetadata(map.get("id2")
+                .getMetadata(), "t2", "f2", asValidUrl("cb2"), "id2");
+        validateSubscriptionMetadata(map.get("id3")
+                .getMetadata(), "t3", "f3", asValidUrl("cb3"), "id3");
+    }
+
+    private void validateSubscriptionMetadata(SubscriptionMetadata metadata, String type,
+            String filter, String callback, String id) {
+        notNull(metadata);
+        assertThat(metadata.getId(), is(id));
+        assertThat(metadata.getTypeName(), is(type));
+        assertThat(metadata.getFilter(), is(filter));
+        assertThat(metadata.getCallbackAddress(), is(callback));
+    }
+
+    private String asValidUrl(String variation) {
+        return format("http://localhost:8993/%s", variation);
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheWriterTest.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/SubscriptionCacheWriterTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+
+import javax.cache.integration.CacheWriterException;
+
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionMetadata;
+import org.codice.ddf.catalog.subscriptionstore.common.SubscriptionPersistor;
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionStoreException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriptionCacheWriterTest {
+
+    @Mock
+    private SubscriptionMetadata mockMetadata;
+
+    @Mock
+    private SubscriptionPersistor mockPersistor;
+
+    private SubscriptionCacheWriter cacheWriter;
+
+    @Before
+    public void setup() {
+        when(mockMetadata.getId()).thenReturn("id");
+        when(mockMetadata.getTypeName()).thenReturn("type");
+        when(mockMetadata.getFilter()).thenReturn("filter");
+        when(mockMetadata.getCallbackAddress()).thenReturn("callback");
+        cacheWriter = new SubscriptionCacheWriter(mockPersistor);
+    }
+
+    @Test
+    public void testWrite() {
+        cacheWriter.write(new CacheEntryTestImpl(mockMetadata));
+        verify(mockPersistor).insert(mockMetadata);
+        verifyNoMoreInteractions(mockPersistor);
+    }
+
+    @Test
+    public void testWriteAll() {
+        Collection entries = ImmutableList.of(new CacheEntryTestImpl(mockMetadata),
+                new CacheEntryTestImpl(mockMetadata));
+        cacheWriter.writeAll(entries);
+        verify(mockPersistor, times(2)).insert(mockMetadata);
+        verifyNoMoreInteractions(mockPersistor);
+    }
+
+    @Test(expected = SubscriptionStoreException.class)
+    public void testOnWritePersistorExceptionNotSurpressed() {
+        doThrow(SubscriptionStoreException.class).when(mockPersistor)
+                .insert(anyObject());
+        cacheWriter.write(new CacheEntryTestImpl(mockMetadata));
+    }
+
+    @Test
+    public void testDelete() {
+        String key = "key";
+        cacheWriter.delete(key);
+        verify(mockPersistor).delete(key);
+        verifyNoMoreInteractions(mockPersistor);
+    }
+
+    @Test(expected = CacheWriterException.class)
+    public void testDeleteWithNonStringKey() {
+        cacheWriter.delete(5);
+    }
+
+    @Test
+    public void testDeleteAll() {
+        Collection entries = ImmutableList.of("key1", "key2");
+        cacheWriter.deleteAll(entries);
+        verify(mockPersistor).delete("key1");
+        verify(mockPersistor).delete("key2");
+        verifyNoMoreInteractions(mockPersistor);
+    }
+
+    @Test(expected = CacheWriterException.class)
+    public void testDeleteAllWhenSomeKeyIsntString() {
+        Collection entries = ImmutableList.of("key1", "key2", 5, "key3");
+        cacheWriter.deleteAll(entries);
+        verifyZeroInteractions(mockPersistor);
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/common/CachedSubscriptionTest.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-impl/src/test/java/org/codice/ddf/catalog/subscriptionstore/common/CachedSubscriptionTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Dictionary;
+
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionFactory;
+import org.codice.ddf.catalog.subscriptionstore.internal.SubscriptionRegistrationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+import ddf.catalog.event.Subscription;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CachedSubscriptionTest {
+    private static final String TYPE = "type";
+
+    private static final String NOT_TYPE = "not_type";
+
+    private static final String FILTER = "filter";
+
+    private static final String CALLBACK = "http://localhost:1234/test";
+
+    private static final String SUBSCRIPTION_ID_OSGI = "subscription-id";
+
+    private static final String EVENT_ENDPOINT = "event-endpoint";
+
+    @Mock
+    private BundleContext mockBundleContext;
+
+    @Mock
+    private ServiceRegistration mockRegistration;
+
+    @Mock
+    private Subscription mockSubscription;
+
+    @Mock
+    private SubscriptionFactory mockFactory;
+
+    private SubscriptionMetadata metadata;
+
+    private CachedSubscription cachedSubscription;
+
+    @Before
+    public void setup() {
+        ServiceReference mockRef = mock(ServiceReference.class);
+        Bundle mockBundle = mock(Bundle.class);
+        when(mockRegistration.getReference()).thenReturn(mockRef);
+        when(mockRef.getBundle()).thenReturn(mockBundle);
+        when(mockBundle.getBundleId()).thenReturn(10L);
+
+        when(mockBundleContext.registerService(anyString(), anyObject(), anyObject())).thenReturn(
+                mockRegistration);
+
+        when(mockFactory.getTypeName()).thenReturn(TYPE);
+        when(mockFactory.createSubscription(anyObject())).thenReturn(mockSubscription);
+
+        metadata = new SubscriptionMetadata(TYPE, FILTER, CALLBACK);
+        cachedSubscription = new CachedSubscription(metadata) {
+            protected BundleContext getBundleContext() {
+                return mockBundleContext;
+            }
+        };
+    }
+
+    @Test
+    public void testUnregister() {
+        assertThat(cachedSubscription.isNotRegistered(), is(true));
+        cachedSubscription.registerSubscription(mockSubscription);
+        assertThat(cachedSubscription.isNotRegistered(), is(false));
+        cachedSubscription.unregisterSubscription();
+        assertThat(cachedSubscription.isNotRegistered(), is(true));
+        verify(mockRegistration).unregister();
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testDoubleUnregister() {
+        cachedSubscription.registerSubscription(mockSubscription);
+        cachedSubscription.unregisterSubscription();
+        cachedSubscription.unregisterSubscription();
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testUnregisterWhenNotRegistered() {
+        cachedSubscription.unregisterSubscription();
+    }
+
+    @Test
+    public void testRegisterSubscription() {
+        cachedSubscription.registerSubscription(mockSubscription);
+        validateRegistration();
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testRegisterSubscriptionWhenAlreadyRegistered() {
+        cachedSubscription.registerSubscription(mockSubscription);
+        cachedSubscription.registerSubscription(mockSubscription);
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testRegisterSubscriptionWhenOsgiReturnsNull() {
+        when(mockBundleContext.registerService(anyString(), anyObject(), anyObject())).thenReturn(
+                null);
+        cachedSubscription.registerSubscription(mockSubscription);
+    }
+
+    @Test
+    public void testRegisterWithFactory() {
+        cachedSubscription.registerSubscription(mockFactory);
+        validateRegistration();
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testRegisterWithFactoryThrowsException() {
+        when(mockFactory.getTypeName()).thenReturn(NOT_TYPE);
+        cachedSubscription.registerSubscription(mockFactory);
+    }
+
+    @Test(expected = SubscriptionRegistrationException.class)
+    public void testRegisterWithFactoryReturningNull() {
+        when(mockFactory.createSubscription(anyObject())).thenReturn(null);
+        cachedSubscription.registerSubscription(mockFactory);
+    }
+
+    private void validateRegistration() {
+        ArgumentCaptor<Dictionary> argCaptor = ArgumentCaptor.forClass(Dictionary.class);
+        verify(mockBundleContext).registerService(eq(Subscription.class.getName()),
+                eq(mockSubscription),
+                argCaptor.capture());
+        Dictionary<String, String> props = argCaptor.getValue();
+        assertThat(props.size(), is(2));
+        assertThat(metadata.getId(), is(props.get(SUBSCRIPTION_ID_OSGI)));
+        assertThat(metadata.getCallbackAddress(), is(props.get(EVENT_ENDPOINT)));
+        assertThat(cachedSubscription.getSubscription()
+                .get(), is(mockSubscription));
+    }
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionFactory.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.subscriptionstore.internal;
+
+import ddf.catalog.event.Subscription;
+
+/**
+ * Provides a way for endpoints or other subscription providers to define the deserialization semantics
+ * when new subscription metadata is received as a result of another node's processing. Endpoints or
+ * other subscription providers should register their own implementation of this interface with the
+ * OSGi Framework.
+ * <p>
+ * It is important that subscription providers guarantee that <b>if their services are up, their
+ * factory is up</b>. This can be easily done by registering their factory in the same bundle as
+ * their services. For example, consider the case of a REST endpoint. If an external client can use
+ * the endpoint, then the OSGi Framework should have access to the factory.
+ * <p>
+ * <b>This interface is for internal use only and should not be implemented by a third party. </b>
+ * <i>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</i>
+ */
+public interface SubscriptionFactory<S extends Subscription> extends SubscriptionType {
+
+    /**
+     * Revive a subscription from its serialized form.
+     *
+     * @param marshalledSubscription the subscription data to deserialize.
+     * @return a valid instance of {@link S}.
+     */
+    S createSubscription(MarshalledSubscription marshalledSubscription);
+}

--- a/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionRegistrationException.java
+++ b/catalog/core/catalog-core-subscriptionstore/subscriptionstore-internal-api/src/main/java/org/codice/ddf/catalog/subscriptionstore/internal/SubscriptionRegistrationException.java
@@ -14,29 +14,31 @@
 package org.codice.ddf.catalog.subscriptionstore.internal;
 
 /**
- * Describes the pieces of a {@link ddf.catalog.event.Subscription} that can be immediately serialized
- * without any special factory logic.
+ * Exception specific to subscription registration with OSGi, where the registration process either
+ * did not succeed or was invoked incorrectly.
  * <p>
  * <b>This interface is for internal use only and should not be implemented by a third party. </b>
  * <i>This code is experimental. While this interface is functional and tested, it may change or be
  * removed in a future version of the library.</i>
  */
-public interface MarshalledSubscription {
+public class SubscriptionRegistrationException extends RuntimeException {
+    public SubscriptionRegistrationException() {
+    }
 
-    /**
-     * Get the subscription filter as a marshalled string. This can be JSON, XML with any schema, etc.
-     * No guarantees are made to the format of this String, only that providing it to the correct
-     * {@link SubscriptionFactory} will yield a valid instance of {@code Subscription}.
-     *
-     * @return the marshalled subscription filter.
-     */
-    String getFilter();
+    public SubscriptionRegistrationException(String message) {
+        super(message);
+    }
 
-    /**
-     * Get the subscription callback address. While current endpoints conform to using a {@link java.net.URL}
-     * for their {@link ddf.catalog.event.DeliveryMethod}, this is <b>not</b> a guarantee.
-     *
-     * @return the callback address to send events to for this {@code Subscription}.
-     */
-    String getCallbackAddress();
+    public SubscriptionRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SubscriptionRegistrationException(Throwable cause) {
+        super(cause);
+    }
+
+    public SubscriptionRegistrationException(String message, Throwable cause,
+            boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
_DDF-2927 PR 2 out of 4._ 
The cache loader and writer implementations use the SubscriptionPersistor to read, write, and delete subscriptions from the persistent store. The container impl itself (PR 3/4) does not interact with the persistor directly; only through cache operations. 

Instances of `CachedSubscription` will be stored in the cache. While DDF is starting up, it is possible to have unregistered and uninitialized `CachedSubscription`s in the cache. This should be resolved after DDF has finished booting and is necessary because:

1. An instance of `SubscriptionFactory` is required to regenerate the original, non-serializable subscription for each subscription type. 
2. Consumers of the subscription store register their factory impl with osgi, but the subscription store loads the cache with existing subscriptions before any factories are registered. 
3. In tandem with the above, cache events may be firing from other nodes during startup. They can't be ignored because Solr was already polled for existing subscriptions, and the subscription store wouldn't know when to re-poll solr because the number of factories to be registered is indeterminate.  

For related code that impacts, but is not apart of this PR, see: [catalog-core-subscriptionstore](https://github.com/codice/ddf/tree/master/catalog/core/catalog-core-subscriptionstore)

#### Who is reviewing it?
@brjeter 
@paouelle 
@lessarderic 
@pklinef 
@ryeats 
@rzwiefel 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR.
@figliold 
@shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
Part 2 of 4 is not testable by the end user, as it exposes no functionality. Please refer to the unit tests. 

#### Any background context you want to provide?
This is part of an effort to centralize durable subscriptions to Solr. Later on, there are high availability implications and benefits. 

#### What are the relevant tickets?
[DDF-2927](https://codice.atlassian.net/browse/DDF-2927)

#### Checklist:
- [x] Documentation Updated - N/A
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests - N/A