### PR TITLE
DDF-3070 Allow the ability to logout if currently guest.

### DIFF
--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpLogoutActionProvider.java
@@ -56,7 +56,9 @@ public class IdpLogoutActionProvider implements ActionProvider {
             try {
 
                 @SuppressWarnings("unchecked")
-                String nameId = SubjectUtils.getName((Subject) ((Map) realmSubjectMap).get("idp"));
+                String nameId = SubjectUtils.getName((Subject) ((Map) realmSubjectMap).get("idp"),
+                        "You",
+                        true);
 
                 String nameIdTimestamp = nameId + "\n" + System.currentTimeMillis();
                 nameIdTimestamp = encryptionService.encrypt(nameIdTimestamp);

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
@@ -73,24 +73,20 @@ public class LogoutService {
             if (action != null) {
                 String realm = StringUtils.substringAfterLast(action.getId(), ".");
 
-                //if the user is logged in and isn't a guest, add them
                 if (realmTokenMap.get(realm) != null) {
                     Map<String, String> actionProperties = new HashMap<>();
                     String displayName = SubjectUtils.getName(realmSubjectMap.get(realm),
                             "",
                             true);
 
-                    if (displayName != null
-                            && !displayName.equals(SubjectUtils.GUEST_DISPLAY_NAME)) {
-                        actionProperties.put("title", action.getTitle());
-                        actionProperties.put("realm", realm);
-                        actionProperties.put("auth", displayName);
-                        actionProperties.put("description", action.getDescription());
-                        actionProperties.put("url",
-                                action.getUrl()
-                                        .toString());
-                        realmToPropMaps.add(actionProperties);
-                    }
+                    actionProperties.put("title", action.getTitle());
+                    actionProperties.put("realm", realm);
+                    actionProperties.put("auth", displayName);
+                    actionProperties.put("description", action.getDescription());
+                    actionProperties.put("url",
+                            action.getUrl()
+                                    .toString());
+                    realmToPropMaps.add(actionProperties);
                 }
             }
         }

--- a/platform/security/servlet/security-servlet-logout/src/main/webapp/js/logout-response.js
+++ b/platform/security/servlet/security-servlet-logout/src/main/webapp/js/logout-response.js
@@ -10,7 +10,7 @@
             var param = paramString.split('=');
 
             if (param[0] === "msg") {
-                $('#extramessage').html(param[1].split('+').join(' '));
+                $('#extramessage').html(decodeURIComponent(param[1].split('+').join(' ')));
             }
             //add additional params here if needed
         });


### PR DESCRIPTION
#### What does this PR do?
- Fixed bug that would not allow logging out if guest.
- Fixed IdP logout action provider to use the user’s display name
  instead of their full name id.
- Fixed logout confirmation to URI decode the response message.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brjeter 
@harrison-tarr 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Security](https://github.com/orgs/codice/teams/security)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Login as guest.  Go to `https://localhost:8993/logout` and verify that you can logout as guest and log in as a different user.

#### Any background context you want to provide?


#### What are the relevant tickets?
[DDF-3070](https://codice.atlassian.net/browse/DDF-3070)

#### Screenshots (if appropriate)
![idp guest logout](https://user-images.githubusercontent.com/700518/26998360-8c039702-4d37-11e7-8242-51b8f4671cdb.png)
![before](https://user-images.githubusercontent.com/700518/26998361-8e497450-4d37-11e7-834c-b9796d662684.png)
![after](https://user-images.githubusercontent.com/700518/26998363-900a0610-4d37-11e7-8564-8714fd3b7697.png)

#### Checklist:
- [ n/a ] Documentation Updated
- [ n/a ] Change Log Updated
- [ n/a ] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests
