### PR TITLE
DDF-3098 fix XstreamTreeWriter to correctly handle parent/child attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,8 @@ _This is a preview of a pending release and is subject to change._
     </li>
     <li><a href='https://codice.atlassian.net/browse/DDF-2928'>DDF-2928</a> - SolrCatalogProvider uses default row value of 10, which causes only the first 10 metacards to be updated from an UpdateRequest
     </li>
+    <li><a href='https://codice.atlassian.net/browse/DDF-2928'>DDF-3098</a> - Fix XstreamTreeWriter to correctly handle the case when a parent and child element contain the same attribute.
+    </li>
 </ul>
 
 <h3>Story</h3>

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamTreeWriter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/XstreamTreeWriter.java
@@ -26,6 +26,8 @@ public class XstreamTreeWriter {
 
     private static final Pattern NORMALIZE_NODE = Pattern.compile("\\[[0-9]+\\]");
 
+    private static final String PATH_SEP = "/";
+
     private PathTrackingWriter writer = null;
 
     private PathTracker tracker = null;
@@ -51,7 +53,7 @@ public class XstreamTreeWriter {
 
             if (value != null) {
 
-                if (currentPath.isAncestor(path) && path.toString()
+                if (isParent(currentPath, path) && path.toString()
                         .endsWith(node)) {
 
                     if (isAttributePath(path) && isAttributeNode(node)) {
@@ -62,6 +64,15 @@ public class XstreamTreeWriter {
             }
         }
 
+    }
+
+    /**
+     * Determine if currentPath is the parent of otherPath.
+     */
+    private boolean isParent(Path currentPath, Path otherPath) {
+        return !currentPath.relativeTo(otherPath)
+                .toString()
+                .contains(PATH_SEP);
     }
 
     private String normalizeNode(String node) {
@@ -80,7 +91,7 @@ public class XstreamTreeWriter {
                 if (value != null) {
 
                     if (currentPath.isAncestor(path) && path.toString()
-                            .endsWith("/" + node)) {
+                            .endsWith(PATH_SEP + node)) {
 
                         if (!isAttributeNode(node) && !isAttributePath(path)) {
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamTreeWriter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamTreeWriter.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+
+package org.codice.ddf.spatial.ogc.csw.catalog.converter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.thoughtworks.xstream.io.path.Path;
+import com.thoughtworks.xstream.io.path.PathTracker;
+import com.thoughtworks.xstream.io.path.PathTrackingWriter;
+
+public class TestXstreamTreeWriter {
+
+    @Test
+    public void testParentAndChildWithSameAttribute() {
+
+        Path pathA = new Path("/A");
+        Path pathB = new Path("/A/B");
+
+        PathTracker pathTracker = mock(PathTracker.class);
+        when(pathTracker.getPath()).thenReturn(pathA, pathA, pathB, pathB, pathB, pathA);
+
+        XstreamPathValueTracker xstreamPathValueTracker = new XstreamPathValueTracker();
+        xstreamPathValueTracker.add(new Path("/A/@x"), "1");
+        xstreamPathValueTracker.add(new Path("/A/B/@x"), "1");
+
+        PathTrackingWriter pathTrackingWriter = mock(PathTrackingWriter.class);
+
+        XstreamTreeWriter xstreamTreeWriter = new XstreamTreeWriter(pathTrackingWriter,
+                pathTracker,
+                xstreamPathValueTracker);
+
+        xstreamTreeWriter.startVisit("A");
+        xstreamTreeWriter.startVisit("@x");
+        xstreamTreeWriter.endVisit("@x");
+        xstreamTreeWriter.startVisit("B");
+        xstreamTreeWriter.startVisit("@x");
+        xstreamTreeWriter.endVisit("@x");
+        xstreamTreeWriter.endVisit("B");
+        xstreamTreeWriter.endVisit("A");
+
+        verify(pathTrackingWriter, times(2)).addAttribute("x", "1");
+
+    }
+
+}


### PR DESCRIPTION
#### What does this PR do?
Fix XstreamTreeWriter to correctly handle the case when a parent and child element contain the same attribute.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@bdeining 
@jlcsmith 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
IO - @coyotesqrl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Run unit tests and itests.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3098](https://codice.atlassian.net/browse/DDF-3098)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
