### PR TITLE
DDF-3100 Corrected catalog:validate usage message

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
@@ -92,7 +92,7 @@ public class ValidateCommand extends CqlCommands {
                 metacards = getMetacardsFromCatalog();
             } else {
                 printer.printError(
-                        "Usage: catalog:validate < --path filePath > < --cqlQuery cqlQuery >");
+                        "Usage: catalog:validate < --path filePath > < --cql cqlQuery >");
                 return null;
             }
 


### PR DESCRIPTION
#### What does this PR do?
Changes the usage message of catalog:validate to reflect the correct option
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@josephthweatt 
@emmberk 
@vinamartin 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
1. Build & run DDF
2. go through the setup process in the admin console
3. run `catalog:validate` 
4. see _correct_ usage message
5. verify correctness by seeing the difference between running `catalog:validate --cql *` & `catalog:validate --cqlQuery *`:
#### What are the relevant tickets?
[DDF-3100](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
