### PR TITLE
DDF-3030 Added support for match any validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -157,6 +157,8 @@ _This is a preview of a pending release and is subject to change._
     </li>
     <li><a href='https://codice.atlassian.net/browse/DDF-2919'>DDF-2919</a> - Create generic WebClients with SecureCxfClientFactory
     </li>
+    <li><a href='https://codice.atlassian.net/browse/DDF-3030'>DDF-3030</a> - Added support for match any validator
+    </li>    	
 </ul>
 
 <h3>Technical Debt</h3>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
@@ -40,6 +40,19 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
     }
 
     /**
+     * Adds a set of {@link ValidationViolation} to the report.
+     *
+     * @param violations the violation set to add to the report, cannot be null or empty
+     * @throws IllegalArgumentException if {@code violation} is null or empty
+     */
+    public void addViolations(Set<ValidationViolation> violations) {
+        Preconditions.checkArgument(violations != null, "The violation list cannot be null.");
+        Preconditions.checkArgument(violations.size() > 0, "The violation list cannot be empty.");
+
+        attributeValidationViolations.addAll(violations);
+    }
+
+    /**
      * Adds a suggested attribute value to the report.
      *
      * @param value a suggested attribute value to add to the report
@@ -50,6 +63,20 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
 
         suggestedValues.add(value);
     }
+
+    /**
+     * Adds a a set of attribute values to the report.
+     *
+     * @param values a set of suggested attribute values to add to the report, cannot be null or empty
+     * @throws IllegalArgumentException if {@code value} is null or empty
+     */
+    public void addSuggestedValues(Set<String> values) {
+        Preconditions.checkArgument(values != null, "The suggested values cannot be null.");
+        Preconditions.checkArgument(values.size() > 0, "The suggested values cannot be empty.");
+
+        suggestedValues.addAll(values);
+    }
+
 
     @Override
     public Set<ValidationViolation> getAttributeValidationViolations() {

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.validator;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.validation.AttributeValidator;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.report.AttributeValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class MatchAnyValidator implements AttributeValidator {
+    private final List<AttributeValidator> validators;
+
+    public MatchAnyValidator(List<AttributeValidator> validators) {
+        this.validators = validators;
+    }
+
+    @Override
+    public Optional<AttributeValidationReport> validate(Attribute attribute) {
+        if (attribute == null || CollectionUtils.isEmpty(validators)) {
+            return Optional.empty();
+        }
+
+        List<Optional<AttributeValidationReport>> validationReportList = validators.stream()
+                .map(validator -> validator.validate(attribute))
+                .collect(Collectors.toList());
+
+        return generateValidationReports(validationReportList);
+    }
+
+    private Optional<AttributeValidationReport> generateValidationReports(
+            List<Optional<AttributeValidationReport>> validationReportList) {
+
+        AttributeValidationReportImpl result = new AttributeValidationReportImpl();
+
+        for (Optional<AttributeValidationReport> attributeValidationReportOptional : validationReportList) {
+
+            if (attributeValidationReportOptional.isPresent()) {
+                AttributeValidationReport attributeValidationReport =
+                        attributeValidationReportOptional.get();
+
+                Set<ValidationViolation> validationViolations =
+                        attributeValidationReport.getAttributeValidationViolations();
+                Set<String> suggestedValues = attributeValidationReport.getSuggestedValues();
+
+
+                if (CollectionUtils.isEmpty(validationViolations)) {
+                    return Optional.empty();
+                }
+
+                result.addViolations(validationViolations);
+
+                if (CollectionUtils.isNotEmpty(suggestedValues)) {
+                    result.addSuggestedValues(suggestedValues);
+                }
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(result);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import com.google.common.collect.ImmutableSet;
+
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.validator.EnumerationValidator;
+import ddf.catalog.validation.impl.validator.MatchAnyValidator;
+import ddf.catalog.validation.impl.validator.SizeValidator;
+import ddf.catalog.validation.report.AttributeValidationReport;
+
+public class MatchAnyValidatorTest {
+
+    private static final AttributeImpl VALID_ATTRIBUTE_1 = new AttributeImpl(Core.TITLE, "bob");
+
+    private static final AttributeImpl VALID_ATTRIBUTE_2 = new AttributeImpl(Core.TITLE, "bobby");
+
+    private static final AttributeImpl INVALID_ATTRIBUTE = new AttributeImpl(Core.TITLE, "robert");
+
+    private static final Set<String> VALID_ENUMERATIONS = ImmutableSet.of("bob", "rob", "bobby");
+
+    private static final Set<String> VALID_ENUMERATIONS_2 = ImmutableSet.of("ben");
+
+    private MatchAnyValidator matchAnyValidator;
+
+    private EnumerationValidator stubEmptyValidator;
+
+    private EnumerationValidator enumerationValidator;
+
+    private EnumerationValidator enumerationValidator2;
+
+    @Before
+    public void setUp() {
+        stubEmptyValidator = mock(EnumerationValidator.class);
+        when(stubEmptyValidator.validate(Matchers.any(AttributeImpl.class))).thenReturn(Optional.of(
+                new AttributeValidationReportImpl()));
+
+        enumerationValidator = new EnumerationValidator(VALID_ENUMERATIONS, false);
+        enumerationValidator2 = new EnumerationValidator(VALID_ENUMERATIONS_2, false);
+        SizeValidator sizeValidator = new SizeValidator(1, 3);
+        matchAnyValidator = new MatchAnyValidator(Arrays.asList(enumerationValidator,
+                sizeValidator));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWhenValidatorListIsNull() {
+        matchAnyValidator = new MatchAnyValidator(null);
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_1);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMatchAnyValidatorPassesWhenValidatorListIsEmpty() {
+        matchAnyValidator = new MatchAnyValidator(Collections.EMPTY_LIST);
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_1);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWhenValidatorAttributeIsNull() {
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(null);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWhenValidationReportIsEmpty() {
+        matchAnyValidator = new MatchAnyValidator(Collections.singletonList(stubEmptyValidator));
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_1);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testMatchAnyValidatorFailsWhenAllValidatorsHaveErrors() {
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(INVALID_ATTRIBUTE);
+        AttributeValidationReport attributeValidationReport =
+                attributeValidationReportOptional.get();
+        assertThat(attributeValidationReport.getAttributeValidationViolations(), not(empty()));
+        assertThat(attributeValidationReport.getSuggestedValues(), not(empty()));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWhenNoValidatorsHaveErrors() {
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_1);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWhenOneValidatorHasErrors() {
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_2);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testMatchAnyValidatorPassesWithTwoEnumerationValidators() {
+        matchAnyValidator = new MatchAnyValidator(Arrays.asList(enumerationValidator,
+                enumerationValidator2));
+        Optional<AttributeValidationReport> attributeValidationReportOptional =
+                matchAnyValidator.validate(VALID_ATTRIBUTE_2);
+        assertThat(attributeValidationReportOptional.isPresent(), is(false));
+    }
+}

--- a/distribution/docs/src/main/resources/_contents/_catalog-frameworks/global-attribute-validators-definition-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-frameworks/global-attribute-validators-definition-contents.adoc
@@ -40,6 +40,7 @@ Each object in the list of validators is the validator name and list of argument
 [WARNING]
 ====
 The value of the `arguments` key must always be an array of strings, even for numeric arguments, e.g. `["1", "10"]`
+
 ====
 
 The `validator` key must have a value of one of the following:
@@ -60,6 +61,8 @@ The `validator` key must have a value of one of the following:
  ** (3) [number (decimal or integer): inclusive lower bound, number (decimal or integer): inclusive upper bound, decimal number: epsilon (the maximum tolerable error on either side of the range)]
  - `enumeration`
  * `arguments`: (unlimited) [list of strings: each argument is one case-sensitive, valid enumeration value]
+ - `match_any`
+ * `validators`: (unlimited) [list of previously defined validators: valid if any validator succeeds]
 ====
 
 .Example Validator Definition
@@ -105,6 +108,21 @@ The `validator` key must have a value of one of the following:
             {
                 "validator": "enumeration",
                 "arguments": ["1080p", "1080i", "720p"]
+            }
+        ],
+        "datatype": [
+            {
+                "validator": "match_any",
+                "validators": [
+                    {
+                        "validator": "range",
+                        "arguments": ["1", "25"]
+                    },
+                    {
+                        "validator": "enumeration",
+                        "arguments": ["Collection", "Dataset", "Event"]
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
#### What does this PR do?
This PR adds a MatchOneValidator to support the ability to or validators together in a JSON file.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel @troymohl 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Build / Install / Configure a MatchOneValidator / Verify Proper behavior
Example:
`
{
    "validators": {
        "title": [
            {
                "validator": "size",
                "arguments": ["0", "128"]
            },
            {
                "validator": "match_one",
                "validators": [
                    { 
                        "validator": "enumeration", 
                        "arguments": ["abe", "lincoln"] 
                    },
                    {
                        "validator": "pattern",
                        "arguments": ["sc-[0-9]\+"] 
                    }
                ]
            }
        ]
    }
}
`
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3030](https://codice.atlassian.net/browse/DDF-3030)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
