### PR TITLE
DDF-3096 Migrates the security audit plugin from Alliance to DDF

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -609,5 +609,10 @@
             <artifactId>catalog-plugin-metacardbackup-s3storage</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-security-audit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -359,6 +359,12 @@
         </bundle>
     </feature>
 
+    <feature name="catalog-plugin-security-audit" install="auto" version="${project.version}"
+             description="Plugin to audit security changes on metacards.">
+        <feature prerequisite="true">security-pdp-authz</feature>
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-security-audit/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-admin-module-sources" install="auto" version="${project.version}"
              description="DDF Admin Module">
         <feature prerequisite="true">catalog-app</feature>

--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>ddf.security.core</groupId>
             <artifactId>security-core-api</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <powermock.agent>
+            ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
+        </powermock.agent>
+    </properties>
+
+
+    <name>DDF :: Catalog :: Plugin :: Security Audit</name>
+    <artifactId>catalog-plugin-security-audit</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule-agent</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine} -javaagent:${powermock.agent} -Djava.awt.headless=true
+                        -noverify
+                    </argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.85</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.76</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.36</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPlugin.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPlugin.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.catalog.plugin.security.audit;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.Request;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.AccessPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.common.audit.SecurityLogger;
+
+/**
+ * SecurityAuditPlugin
+ * Allows changes to security attributes on a metacard to be audited
+ */
+public class SecurityAuditPlugin implements AccessPlugin {
+
+    private List<String> auditAttributes = new ArrayList<>();
+
+    @Override
+    public CreateRequest processPreCreate(CreateRequest createRequest)
+            throws StopProcessingException {
+        return createRequest;
+    }
+
+    @Override
+    public UpdateRequest processPreUpdate(UpdateRequest updateRequest,
+                                          Map<String, Metacard> existingMetacards) throws StopProcessingException {
+        if (updateRequest == null || !isLocal(updateRequest)
+                || MapUtils.isEmpty(existingMetacards)) {
+            return updateRequest;
+        }
+        for (Map.Entry<Serializable, Metacard> entry : updateRequest.getUpdates()) {
+            Metacard updateMetacard = entry.getValue();
+            Metacard existingMetacard = existingMetacards.get(entry.getKey()
+                    .toString());
+            Set<AttributeDescriptor> attributeDescriptors = updateMetacard.getMetacardType()
+                    .getAttributeDescriptors();
+
+            for (AttributeDescriptor descriptor : attributeDescriptors) {
+                String descriptorName = descriptor.getName();
+                if (auditAttributes.contains(descriptorName)) {
+                    if (hasAttributeValueChanged(existingMetacard.getAttribute(descriptorName),
+                            updateMetacard.getAttribute(descriptorName))) {
+                        String originalValue = getNonNullAttributeValues(existingMetacard,
+                                descriptorName);
+                        String updateValue = getNonNullAttributeValues(updateMetacard,
+                                descriptorName);
+                        SecurityLogger.audit(String.format(
+                                "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s",
+                                descriptorName,
+                                updateMetacard.getId(),
+                                originalValue,
+                                updateValue));
+                    }
+                }
+            }
+        }
+
+        return updateRequest;
+    }
+
+    private boolean hasAttributeValueChanged(Attribute oldAttribute, Attribute newAttribute) {
+        if (oldAttribute == null && (newAttribute != null)) {
+            //The attribute was added and is not null
+            return true;
+        } else if (oldAttribute == null || CollectionUtils.isEmpty(oldAttribute.getValues())) {
+            //The old attribute is null
+            return false;
+        } else if (newAttribute == null || CollectionUtils.isEmpty(newAttribute.getValues())) {
+            //The attribute has been removed
+            return true;
+        }
+        //The attribute exists in both metacards, check their equality
+        return !CollectionUtils.isEqualCollection(oldAttribute.getValues(),
+                newAttribute.getValues());
+    }
+
+    private String getNonNullAttributeValues(Metacard metacard, String descriptorName) {
+        String value;
+        if (metacard.getAttribute(descriptorName) == null || metacard.getAttribute(descriptorName)
+                .getValues() == null) {
+            value = "[NO VALUE]";
+        } else {
+            value = StringUtils.join(metacard.getAttribute(descriptorName)
+                    .getValues(), ",");
+        }
+
+        return value;
+    }
+
+    @Override
+    public DeleteRequest processPreDelete(DeleteRequest deleteRequest)
+            throws StopProcessingException {
+        return deleteRequest;
+    }
+
+    @Override
+    public DeleteResponse processPostDelete(DeleteResponse deleteResponse)
+            throws StopProcessingException {
+        return deleteResponse;
+    }
+
+    @Override
+    public QueryRequest processPreQuery(QueryRequest queryRequest) throws StopProcessingException {
+        return queryRequest;
+    }
+
+    @Override
+    public QueryResponse processPostQuery(QueryResponse queryResponse)
+            throws StopProcessingException {
+        return queryResponse;
+    }
+
+    @Override
+    public ResourceRequest processPreResource(ResourceRequest resourceRequest)
+            throws StopProcessingException {
+        return resourceRequest;
+    }
+
+    @Override
+    public ResourceResponse processPostResource(ResourceResponse resourceResponse,
+                                                Metacard metacard) throws StopProcessingException {
+        return resourceResponse;
+    }
+
+    public void setAuditAttributes(List<String> auditAttributes) {
+        SecurityLogger.audit(String.format(
+                "Security Audit Plugin configuration changed to audit : %s",
+                StringUtils.join(auditAttributes, ",")));
+        this.auditAttributes = auditAttributes;
+    }
+
+    public void init() {
+        SecurityLogger.audit("Security Audit Plugin started");
+    }
+
+    public void destroy() {
+        SecurityLogger.audit("Security Audit Plugin stopped");
+    }
+
+    public static boolean isLocal(Request req) {
+        return req == null || !req.hasProperties() || isLocal(req.getProperties());
+    }
+
+    public static boolean isLocal(Map<String, Serializable> props) {
+        return props == null || props.get(Constants.LOCAL_DESTINATION_KEY) == null
+                || (boolean) props.get(Constants.LOCAL_DESTINATION_KEY);
+    }
+
+}

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="securityAuditPlugin"
+          class="org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin"
+          init-method="init"
+          destroy-method="destroy">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin"
+                update-strategy="container-managed"/>
+        <property name="auditAttributes">
+            <list>
+                <value>security.access-groups</value>
+                <value>security.access-individuals</value>
+                <value>security.classification</value>
+                <value>security.classification-system</value>
+                <value>security.codewords</value>
+                <value>security.dissemination-controls</value>
+                <value>security.other-dissemination-controls</value>
+                <value>security.owner-producer</value>
+                <value>security.releasability</value>
+                <value>ext.metadata-originator-classification</value>
+                <value>ext.metadata-classification</value>
+                <value>ext.metadata-classification-system</value>
+                <value>ext.metadata-dissemination-controls</value>
+                <value>ext.metadata-releasability</value>
+                <value>ext.resource-originator-classification</value>
+                <value>ext.resource-classification</value>
+                <value>ext.resource-classification-system</value>
+                <value>ext.resource-releasability</value>
+                <value>ext.resource-dissemination-controls</value>
+            </list>
+        </property>
+    </bean>
+
+    <service ref="securityAuditPlugin" interface="ddf.catalog.plugin.AccessPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,23 +26,6 @@
             <list>
                 <value>security.access-groups</value>
                 <value>security.access-individuals</value>
-                <value>security.classification</value>
-                <value>security.classification-system</value>
-                <value>security.codewords</value>
-                <value>security.dissemination-controls</value>
-                <value>security.other-dissemination-controls</value>
-                <value>security.owner-producer</value>
-                <value>security.releasability</value>
-                <value>ext.metadata-originator-classification</value>
-                <value>ext.metadata-classification</value>
-                <value>ext.metadata-classification-system</value>
-                <value>ext.metadata-dissemination-controls</value>
-                <value>ext.metadata-releasability</value>
-                <value>ext.resource-originator-classification</value>
-                <value>ext.resource-classification</value>
-                <value>ext.resource-classification-system</value>
-                <value>ext.resource-releasability</value>
-                <value>ext.resource-dissemination-controls</value>
             </list>
         </property>
     </bean>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Security Audit Plugin"
+         id="org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin"
+         description="Plugin to audit security attribute changes">
+        <AD name="Security attributes to audit" id="auditAttributes"
+            required="true"
+            type="String"
+            cardinality="1000"
+            description="List of security attributes to audit when modified"
+            default="security.access-groups,security.access-individuals,security.classification,security.classification-system,security.codewords,security.dissemination-controls,security.other-dissemination-controls,security.owner-producer,security.releasability,ext.metadata-originator-classification,ext.metadata-classification,ext.metadata-classification-system,ext.metadata-dissemination-controls,ext.metadata-releasability,ext.resource-originator-classification,ext.resource-classification,ext.resource-classification-system,ext.resource-releasability,ext.resource-dissemination-controls">
+        </AD>
+    </OCD>
+
+    <Designate pid="org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin">
+        <Object ocdref="org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin"/>
+    </Designate>
+
+
+</metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -22,7 +22,7 @@
             type="String"
             cardinality="1000"
             description="List of security attributes to audit when modified"
-            default="security.access-groups,security.access-individuals,security.classification,security.classification-system,security.codewords,security.dissemination-controls,security.other-dissemination-controls,security.owner-producer,security.releasability,ext.metadata-originator-classification,ext.metadata-classification,ext.metadata-classification-system,ext.metadata-dissemination-controls,ext.metadata-releasability,ext.resource-originator-classification,ext.resource-classification,ext.resource-classification-system,ext.resource-releasability,ext.resource-dissemination-controls">
+            default="security.access-groups,security.access-individuals">
         </AD>
     </OCD>
 

--- a/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/ddf/catalog/security/audit/SecurityAuditPluginTest.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/ddf/catalog/security/audit/SecurityAuditPluginTest.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.catalog.security.audit;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.common.audit.SecurityLogger;
+
+@PrepareForTest({SecurityLogger.class})
+public class SecurityAuditPluginTest {
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+    private SecurityAuditPlugin securityAuditPlugin;
+
+    private String metacardKey = "metacardKey";
+
+    private String auditMessageFormat =
+            "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s";
+
+    @Before
+    public void setup() {
+        List<String> auditAttributes = new ArrayList<>();
+        auditAttributes.add(Metacard.TITLE);
+        securityAuditPlugin = new SecurityAuditPlugin();
+        securityAuditPlugin.setAuditAttributes(auditAttributes);
+    }
+
+    @Test
+    public void testChangedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "A");
+        updateMetacard.setAttribute(Metacard.TITLE, "1");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "A", "1"));
+    }
+
+    @Test
+    public void testUnchangedAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "B");
+        updateMetacard.setAttribute(Metacard.TITLE, "B");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "B", "B"));
+    }
+
+    @Test
+    public void testChangedAttributeNotInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.METADATA, "A test string");
+        updateMetacard.setAttribute(Metacard.METADATA, "A different test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.METADATA,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.METADATA,
+                "test",
+                "A test string",
+                "A different test string"));
+    }
+
+    @Test
+    public void testUnchangedAttributeNotInAuditConfigIsNotAudited()
+            throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.METADATA, "A test string");
+        updateMetacard.setAttribute(Metacard.METADATA, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.METADATA,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.METADATA,
+                "test",
+                "A test string",
+                "A test string"));
+    }
+
+    @Test
+    public void testDeletedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.TITLE,
+                "test",
+                "A test string",
+                "[NO VALUE]"));
+    }
+
+    @Test
+    public void testAddedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        updateMetacard.setAttribute(Metacard.TITLE, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.TITLE,
+                "test",
+                "[NO VALUE]",
+                "A test string"));
+    }
+
+    @Test
+    public void testNullAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+
+    @Test
+    public void testNullupdateRequest() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        securityAuditPlugin.processPreUpdate(null, null);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+
+    @Test
+    public void testNotLocalRequest() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        Map<String, Serializable> props = new HashMap<>();
+        props.put(Constants.LOCAL_DESTINATION_KEY, false);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                props);
+
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -39,5 +39,6 @@
         <module>catalog-plugin-metacardbackup-storage-common</module>
         <module>catalog-plugin-metacardbackup-filestorage</module>
         <module>catalog-plugin-metacardbackup-s3storage</module>
+        <module>catalog-plugin-security-audit</module>
     </modules>
 </project>

--- a/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
@@ -5,14 +5,14 @@ Any time a metacard attribute listed in the configuration is updated, a log will
 
 ===== Installing the Security Audit Plugin
 
-The Security Audit Plugin is installed by default with a standard installation in the ${ddf-security} application.
+The Security Audit Plugin is installed by default with a standard installation in the ${ddf-catalog} application.
 
 ===== Configuring the Security Audit Plugin
 
 To configure the Security Audit Plugin:
 
 . Navigate to the *${admin-console}*.
-. Select *${ddf-security}* application.
+. Select *${ddf-catalog}* application.
 . Select *Configuration* tab.
 . Select *Security Audit Plugin*.
 

--- a/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
@@ -1,0 +1,20 @@
+==== Security Audit Plugin
+
+The Security Audit Plugin is used to allow the auditing of specific metacard attributes.
+Any time a metacard attribute listed in the configuration is updated, a log will be generated in the security log.
+
+===== Installing the Security Audit Plugin
+
+The Security Audit Plugin is installed by default with a standard installation in the ${ddf-security} application.
+
+===== Configuring the Security Audit Plugin
+
+To configure the Security Audit Plugin:
+
+. Navigate to the *${admin-console}*.
+. Select *${ddf-security}* application.
+. Select *Configuration* tab.
+. Select *Security Audit Plugin*.
+
+Add the desired metacard attributes that will be audited when modified.
+

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -678,6 +678,8 @@ include::{adoc-include}/_plugins/metacardingest-network-contents.adoc[]
 
 include::{adoc-include}/_plugins/developing-plugins-contents.adoc[]
 
+include::{adoc-include}/_plugins/security-audit-plugin-contents.adoc[]
+
 == Operations
 
 include::{adoc-include}/_operations/operations-intro-contents.adoc[]

--- a/distribution/test/itests/test-itests-common/src/main/resources/metacard1.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/metacard1.xml
@@ -21,6 +21,9 @@
     <string name="title">
         <value>Metacard-1</value>
     </string>
+    <string name="description">
+        <value>My Description</value>
+    </string>
     <geometry name="location">
         <value>
             <ns2:Point>

--- a/distribution/test/itests/test-itests-common/src/main/resources/metacard2.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/metacard2.xml
@@ -21,6 +21,9 @@
     <string name="title">
         <value>Metacard-2</value>
     </string>
+    <string name="description">
+        <value>My Description (Updated)</value>
+    </string>
     <geometry name="location">
         <value>
             <ns2:Polygon>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/ContainerPerSuiteItestSuite.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/ContainerPerSuiteItestSuite.java
@@ -24,6 +24,7 @@ import ddf.test.itests.catalog.TestFederation;
 import ddf.test.itests.catalog.TestFtp;
 import ddf.test.itests.catalog.TestMessageBroker;
 import ddf.test.itests.catalog.TestRegistry;
+import ddf.test.itests.catalog.TestSecurityAuditPlugin;
 import ddf.test.itests.catalog.TestSpatial;
 import ddf.test.itests.platform.TestApplicationService;
 import ddf.test.itests.platform.TestConfiguration;
@@ -43,7 +44,7 @@ import ddf.test.itests.platform.TestSolrCommands;
         TestFtp.class, TestSpatial.class, TestCatalogValidation.class, TestCatalog.class,
         TestSingleSignOn.class, TestSolrCommands.class, TestSecurity.class,
         TestApplicationService.class, TestPlatform.class, TestFanout.class, TestMessageBroker.class,
-        TestConfiguration.class})
+        TestConfiguration.class, TestSecurityAuditPlugin.class})
 public class ContainerPerSuiteItestSuite {
 
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.test.itests.catalog;
+
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMetacard;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingest;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.update;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.codice.ddf.itests.common.AbstractIntegrationTest;
+import org.codice.ddf.itests.common.WaitCondition;
+import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+import org.osgi.service.cm.Configuration;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+public class TestSecurityAuditPlugin extends AbstractIntegrationTest {
+
+    private String auditMessageFormat =
+            "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s";
+
+    private String configUpdateMessage =
+            "Security Audit Plugin configuration changed to audit : description";
+
+    private String startedMessage = "Security Audit Plugin started";
+
+    private String stoppedMessage = "Security Audit Plugin stopped";
+
+    @BeforeExam
+    public void beforeExam() throws Exception {
+        waitForSystemReady();
+    }
+
+    @After
+    public void tearDown() {
+        clearCatalog();
+    }
+
+    @Test
+    public void testSecurityAuditPlugin() throws Exception {
+        Configuration config = configAdmin.getConfiguration(
+                "org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin",
+                null);
+        List attributes = new ArrayList<>();
+        attributes.add("description");
+        Dictionary properties = new Hashtable<>();
+        properties.put("auditAttributes", attributes);
+        config.update(properties);
+
+        String logFilePath = System.getProperty("karaf.data") + "/log/security.log";
+
+
+        File securityLog = new File(logFilePath);
+        WaitCondition.expect("Securitylog exists").within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.MINUTES)
+                .until(securityLog::exists);
+
+        WaitCondition.expect("Securitylog has log message: " + configUpdateMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileContent(securityLog).contains(configUpdateMessage));
+
+        String id = ingest(getResourceAsString("metacard1.xml"), "text/xml");
+
+        update(id, getResourceAsString("metacard2.xml"), "text/xml");
+
+        String expectedLogMessage = String.format(auditMessageFormat,
+                "description",
+                id,
+                "My Description",
+                "My Description (Updated)");
+        WaitCondition.expect("Securitylog has log message: " + expectedLogMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileContent(securityLog).contains(expectedLogMessage));
+
+        deleteMetacard(id);
+    }
+
+    @Test
+    public void testFeatureStartAndStop() throws Exception {
+        String logFilePath = System.getProperty("karaf.data") + "/log/security.log";
+        File securityLog = new File(logFilePath);
+        getServiceManager().stopFeature(true, "catalog-plugin-security-audit");
+        WaitCondition.expect("Securitylog has log message: " + stoppedMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileContent(securityLog).contains(stoppedMessage));
+
+        getServiceManager().startFeature(true, "catalog-plugin-security-audit");
+        WaitCondition.expect("Securitylog has log message: " + startedMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileContent(securityLog).contains(startedMessage));
+    }
+
+    private String getResourceAsString(String resourcePath) throws IOException {
+        InputStream inputStream = getFileContentAsStream(resourcePath);
+        return IOUtils.toString(inputStream);
+    }
+
+    private String getFileContent(File file) throws IOException {
+        InputStream inputStream = new FileInputStream(file);
+        return IOUtils.toString(inputStream);
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
It migrates the security audit plugin from Alliance to DDF.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @vinamartin @peterhuffer 

#### Select relevant component teams: 
@codice/security

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Ingest anything into the catalog and then change a security attribute (this is easier with the Catalog UI in DDF). Verify the change was audited.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-215
https://codice.atlassian.net/browse/CAL-315
https://codice.atlassian.net/browse/DDF-3096

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests