### PR TITLE
DDF-3059 corrected map layer transparency logic

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/view/preferences/PreferencesModal.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/view/preferences/PreferencesModal.view.js
@@ -128,25 +128,19 @@ define([
             var prevAlpha = 0;
             for (var index=0;index<this.collection.models.length;index++) {
                 if (index !== 0) {
-                    if (this.getAlpha(index) > prevAlpha) {
+                    if (this.collection.at(index).get('alpha') > prevAlpha) {
                         sort = true;
                         break;
                     } else {
-                        prevAlpha = this.getAlpha(index);
+                        prevAlpha = this.collection.at(index).get('alpha');
                     }
                 } else {
-                    prevAlpha = this.getAlpha(index);
+                    prevAlpha = this.collection.at(index).get('alpha');
                 }
             }
             if (sort) {
                 this.collection.sort();
             }
-        },
-        /*
-         * Get the alpha value set for a specific layer in the range [0,1].
-         */
-        getAlpha: function(index) {
-            return this.collection.at(index).get('alpha') / 100.0;
         }
     });
     PrefsModalView.LayerPicker = Marionette.ItemView.extend({
@@ -163,7 +157,7 @@ define([
         onRender: function () {
             var layerBindings = Backbone.ModelBinder.createDefaultBindings(this.el, 'name');
             this.modelBinder.bind(this.model, this.$el, layerBindings);
-            this.changeShow();           
+            this.changeShow();
         },
         changeShow: function () {
             this.$el.toggleClass('is-disabled', !this.model.get('show'));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/templates/preferences/layerPicker.handlebars
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/templates/preferences/layerPicker.handlebars
@@ -18,5 +18,5 @@
     </label>
 </td>
 <td>
-    <input name="alpha" min="1" max="100" step="1" type="range"/>
+    <input name="alpha" min="0" max="1" step="0.01" type="range"/>
 </td>


### PR DESCRIPTION
#### What does this PR do?
Map layer transparency values were being stored in the model with a range of 1-100.  However, the map expects a range of 0-1.  This resulted incorrect layer transparencies.  Updated the transparency value stored in the model accordingly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@spearskw 
@bdeining 

#### Select relevant component teams: 
@codice/ui 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@andrewkfiedler

#### How should this be tested? (List steps with links to updated documentation)
1) Configure 1 or more map layers in the Intrigue UI configuration.
2) Verify that transparencies can be changed appropriately via map preferences

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3059](https://codice.atlassian.net/browse/DDF-3059)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
