### PR TITLE
DDF-2958 Fix unstable itests in TestCatalogValidation

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -13,8 +13,12 @@
  */
 package org.codice.ddf.itests.common;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.with;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SECURE_ROOT;
+import static org.codice.ddf.itests.common.csw.CswQueryBuilder.PROPERTY_IS_LIKE;
+import static org.hamcrest.Matchers.hasXPath;
 import static org.ops4j.pax.exam.CoreOptions.cleanCaches;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -30,6 +34,7 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRunti
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.useOwnExamBundlesStartLevel;
+import static com.jayway.restassured.RestAssured.given;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,6 +50,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -56,6 +63,7 @@ import org.codice.ddf.itests.common.annotations.PaxExamRule;
 import org.codice.ddf.itests.common.annotations.PostTestConstruct;
 import org.codice.ddf.itests.common.annotations.SkipUnstableTest;
 import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
+import org.codice.ddf.itests.common.csw.CswQueryBuilder;
 import org.codice.ddf.itests.common.security.SecurityPolicyConfigurator;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.Rule;
@@ -71,6 +79,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.response.ValidatableResponse;
 import com.sun.istack.NotNull;
 
 /**
@@ -728,11 +737,48 @@ public abstract class AbstractIntegrationTest {
         getServiceManager().waitForAllBundles();
     }
 
+    /**
+     * Clears out the catalog and catalog cache of all 'resource' metacards. Will not return until
+     * all metacards have been removed. Will throw an AssertionError if catalog could not be cleared
+     * within 30 seconds.
+     */
+    public void clearCatalogAndWait() {
+        clearCatalog();
+        clearCache();
+        with().pollInterval(1, SECONDS)
+                .await()
+                .atMost(30, SECONDS)
+                .until(this::isCatalogEmpty);
+    }
+
     public void clearCatalog() {
         console.runCommand(REMOVE_ALL);
     }
 
     public void clearCache() {
         console.runCommand(CLEAR_CACHE);
+    }
+
+    protected boolean isCatalogEmpty() {
+
+        try {
+            String query = new CswQueryBuilder().addAttributeFilter(PROPERTY_IS_LIKE,
+                    "AnyText",
+                    "*")
+                    .getQuery();
+            ValidatableResponse response = given().header(HttpHeaders.CONTENT_TYPE,
+                    MediaType.APPLICATION_XML)
+                    .body(query)
+                    .auth()
+                    .basic("admin", "admin")
+                    .post(CSW_PATH.getUrl())
+                    .then();
+            response.body(hasXPath(
+                    "/GetRecordsResponse/SearchResults[@numberOfRecordsMatched=\"0\"]"));
+            return true;
+        } catch (AssertionError e) {
+            return false;
+        }
+
     }
 }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/opensearch/OpenSearchTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/opensearch/OpenSearchTestCommons.java
@@ -13,10 +13,15 @@
  */
 package org.codice.ddf.itests.common.opensearch;
 
+import static org.codice.ddf.itests.common.AbstractIntegrationTest.OPENSEARCH_PATH;
+import static com.jayway.restassured.RestAssured.when;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.codice.ddf.itests.common.ServiceManager;
+
+import com.jayway.restassured.response.ValidatableResponse;
 
 public class OpenSearchTestCommons {
 
@@ -30,5 +35,21 @@ public class OpenSearchTestCommons {
         openSearchSourcePropertes.put("shortname", sourceId);
         openSearchSourcePropertes.put("endpointUrl", openSearchUrl);
         return openSearchSourcePropertes;
+    }
+
+    public static ValidatableResponse executeOpenSearch(String format, String... query) {
+        StringBuilder buffer = new StringBuilder(OPENSEARCH_PATH.getUrl()).append("?")
+                .append("format=")
+                .append(format);
+
+        for (String term : query) {
+            buffer.append("&")
+                    .append(term);
+        }
+
+        String url = buffer.toString();
+
+        return when().get(url)
+                .then();
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -25,6 +25,7 @@ import static org.codice.ddf.itests.common.config.ConfigureTestCommons.configure
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswInsertRequest;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswQuery;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getMetacardIdFromCswInsertResponse;
+import static org.codice.ddf.itests.common.opensearch.OpenSearchTestCommons.executeOpenSearch;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -2163,23 +2164,6 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .put(REST_PATH.getUrl() + id);
 
         deleteMetacard(id);
-    }
-
-    private ValidatableResponse executeOpenSearch(String format, String... query) {
-        StringBuilder buffer = new StringBuilder(OPENSEARCH_PATH.getUrl()).append("?")
-                .append("format=")
-                .append(format);
-
-        for (String term : query) {
-            buffer.append("&")
-                    .append(term);
-        }
-
-        String url = buffer.toString();
-        LOGGER.info("Getting response to {}", url);
-
-        return when().get(url)
-                .then();
     }
 
     private ValidatableResponse executeAdminOpenSearch(String format, String... query) {


### PR DESCRIPTION
#### What does this PR do?
Fixes flaky tests in TestCatalogValidation
Fix was to ensure stable base state in setup and make sure ingest/query operations waited long enough for configurations/metacards to be ready. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @emmberk 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Test](https://github.com/orgs/codice/teams/test)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Verify itests pass. This has been tested already on the jenkins server and passed 22 itest runs in a row
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2958](https://codice.atlassian.net/browse/DDF-2958)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Update / Add Integration Tests
