### PR TITLE
DDF-2132 Added version properties for karaf dependencies

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/catalog/resourcemanagement/resourcemanagement-app/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-app/pom.xml
@@ -80,7 +80,6 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
                 <executions>
                     <execution>
                         <id>kar</id>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>org.apache.karaf.webconsole</groupId>
             <artifactId>org.apache.karaf.webconsole.console</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.distribution</groupId>

--- a/libs/libs-pomfix/test/resources/descriptors/pom.xml
+++ b/libs/libs-pomfix/test/resources/descriptors/pom.xml
@@ -25,6 +25,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>features-maven-plugin</artifactId>
+                <version>${karaf.version}</version>
                 <executions>
                     <execution>
                         <id>add-features-to-repo</id>

--- a/platform/admin/core/admin-core-appservice/pom.xml
+++ b/platform/admin/core/admin-core-appservice/pom.xml
@@ -50,14 +50,17 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>org.apache.karaf.features.core</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.bundle</groupId>
             <artifactId>org.apache.karaf.bundle.core</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/platform/platform-scheduler/pom.xml
+++ b/platform/platform-scheduler/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -84,6 +84,7 @@
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.security.core</groupId>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -128,6 +128,7 @@
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.lib</groupId>

--- a/platform/security/sts/security-sts-ldaplogin/pom.xml
+++ b/platform/security/sts/security-sts-ldaplogin/pom.xml
@@ -108,10 +108,12 @@
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.modules</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -185,10 +187,12 @@
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.config</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>
             <artifactId>org.apache.karaf.util</artifactId>
+            <version>${karaf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
#### What does this PR do?
This PR adds `${karaf.version}` to karaf dependencies so that the version does not rely on dependency management (see [DDF-2985](https://codice.atlassian.net/browse/DDF-2985)). This PR shouldn't affect any versions. It just cleans up the dependency management before the Karaf upgrade to 4.1.1.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@vinamartin @mcalcote @josephthweatt 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@clockard
#### How should this be tested? (List steps with links to updated documentation)
Full build.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2132](https://codice.atlassian.net/browse/DDF-2132)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
