### PR TITLE
DDF-3089 Added pubsub support for metacard.created/modified

### DIFF
--- a/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/EventProcessorImpl.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/EventProcessorImpl.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.event.EventProcessor;
 import ddf.catalog.event.InvalidSubscriptionException;
 import ddf.catalog.event.Subscription;
@@ -435,8 +436,49 @@ public class EventProcessorImpl implements EventProcessor, EventHandler, PostIng
         return deleteResponse;
     }
 
-    public static enum DateType {
-        modified, effective, expiration, created
+    /**
+     * Enumeration of metacard Date attributes that can be used for subscriptions. In order to use
+     * metacard attribute names for getting DateType values, {@link DateType#getDateType(String)}
+     * should be used. To get the metacard attribute name for a DateType,
+     * {@link DateType#getAttributeName()} should be used, where "dt" is an instance of DateType.
+     * <p>
+     * The standard {@link DateType#valueOf(String)} and {@link DateType#name()} enum methods will
+     * not use the names of the attributes as they appear on the metacard, but as they appear in the
+     * enum class as defined below.
+     */
+    public enum DateType {
+        MODIFIED, EFFECTIVE, EXPIRATION, CREATED, METACARD_CREATED(Core.METACARD_CREATED), METACARD_MODIFIED(
+                Core.METACARD_MODIFIED);
+
+        private final String attributeName;
+
+        DateType() {
+            attributeName = this.name();
+        }
+
+        DateType(String attributeName) {
+            this.attributeName = attributeName;
+        }
+
+        public String getAttributeName() {
+            return attributeName;
+        }
+
+        public static DateType getDateType(String attr) {
+            if (attr == null) {
+                throw new NullPointerException("Provided DateTime attribute was null.");
+            }
+
+            for (DateType dt : DateType.values()) {
+                if (dt.getAttributeName()
+                        .equalsIgnoreCase(attr)) {
+                    return dt;
+                }
+            }
+            throw new IllegalArgumentException(String.format(
+                    "Provided DateTime attribute %s was not found.",
+                    attr));
+        }
     }
 
 }

--- a/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/internal/SubscriptionFilterVisitor.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/internal/SubscriptionFilterVisitor.java
@@ -135,12 +135,9 @@ public class SubscriptionFilterVisitor extends DefaultFilterVisitor {
     /**
      * Asserts whether the value is <b>not</b> <tt>null</tt>
      *
-     * @param value
-     *            the value to test
-     * @param name
-     *            the key that resolved the value
-     * @throws IllegalArgumentException
-     *             is thrown if assertion fails
+     * @param value the value to test
+     * @param name  the key that resolved the value
+     * @throws IllegalArgumentException is thrown if assertion fails
      */
     public static void notNull(Object value, String name) {
         if (value == null) {
@@ -362,14 +359,14 @@ public class SubscriptionFilterVisitor extends DefaultFilterVisitor {
 
             LOGGER.debug("EXITING: (temporal) filter");
 
-            returnPredicate = new TemporalPredicate(start, end, DateType.valueOf(temporalType));
+            returnPredicate = new TemporalPredicate(start, end, DateType.getDateType(temporalType));
             // CREATE RELATIVE
         } else if (literal instanceof PeriodDuration) {
             DefaultPeriodDuration duration = (DefaultPeriodDuration) literal;
 
             long offset = duration.getTimeInMillis();
             LOGGER.debug("EXITING: (temporal) filter");
-            returnPredicate = new TemporalPredicate(offset, DateType.valueOf(temporalType));
+            returnPredicate = new TemporalPredicate(offset, DateType.getDateType(temporalType));
         }
 
         LOGGER.debug("temporalType: " + temporalType);

--- a/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/predicate/TemporalPredicate.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/main/java/ddf/catalog/pubsub/predicate/TemporalPredicate.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.pubsub.EventProcessorImpl.DateType;
 import ddf.catalog.pubsub.criteria.temporal.TemporalEvaluationCriteria;
 import ddf.catalog.pubsub.criteria.temporal.TemporalEvaluationCriteriaImpl;
@@ -43,12 +44,9 @@ public class TemporalPredicate implements Predicate {
     /**
      * Instantiates a new temporal predicate.
      *
-     * @param start
-     *            the start date
-     * @param end
-     *            the end date
-     * @param type
-     *            What date
+     * @param start the start date
+     * @param end   the end date
+     * @param type  What date
      */
     public TemporalPredicate(Date start, Date end, DateType type) {
         if (end != null) {
@@ -103,21 +101,31 @@ public class TemporalPredicate implements Predicate {
             LOGGER.debug("entry id: {}", entry.getId());
 
             switch (this.type) {
-            case modified:
+            case MODIFIED:
                 LOGGER.debug("search by modified: {}", entry.getModifiedDate());
                 date = entry.getModifiedDate();
                 break;
-            case effective:
+            case METACARD_MODIFIED:
+                LOGGER.debug("search by metacard modified: {}",
+                        entry.getAttribute(Core.METACARD_MODIFIED));
+                date = (Date) entry.getAttribute(Core.METACARD_MODIFIED)
+                        .getValue();
+                break;
+            case EFFECTIVE:
                 LOGGER.debug("search by effective: {}", entry.getEffectiveDate());
                 date = entry.getEffectiveDate();
                 break;
-            case created:
-                // currently searches by createdDate not supported by endpoints
+            case CREATED:
                 LOGGER.debug("search by created: {}", entry.getCreatedDate());
                 date = entry.getCreatedDate();
                 break;
-            case expiration:
-                // currently searches by expirationDate not supported by endpoints
+            case METACARD_CREATED:
+                LOGGER.debug("search by metacard created: {}",
+                        entry.getAttribute(Core.METACARD_CREATED));
+                date = (Date) entry.getAttribute(Core.METACARD_CREATED)
+                        .getValue();
+                break;
+            case EXPIRATION:
                 LOGGER.debug("search by expiration: {}", entry.getExpirationDate());
                 date = entry.getExpirationDate();
                 break;

--- a/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/MockQuery.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/MockQuery.java
@@ -133,15 +133,8 @@ public class MockQuery implements FederatedSource, Query {
     }
 
     public void addTemporalFilter(XMLGregorianCalendar start, XMLGregorianCalendar end,
-            String timeType) {
-        Filter filter = null;
-
-        String timeProperty = Metacard.MODIFIED;
-
-        if (timeType != null && timeType.toLowerCase()
-                .equals(Metacard.EFFECTIVE)) {
-            timeProperty = Metacard.EFFECTIVE;
-        }
+            String timeProperty) {
+        Filter filter;
 
         if (start != null && end != null) {
             int compareTo = start.toGregorianCalendar()

--- a/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/PredicateTest.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/PredicateTest.java
@@ -47,6 +47,7 @@ import com.vividsolutions.jts.geom.Geometry;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.pubsub.criteria.contenttype.ContentTypeEvaluationCriteriaImpl;
 import ddf.catalog.pubsub.criteria.contenttype.ContentTypeEvaluator;
 import ddf.catalog.pubsub.criteria.contextual.ContextualEvaluator;
@@ -566,8 +567,37 @@ public class PredicateTest {
     }
 
     @Test
-    public void testTemporal() throws Exception {
-        String methodName = "testTemporal";
+    public void testTemporalEffective() throws Exception {
+        testTemporalAttribute(Metacard.EFFECTIVE);
+    }
+
+    @Test
+    public void testTemporalModified() throws Exception {
+        testTemporalAttribute(Core.MODIFIED);
+    }
+
+    @Test
+    public void testTemporalCreated() throws Exception {
+        testTemporalAttribute(Core.CREATED);
+    }
+
+    @Test
+    public void testTemporalExpiration() throws Exception {
+        testTemporalAttribute(Core.EXPIRATION);
+    }
+
+    @Test
+    public void testTemporalMetacardCreated() throws Exception {
+        testTemporalAttribute(Core.METACARD_CREATED);
+    }
+
+    @Test
+    public void testTemporalMetacardModified() throws Exception {
+        testTemporalAttribute(Core.METACARD_MODIFIED);
+    }
+
+    private void testTemporalAttribute(String temporalAttr) throws Exception {
+        String methodName = "testTemporal: " + temporalAttr;
         LOGGER.debug("***************  START: {}  *****************", methodName);
 
         MockQuery query = new MockQuery();
@@ -575,7 +605,7 @@ public class PredicateTest {
         DatatypeFactory df = DatatypeFactory.newInstance();
         XMLGregorianCalendar start = df.newXMLGregorianCalendarDate(2011, 10, 25, 0);
         XMLGregorianCalendar end = df.newXMLGregorianCalendarDate(2011, 10, 27, 0);
-        query.addTemporalFilter(start, end, Metacard.EFFECTIVE);
+        query.addTemporalFilter(start, end, temporalAttr);
 
         SubscriptionFilterVisitor visitor = new SubscriptionFilterVisitor();
         Predicate pred = (Predicate) query.getFilter()
@@ -594,12 +624,14 @@ public class PredicateTest {
         metacard.setCreatedDate(new Date());
         metacard.setExpirationDate(new Date());
         metacard.setModifiedDate(new Date());
+        metacard.setAttribute(Core.METACARD_CREATED, new Date());
+        metacard.setAttribute(Core.METACARD_MODIFIED, new Date());
         metacard.setMetadata(TestDataLibrary.getCatAndDogEntry());
 
         XMLGregorianCalendar cal = df.newXMLGregorianCalendarDate(2011, 10, 26, 0);
-        Date effectiveDate = cal.toGregorianCalendar()
+        Date dateAttr = cal.toGregorianCalendar()
                 .getTime();
-        metacard.setEffectiveDate(effectiveDate);
+        metacard.setAttribute(temporalAttr, dateAttr);
 
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(PubSubConstants.HEADER_OPERATION_KEY, PubSubConstants.CREATE);
@@ -617,10 +649,10 @@ public class PredicateTest {
         LOGGER.debug("\nfail temporal.  fail content type.\n");
         XMLGregorianCalendar cal1 = df.newXMLGregorianCalendarDate(2012, 10, 30, 0); // time out of
         // range
-        Date effectiveDate1 = cal1.toGregorianCalendar()
+        Date dateAttr1 = cal1.toGregorianCalendar()
                 .getTime();
-        metacard.setEffectiveDate(effectiveDate1);
-        LOGGER.debug("metacard date: {}", metacard.getEffectiveDate());
+        metacard.setAttribute(temporalAttr, dateAttr1);
+        LOGGER.debug("metacard date: {}", metacard.getAttribute(temporalAttr));
 
         properties.clear();
         properties.put(PubSubConstants.HEADER_OPERATION_KEY, PubSubConstants.CREATE);

--- a/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/TestEventProcessorImpl.java
+++ b/catalog/core/catalog-core-impl/pubsub/src/test/java/ddf/catalog/pubsub/TestEventProcessorImpl.java
@@ -13,6 +13,8 @@
  */
 package ddf.catalog.pubsub;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.After;
@@ -89,4 +91,23 @@ public class TestEventProcessorImpl {
 
     }
 
+    @Test
+    public void testDateType() throws Exception {
+        for (EventProcessorImpl.DateType dt : EventProcessorImpl.DateType.values()) {
+            //for each DateType, verify enum is the same if derived from attribute string or enum name
+            assertThat(EventProcessorImpl.DateType.valueOf(dt.name()),
+                    equalTo(EventProcessorImpl.DateType.getDateType(dt.getAttributeName())));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDateTypeNullAttr() {
+        EventProcessorImpl.DateType.getDateType(null);
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDateTypeInvalidAttr() {
+        EventProcessorImpl.DateType.getDateType("some obviously invalid attribute.");
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
Adds handling of metacard.created and metacard.modified as temporal fields for pubsub.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@brendan-hofmann 
@ahoffer 
@codymacdonald 
@mweser 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Data](https://github.com/orgs/codice/teams/data)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
TBD

#### How should this be tested? (List steps with links to updated documentation)
Full test build

#### Any background context you want to provide?
This is to help support possible programs that build on the DDF that relied on "modified" or "created" referring to the metacard instead of the resource.

#### What are the relevant tickets?
[DDF-3089](https://codice.atlassian.net/browse/DDF-3089)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
