### PR TITLE
DDF-2486 Created a command to list active transformers (catalog:transformers)

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/TransformersCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/TransformersCommand.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import ddf.catalog.Constants;
+import ddf.catalog.transform.InputTransformer;
+
+/**
+ * Provides information on available transformers
+ */
+@Service
+@Command(scope = CatalogCommands.NAMESPACE, name = "transformers", description = "Provides information on available transformers.")
+public class TransformersCommand extends CatalogCommands {
+
+    // output strings
+
+    static final String ACTIVE_TRANSFORMERS_HEADER = "Active Transformers: ";
+
+    static final String NO_ACTIVE_TRANSFORMERS = "There are no active transformers";
+
+    private static final String LINE = "------------------------";
+
+    // Transformer Properties
+
+    private static final String MIME_TYPE = "mime-type";
+
+    private static final String SCHEMA = "schema";
+
+    private static final String NOT_AVAILABLE = "N/A";
+
+    @Override
+    protected Object executeWithSubject() throws Exception {
+
+        // ServiceReferences are needed to get property information from InputTransformers
+        List<ServiceReference<InputTransformer>> serviceReferences =
+                (List<ServiceReference<InputTransformer>>) bundleContext.getServiceReferences(
+                        InputTransformer.class,
+                        "(id=*)");
+
+        List<TransformerProperties> transformersProperties = serviceReferences.stream()
+                .map(TransformerProperties::new)
+                .collect(Collectors.toList());
+
+        int activeTransformers = transformersProperties.size();
+
+        if (activeTransformers == 0) {
+            console.printf("%s%n%n", NO_ACTIVE_TRANSFORMERS);
+            return null;
+        }
+
+        console.printf("%n%s%d%n%s%n%n", ACTIVE_TRANSFORMERS_HEADER, activeTransformers, LINE);
+
+        Iterator<TransformerProperties> tpIterator = transformersProperties.iterator();
+        TransformerProperties tp;
+
+        while (tpIterator.hasNext()) {
+            tp = tpIterator.next();
+            console.printf("%s", tp.printProperties());
+
+            if (tpIterator.hasNext()) {
+                console.printf("%n%s%n", StringUtils.repeat(LINE, 3));
+            }
+            console.printf("%n");
+        }
+
+        return null;
+    }
+
+    private static class TransformerProperties {
+
+        private String id;
+
+        private String schema;
+
+        private List<String> mimeTypes;
+
+        public TransformerProperties(ServiceReference ref) {
+
+            this.id = getTransformerPropertyString(ref, Constants.SERVICE_ID);
+            this.schema = getTransformerPropertyString(ref, SCHEMA);
+            this.mimeTypes = getTransformerMimeTypes(ref);
+        }
+
+        public String printProperties() {
+
+            StringBuilder s = new StringBuilder(MessageFormat.format(
+                    "{0}: {1}\n\n\t{2}: {3}\n\t{4}s: {5}\n",
+                    Constants.SERVICE_ID,
+                    id,
+                    SCHEMA,
+                    schema,
+                    MIME_TYPE,
+                    mimeTypes.remove(0)));
+
+            for (String mimeType : mimeTypes) {
+                s.append("\t\t    ")
+                        .append(mimeType)
+                        .append("\n");
+            }
+            return s.toString();
+        }
+
+        private String getTransformerPropertyString(ServiceReference ref, String property) {
+
+            return Optional.ofNullable(ref.getProperty(property))
+                    .map(String.class::cast)
+                    .filter(String.class::isInstance)
+                    .orElse(NOT_AVAILABLE);
+        }
+
+        private List<String> getTransformerMimeTypes(ServiceReference ref) {
+
+            List<String> mimeProperties;
+
+            if (ref.getProperty(MIME_TYPE) instanceof List) {
+                mimeProperties = (ArrayList<String>) ref.getProperty(MIME_TYPE);
+            } else {
+                mimeProperties = new ArrayList<>();
+                mimeProperties.add(getTransformerPropertyString(ref, MIME_TYPE));
+            }
+            return mimeProperties;
+        }
+    }
+
+    // Used for testing TransformersCommand
+    protected void setBundleContext(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+}

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TransformersCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TransformersCommandTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.catalog;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import com.google.common.collect.ImmutableList;
+
+import ddf.catalog.Constants;
+import ddf.catalog.transform.InputTransformer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TransformersCommandTest extends ConsoleOutputCommon {
+
+    private static final String SERVICE_ID = "id";
+
+    private static final String MIME_TYPE = "mime-type";
+
+    private static final String SCHEMA = "schema";
+
+    @Mock
+    BundleContext bundleContext;
+
+    TransformersCommand transformersCommand;
+
+    @Before
+    public void setUp() {
+
+        transformersCommand = new TransformersCommand();
+        transformersCommand.setBundleContext(bundleContext);
+    }
+
+    @Test
+    public void testNullIds() throws Exception {
+
+        List<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+        ServiceReference<InputTransformer> serviceReference = mock(ServiceReference.class);
+        serviceReferences.add(serviceReference);
+
+        List<ServiceReference<InputTransformer>> serviceReferencesFiltered =
+                serviceReferences.stream()
+                        .filter(ref -> ref.getProperty(Constants.SERVICE_ID) != null)
+                        .collect(Collectors.toList());
+
+        when(serviceReference.getProperty(SERVICE_ID)).thenReturn(null);
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=*)")).thenReturn(
+                serviceReferencesFiltered);
+
+        transformersCommand.executeWithSubject();
+        assertThat(consoleOutput.getOutput(),
+                containsString(TransformersCommand.NO_ACTIVE_TRANSFORMERS));
+    }
+
+    @Test
+    public void testNullAndNotNullIds() throws Exception {
+
+        int nullIds = 5;
+        int notNullIds = 7;
+
+        List<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+
+        // mock service refs with null and not null ids
+        for (int i = 0; i < nullIds + notNullIds; i++) {
+            ServiceReference<InputTransformer> serviceReference = mock(ServiceReference.class);
+            serviceReferences.add(serviceReference);
+
+            if (i < nullIds) {
+                when(serviceReference.getProperty(SERVICE_ID)).thenReturn(null);
+            } else {
+                when(serviceReference.getProperty(SERVICE_ID)).thenReturn("Test");
+            }
+        }
+
+        List<ServiceReference<InputTransformer>> serviceReferencesFiltered =
+                serviceReferences.stream()
+                        .filter(ref -> ref.getProperty(Constants.SERVICE_ID) != null)
+                        .collect(Collectors.toList());
+
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=*)")).thenReturn(
+                serviceReferencesFiltered);
+
+        transformersCommand.executeWithSubject();
+        assertThat(consoleOutput.getOutput(),
+                containsString(String.format("%s%d",
+                        TransformersCommand.ACTIVE_TRANSFORMERS_HEADER,
+                        notNullIds)));
+    }
+
+    @Test
+    public void testActiveTransformerCount() throws Exception {
+
+        List<ServiceReference<InputTransformer>> serviceReferences;
+
+        ServiceReference<InputTransformer> serviceReference = mock(ServiceReference.class);
+        when(serviceReference.getProperty(SERVICE_ID)).thenReturn("Test");
+
+        serviceReferences = ImmutableList.of(serviceReference, serviceReference, serviceReference);
+
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=*)")).thenReturn(
+                serviceReferences);
+
+        transformersCommand.executeWithSubject();
+        assertThat(consoleOutput.getOutput(),
+                containsString(String.format("%s3",
+                        TransformersCommand.ACTIVE_TRANSFORMERS_HEADER)));
+    }
+
+    @Test
+    public void testNullPropertiesWithValidId() throws Exception {
+
+        List<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+
+        ServiceReference<InputTransformer> serviceReference = mock(ServiceReference.class);
+
+        when(serviceReference.getProperty(SERVICE_ID)).thenReturn("Test");
+        when(serviceReference.getProperty(SCHEMA)).thenReturn(null);
+        when(serviceReference.getProperty(MIME_TYPE)).thenReturn(null);
+
+        serviceReferences.add(serviceReference);
+
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=*)")).thenReturn(
+                serviceReferences);
+
+        transformersCommand.executeWithSubject();
+        String output = consoleOutput.getOutput();
+        assertThat(output, containsString("schema: N/A"));
+        assertThat(output, containsString("mime-types: N/A"));
+    }
+
+    @Test
+    public void testMultipleMimeTypes() throws Exception {
+
+        List<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+
+        ServiceReference<InputTransformer> serviceReference = mock(ServiceReference.class);
+        List<String> mimeTypes = new ArrayList<>();
+        mimeTypes.add("mime1");
+        mimeTypes.add("mime2");
+        mimeTypes.add("mime3");
+
+        when(serviceReference.getProperty(SERVICE_ID)).thenReturn("Test");
+        when(serviceReference.getProperty(MIME_TYPE)).thenReturn(mimeTypes);
+
+        serviceReferences.add(serviceReference);
+
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=*)")).thenReturn(
+                serviceReferences);
+
+        transformersCommand.executeWithSubject();
+        String output = consoleOutput.getOutput();
+        assertThat(output, containsString("mime-types: mime1"));
+        assertThat(output, containsString("mime2"));
+        assertThat(output, containsString("mime3"));
+    }
+}

--- a/distribution/docs/src/main/jdocs/content/_running/console-commands-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/console-commands-contents.adoc
@@ -145,6 +145,9 @@ Provides a list of environment variables.
 |catalog:spatial
 |Searches spatially the local Catalog.
 
+|catalog:transformers
+|Provides information on available transformers.
+
 |catalog:validate
 |Validates an XML file against all installed validators and prints out human readable errors and warnings.
 

--- a/distribution/docs/src/main/resources/_contents/_running/console-commands-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/console-commands-contents.adoc
@@ -140,6 +140,9 @@ Provides a list of environment variables.
 |catalog:spatial
 |Searches spatially the local Catalog.
 
+|catalog:transformers
+|Provides information on available transformers.
+
 |catalog:validate
 |Validates an XML file against all installed validators and prints out human readable errors and warnings.
 


### PR DESCRIPTION
#### What does this PR do?

This is a new feature to assist the user in finding available transformers. It is called with `catalog:transformers`, and displays three details about each transformer:

- id
- schema
- mime-type (multiple values)

Schema & mime-type can have no values ("N/A"), but id must be included.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@vinamartin 
@emmberk 
@coyotesqrl 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)
1. Build and run DDF
2. Load the catalog commands by setting up the Admin Console
3. In DDF, type in `catalog:transformers`
4. Review the output. Verify that the formatting is correct and that all of your available transformers are shown in the output.
5. Go to the Admin Console and select Catalog. In the features tab, uninstall some transformers and execute `catalog:transformers` again to see if the number of "Active Transformers" decreases. 

#### Any background context you want to provide?
#### What are the relevant tickets?
[2486](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
<img width="841" alt="screen shot 2017-06-22 at 4 27 25 pm" src="https://user-images.githubusercontent.com/11358088/27460835-343db69a-576b-11e7-9718-bcb4f6290a70.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
