### PR TITLE
DDF-3081 Fixed typo on project version variable in feature files

### DIFF
--- a/broker/broker-app/src/main/resources/features.xml
+++ b/broker/broker-app/src/main/resources/features.xml
@@ -28,12 +28,12 @@
           xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="broker-undelivered-messages-ui" install="auto" version="${project.version">
+    <feature name="broker-undelivered-messages-ui" install="auto" version="${project.version}">
         <bundle>mvn:org.codice.ddf.broker/broker-undelivered-messages-ui/${project.version}
         </bundle>
     </feature>
 
-    <feature name="broker-route-manager" install="auto" version="${project.version">
+    <feature name="broker-route-manager" install="auto" version="${project.version}">
         <bundle>mvn:org.codice.ddf.broker/broker-route-manager/${project.version}
         </bundle>
     </feature>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -456,13 +456,13 @@
         </bundle>
     </feature>
 
-    <feature name="catalog-metacard-backup-storage-api" install="manual" version="${project.version"
+    <feature name="catalog-metacard-backup-storage-api" install="manual" version="${project.version}"
              description="API for the metacard backup storage">
         <bundle>mvn:ddf.catalog.plugin/catalog-plugin-metacardbackup-storage-api/${project.version}
         </bundle>
     </feature>
 
-    <feature name="catalog-metacard-backup-filestorage" install="manual" version="${project.version"
+    <feature name="catalog-metacard-backup-filestorage" install="manual" version="${project.version}"
              description="File system storage for metacard backup">
         <feature prerequisite="true">catalog-core</feature>
         <feature prerequisite="true">catalog-metacard-backup-storage-api</feature>
@@ -470,7 +470,7 @@
         </bundle>
     </feature>
 
-    <feature name="catalog-metacard-backup-s3storage" install="manual" version="${project.version"
+    <feature name="catalog-metacard-backup-s3storage" install="manual" version="${project.version}"
              description="S3 storage for metacard backup">
         <feature prerequisite="true">catalog-core</feature>
         <feature prerequisite="true">catalog-metacard-backup-storage-api</feature>

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -18,7 +18,7 @@
 
     <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
 
-    <feature name="security-rest-authentication" install="manual" version="${project.version"
+    <feature name="security-rest-authentication" install="manual" version="${project.version}"
              description="Authentication endpoint for handling multiple realms">
         <bundle>mvn:ddf.platform.security/security-rest-authentication/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
#### What does this PR do?

 Fixed typo on project version variable in feature files that was causing some features to have invalid version information

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@brianfelix 
@bdeining 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
@coyotesqrl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Build it, run it, type feature:list on the CLI and confirm all feature versions (2nd column) make sense.  In particular, there should be nothing in the form of 0.0.0.__project_version

#### Any background context you want to provide?
There was a typo omitting the trailing } on the project.version variable in multiple feature files.  The result was the variable was not recognized as a variable, but as the actual version, the version was set to 0.0.0.<text> where the text was the an underscore-escaped version of what was supposed to be the variable.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3081

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
