### PR TITLE
DDF-3007 Metadata Extractor

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/MetadataExtractor.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/MetadataExtractor.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.content.operation;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+
+/**
+ * Enrich metacard using provided input.
+ * <b>This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library.</b>
+ * </p>
+ */
+public interface MetadataExtractor {
+
+    /**
+     * Parses the input string, extracting metadata from it to add to the metacard.
+     *
+     * @param metadata the metadata to process
+     * @param metacard the metacard to enrich
+     */
+    void process(String metadata, Metacard metacard);
+
+    MetacardType getMetacardType(String contentType);
+
+    boolean canProcess(String contentType);
+
+}

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -41,11 +41,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -374,8 +374,7 @@ public class TikaInputTransformer implements InputTransformer {
             }
 
             String contentType = metadata.get(Metadata.CONTENT_TYPE);
-            MetacardType metacardType = getMetacardType(contentType);
-            metacardType = mergeAttributes(metacardType);
+            MetacardType metacardType = mergeAttributes(getMetacardType(contentType));
             Metacard metacard = MetacardCreator.createMetacard(metadata,
                     id,
                     metadataText,
@@ -462,7 +461,7 @@ public class TikaInputTransformer implements InputTransformer {
     private MetacardType getMetacardType(String contentType) {
         return metadataExtractors.values()
                 .stream()
-                .filter((e) -> e.canProcess(contentType))
+                .filter(e -> e.canProcess(contentType))
                 .findFirst()
                 .map(e -> e.getMetacardType(contentType))
                 .orElse(getMetacardTypeFromMimeType(contentType).orElse(commonTikaMetacardType));

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -468,6 +468,7 @@ public class TikaInputTransformer implements InputTransformer {
     }
 
     protected MetacardType mergeAttributes(MetacardType metacardType) {
+        MetacardType returnObject = metacardType;
         Set<AttributeDescriptor> additionalAttributes = contentExtractors.values()
                 .stream()
                 .map(ContentMetadataExtractor::getMetacardAttributes)
@@ -477,12 +478,12 @@ public class TikaInputTransformer implements InputTransformer {
         // Guard against empty collection. If the collection is empty,
         // the MetacardTypeImpl constructor throws an exception.
         if (!additionalAttributes.isEmpty()) {
-            metacardType = new MetacardTypeImpl(metacardType.getName(),
+            returnObject = new MetacardTypeImpl(metacardType.getName(),
                     metacardType,
                     additionalAttributes);
         }
 
-        return metacardType;
+        return returnObject;
     }
 
     protected void enrichMetacard(TemporaryFileBackedOutputStream fileBackedOutputStream,

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -79,6 +79,7 @@ import com.github.jaiimageio.impl.plugins.tiff.TIFFImageReaderSpi;
 import com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi;
 
 import ddf.catalog.content.operation.ContentMetadataExtractor;
+import ddf.catalog.content.operation.MetadataExtractor;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
@@ -93,172 +94,6 @@ import ddf.catalog.util.impl.ServiceComparator;
 
 public class TikaInputTransformer implements InputTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(TikaInputTransformer.class);
-
-    private Templates templates = null;
-
-    private Map<ServiceReference, ContentMetadataExtractor> contentMetadataExtractors =
-            Collections.synchronizedMap(new TreeMap<>(new ServiceComparator()));
-
-    private MetacardType fallbackExcelMetacardType = null;
-
-    private MetacardType fallbackJpegMetacardType = null;
-
-    private MetacardType fallbackMp4MetacardType = null;
-
-    private MetacardType fallbackMpegMetacardType = null;
-
-    private MetacardType fallbackOfficeDocMetacardType = null;
-
-    private MetacardType fallbackPdfMetacardType = null;
-
-    private MetacardType fallbackPowerpointMetacardType = null;
-
-    // commonTikaMetacardType represents the MetacardType to be used when an ingested product's mime
-    // type does not match a mime type that is supported by the mimeTypeToMetacardTypeMap
-    private MetacardType commonTikaMetacardType = null;
-
-    public void setCommonTikaMetacardType(MetacardType metacardType) {
-        this.commonTikaMetacardType = metacardType;
-    }
-
-    public void setFallbackExcelMetacardType(MetacardType metacardType) {
-        this.fallbackExcelMetacardType = metacardType;
-    }
-
-    public void setFallbackJpegMetacardType(MetacardType metacardType) {
-        this.fallbackJpegMetacardType = metacardType;
-    }
-
-    public void setFallbackMp4MetacardType(MetacardType metacardType) {
-        this.fallbackMp4MetacardType = metacardType;
-    }
-
-    public void setFallbackMpegMetacardType(MetacardType metacardType) {
-        this.fallbackMpegMetacardType = metacardType;
-    }
-
-    public void setFallbackOfficeDocMetacardType(MetacardType metacardType) {
-        this.fallbackOfficeDocMetacardType = metacardType;
-    }
-
-    public void setFallbackPdfMetacardType(MetacardType metacardType) {
-        this.fallbackPdfMetacardType = metacardType;
-    }
-
-    public void setFallbackPowerpointMetacardType(MetacardType metacardType) {
-        this.fallbackPowerpointMetacardType = metacardType;
-    }
-
-    private Map<String, MetacardType> mimeTypeToMetacardTypeMap = new HashMap<>();
-
-    /**
-     * Populates the mimeTypeToMetacardMap for use in determining the {@link MetacardType} that
-     * corresponds to an ingested product's mimeType.
-     */
-
-    public void populateMimeTypeMap() {
-        //.pptm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.presentation.macroenabled.12",
-                fallbackPowerpointMetacardType);
-        //.ppt, .ppz, .pps, .pot, .ppa
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_POWERPOINT.toString(), fallbackPowerpointMetacardType);
-        //.pptx, .thmx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                fallbackPowerpointMetacardType);
-        // .ppsx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-                fallbackPowerpointMetacardType);
-        //.potx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.presentationml.template",
-                fallbackPowerpointMetacardType);
-        //.ppam
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.addin.macroenabled.12",
-                fallbackPowerpointMetacardType);
-        //.ppsm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.slideshow.macroenabled.12",
-                fallbackPowerpointMetacardType);
-        //.sldm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.slide.macroenabled.12",
-                fallbackPowerpointMetacardType);
-        //.potm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.template.macroenabled.12",
-                fallbackPowerpointMetacardType);
-        //.doc, .dot
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_WORD.toString(), fallbackOfficeDocMetacardType);
-        //.docx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                fallbackOfficeDocMetacardType);
-        //.doc, .dot, allias for "application/msword"
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word", fallbackOfficeDocMetacardType);
-        //.docm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word.document.macroenabled.12",
-                fallbackOfficeDocMetacardType);
-        //.dotm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word.template.macroenabled.12",
-                fallbackOfficeDocMetacardType);
-        //.dotx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-                fallbackOfficeDocMetacardType);
-        //.pdf
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.PDF.toString(), fallbackPdfMetacardType);
-        //.mpeg, .mpg, .mpe, .m1v, .m2v
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MPEG_VIDEO.toString(), fallbackMpegMetacardType);
-        //.mpga, .mp2, .mp2a, .mp3, .m2a, .m3a
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MPEG_AUDIO.toString(), fallbackMpegMetacardType);
-        //.mp4 is defined for mpeg-4 content but is not directly correlated with this mime type
-        mimeTypeToMetacardTypeMap.put("audio/mpeg4-generic", fallbackMpegMetacardType);
-        //.mp4 is defined for mpeg-4 content but is not directly correlated with this mime type
-        mimeTypeToMetacardTypeMap.put("video/mpeg4-generic", fallbackMpegMetacardType);
-        //.mp4s
-        mimeTypeToMetacardTypeMap.put("application/mp4", fallbackMp4MetacardType);
-        //.mp4a, .m4a,.m4b
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MP4_AUDIO.toString(), fallbackMp4MetacardType);
-        //.mp4, .mp4v, .mpg4
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MP4_VIDEO.toString(), fallbackMp4MetacardType);
-        //.jpg, .jpeg, .jpe, .jif, .jfif, .jfi
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.JPEG.toString(), fallbackJpegMetacardType);
-        //.jpgv is defined for jpeg content but is not directly correlated with this mime type
-        mimeTypeToMetacardTypeMap.put("video/jpeg", fallbackJpegMetacardType);
-        //.jpgv is defined for jpeg2000 content but is not directly correlated with this mime type
-        mimeTypeToMetacardTypeMap.put("video/jpeg2000", fallbackJpegMetacardType);
-        //.xls, .xlm, .xla, .xlc, .xlt, .xlw, .xll, .xld
-        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_EXCEL.toString(), fallbackExcelMetacardType);
-        //.xlsx
-        mimeTypeToMetacardTypeMap.put(
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                fallbackExcelMetacardType);
-        //.xlsm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.sheet.macroenabled.12",
-                fallbackExcelMetacardType);
-        //.xlsb
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.sheet.binary.macroenabled.12",
-                fallbackExcelMetacardType);
-        //.xlam
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.addin.macroenabled.12",
-                fallbackExcelMetacardType);
-        //.xltm
-        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.template.macroenabled.12",
-                fallbackExcelMetacardType);
-
-    }
-
-    /**
-     * Determines which {@link MetacardType} should be used to create a metacard for an input
-     * file of a given mime type
-     *
-     * @param mimeType the String representing the mime type of the file
-     * @return a {@link MetacardType} that should be used to create a {@link Metacard} for the
-     * given mimeType
-     * Returns null if no {@link MetacardType} was found that matched the given mime type.
-     */
-    public MetacardType getMetacardTypeFromMimeType(String mimeType) {
-        return mimeTypeToMetacardTypeMap.get(mimeType);
-    }
 
     private static final Map<com.google.common.net.MediaType, String>
             SPECIFIC_MIME_TYPE_DATA_TYPE_MAP;
@@ -308,28 +143,288 @@ public class TikaInputTransformer implements InputTransformer {
                 "Sound");
     }
 
-    public void addContentMetadataExtractors(
+    private Templates templates = null;
+
+    private Map<ServiceReference, ContentMetadataExtractor> contentExtractors =
+            Collections.synchronizedMap(new TreeMap<>(new ServiceComparator()));
+
+    private Map<ServiceReference, MetadataExtractor> metadataExtractors =
+            Collections.synchronizedMap(new TreeMap<>(new ServiceComparator()));
+
+    private MetacardType fallbackExcelMetacardType = null;
+
+    private MetacardType fallbackJpegMetacardType = null;
+
+    private MetacardType fallbackMp4MetacardType = null;
+
+    private MetacardType fallbackMpegMetacardType = null;
+
+    private MetacardType fallbackOfficeDocMetacardType = null;
+
+    private MetacardType fallbackPdfMetacardType = null;
+
+    private MetacardType fallbackPowerpointMetacardType = null;
+
+    // commonTikaMetacardType represents the MetacardType to be used when an ingested product's mime
+    // type does not match a mime type that is supported by the mimeTypeToMetacardTypeMap
+    private MetacardType commonTikaMetacardType = null;
+
+    private Map<String, MetacardType> mimeTypeToMetacardTypeMap = new HashMap<>();
+
+    public TikaInputTransformer(BundleContext bundleContext, MetacardType metacardType) {
+        this.commonTikaMetacardType = metacardType;
+        classLoaderAndBundleContextSetup(bundleContext);
+    }
+
+    @SuppressWarnings("unused")
+    public void setCommonTikaMetacardType(MetacardType metacardType) {
+        this.commonTikaMetacardType = metacardType;
+    }
+
+    public void setFallbackExcelMetacardType(MetacardType metacardType) {
+        this.fallbackExcelMetacardType = metacardType;
+    }
+
+    public void setFallbackJpegMetacardType(MetacardType metacardType) {
+        this.fallbackJpegMetacardType = metacardType;
+    }
+
+    public void setFallbackMp4MetacardType(MetacardType metacardType) {
+        this.fallbackMp4MetacardType = metacardType;
+    }
+
+    public void setFallbackMpegMetacardType(MetacardType metacardType) {
+        this.fallbackMpegMetacardType = metacardType;
+    }
+
+    public void setFallbackOfficeDocMetacardType(MetacardType metacardType) {
+        this.fallbackOfficeDocMetacardType = metacardType;
+    }
+
+    public void setFallbackPdfMetacardType(MetacardType metacardType) {
+        this.fallbackPdfMetacardType = metacardType;
+    }
+
+    public void setFallbackPowerpointMetacardType(MetacardType metacardType) {
+        this.fallbackPowerpointMetacardType = metacardType;
+    }
+
+    /**
+     * Populates the mimeTypeToMetacardMap for use in determining the {@link MetacardType} that
+     * corresponds to an ingested product's mimeType.
+     */
+
+    public void populateMimeTypeMap() {
+        //.pptm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.presentation.macroenabled.12",
+                fallbackPowerpointMetacardType);
+        //.ppt, .ppz, .pps, .pot, .ppa
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_POWERPOINT.toString(),
+                fallbackPowerpointMetacardType);
+        //.pptx, .thmx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                fallbackPowerpointMetacardType);
+        // .ppsx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+                fallbackPowerpointMetacardType);
+        //.potx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.presentationml.template",
+                fallbackPowerpointMetacardType);
+        //.ppam
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.addin.macroenabled.12",
+                fallbackPowerpointMetacardType);
+        //.ppsm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.slideshow.macroenabled.12",
+                fallbackPowerpointMetacardType);
+        //.sldm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.slide.macroenabled.12",
+                fallbackPowerpointMetacardType);
+        //.potm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-powerpoint.template.macroenabled.12",
+                fallbackPowerpointMetacardType);
+        //.doc, .dot
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_WORD.toString(),
+                fallbackOfficeDocMetacardType);
+        //.docx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                fallbackOfficeDocMetacardType);
+        //.doc, .dot, allias for "application/msword"
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word", fallbackOfficeDocMetacardType);
+        //.docm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word.document.macroenabled.12",
+                fallbackOfficeDocMetacardType);
+        //.dotm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-word.template.macroenabled.12",
+                fallbackOfficeDocMetacardType);
+        //.dotx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+                fallbackOfficeDocMetacardType);
+        //.pdf
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.PDF.toString(),
+                fallbackPdfMetacardType);
+        //.mpeg, .mpg, .mpe, .m1v, .m2v
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MPEG_VIDEO.toString(),
+                fallbackMpegMetacardType);
+        //.mpga, .mp2, .mp2a, .mp3, .m2a, .m3a
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MPEG_AUDIO.toString(),
+                fallbackMpegMetacardType);
+        //.mp4 is defined for mpeg-4 content but is not directly correlated with this mime type
+        mimeTypeToMetacardTypeMap.put("audio/mpeg4-generic", fallbackMpegMetacardType);
+        //.mp4 is defined for mpeg-4 content but is not directly correlated with this mime type
+        mimeTypeToMetacardTypeMap.put("video/mpeg4-generic", fallbackMpegMetacardType);
+        //.mp4s
+        mimeTypeToMetacardTypeMap.put("application/mp4", fallbackMp4MetacardType);
+        //.mp4a, .m4a,.m4b
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MP4_AUDIO.toString(),
+                fallbackMp4MetacardType);
+        //.mp4, .mp4v, .mpg4
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MP4_VIDEO.toString(),
+                fallbackMp4MetacardType);
+        //.jpg, .jpeg, .jpe, .jif, .jfif, .jfi
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.JPEG.toString(),
+                fallbackJpegMetacardType);
+        //.jpgv is defined for jpeg content but is not directly correlated with this mime type
+        mimeTypeToMetacardTypeMap.put("video/jpeg", fallbackJpegMetacardType);
+        //.jpgv is defined for jpeg2000 content but is not directly correlated with this mime type
+        mimeTypeToMetacardTypeMap.put("video/jpeg2000", fallbackJpegMetacardType);
+        //.xls, .xlm, .xla, .xlc, .xlt, .xlw, .xll, .xld
+        mimeTypeToMetacardTypeMap.put(com.google.common.net.MediaType.MICROSOFT_EXCEL.toString(),
+                fallbackExcelMetacardType);
+        //.xlsx
+        mimeTypeToMetacardTypeMap.put(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                fallbackExcelMetacardType);
+        //.xlsm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.sheet.macroenabled.12",
+                fallbackExcelMetacardType);
+        //.xlsb
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.sheet.binary.macroenabled.12",
+                fallbackExcelMetacardType);
+        //.xlam
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.addin.macroenabled.12",
+                fallbackExcelMetacardType);
+        //.xltm
+        mimeTypeToMetacardTypeMap.put("application/vnd.ms-excel.template.macroenabled.12",
+                fallbackExcelMetacardType);
+    }
+
+    /**
+     * Determines which {@link MetacardType} should be used to create a metacard for an input
+     * file of a given mime type
+     *
+     * @param mimeType the String representing the mime type of the file
+     * @return a {@link Optional} of {@link MetacardType} that should be used to create a
+     * {@link Metacard} for the given mimeType. Returns empty {@link Optional} if
+     * no {@link MetacardType}  matched the given mime type.
+     */
+    public Optional<MetacardType> getMetacardTypeFromMimeType(String mimeType) {
+        return Optional.ofNullable(mimeTypeToMetacardTypeMap.get(mimeType));
+    }
+
+    @Override
+    public Metacard transform(InputStream input) throws IOException, CatalogTransformerException {
+        return transform(input, null);
+    }
+
+    @Override
+    public Metacard transform(InputStream input, String id)
+            throws IOException, CatalogTransformerException {
+        LOGGER.debug("Transforming input stream using Tika.");
+        long bytes;
+        if (input == null) {
+            throw new CatalogTransformerException("Cannot transform null input.");
+        }
+
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
+            try {
+                bytes = IOUtils.copyLarge(input, fileBackedOutputStream);
+            } catch (IOException e) {
+                throw new CatalogTransformerException("Could not copy bytes of content message.",
+                        e);
+            }
+
+            Parser parser = new AutoDetectParser();
+            ToXMLContentHandler xmlContentHandler = new ToXMLContentHandler();
+            ToTextContentHandler textContentHandler = null;
+            ContentHandler contentHandler;
+            if (!contentExtractors.isEmpty()) {
+                textContentHandler = new ToTextContentHandler();
+                contentHandler = new TeeContentHandler(xmlContentHandler, textContentHandler);
+            } else {
+                contentHandler = xmlContentHandler;
+            }
+
+            TikaMetadataExtractor tikaMetadataExtractor = new TikaMetadataExtractor(parser,
+                    contentHandler);
+
+            Metadata metadata;
+            try (InputStream inputStreamCopy = fileBackedOutputStream.asByteSource()
+                    .openStream()) {
+                metadata = tikaMetadataExtractor.parseMetadata(inputStreamCopy, new ParseContext());
+            }
+
+            String metadataText = xmlContentHandler.toString();
+            if (templates != null) {
+                metadataText = transformToXml(metadataText);
+            }
+
+            String contentType = metadata.get(Metadata.CONTENT_TYPE);
+            MetacardType metacardType = getMetacardType(contentType);
+            metacardType = mergeAttributes(metacardType);
+            Metacard metacard = MetacardCreator.createMetacard(metadata,
+                    id,
+                    metadataText,
+                    metacardType);
+
+            if (textContentHandler != null) {
+                String plainText = textContentHandler.toString();
+                for (ContentMetadataExtractor contentMetadataExtractor : contentExtractors.values()) {
+                    contentMetadataExtractor.process(plainText, metacard);
+                }
+            }
+
+            for (MetadataExtractor metadataExtractor : metadataExtractors.values()) {
+                metadataExtractor.process(metadataText, metacard);
+            }
+
+            enrichMetacard(fileBackedOutputStream, contentType, bytes, metacard);
+
+            LOGGER.debug("Finished transforming input stream using Tika.");
+            return metacard;
+        }
+    }
+
+    public void addContentMetadataExtractor(
             ServiceReference<ContentMetadataExtractor> contentMetadataExtractorRef) {
         Bundle bundle = getBundle();
         if (bundle != null) {
             ContentMetadataExtractor cme = bundle.getBundleContext()
                     .getService(contentMetadataExtractorRef);
-            contentMetadataExtractors.put(contentMetadataExtractorRef, cme);
+            contentExtractors.put(contentMetadataExtractorRef, cme);
         }
     }
 
-    Bundle getBundle() {
-        return FrameworkUtil.getBundle(TikaInputTransformer.class);
+    public void addMetadataExtractor(ServiceReference<MetadataExtractor> metadataExtractorRef) {
+        Bundle bundle = getBundle();
+        if (bundle != null) {
+            MetadataExtractor cme = bundle.getBundleContext()
+                    .getService(metadataExtractorRef);
+            metadataExtractors.put(metadataExtractorRef, cme);
+        }
     }
 
     public void removeContentMetadataExtractor(
             ServiceReference<ContentMetadataExtractor> contentMetadataExtractorRef) {
-        contentMetadataExtractors.remove(contentMetadataExtractorRef);
+        contentExtractors.remove(contentMetadataExtractorRef);
     }
 
-    public TikaInputTransformer(BundleContext bundleContext, MetacardType metacardType) {
-        this.commonTikaMetacardType = metacardType;
-        classLoaderAndBundleContextSetup(bundleContext);
+    public void removeMetadataExtractor(ServiceReference<MetadataExtractor> metadataExtractorRef) {
+        metadataExtractors.remove(metadataExtractorRef);
     }
 
     private void classLoaderAndBundleContextSetup(BundleContext bundleContext) {
@@ -364,97 +459,50 @@ public class TikaInputTransformer implements InputTransformer {
                 .registerServiceProvider(new TIFFImageReaderSpi());
     }
 
-    @Override
-    public Metacard transform(InputStream input) throws IOException, CatalogTransformerException {
-        return transform(input, null);
+    private MetacardType getMetacardType(String contentType) {
+        return metadataExtractors.values()
+                .stream()
+                .filter((e) -> e.canProcess(contentType))
+                .findFirst()
+                .map(e -> e.getMetacardType(contentType))
+                .orElse(getMetacardTypeFromMimeType(contentType).orElse(commonTikaMetacardType));
     }
 
-    @Override
-    public Metacard transform(InputStream input, String id)
-            throws IOException, CatalogTransformerException {
-        LOGGER.debug("Transforming input stream using Tika.");
+    protected MetacardType mergeAttributes(MetacardType metacardType) {
+        Set<AttributeDescriptor> additionalAttributes = contentExtractors.values()
+                .stream()
+                .map(ContentMetadataExtractor::getMetacardAttributes)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
 
-        if (input == null) {
-            throw new CatalogTransformerException("Cannot transform null input.");
+        // Guard against empty collection. If the collection is empty,
+        // the MetacardTypeImpl constructor throws an exception.
+        if (!additionalAttributes.isEmpty()) {
+            metacardType = new MetacardTypeImpl(metacardType.getName(),
+                    metacardType,
+                    additionalAttributes);
         }
 
-        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
-            try {
-                IOUtils.copy(input, fileBackedOutputStream);
-            } catch (IOException e) {
-                throw new CatalogTransformerException("Could not copy bytes of content message.",
-                        e);
-            }
+        return metacardType;
+    }
 
-            Parser parser = new AutoDetectParser();
-            ToXMLContentHandler xmlContentHandler = new ToXMLContentHandler();
-            ToTextContentHandler textContentHandler = null;
-            ContentHandler contentHandler;
-            if (!contentMetadataExtractors.isEmpty()) {
-                textContentHandler = new ToTextContentHandler();
-                contentHandler = new TeeContentHandler(xmlContentHandler, textContentHandler);
-            } else {
-                contentHandler = xmlContentHandler;
-            }
+    protected void enrichMetacard(TemporaryFileBackedOutputStream fileBackedOutputStream,
+            String metacardContentType, long bytes, Metacard metacard) throws IOException {
 
-            TikaMetadataExtractor tikaMetadataExtractor = new TikaMetadataExtractor(parser,
-                    contentHandler);
+        if (StringUtils.isNotBlank(metacardContentType)) {
+            metacard.setAttribute(new AttributeImpl(Core.DATATYPE,
+                    getDatatype(metacardContentType)));
+        }
 
-            Metadata metadata;
+        if (StringUtils.startsWith(metacardContentType, "image")) {
             try (InputStream inputStreamCopy = fileBackedOutputStream.asByteSource()
                     .openStream()) {
-                metadata = tikaMetadataExtractor.parseMetadata(inputStreamCopy, new ParseContext());
+                createThumbnail(inputStreamCopy, metacard);
             }
-
-            String metadataText = xmlContentHandler.toString();
-            if (templates != null) {
-                metadataText = transformToXml(metadataText);
-            }
-            String metacardContentType = metadata.get(Metadata.CONTENT_TYPE);
-            MetacardType metacardType = getMetacardTypeFromMimeType(metacardContentType);
-            if (metacardType == null) {
-                metacardType = commonTikaMetacardType;
-            }
-            Metacard metacard;
-            if (textContentHandler != null) {
-                String plainText = textContentHandler.toString();
-
-                Set<AttributeDescriptor> attributes = contentMetadataExtractors.values()
-                        .stream()
-                        .map(ContentMetadataExtractor::getMetacardAttributes)
-                        .flatMap(Collection::stream)
-                        .collect(Collectors.toSet());
-                MetacardTypeImpl extendedMetacardType = new MetacardTypeImpl(metacardType.getName(),
-                        metacardType,
-                        attributes);
-
-                metacard = MetacardCreator.createMetacard(metadata,
-                        id,
-                        metadataText,
-                        extendedMetacardType);
-
-                for (ContentMetadataExtractor contentMetadataExtractor : contentMetadataExtractors.values()) {
-                    contentMetadataExtractor.process(plainText, metacard);
-                }
-            } else {
-                metacard = MetacardCreator.createMetacard(metadata, id, metadataText, metacardType);
-            }
-
-            if (StringUtils.isNotBlank(metacardContentType)) {
-                metacard.setAttribute(new AttributeImpl(Core.DATATYPE,
-                        getDatatype(metacardContentType)));
-            }
-
-            if (StringUtils.startsWith(metacardContentType, "image")) {
-                try (InputStream inputStreamCopy = fileBackedOutputStream.asByteSource()
-                        .openStream()) {
-                    createThumbnail(inputStreamCopy, metacard);
-                }
-            }
-
-            LOGGER.debug("Finished transforming input stream using Tika.");
-            return metacard;
         }
+
+        metacard.setAttribute(new AttributeImpl(Core.RESOURCE_SIZE, String.valueOf(bytes)));
+
     }
 
     @Nullable
@@ -592,5 +640,9 @@ public class TikaInputTransformer implements InputTransformer {
             }
         }
         return xhtml;
+    }
+
+    Bundle getBundle() {
+        return FrameworkUtil.getBundle(TikaInputTransformer.class);
     }
 }

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,8 +31,16 @@
     <reference-list id="contentExtractors"
                     interface="ddf.catalog.content.operation.ContentMetadataExtractor"
                     availability="optional">
-        <reference-listener bind-method="addContentMetadataExtractors"
+        <reference-listener bind-method="addContentMetadataExtractor"
                             unbind-method="removeContentMetadataExtractor"
+                            ref="tikaTransformer"/>
+    </reference-list>
+
+    <reference-list id="metadataExtractors"
+                    interface="ddf.catalog.content.operation.MetadataExtractor"
+                    availability="optional">
+        <reference-listener bind-method="addMetadataExtractor"
+                            unbind-method="removeMetadataExtractor"
                             ref="tikaTransformer"/>
     </reference-list>
 
@@ -45,6 +53,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -58,6 +67,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -71,6 +81,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -85,6 +96,7 @@
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.transformer.common.tika.Mp4MetacardType"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -98,6 +110,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -111,6 +124,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -124,6 +138,7 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
             </list>
         </argument>
     </bean>
@@ -137,6 +152,8 @@
                 <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
+
             </list>
         </argument>
     </bean>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -153,7 +153,6 @@
                 <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
                 <bean class="ddf.catalog.data.impl.types.CoreAttributes"/>
-
             </list>
         </argument>
     </bean>


### PR DESCRIPTION
#### What does this PR do?
1. Add a new interface, MetadataExtractor to catalog operations. Modified TikaInputTransformer to use the new interface. Services that implement the MetadataExtractor interface are called with the Tika transformer ingests a document. The transformer will call the service twice. Once to get a list of attribute descriptors to add to the metacard type. The second time, the transformer passes the tika-extracted metadata and the new metacard to the extractor. The extractor has the opportunity to enrich the metacard by adding new attributes derived from the tika-extracted metadata.

2. Light cleanup of TikaInputTransformer.transform() method. Some of the functionality was moved into helper methods. Complexity of the method was reduced.

3. Additional unit tests.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann @emanns95 @AzGoalie @codymacdonald @mweser
#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@brendan-hofmann 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 
#### How should this be tested? (List steps with links to updated documentation)
Run unit and integration tests. 
Ingest a PDF file, text file, and PowerPoint or Word file from the Catalog UI.
#### Any background context you want to provide?
The new interface, MetadataExtractor, is modeled on the existing interface, ContentMetadataExtractor.
#### What are the relevant tickets?
[DDF-3007](https://codice.atlassian.net/browse/DDF-3007)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
The MetadataExtractor is an experimental API and not documented in the DDF manual. The class javadoc indicates this is an experimental API.
- [X] Update / Add Unit Tests