### PR TITLE
DDF-3052 Update GeoCoder to handle bad locations. Add location validator to flag invalid location data.

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -481,6 +481,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.codice.ddf.validator</groupId>
+            <artifactId>catalog-validator-metacardlocation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.transformer</groupId>
             <artifactId>catalog-transformer-overlay</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -427,6 +427,15 @@
         </bundle>
     </feature>
 
+    <feature name="catalog-validator-metacardlocation" install="auto"
+             version="${project.version}"
+             description="DDF Metacard Location Validator">
+        <feature prerequisite="true">catalog-core</feature>
+        <bundle>
+            mvn:org.codice.ddf.validator/catalog-validator-metacardlocation/${project.version}
+        </bundle>
+    </feature>
+
     <feature name="catalog-transformer-overlay" install="auto" version="${project.version}"
              description="Transforms a metacard into a geographically aligned image suitable for overlaying on a map">
         <feature prerequisite="true">catalog-app</feature>

--- a/catalog/spatial/geocoding/spatial-geocoding-plugin/src/main/java/org/codice/ddf/spatial/geocoding/plugin/GeoCoderPlugin.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-plugin/src/main/java/org/codice/ddf/spatial/geocoding/plugin/GeoCoderPlugin.java
@@ -61,9 +61,13 @@ public class GeoCoderPlugin implements PreIngestPlugin {
             return input;
         }
 
-        GeoCoder geoCoder = geoCoderFactory.getService();
-        input.getMetacards()
-                .forEach(metacard -> setCountryCode(metacard, geoCoder));
+        try {
+            GeoCoder geoCoder = geoCoderFactory.getService();
+            input.getMetacards()
+                    .forEach(metacard -> setCountryCode(metacard, geoCoder));
+        } catch (Exception e) {
+            throw new PluginExecutionException("Unable to determine country code for data", e);
+        }
 
         return input;
     }
@@ -76,10 +80,14 @@ public class GeoCoderPlugin implements PreIngestPlugin {
         }
 
         GeoCoder geoCoder = geoCoderFactory.getService();
-        input.getUpdates()
-                .stream()
-                .map(Map.Entry::getValue)
-                .forEach(metacard -> setCountryCode(metacard, geoCoder));
+        try {
+            input.getUpdates()
+                    .stream()
+                    .map(Map.Entry::getValue)
+                    .forEach(metacard -> setCountryCode(metacard, geoCoder));
+        } catch (Exception e) {
+            throw new PluginExecutionException("Unable to determine country code for data", e);
+        }
 
         return input;
     }

--- a/catalog/spatial/geocoding/spatial-geocoding-plugin/src/test/groovy/org/codice/ddf/spatial/geocoding/plugin/GeoCoderPluginTest.groovy
+++ b/catalog/spatial/geocoding/spatial-geocoding-plugin/src/test/groovy/org/codice/ddf/spatial/geocoding/plugin/GeoCoderPluginTest.groovy
@@ -21,6 +21,7 @@ import ddf.catalog.data.types.Core
 import ddf.catalog.data.types.Location
 import ddf.catalog.operation.CreateRequest
 import ddf.catalog.operation.UpdateRequest
+import ddf.catalog.plugin.PluginExecutionException
 import ddf.catalog.util.impl.ServiceSelector
 import org.codice.ddf.spatial.geocoder.GeoCoder
 import spock.lang.Specification
@@ -35,6 +36,8 @@ class GeoCoderPluginTest extends Specification {
     private static Optional<String> countryCode = Optional.of('NO')
 
     private static String locationWKT = 'POINT(10.402439 63.418399)'
+
+    private static String invalidLocationWkt = 'POINT(350.0 350.0)'
 
     private CreateRequest createRequest
 
@@ -228,9 +231,47 @@ class GeoCoderPluginTest extends Specification {
         geoCoderPlugin.getRadius() == 15
     }
 
+    def 'test invalid geo location Metacard CreateRequest'() {
+        setup:
+        GeoCoderPlugin errorGeoCoderPlugin = initErrorGeoCoderPlugin(countryCode, false);
+        createRequest.getMetacards() >> getTestMetacards(new AttributeImpl(Core.LOCATION, invalidLocationWkt))
+
+        when:
+        errorGeoCoderPlugin.process(createRequest)
+
+        then:
+        thrown(PluginExecutionException)
+    }
+
+    def 'test invalid geo location Metacard UpdateRequest'() {
+        setup:
+        GeoCoderPlugin errorGeoCoderPlugin = initErrorGeoCoderPlugin(countryCode, false);
+        updateRequest.getUpdates() >> getTestUpdates(new AttributeImpl(Core.LOCATION, invalidLocationWkt))
+
+        when:
+        errorGeoCoderPlugin.process(updateRequest)
+
+        then:
+        thrown(PluginExecutionException)
+    }
+
     def initGeoCoderPlugin(Optional<String> countryCode, boolean overrideDefaultGeocoder) {
         GeoCoder geocoder = (overrideDefaultGeocoder == true) ? null : Mock(GeoCoder) {
             getCountryCode(_ as String, _ as Integer) >> countryCode
+        }
+
+        geocoderFactory = Mock(ServiceSelector) {
+            getService() >> geocoder
+        }
+
+        return new GeoCoderPlugin(geocoderFactory)
+    }
+
+    def initErrorGeoCoderPlugin(Optional<String> countryCode, boolean overrideDefaultGeocoder) {
+        GeoCoder geocoder = (overrideDefaultGeocoder == true) ? null : Mock(GeoCoder) {
+            getCountryCode(_ as String, _ as Integer) >> {
+                _ -> throw new PluginExecutionException("Invalid Location")
+            }
         }
 
         geocoderFactory = Mock(ServiceSelector) {

--- a/catalog/validator/catalog-validator-metacardlocation/pom.xml
+++ b/catalog/validator/catalog-validator-metacardlocation/pom.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -12,61 +12,72 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>geocoding</artifactId>
-        <groupId>org.codice.ddf.spatial</groupId>
+        <groupId>org.codice.ddf.validator</groupId>
+        <artifactId>validator</artifactId>
         <version>2.11.0-SNAPSHOT</version>
     </parent>
-    <artifactId>spatial-geocoding-plugin</artifactId>
-    <name>DDF :: Spatial :: Geocoding :: Plugin</name>
+
+    <name>DDF :: Catalog :: Validator :: Metacard Location</name>
+    <artifactId>catalog-validator-metacardlocation</artifactId>
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.codice.ddf.spatial</groupId>
-            <artifactId>spatial-geocoding-geocoder</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>spock-shaded</artifactId>
-            <version>${project.version}</version>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.locationtech.spatial4j</groupId>
+            <artifactId>spatial4j</artifactId>
+            <version>${spatial4j.version}</version>
+        </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Private-Package>
-                            ddf.catalog.data.impl.*,
-                            ddf.catalog.util.impl
-                        </Private-Package>
                         <Embed-Dependency>
-                            commons-lang3
+                            catalog-core-api-impl,
+                            platform-util,
+                            spatial4j
                         </Embed-Dependency>
+                        <Export-Package/>
+                        <Import-Package>
+                            !org.noggit,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -88,19 +99,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>
@@ -108,19 +118,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
 </project>

--- a/catalog/validator/catalog-validator-metacardlocation/pom.xml
+++ b/catalog/validator/catalog-validator-metacardlocation/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>

--- a/catalog/validator/catalog-validator-metacardlocation/src/main/java/org/codice/ddf/validator/metacard/location/MetacardLocationValidator.java
+++ b/catalog/validator/catalog-validator-metacardlocation/src/main/java/org/codice/ddf/validator/metacard/location/MetacardLocationValidator.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.metacard.location;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
+import org.locationtech.spatial4j.io.WKTReader;
+
+import com.google.common.collect.ImmutableSet;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Validation;
+import ddf.catalog.validation.MetacardValidator;
+import ddf.catalog.validation.ReportingMetacardValidator;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.impl.ValidationExceptionImpl;
+import ddf.catalog.validation.impl.report.MetacardValidationReportImpl;
+import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class MetacardLocationValidator implements MetacardValidator, ReportingMetacardValidator {
+    private static final JtsSpatialContextFactory JTS_SPATIAL_CONTEXT_FACTORY =
+            new JtsSpatialContextFactory();
+
+    private static final String ERROR_MSG = Core.LOCATION + " is invalid: ";
+
+    private static final Set<String> VALIDATED_ATTRIBUTES = ImmutableSet.of(Core.LOCATION);
+
+    static {
+        JTS_SPATIAL_CONTEXT_FACTORY.allowMultiOverlap = true;
+    }
+
+    private static final SpatialContext SPATIAL_CONTEXT =
+            JTS_SPATIAL_CONTEXT_FACTORY.newSpatialContext();
+
+    @Override
+    public Optional<MetacardValidationReport> validateMetacard(Metacard metacard) {
+        MetacardValidationReportImpl report = null;
+
+        if (StringUtils.isNotEmpty(metacard.getLocation())) {
+            WKTReader wktReader = new WKTReader(SPATIAL_CONTEXT, JTS_SPATIAL_CONTEXT_FACTORY);
+            try {
+                wktReader.parse(metacard.getLocation());
+            } catch (ParseException | InvalidShapeException e) {
+                String message = ERROR_MSG + metacard.getLocation();
+                ValidationViolation violation = new ValidationViolationImpl(VALIDATED_ATTRIBUTES,
+                        message,
+                        ValidationViolation.Severity.ERROR);
+                report = new MetacardValidationReportImpl();
+                report.addMetacardViolation(violation);
+            }
+        } else {
+            Attribute validationErrorAttr = metacard.getAttribute(Validation.VALIDATION_ERRORS);
+            if (validationErrorAttr != null) {
+                List<Serializable> errors = validationErrorAttr.getValues();
+                for (Serializable error : errors) {
+                    String errorStr = String.valueOf(error);
+                    if (errorStr.startsWith(ERROR_MSG)) {
+                        ValidationViolation violation = new ValidationViolationImpl(VALIDATED_ATTRIBUTES,
+                                errorStr,
+                                ValidationViolation.Severity.ERROR);
+                        report = new MetacardValidationReportImpl();
+                        report.addMetacardViolation(violation);
+                    }
+                }
+            }
+        }
+
+        return Optional.ofNullable(report);
+    }
+
+    @Override
+    public void validate(Metacard metacard) throws ValidationException {
+        Optional<MetacardValidationReport> validationReport = validateMetacard(metacard);
+        if (validationReport.isPresent()) {
+            MetacardValidationReport report = validationReport.get();
+            Set<ValidationViolation> violations = report.getMetacardValidationViolations();
+            if (!violations.isEmpty()) {
+                metacard.setAttribute(new AttributeImpl(Core.LOCATION, (Serializable) null));
+                final ValidationExceptionImpl exception = new ValidationExceptionImpl();
+                exception.setErrors(violations.stream()
+                        .map(ValidationViolation::getMessage)
+                        .collect(Collectors.toList()));
+                throw exception;
+            }
+        }
+
+    }
+}

--- a/catalog/validator/catalog-validator-metacardlocation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/validator/catalog-validator-metacardlocation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="metacardLocationValidator" class="org.codice.ddf.validator.metacard.location.MetacardLocationValidator"/>
+    
+    <service ref="metacardLocationValidator">
+        <interfaces>
+            <value>ddf.catalog.validation.MetacardValidator</value>
+            <value>ddf.catalog.validation.ReportingMetacardValidator</value>
+        </interfaces>
+    </service>
+</blueprint>

--- a/catalog/validator/catalog-validator-metacardlocation/src/test/java/org/codice/ddf/validator/metacard/location/MetacardLocationValidatorTest.java
+++ b/catalog/validator/catalog-validator-metacardlocation/src/test/java/org/codice/ddf/validator/metacard/location/MetacardLocationValidatorTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.metacard.location;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Validation;
+import ddf.catalog.validation.ValidationException;
+import ddf.catalog.validation.report.MetacardValidationReport;
+import ddf.catalog.validation.violation.ValidationViolation;
+
+public class MetacardLocationValidatorTest {
+    private MetacardLocationValidator locationValidator = new MetacardLocationValidator();
+
+    @Test
+    public void testMetacardWithValidLocation() throws Exception {
+        Metacard metacard = getMetacard();
+        String wktLoc = "POINT(50 50)";
+        metacard.setAttribute(new AttributeImpl(Core.LOCATION, wktLoc));
+        locationValidator.validate(metacard);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testMetacardWithInvalidLocation() throws Exception {
+        Metacard metacard = getMetacard();
+        String wktLoc = "POINT(250  250)";
+        metacard.setAttribute(new AttributeImpl(Core.LOCATION, wktLoc));
+        locationValidator.validate(metacard);
+    }
+
+    @Test
+    public void testNoLocation() throws Exception {
+        Metacard metacard = getMetacard();
+        locationValidator.validate(metacard);
+    }
+
+    @Test
+    public void testLocationValidationErrorNoLocation() throws Exception {
+        Metacard metacard = getMetacard();
+        metacard.setAttribute(new AttributeImpl(Validation.VALIDATION_ERRORS, "location is invalid: POINT(2000 2000)"));
+        Optional<MetacardValidationReport> validationReportOptional = locationValidator.validateMetacard(metacard);
+        assertThat(validationReportOptional.isPresent(), is(true));
+
+        Set<ValidationViolation> validationViolationSet = validationReportOptional.get().getMetacardValidationViolations();
+        assertThat(validationViolationSet, hasSize(1));
+    }
+
+    @Test
+    public void testNoLocationNoErrors() throws Exception {
+        Metacard metacard = getMetacard();
+        Optional<MetacardValidationReport> validationReportOptional = locationValidator.validateMetacard(metacard);
+        assertThat(validationReportOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void testNoLocationNonLocationError() throws Exception {
+        Metacard metacard = getMetacard();
+        metacard.setAttribute(new AttributeImpl(Validation.VALIDATION_ERRORS, "another attribute error"));
+        Optional<MetacardValidationReport> validationReportOptional = locationValidator.validateMetacard(metacard);
+        assertThat(validationReportOptional.isPresent(), is(false));
+    }
+
+    private Metacard getMetacard() {
+        Metacard metacard = new MetacardImpl();
+        metacard.setAttribute(new AttributeImpl(Core.ID, UUID.randomUUID().toString()));
+        return metacard;
+    }
+}

--- a/catalog/validator/pom.xml
+++ b/catalog/validator/pom.xml
@@ -28,5 +28,6 @@
     <name>DDF :: Catalog :: Validator</name>
     <modules>
         <module>catalog-validator-metacardduplication</module>
+        <module>catalog-validator-metacardlocation</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
Updates GeoCoder so that bad location data will generate a plugin exception that is caught above. Added a location validator for to mark invalid locations as well as clear the location field such that the metacard can be stored.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@glenhein 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Core APIs](https://github.com/orgs/codice/teams/core-apis)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
1. Post the following CSW transaction with invalid location information:
```<csw:Transaction service="CSW" version="2.0.2" verboseResponse="true" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
    <csw:Insert typeName="csw:Record">
        <csw:Record
            xmlns:ows="http://www.opengis.net/ows"
            xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
            xmlns:dc="http://purl.org/dc/elements/1.1/"
            xmlns:dct="http://purl.org/dc/terms/"
            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
            <dc:identifier>123</dc:identifier>
            <dc:title>Aliquam fermentum purus quis arcu</dc:title>
            <dc:type>http://purl.org/dc/dcmitype/Text</dc:type>
            <dc:subject>Foo</dc:subject>
            <dc:format>application/pdf</dc:format>
            <dc:date>2006-05-12</dc:date>
            <dc:issued>2006-05-12</dc:issued>            
            <dct:abstract>Vestibulum quis ipsum sit amet metus imperdiet vehicula. Nulla scelerisque cursus mi.</dct:abstract>
                <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
                    <ows:LowerCorner>44.792 -6.171</ows:LowerCorner>
                    <ows:UpperCorner>351.126 -2.228</ows:UpperCorner>
            </ows:BoundingBox>
        </csw:Record>
    </csw:Insert>
</csw:Transaction>
```

2. Login to Solr and query for all data `Execute Query` on the `Catalog` core.
https://localhost:8993/solr/#/catalog/query

3. a. Verify that "metacard-tags_txt" contains value "INVALID"  
    b. Verify that "validation-errors_txt" contains value "location is invalid: POLYGON ((44.792 -6.171, 351.126 -6.171, 351.126 -2.228, 44.792 -2.228, 44.792 -6.171))"

#### Any background context you want to provide?
The location field needed to be cleared as Solr will error and not store data if invalid locations are present in this field. Due to this restriction, the ReportingMetacardValidator can't revalidate the metacard for the Quality tab in Intrigue. A work around was added to parse the `validation-errors` attribute and return the error if one is present based on location.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3052

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
