### PR TITLE
DDF-3033 Ensure SecurityManager service is available before trying to use it in ServiceManagerProxy

### DIFF
--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -131,6 +131,11 @@
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -251,6 +251,11 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -47,7 +47,7 @@
         </bundle>
         <bundle>wrap:mvn:commons-logging/commons-logging/1.2</bundle>
         <bundle>wrap:mvn:commons-net/commons-net/3.5</bundle>
-
+        <bundle>wrap:mvn:org.awaitility/awaitility/${awaitility.version}</bundle>
         <bundle>
         wrap:mvn:org.cometd.java/cometd-java-client/${cometd.version}$Export-Package=*;version=${cometd.version}
         </bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <mockito.version>1.10.19</mockito.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <junit.version>4.12</junit.version>
+        <awaitility.version>3.0.0</awaitility.version>
         <tika.version>1.14</tika.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.4</commons-lang3.version>


### PR DESCRIPTION
#### What does this PR do?
The issue of the ServiceManagerProxy getting a NPE when trying to get the system subject became very apparent when working on the karaf upgrade ticket. We did find that it is also occasionally happening right now on master as well though. This pr should protect against this.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @emmberk 
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).

[Test](https://github.com/orgs/codice/teams/test)
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Verify build passes
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3033](https://codice.atlassian.net/browse/DDF-3033)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
