### PR TITLE
DDF-3040 Remove Insecure Defaults Warning

### DIFF
--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBean.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsServiceBean.java
@@ -277,7 +277,7 @@ public class InsecureDefaultsServiceBean implements InsecureDefaultsServiceBeanM
     }
 
     private String getTruststorePath() {
-        return new AbsolutePathResolver(TRUSTSTORE_SYSTEM_PROPERTY).getPath();
+        return new AbsolutePathResolver(System.getProperty(TRUSTSTORE_SYSTEM_PROPERTY)).getPath();
     }
 
     private String getTruststorePassword() {


### PR DESCRIPTION
#### What does this PR do?
Fixed truststore path resolution in InsecureDefualts tests.  The getTrustStorePath() method was returning the name of the truststore path property, instead of the path itself. Updated that class to retrieve the path from the System properties.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@gordocanchola 
@ahoffer 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@kcwire 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1.     Enable TLS on DDF
2.     Open admin console web page
3.     The warning "Unable to determine if keystore [/javax.net.ssl.trustStore] is using insecure defualts. Cannot read keystore" should not be displayed

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3040](https://codice.atlassian.net/browse/DDF-3040)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
