### PR TITLE
DDF-2824 fixed broken table in ReST endpoint docs

### DIFF
--- a/distribution/docs/src/main/jdocs/content/_endpoints/catalog-rest-endpoint-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_endpoints/catalog-rest-endpoint-contents.adoc
@@ -51,8 +51,6 @@ The updated metadata is contained in the HTTP body.
 
 |\${public_url}/services/catalog/<metacardId>?transform=<input transformer>
 
-
-
 |delete
 |HTTP DELETE
 |The ID of the Metacard to be deleted is appended to the end of the URL.
@@ -87,48 +85,6 @@ By default, the response body will include the XML representation of the Metacar
 
 |===
 
-|The ID of the Metacard to be updated is appended to the end of the URL.
-The updated metadata is contained in the HTTP body.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be updated and `<input transformer>` is the name of the transformer to use when parsing an override metadata attribute (optional).
-
-|\${public_url}/services/catalog/<metacardId>?transform=<input transformer>
-
-
-
-|delete
-|HTTP DELETE
-|The ID of the Metacard to be deleted is appended to the end of the URL.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be deleted.
-
-|\${public_url}/services/catalog/<metacardId>
-
-|read
-|HTTP GET
-|The ID of the Metacard to be retrieved is appended to the end of the URL.
-
-By default, the response body will include the XML representation of the Metacard.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be retrieved.
-
-|\${public_url}/services/catalog/<metacardId>
-
-|federated read
-|HTTP GET
-|The SOURCE ID of a federated source is appended to the URL before the ID of the Metacard to be retrieved is appended to the end.
-
-`<sourceId>` is the `FEDERATED SOURCE ID` and `<metacardId>` is the `Metacard.ID` of the Metacard to be retrieved.
-
-|\${public_url}/services/catalog/sources/&lt;sourceId&gt;/&lt;metacardId&gt;
-
-|sources
-|HTTP GET
-|Retrieves information about federated sources, including `sourceId`, `availability`, `contentTypes`,and `version`.
-
-|\${public_url}/services/catalog/sources/
-
-|===
 
 ====== Sources Operation Example
 

--- a/distribution/docs/src/main/resources/_contents/_endpoints/catalog-rest-endpoint-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_endpoints/catalog-rest-endpoint-contents.adoc
@@ -43,51 +43,6 @@ The updated metadata is contained in the HTTP body.
 
 |\${public_url}/services/catalog/<metacardId>?transform=<input transformer>
 
-
-
-|delete
-|HTTP DELETE
-|The ID of the Metacard to be deleted is appended to the end of the URL.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be deleted.
-
-|\${public_url}/services/catalog/<metacardId>
-
-|read
-|HTTP GET
-|The ID of the Metacard to be retrieved is appended to the end of the URL.
-
-By default, the response body will include the XML representation of the Metacard.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be retrieved.
-
-|\${public_url}/services/catalog/<metacardId>
-
-|federated read
-|HTTP GET
-|The SOURCE ID of a federated source is appended to the URL before the ID of the Metacard to be retrieved is appended to the end.
-
-`<sourceId>` is the `FEDERATED SOURCE ID` and `<metacardId>` is the `Metacard.ID` of the Metacard to be retrieved.
-
-|\${public_url}/services/catalog/sources/&lt;sourceId&gt;/&lt;metacardId&gt;
-
-|sources
-|HTTP GET
-|Retrieves information about federated sources, including `sourceId`, `availability`, `contentTypes`,and `version`.
-
-|\${public_url}/services/catalog/sources/
-
-|===
-
-|The ID of the Metacard to be updated is appended to the end of the URL.
-The updated metadata is contained in the HTTP body.
-
-`<metacardId>` is the `Metacard.ID` of the metacard to be updated and `<input transformer>` is the name of the transformer to use when parsing an override metadata attribute (optional).
-
-|\${public_url}/services/catalog/<metacardId>?transform=<input transformer>
-
-
-
 |delete
 |HTTP DELETE
 |The ID of the Metacard to be deleted is appended to the end of the URL.


### PR DESCRIPTION
#### What does this PR do?

Fixes (removes) duplicated lines in Catalog Rest Endpoint docs breaking formatting. 

#### Who is reviewing it?

@vinamartin @Lambeaux @jrnorth @ahoffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@ricklarsen
@clockard
@coyotesqrl
@lessarderic
@pklinef
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

- Verify the table in section `22.1.3(documentation.pdf)/7.1.2(jdocumentation.pdf) Using the Catalog REST Endpoint` is formatted correctly.
- Verify formatting for section headers following.

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Screenshots (if appropriate)

[jdocumentation.pdf](https://github.com/codice/ddf/files/1086321/jdocumentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
