### PR TITLE
DDF-2881  added quick start tutorial to templated documentation

### DIFF
--- a/distribution/docs/src/main/jdocs/content/_installing/installing-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_installing/installing-intro-contents.adoc
@@ -247,12 +247,13 @@ unzip ${branding-lowercase}-${project.version}.zip
 .Windows Zip Utility Warning
 [WARNING]
 ====
-DO NOT use the Windows zip utility bundled with Windows to unzip {branding}.
-Unzipping {branding} using the Windows zip utility will cause unexpected behavior and errors in {branding}!
+The Windows Zip implementation, which is invoked when a user double-clicks on a zip file in the Windows Explorer, creates a corrupted installation.
+This is a consequence of its inability to process long file paths.
+Instead, use the java jar command line utility to unzip the distribution (see example below) or use a third party utility such as 7-Zip.
 
-.Use Java to Unzip in Windows
+.Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
 ----
-"%JAVA_HOME%\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
+"<PATH_TO_JAVA>\jdk<JAVA_VERSION>\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
 ----
 
 The unzipping process may take time to complete.

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-configuring-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-configuring-contents.adoc
@@ -14,8 +14,9 @@ Set the configurations needed to run ${branding}.
 . Follow the installer prompts for a standard installation.
 .. Click start to begin the setup process.
 .. Configure <<_guest_interceptor,guest claims attributes>> or use defaults.
-... (these attributes represent the minimum authorization for all users)
+... *All users will be automatically granted these authorizations*
 .. Select *Standard Installation*.
+... This step may take several minutes to complete.
 .. On the System Configuration page, configure any port or protocol changes desired and add any keystores/truststores needed.
 ... See <<_configuring_new_certificates,Configuring New Certificates>> for more details.
 .. Click *Next*

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-configuring-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-configuring-contents.adoc
@@ -1,0 +1,23 @@
+:title: Configuring (Quick Start)
+:type: quickStart
+:status: published
+:summary: Set configurations for an example instance.
+:order: 01
+
+=== Configuring (Quick Start)
+
+Set the configurations needed to run ${branding}.
+
+. In a browser, navigate to the ${admin-console} at ${secure_url}/admin.
+.. The ${admin-console} may take a few minutes to start up.
+. Enter the default username of `admin` and the password of `admin`.
+. Follow the installer prompts for a standard installation.
+.. Click start to begin the setup process.
+.. Configure <<_guest_interceptor,guest claims attributes>> or use defaults.
+... (these attributes represent the minimum authorization for all users)
+.. Select *Standard Installation*.
+.. On the System Configuration page, configure any port or protocol changes desired and add any keystores/truststores needed.
+... See <<_configuring_new_certificates,Configuring New Certificates>> for more details.
+.. Click *Next*
+.. Click *Finish*
+

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-ingesting-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-ingesting-contents.adoc
@@ -1,0 +1,33 @@
+:title: Ingesting (Quick Start)
+:type: quickStart
+:status: published
+:summary: Ingest sample data.
+:order: 02
+
+=== Ingesting (Quick Start)
+
+Now that ${branding} has been configured, ingest some sample data to demonstrate search capabilities.
+
+This is one way to ingest into the catalog, for a complete list of the different methods, see <<_ingesting_data,Ingesting Data>>.
+
+==== Ingesting Sample Data
+
+. Download a sample valid https://codice.atlassian.net/wiki/download/attachments/1179756/geojson_valid.json?version=1&modificationDate=1368249436010&api=v2[GeoJson file here].
+. Navigate in the browser to the Search UI at ${secure_url}/search.
+. Click the *upload* icon in the upper right corner.
+. Select the file to upload.
+
+[NOTE]
+====
+XML metadata for text searching is not automatically generated from GeoJson fields.
+====
+
+Querying from the Search UI (${secure_url}/search) will return the record for the file ingested:
+
+* Enter `*` in the Text search box and click the *Search* button.
+
+[NOTE]
+====
+The sample data was selected as an example of well-formed metadata.
+Other data can and should be used to test other usage scenarios.
+====

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-installing-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-installing-contents.adoc
@@ -34,7 +34,7 @@ Set up Java to run ${branding}.
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
 ** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 ** Java Version and Build numbers must contain only number values.
-* Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
+* Supported platforms are Microsoft Windows, Linux, Solaris, and macOS.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
 
@@ -43,24 +43,18 @@ Set up Java to run ${branding}.
 
 . Determine Java Installation Directory (This varies between operating system versions).
 
-.Find Java Path in *NIX
-----
-which java
-----
-
 .Find Java Path in Windows
 ----
 for %i in (java.exe) do @echo. %~$PATH:i
 ----
 
+.Find Java Path in *nix
+----
+which java
+----
+
 . Copy path to Java installation. (example: `/usr/java/<JAVA_VERSION>`)
 . Set `JAVA_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
-
-.Setting `JAVA_HOME` on *NIX
-----
-JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
-export JAVA_HOME
-----
 
 .Setting `JAVA_HOME` on Windows
 ----
@@ -71,9 +65,15 @@ set JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION> /m
 ----
 setx PATH "%PATH%;%JAVA_HOME%\bin" /m
 ----
+
+.Setting `JAVA_HOME` on *nix
+----
+JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+export JAVA_HOME
+----
 ====
 
-.*NIX
+.*nix
 [WARNING]
 ====
 Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
@@ -84,14 +84,14 @@ Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
 [TIP]
 ====
 
-.*NIX
-----
-echo $JAVA_HOME
-----
-
 .Windows
 ----
 echo %JAVA_HOME%
+----
+
+.*nix
+----
+echo $JAVA_HOME
 ----
 ====
 
@@ -107,7 +107,7 @@ fs.file-max = 6815744
 * (This file may need permissions changed to allow write access).
 * For the change to take effect, a restart is required.
 
-. *Nix Restart Command
+. *nix Restart Command
 ----
 init 6
 ----
@@ -121,19 +121,15 @@ Prior to installing ${branding}, ensure the system time is accurate to prevent f
 
 === Quick Install of ${branding}
 
-.Check System Time
-[WARNING]
-====
-Prior to installing ${branding}, ensure the system time is accurate to prevent federation issues.
-====
-
 . Download the ${branding} {download-url}[zip file].
 . Install ${branding} by unzipping the zip file.
 +
 .Windows Zip Utility Warning
 [WARNING]
 ====
-The default Windows zip utility (such as double-clicking file) will not work to unzip the distribution, use Java or a third party utility instead.
+The Windows Zip implementation, which is invoked when a user double-clicks on a zip file in the Windows Explorer, creates a corrupted installation.
+This is a consequence of its inability to process long file paths.
+Instead, use the java jar command line utility to unzip the distribution (see example below) or use a third party utility such as 7-Zip.
 
 .Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
 ----

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-installing-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-installing-contents.adoc
@@ -1,0 +1,153 @@
+:title: Installing (Quick Start)
+:type: quickStart
+:status: published
+:summary: Installation of an example instance.
+:order: 00
+
+This quick tutorial will enable install, configuring and using a basic instance of ${branding}.
+
+[NOTE]
+====
+This tutorial is intended for setting up a test, demonstration, or trial installation of ${branding}.
+For more complete installation and configuration steps, see <<_installing,Installing>>.
+====
+
+These steps will demonstrate:
+
+- [*] <<_quick_install_prerequisites,Prerequisites>>.
+- [*] <<_quick_install_of_${branding-lowercase},Quick Install of ${branding}>>.
+- [*] <<_ingesting_sample_data,Ingesting Data>>.
+
+=== Quick Install Prerequisites
+
+These are the basic requirements to set up the environment to run a ${branding}.
+
+==== Hardware Requirements (Quick Install)
+
+* At least 4096MB of memory for ${branding}.
+** This amount can be increased to support memory-intensive applications. See <<jvm-memory-configuration, Memory Considerations>>.
+
+==== Java Requirements (Quick Install)
+
+Set up Java to run ${branding}.
+
+* Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
+** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
+** Java Version and Build numbers must contain only number values.
+* Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
+* http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
+* The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
+
+.Setting JAVA_HOME variable (Replace `<JAVA_VERSION>` with the version and build number installed.)
+====
+
+. Determine Java Installation Directory (This varies between operating system versions).
+
+.Find Java Path in *NIX
+----
+which java
+----
+
+.Find Java Path in Windows
+----
+for %i in (java.exe) do @echo. %~$PATH:i
+----
+
+. Copy path to Java installation. (example: `/usr/java/<JAVA_VERSION>`)
+. Set `JAVA_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
+
+.Setting `JAVA_HOME` on *NIX
+----
+JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+export JAVA_HOME
+----
+
+.Setting `JAVA_HOME` on Windows
+----
+set JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION> /m
+----
+
+.Adding `JAVA_HOME` to `PATH` Environment Variable on Windows
+----
+setx PATH "%PATH%;%JAVA_HOME%\bin" /m
+----
+====
+
+.*NIX
+[WARNING]
+====
+Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
+`unlink JAVA_HOME`
+====
+
+.Verify that the `JAVA_HOME` was set correctly.
+[TIP]
+====
+
+.*NIX
+----
+echo $JAVA_HOME
+----
+
+.Windows
+----
+echo %JAVA_HOME%
+----
+====
+
+.File Descriptor Limit on Linux
+[NOTE]
+====
+* For Linux systems, increase the file descriptor limit by editing `/etc/sysctl.conf` to include:
+
+----
+fs.file-max = 6815744
+----
+
+* (This file may need permissions changed to allow write access).
+* For the change to take effect, a restart is required.
+
+. *Nix Restart Command
+----
+init 6
+----
+====
+
+.Check System Time
+[WARNING]
+====
+Prior to installing ${branding}, ensure the system time is accurate to prevent federation issues.
+====
+
+=== Quick Install of ${branding}
+
+.Check System Time
+[WARNING]
+====
+Prior to installing ${branding}, ensure the system time is accurate to prevent federation issues.
+====
+
+. Download the ${branding} {download-url}[zip file].
+. Install ${branding} by unzipping the zip file.
++
+.Windows Zip Utility Warning
+[WARNING]
+====
+The default Windows zip utility (such as double-clicking file) will not work to unzip the distribution, use Java or a third party utility instead.
+
+.Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
+----
+"<PATH_TO_JAVA>\jdk<JAVA_VERSION>\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
+----
+====
++
+. This will create an installation directory, which is typically created with the name and version of the application.
+This installation directory will be referred to as `<${branding}_HOME>`.
+(Substitute the actual directory name.)
+. Start ${branding} by running the `<${branding}_HOME>/bin/${branding-lowercase}` script (or `${branding-lowercase}.bat` on Windows).
+. The ${command-console} will display.
+
+.${command-console} Prompt
+----
+${branding-lowercase}${at-symbol}local>
+----

--- a/distribution/docs/src/main/jdocs/jbake.properties
+++ b/distribution/docs/src/main/jdocs/jbake.properties
@@ -22,6 +22,7 @@ template.maintaining.file=managing.ftl
 template.monitoring.file=managing.ftl
 template.troubleshooting.file=managing.ftl
 template.dataManagement.file=managing.ftl
+template.quickStart.file=quickstart.ftl
 template.endpoint.file=endpoints.ftl
 template.endpointService.file=endpoints.ftl
 template.endpointIntro.file=endpoints.ftl

--- a/distribution/docs/src/main/jdocs/templates/documentation.ftl
+++ b/distribution/docs/src/main/jdocs/templates/documentation.ftl
@@ -6,13 +6,13 @@ include::${project.build.directory}/doc-contents/_contents/config.adoc[]
 :sectnums:
 
 <#include "introduction.ftl">
-include::${project.build.directory}/doc-contents/_contents/config.adoc[]
+
+== Quick Start Tutorial
+<#include "quickstart.ftl">
 
 :sectnums!:
 == Managing
 :sectnums:
-
-<#-- <#include "quickstart.ftl"> -->
 
 <#include "managing.ftl">
 

--- a/distribution/docs/src/main/jdocs/templates/quickstart.ftl
+++ b/distribution/docs/src/main/jdocs/templates/quickstart.ftl
@@ -1,0 +1,6 @@
+<#list quickStarts?sort_by("order") as quickStart>
+<#if (quickStart.status == "published")>
+include::${quickStart.file}[]
+
+</#if>
+</#list>

--- a/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_installing/installing-intro-contents.adoc
@@ -243,12 +243,13 @@ unzip ${branding-lowercase}-${project.version}.zip
 .Windows Zip Utility Warning
 [WARNING]
 ====
-DO NOT use the windows zip utility bundled with windows to unzip {branding}.
-Unzipping {branding} using the windows zip utility will cause unexpected behavior and errors in {branding}!
+The Windows Zip implementation, which is invoked when a user double-clicks on a zip file in the Windows Explorer, creates a corrupted installation.
+This is a consequence of its inability to process long file paths.
+Instead, use the java jar command line utility to unzip the distribution (see example below) or use a third party utility such as 7-Zip.
 
-.Use Java to Unzip in Windows
+.Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
 ----
-"%JAVA_HOME%\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
+"<PATH_TO_JAVA>\jdk<JAVA_VERSION>\bin\jar.exe" xf ${branding-lowercase}-${project.version}.zip
 ----
 
 The unzipping process may take time to complete.

--- a/distribution/docs/src/main/resources/_contents/_quickstart/quickstart-configuring-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_quickstart/quickstart-configuring-contents.adoc
@@ -9,8 +9,9 @@ Set the configurations needed to run ${branding}.
 . Follow the installer prompts for a standard installation.
 .. Click start to begin the setup process.
 .. Configure <<_guest_interceptor,guest claims attributes>> or use defaults.
-... (these attributes represent the minimum authorization for all users)
+... *All users will be automatically granted these authorizations*
 .. Select *Standard Installation*.
+... This step may take several minutes to complete.
 .. On the System Configuration page, configure any port or protocol changes desired and add any keystores/truststores needed.
 ... See <<_configuring_new_certificates,Configuring New Certificates>> for more details.
 .. Click *Next*

--- a/distribution/docs/src/main/resources/_contents/_quickstart/quickstart-installing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_quickstart/quickstart-installing-contents.adoc
@@ -29,7 +29,7 @@ Set up Java to run ${branding}.
 * Install/Upgrade to Java 8 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK]
 ** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
 ** Java Version and Build numbers must contain only number values.
-* Supported platforms are *NIX - Unix/Linux/OSX, Solaris, and Windows.
+* Supported platforms are Microsoft Windows, Linux, Solaris, and macOS.
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
 * The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
 
@@ -38,24 +38,18 @@ Set up Java to run ${branding}.
 
 . Determine Java Installation Directory (This varies between operating system versions).
 
-.Find Java Path in *NIX
-----
-which java
-----
-
 .Find Java Path in Windows
 ----
 for %i in (java.exe) do @echo. %~$PATH:i
 ----
 
+.Find Java Path in *nix
+----
+which java
+----
+
 . Copy path to Java installation. (example: `/usr/java/<JAVA_VERSION>`)
 . Set `JAVA_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
-
-.Setting `JAVA_HOME` on *NIX
-----
-JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
-export JAVA_HOME
-----
 
 .Setting `JAVA_HOME` on Windows
 ----
@@ -66,9 +60,15 @@ set JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION> /m
 ----
 setx PATH "%PATH%;%JAVA_HOME%\bin" /m
 ----
+
+.Setting `JAVA_HOME` on *nix
+----
+JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+export JAVA_HOME
+----
 ====
 
-.*NIX
+.*nix
 [WARNING]
 ====
 Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
@@ -79,14 +79,14 @@ Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
 [TIP]
 ====
 
-.*NIX
-----
-echo $JAVA_HOME
-----
-
 .Windows
 ----
 echo %JAVA_HOME%
+----
+
+.*nix
+----
+echo $JAVA_HOME
 ----
 ====
 
@@ -102,7 +102,7 @@ fs.file-max = 6815744
 * (This file may need permissions changed to allow write access).
 * For the change to take effect, a restart is required.
 
-. *Nix Restart Command
+. *nix Restart Command
 ----
 init 6
 ----
@@ -116,19 +116,15 @@ Prior to installing ${branding}, ensure the system time is accurate to prevent f
 
 === Quick Install of ${branding}
 
-.Check System Time
-[WARNING]
-====
-Prior to installing ${branding}, ensure the system time is accurate to prevent federation issues.
-====
-
 . Download the ${branding} {download-url}[zip file].
 . Install ${branding} by unzipping the zip file.
 +
 .Windows Zip Utility Warning
 [WARNING]
 ====
-The default Windows zip utility (such as double-clicking file) will not work to unzip the distribution, use Java or a third party utility instead.
+The Windows Zip implementation, which is invoked when a user double-clicks on a zip file in the Windows Explorer, creates a corrupted installation.
+This is a consequence of its inability to process long file paths.
+Instead, use the java jar command line utility to unzip the distribution (see example below) or use a third party utility such as 7-Zip.
 
 .Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
 ----


### PR DESCRIPTION
#### What does this PR do?

- Adds Quick Start tutorial to jbake/freemarker templates for documentation.

#### Who is reviewing it?

@vinamartin @Lambeaux @ahoffer @jrnorth 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@clockard
@coyotesqrl
@lessarderic
@pklinef
@shaundmorris

#### How should this be tested?

- compare attached pdf to current documentation for completeness.
- "New" `-contents.adoc` files are existing material with headers added. Content review is OPTIONAL.

#### Any background context you want to provide?

Moved Quick Start section closer to beginning of documentation, to before the complete installation/configuration instructions.

#### What are the relevant tickets?
[DDF-2881](https://codice.atlassian.net/browse/DDF-2881)

#### Screenshots (if appropriate)

[jdocumentation.pdf](https://github.com/codice/ddf/files/1068995/jdocumentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
