### PR TITLE
DDF-3090 Fixed ui.config regex to match default metatype configuration.

### DIFF
--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -13,12 +13,13 @@ gazetteer=B"true"
 ingest=B"true"
 externalAuthentication=B"false"
 readOnly=[
-    "checksum",
-    "checksum-algorithm",
-    "id",
-    "metadata",
-    "source-id",
-    "point-of-contact",
+    "^checksum$",
+    "^checksum-algorithm$",
+    "^id$",
+    "^metadata$",
+    "^metacard-type$",
+    "^source-id$",
+    "^point-of-contact$",
     "^metacard\\.",
     "^version\\.",
     "^validation\\."


### PR DESCRIPTION
#### What does this PR do?
Fixes the default org.codice.ddf.catalog.ui.config file to match defaults in the metatype.xml. This adds correct pattern matching for read-only fields on the UI.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@glenhein 
@adimka 
@dannythk 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Verify that fields containing the names, but not exactly matching can be edited. For instance an `ext.point-of-contact-name` would no longer be read-only and allow editing.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3090

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
