### PR TITLE
DDF-3111 Made JMX uninstalled by default

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -65,3 +65,4 @@ export JAVA_MAX_MEM=4096M
 # export KARAF_BASE # Karaf base folder
 
 export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME"
+export JAVA_OPTS=-"server -Xms128M -Xmx4096M -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass"

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -56,10 +56,10 @@ rem SET KARAF_DATA
 rem Karaf base folder
 rem SET KARAF_BASE
 rem Additional available Karaf options
-rem SET KARAF_OPTS=-Dderby.system.home="..\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dcom.sun.management.jmxremote -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
+rem SET KARAF_OPTS=-Dderby.system.home="..\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
 
 rem comment out the line below to enable cxf logging interceptors
 rem set EXTRA_JAVA_OPTS="-Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
 
-set JAVA_OPTS=-server -Xmx4096M -Dderby.system.home="%DDF_HOME%\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dcom.sun.management.jmxremote -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
+set JAVA_OPTS=-server -Xmx4096M -Dderby.system.home="%DDF_HOME%\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME%
 :: set JAVA_OPTS=-server -Xmx2048M -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore=../etc/keystores/serverKeystore.jks -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=../etc/keystores/serverTruststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Dddf.home=%DDF_HOME%

--- a/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
@@ -23,8 +23,7 @@ It is recommended to apply the following security mitigations to the ${branding}
 
 |JMX
 |tampering, information disclosure, and unauthorized access
-a|* Remove `-Dcom.sun.management.jmxremote` from `<${branding}_HOME>/bin/karaf`. +
-* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg`. +
+a|* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg`. +
 * Uninstall the management bundle using the command line console: `uninstall management`. +
 
 |File System Access

--- a/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
@@ -145,20 +145,19 @@ RUN_AS_USER=<${branding-lowercase}-user>
 wrapper.java.additional.10=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
 wrapper.java.additional.11=-Dderby.storage.fileSyncTransactionLog=true
 wrapper.java.additional.12=-server
-wrapper.java.additional.13=-Dcom.sun.management.jmxremote
-wrapper.java.additional.14=-Djava.security.egd=file:/dev/./urandom
-wrapper.java.additional.15=-Dfile.encoding=UTF8
-wrapper.java.additional.16=-Dkaraf.instances=%KARAF_HOME%/instances
-wrapper.java.additional.17=-Dkaraf.restart.jvm.supported=true
-wrapper.java.additional.18=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
-wrapper.java.additional.19=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
-wrapper.java.additional.20=-XX:+UnlockDiagnosticVMOptions
-wrapper.java.additional.21=-XX:+UnsyncloadClass
-wrapper.java.additional.22=-Dderby.system.home=%KARAF_HOME%/data/derby
-wrapper.java.additional.23=-Djava.awt.headless=true
+wrapper.java.additional.13=-Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.14=-Dfile.encoding=UTF8
+wrapper.java.additional.15=-Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.16=-Dkaraf.restart.jvm.supported=true
+wrapper.java.additional.17=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
+wrapper.java.additional.18=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
+wrapper.java.additional.19=-XX:+UnlockDiagnosticVMOptions
+wrapper.java.additional.20=-XX:+UnsyncloadClass
+wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
+wrapper.java.additional.22=-Djava.awt.headless=true
 
 # Set the JVM max heap space as desired
-wrapper.java.additional.24=-Xmx4g
+wrapper.java.additional.23=-Xmx4g
 
 ----
 +

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -141,20 +141,19 @@ RUN_AS_USER=<${branding-lowercase}-user>
 wrapper.java.additional.10=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
 wrapper.java.additional.11=-Dderby.storage.fileSyncTransactionLog=true
 wrapper.java.additional.12=-server
-wrapper.java.additional.13=-Dcom.sun.management.jmxremote
-wrapper.java.additional.14=-Djava.security.egd=file:/dev/./urandom
-wrapper.java.additional.15=-Dfile.encoding=UTF8
-wrapper.java.additional.16=-Dkaraf.instances=%KARAF_HOME%/instances
-wrapper.java.additional.17=-Dkaraf.restart.jvm.supported=true
-wrapper.java.additional.18=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
-wrapper.java.additional.19=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
-wrapper.java.additional.20=-XX:+UnlockDiagnosticVMOptions
-wrapper.java.additional.21=-XX:+UnsyncloadClass
-wrapper.java.additional.22=-Dderby.system.home=%KARAF_HOME%/data/derby
-wrapper.java.additional.23=-Djava.awt.headless=true
+wrapper.java.additional.13=-Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.14=-Dfile.encoding=UTF8
+wrapper.java.additional.15=-Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.16=-Dkaraf.restart.jvm.supported=true
+wrapper.java.additional.17=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
+wrapper.java.additional.18=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
+wrapper.java.additional.19=-XX:+UnlockDiagnosticVMOptions
+wrapper.java.additional.20=-XX:+UnsyncloadClass
+wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
+wrapper.java.additional.22=-Djava.awt.headless=true
 
 # Set the JVM max heap space as desired
-wrapper.java.additional.24=-Xmx4g
+wrapper.java.additional.23=-Xmx4g
 
 ----
 +

--- a/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
@@ -18,8 +18,7 @@ It is recommended to apply the following security mitigations to the ${branding}
 
 |JMX
 |tampering, information disclosure, and unauthorized access
-a|* Remove `-Dcom.sun.management.jmxremote` from `<${branding}_HOME>/bin/karaf`. +
-* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg`. +
+a|* Disable ${branding}'s JMX management `rmiRegistryPort` and `rmiServerPort` (`1099`, `44444`) by removing these entries from `etc/org.apache.karaf.management.cfg`. +
 * Uninstall the management bundle using the command line console: `uninstall management`. +
 
 |File System Access


### PR DESCRIPTION
#### What does this PR do?
Makes JMX turned off as the default
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@emmberk 
@vinamartin 
@josephthweatt 
@mcalcote 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@coyotesqrl
#### What are the relevant tickets?
[DDF-3111](https://codice.atlassian.net/browse/)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
