### PR TITLE
DDF-3062 Adds null check for application name regex

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/models/Applications.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Applications.js
@@ -132,7 +132,7 @@ define([
             changeObj.displayName = this.get('name');
             if (this.get('version') === '0.0.0') {
                 var matches = this.get('name').match(versionRegex);
-                if (matches.length === 3) {
+                if (matches !== null && matches.length === 3) {
                     changeObj.displayName = matches[1];
                     changeObj.version = matches[2];
                 }

--- a/platform/admin/ui/src/main/webapp/js/models/Applications.js
+++ b/platform/admin/ui/src/main/webapp/js/models/Applications.js
@@ -132,7 +132,7 @@ define([
             changeObj.displayName = this.get('name');
             if (this.get('version') === '0.0.0') {
                 var matches = this.get('name').match(versionRegex);
-                if (matches !== null && matches.length === 3) {
+                if (matches !== null) {
                     changeObj.displayName = matches[1];
                     changeObj.version = matches[2];
                 }


### PR DESCRIPTION
#### What does this PR do?
Adds in a null check for the application name regex in the case where an application neither has a version or a version in its name. The `.match` method returns null when the regex isn't matched. 
This isn't currently an issue with any of our apps, but it could become an issue in the future. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue @andrewkfiedler 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Run through the installer and make sure everything installs properly

#### Any background context you want to provide?
This is related to work being done for the Karaf 4.1.1 upgrade.
