### PR TITLE
DDF-2523 Made password fields consistent in the UI

### DIFF
--- a/catalog/spatial/csw/spatial-csw-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,7 +34,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"

--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -37,7 +37,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"
@@ -133,7 +133,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
     </OCD>
 
     <OCD name="GMD CSW ISO Federated Source" id="Gmd_Csw_Federated_Source"
@@ -148,7 +148,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"
@@ -243,7 +243,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -31,7 +31,7 @@
         <AD description="Username for WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for WFS Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -30,7 +30,7 @@
         <AD description="Username for WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for WFS Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
         <AD description="Force only a specific FeatureType to be queried instead of all featureTypes"
             name="Forced Feature Type" id="forcedFeatureType" type="String" required="false"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-connectedsource/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -39,7 +39,7 @@
         <AD description="Username for the WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for the WFS Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -44,7 +44,7 @@
         <AD description="Username for tge WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for the WFS Service (optional)" name="Password" id="password"
-            required="false" type="Password"/>
+            required="false" type="Password" default=""/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -294,7 +294,13 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
                     .filter(metatype -> AttributeDefinition.PASSWORD == metatype.getType())
                     .forEach(metatype -> {
                         String passwordProperty = metatype.getId();
-                        propertiesTable.put(passwordProperty, "password");
+                        if (propertiesTable.get(passwordProperty) == null){
+                            propertiesTable.put(passwordProperty, "");
+                        } else {
+                            if (propertiesTable.get(passwordProperty).toString() != ""){
+                                propertiesTable.put(passwordProperty, "password");
+                            }
+                        }
                     });
 
             configData.setConfigurationProperties(propertiesTable);

--- a/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -222,8 +222,8 @@ define([
             this.service.get('metatype').each(function(value) {
                 if (value.get('type') === passwordType) {
                     var password = view.model.get('properties').get(value.get('id'));
-                    if (password === "" || password === null) {
-                        view.model.get('properties').set(value.get('id'), 'unmodified');
+                    if (password === null) {
+                        view.model.get('properties').set(value.get('id'), "");
                     }
                 }
             });
@@ -269,15 +269,6 @@ define([
                 if (!this.model.get('properties').has('service.pid')) {
                     this.model.get('properties').set('service.pid', this.service.get('id'));
                 }
-
-                this.service.get('metatype').each(function(value) {
-                    if (value.get('type') === passwordType) {
-                        var password = view.model.get('properties').get(value.get('id'));
-                        if (password === "unmodified") {
-                            view.model.get('properties').set(value.get('id'), '');
-                        }
-                    }
-                });
             }
 
             this.model.save().always(function (dataOrjqXHR, textStatus, jqXHROrerrorThrown) {


### PR DESCRIPTION
#### What does this PR do?
Makes the password fields consistent in the UI so that if no password is set then the field is left blank
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk 
@vinamartin 
@clockard 
@josephthweatt 
@ricklarsen 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Check each of the configuration modals and see that all password fields default to a blank value
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2523](https://codice.atlassian.net/browse/DDF-2523)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.