### PR TITLE
DDF-3034 Paginator and paginator unit tests

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CatalogRuntimeException.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CatalogRuntimeException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.util.impl;
+
+public class CatalogRuntimeException extends RuntimeException {
+    public CatalogRuntimeException() {
+        super();
+    }
+
+    public CatalogRuntimeException(String message) {
+        super(message);
+    }
+
+    public CatalogRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CatalogRuntimeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/QueryResultPaginator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/QueryResultPaginator.java
@@ -74,7 +74,6 @@ public class QueryResultPaginator implements Iterator<List<Result>> {
      */
     public boolean hasNext() {
 
-        boolean hasMoreResults;
         if (notEmpty()) {
             return true;
         } else {

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/QueryResultPaginator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/QueryResultPaginator.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.util.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.apache.commons.lang3.Validate;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Result;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+/**
+ * Implements iterator. Acts like a decorator.
+ * NOTE: This class is not thread safe. Do not share an object between multiple threads.
+ * Create a new instance by passing a QueryRequestImpl and a CatalogFramework to the constructor.
+ * The paginator will inspect the query's start index and desired page size.
+ * Calling next() returns a list of Result objects in the desired page size.
+ * If the page size is not evenly divisible by the number of results,
+ * then the last page will be smaller than the desired page size.
+ */
+public class QueryResultPaginator implements Iterator<List<Result>> {
+
+    private final CatalogFramework catalogFramework;
+
+    private final QueryRequestImpl queryRequestCopy;
+
+    private int currentIndex;
+
+    private int pageSize;
+
+    //Set to true when a query returns zero results.
+    private boolean exhausted;
+
+    private BlockingQueue<Result> buffer;
+
+    public QueryResultPaginator(CatalogFramework catalogFramework, QueryRequestImpl queryRequest) {
+        Validate.notNull(catalogFramework);
+        Validate.notNull(queryRequest);
+        this.catalogFramework = catalogFramework;
+        this.queryRequestCopy = clone(queryRequest);
+        pageSize = queryRequestCopy.getQuery()
+                .getPageSize();
+        currentIndex = queryRequest.getQuery()
+                .getStartIndex();
+        Validate.inclusiveBetween(1,
+                Integer.MAX_VALUE,
+                currentIndex,
+                "Query request start index must be greater than zero");
+        exhausted = false;
+        buffer = new LinkedBlockingDeque<>();
+    }
+
+    /**
+     * @return true if there are more results for the client
+     */
+    public boolean hasNext() {
+
+        if (exhausted && buffer.isEmpty()) {
+            return false;
+        }
+
+        if (!exhausted) {
+            fetchNext();
+        }
+
+        return !buffer.isEmpty();
+    }
+
+    /**
+     * Catalog Framework queried for results until current page is full of results
+     * or endIndex is reached.
+     *
+     * @return Collection of results
+     * @throws NoSuchElementException if the iteration has no more elements
+     */
+    public List<Result> next() throws NoSuchElementException {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        while (!exhausted && getBufferSize() < pageSize) {
+            fetchNext();
+        }
+
+        List<Result> copy = new ArrayList<>(pageSize);
+        buffer.drainTo(copy, pageSize);
+        return copy;
+    }
+
+    int getBufferSize() {
+        return buffer.size();
+    }
+
+    QueryRequestImpl clone(QueryRequestImpl queryRequest) {
+        QueryImpl query = (QueryImpl) queryRequest.getQuery();
+        return new QueryRequestImpl(new QueryImpl(query.getFilter(),
+                query.getStartIndex(),
+                query.getPageSize(),
+                query.getSortBy(),
+                query.requestsTotalResultsCount(),
+                query.getTimeoutMillis()));
+    }
+
+    int getCurrentIndex() {
+        return currentIndex;
+    }
+
+    /**
+     * Get the next batch of results.
+     * Assume the current index is pointed to the first result
+     * that has not been retrieved.
+     * Update the current index after the results are fetched.
+     * Add the fetched results to the buffer.
+     * If no results were returned, assume there are no more results possible.
+     */
+    private void fetchNext() {
+        ((QueryImpl) queryRequestCopy.getQuery()).setStartIndex(currentIndex);
+        List<Result> results = queryCatalogFramework();
+        if (results.isEmpty()) {
+            exhausted = true;
+        } else {
+            currentIndex += results.size();
+            buffer.addAll(results);
+        }
+    }
+
+    private List<Result> queryCatalogFramework() {
+        try {
+            return catalogFramework.query(queryRequestCopy)
+                    .getResults();
+        } catch (UnsupportedQueryException | SourceUnavailableException | FederationException e) {
+            throw new CatalogRuntimeException(e);
+        }
+    }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/QueryResultPaginatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/QueryResultPaginatorTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.util.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+
+public class QueryResultPaginatorTest {
+
+    private CatalogFramework catalogFrameworkMock;
+
+    private QueryRequestImpl queryRequestMock;
+
+    private QueryResponseImpl queryResponseMock;
+
+    private QueryImpl queryMock;
+
+    private QueryResultPaginator paginator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        catalogFrameworkMock = mock(CatalogFramework.class);
+        queryRequestMock = mock(QueryRequestImpl.class);
+        queryResponseMock = mock(QueryResponseImpl.class);
+        queryMock = mock(QueryImpl.class);
+        when(catalogFrameworkMock.query(queryRequestMock)).thenReturn(queryResponseMock);
+        when(catalogFrameworkMock.query(queryRequestMock)).thenReturn(queryResponseMock);
+        when(queryRequestMock.getQuery()).thenReturn(queryMock);
+    }
+
+    @Test
+    public void testhasNextIdempotency() throws Exception {
+        setStartIndexAndPageSize(1, 1);
+        setResponses(1, 0);
+        assertThat(paginator.hasNext(), equalTo(true));
+        assertThat(paginator.hasNext(), equalTo(true));
+        assertThat(paginator.hasNext(), equalTo(true));
+        paginator.next();
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.getBufferSize(), equalTo(0));
+
+    }
+
+    @Test
+    public void testSimpleNextPage() {
+        setStartIndexAndPageSize(1, 1);
+        setResponses(2, 0);
+        assertThat(paginator.next()
+                .size(), equalTo(1));
+        assertThat(paginator.next()
+                .size(), equalTo(1));
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.getBufferSize(), equalTo(0));
+
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testNoSuchElementException() {
+        setStartIndexAndPageSize(1, 1);
+        setResponses(0);
+        paginator.next();
+    }
+
+    @Test
+    public void testDifferentSizePages() {
+        int pageSize = 3;
+        setStartIndexAndPageSize(1, pageSize);
+        setResponses(2, 2, 0);
+        assertThat(paginator.hasNext(), equalTo(true));
+        assertThat(paginator.next()
+                .size(), equalTo(pageSize));
+        assertThat(paginator.next()
+                .size(), equalTo(1));
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.getBufferSize(), equalTo(0));
+    }
+
+    @Test
+    public void testIndexingAcrossPages() {
+        int pageSize = 5;
+        setStartIndexAndPageSize(10, pageSize);
+        setResponses(5, 5, 0);
+        List<Result> pageOne = paginator.next();
+        assertThat(paginator.getCurrentIndex(), equalTo(15));
+        List<Result> pageTwo = paginator.next();
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.getBufferSize(), equalTo(0));
+        assertThat(paginator.getCurrentIndex(), equalTo(20));
+
+        try {
+            paginator.next();
+        } catch (NoSuchElementException e) {
+            //do nothing
+        }
+
+        assertThat(paginator.hasNext(), equalTo(false));
+        assertThat(paginator.getBufferSize(), equalTo(0));
+        assertThat(paginator.getCurrentIndex(), equalTo(20));
+    }
+
+    private void setStartIndexAndPageSize(int startIndex, int pageSize) {
+        when(queryMock.getStartIndex()).thenReturn(startIndex);
+        when(queryMock.getPageSize()).thenReturn(pageSize);
+        paginator = new QueryResultPaginator(catalogFrameworkMock, queryRequestMock) {
+            // Keep the mock object
+            protected QueryRequestImpl clone(QueryRequestImpl queryRequest) {
+                return queryRequest;
+            }
+        };
+    }
+
+    private void setResponses(int... arguments) {
+        int index = 1;
+        List<List<Result>> mockResponses = new ArrayList<>();
+        for (int i = 0; i < arguments.length; ++i) {
+            int numberofResults = arguments[i];
+            mockResponses.add(getResultListOfSize(numberofResults, index));
+            index += numberofResults;
+        }
+        List[] args = new List[arguments.length];
+        mockResponses.toArray(args);
+        List[] vaargs = Arrays.copyOfRange(args, 1, arguments.length);
+        when(queryResponseMock.getResults()).thenReturn(args[0], vaargs);
+    }
+
+    /**
+     * List of result objects populated with distance values to uniquely identify them
+     * for validation.
+     *
+     * @param pageSize    Size of result list to return for validation
+     * @param indexOffset Index value to increment to validate correct results
+     * @return Returns list of Result objects populated with distance values
+     */
+    private List<Result> getResultListOfSize(int pageSize, int indexOffset) {
+        List<Result> resultList = new ArrayList<>();
+        for (int i = 0; i < pageSize; i++) {
+            ResultImpl newResult = new ResultImpl();
+            newResult.setDistanceInMeters((double) i + indexOffset);
+            resultList.add(newResult);
+        }
+        return resultList;
+    }
+}

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -48,7 +48,6 @@ import org.codice.ddf.catalog.transformer.zip.JarSigner;
 import org.codice.ddf.commands.catalog.export.ExportItem;
 import org.codice.ddf.commands.catalog.export.IdAndUriMetacard;
 import org.codice.ddf.commands.util.CatalogCommandRuntimeException;
-import org.codice.ddf.commands.util.QueryResultIterable;
 import org.fusesource.jansi.Ansi;
 import org.geotools.filter.text.cql2.CQLException;
 import org.opengis.filter.Filter;
@@ -75,6 +74,7 @@ import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
+import ddf.catalog.util.impl.QueryResultPaginator;
 import ddf.security.common.audit.SecurityLogger;
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
@@ -91,30 +91,22 @@ public class ExportCommand extends CqlCommands {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExportCommand.class);
 
+    private static final int PAGE_SIZE = 64;
+
     private static final SimpleDateFormat ISO_8601_DATE_FORMAT;
+
+    private static Supplier<String> fileNamer;
 
     static {
         ISO_8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss.SSS'Z'");
         ISO_8601_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+        fileNamer =
+                () -> "export-" + ISO_8601_DATE_FORMAT.format(Date.from(Instant.now())) + ".zip";
     }
-
-    private static final Supplier<String> FILE_NAMER =
-            () -> "export-" + ISO_8601_DATE_FORMAT.format(Date.from(Instant.now())) + ".zip";
-
-    private static final int PAGE_SIZE = 64;
-
-    private MetacardTransformer transformer;
-
-    private Filter revisionFilter;
-
-    private JarSigner jarSigner = new JarSigner();
-
-    @Reference
-    private StorageProvider storageProvider;
 
     @Option(name = "--output", description = "Output file to export Metacards and contents into. Paths are absolute and must be in quotes. Will default to auto generated name inside of ddf.home", multiValued = false, required = false, aliases = {
             "-o"})
-    String output = Paths.get(System.getProperty("ddf.home"), FILE_NAMER.get())
+    String output = Paths.get(System.getProperty("ddf.home"), fileNamer.get())
             .toString();
 
     @Option(name = "--delete", required = true, aliases = {
@@ -131,6 +123,26 @@ public class ExportCommand extends CqlCommands {
 
     @Option(name = "--skip-signature-verification", required = false, multiValued = false, description = "Produces the export zip but does NOT sign the resulting zip file. This file will not be able to be verified on import for integrity and security.")
     boolean unsafe = false;
+
+    private MetacardTransformer transformer;
+
+    private Filter revisionFilter;
+
+    private JarSigner jarSigner = new JarSigner();
+
+    @Reference
+    private StorageProvider storageProvider;
+
+    /**
+     * Generates stateful predicate to filter distinct elements by a certain key in the object.
+     *
+     * @param keyExtractor Function to pull the desired key out of the object
+     * @return the stateful predicate
+     */
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+        Map<Object, Boolean> seen = new ConcurrentHashMap<>();
+        return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
+    }
 
     @Override
     protected Object executeWithSubject() throws Exception {
@@ -226,7 +238,7 @@ public class ExportCommand extends CqlCommands {
         File initialOutputFile = new File(output);
         if (initialOutputFile.isDirectory()) {
             // If directory was specified, auto generate file name
-            resolvedOutput = Paths.get(initialOutputFile.getPath(), FILE_NAMER.get())
+            resolvedOutput = Paths.get(initialOutputFile.getPath(), fileNamer.get())
                     .toString();
         } else {
             resolvedOutput = output;
@@ -238,42 +250,42 @@ public class ExportCommand extends CqlCommands {
     private List<ExportItem> doMetacardExport(/*Mutable,IO*/ZipFile zipFile, Filter filter) {
         Set<String> seenIds = new HashSet<>(1024);
         List<ExportItem> exportedItems = new ArrayList<>();
-        for (Result result : new QueryResultIterable(catalogFramework,
-                (i) -> getQuery(filter, i, PAGE_SIZE),
-                PAGE_SIZE)) {
-            if (!seenIds.contains(result.getMetacard()
-                    .getId())) {
-                writeToZip(zipFile, result);
-                exportedItems.add(new ExportItem(result.getMetacard()
-                        .getId(),
-                        getTag(result),
-                        result.getMetacard()
-                                .getResourceURI(),
-                        getDerivedResources(result)));
-                seenIds.add(result.getMetacard()
-                        .getId());
-            }
+        QueryResultPaginator paginator = new QueryResultPaginator(catalogFramework,
+                getQuery(filter, 1, PAGE_SIZE));
+        while (paginator.hasNext()) {
+            List<Result> results = paginator.next();
+            writeResult(results, seenIds, exportedItems, zipFile);
 
             // Fetch and export all history for each exported item
-            for (Result revision : new QueryResultIterable(catalogFramework,
-                    (i) -> getQuery(getHistoryFilter(result), i, PAGE_SIZE),
-                    PAGE_SIZE)) {
-                if (seenIds.contains(revision.getMetacard()
-                        .getId())) {
-                    continue;
+            for (Result each : results) {
+                QueryResultPaginator historyPaginator = new QueryResultPaginator(catalogFramework,
+                        getQuery(getHistoryFilter(each), 1, PAGE_SIZE));
+                while (historyPaginator.hasNext()) {
+                    List<Result> revisions = historyPaginator.next();
+                    writeResult(revisions, seenIds, exportedItems, zipFile);
                 }
-                writeToZip(zipFile, revision);
-                exportedItems.add(new ExportItem(revision.getMetacard()
-                        .getId(),
-                        getTag(revision),
-                        revision.getMetacard()
-                                .getResourceURI(),
-                        getDerivedResources(result)));
-                seenIds.add(revision.getMetacard()
-                        .getId());
             }
         }
         return exportedItems;
+    }
+
+    private void writeResult(List<Result> items, Set<String> seenIds,
+            List<ExportItem> exportedItems, ZipFile zipFile) {
+
+        for (Result item : items) {
+            if (!seenIds.contains(item.getMetacard()
+                    .getId())) {
+                writeToZip(zipFile, item);
+                exportedItems.add(new ExportItem(item.getMetacard()
+                        .getId(),
+                        getTag(item),
+                        item.getMetacard()
+                                .getResourceURI(),
+                        getDerivedResources(item)));
+                seenIds.add(item.getMetacard()
+                        .getId());
+            }
+        }
     }
 
     private List<String> getDerivedResources(Result result) {
@@ -483,17 +495,6 @@ public class ExportCommand extends CqlCommands {
                             .reset()
                             .toString());
         }
-    }
-
-    /**
-     * Generates stateful predicate to filter distinct elements by a certain key in the object.
-     *
-     * @param keyExtractor Function to pull the desired key out of the object
-     * @return the stateful predicate
-     */
-    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
-        Map<Object, Boolean> seen = new ConcurrentHashMap<>();
-        return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 
     private String getTag(Result r) {

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -24,7 +24,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +66,6 @@ import ddf.catalog.data.Result;
 import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.QueryImpl;
-import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.ResourceRequestByProductUri;
 import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
@@ -95,18 +93,18 @@ public class ExportCommand extends CqlCommands {
 
     private static final SimpleDateFormat ISO_8601_DATE_FORMAT;
 
-    private static Supplier<String> fileNamer;
+    private static final Supplier<String> FILE_NAMER;
 
     static {
         ISO_8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss.SSS'Z'");
         ISO_8601_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-        fileNamer =
+        FILE_NAMER =
                 () -> "export-" + ISO_8601_DATE_FORMAT.format(Date.from(Instant.now())) + ".zip";
     }
 
     @Option(name = "--output", description = "Output file to export Metacards and contents into. Paths are absolute and must be in quotes. Will default to auto generated name inside of ddf.home", multiValued = false, required = false, aliases = {
             "-o"})
-    String output = Paths.get(System.getProperty("ddf.home"), fileNamer.get())
+    String output = Paths.get(System.getProperty("ddf.home"), FILE_NAMER.get())
             .toString();
 
     @Option(name = "--delete", required = true, aliases = {
@@ -238,7 +236,7 @@ public class ExportCommand extends CqlCommands {
         File initialOutputFile = new File(output);
         if (initialOutputFile.isDirectory()) {
             // If directory was specified, auto generate file name
-            resolvedOutput = Paths.get(initialOutputFile.getPath(), fileNamer.get())
+            resolvedOutput = Paths.get(initialOutputFile.getPath(), FILE_NAMER.get())
                     .toString();
         } else {
             resolvedOutput = output;
@@ -555,13 +553,12 @@ public class ExportCommand extends CqlCommands {
         return filter;
     }
 
-    private QueryRequestImpl getQuery(Filter filter, int index, int pageSize) {
-        return new QueryRequestImpl(new QueryImpl(filter,
+    private QueryImpl getQuery(Filter filter, int index, int pageSize) {
+        return new QueryImpl(filter,
                 index,
                 pageSize,
                 SortBy.NATURAL_ORDER,
-                false,
-                TimeUnit.MINUTES.toMillis(1)), new HashMap<>());
+                false, TimeUnit.MINUTES.toMillis(1));
     }
 
 }


### PR DESCRIPTION
#### What does this PR do?
1. Create a new class, QueryResultsPaginator, to return a certain number of records (one page worth of results) until there are not more results left.
2. Modify ExportCommand to use the paginator.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mweser @lessarderic @rzwiefel @AzGoalie @emanns95 @jhunzik 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
For manual testing:
1. Ingest between 129-191 documents into a catalog (export command's page size is 64).
2. From the search UI, do a wildcard search. Note the exact number of results. For example, say there were "130" search results.
3. Edit a metacard, save the changes, and check the History tab for that metcard. There should be one entry in that card's history.
4. From the DDF console, execute `catalog:export --delete=false`.
5. Look at how many metacards were exported.  The expected results it that It should equal the number of search results plus the number of historical entries, 130+1=131. So look for "Number of metacards exported: 131" in the output from the export command.

#### Any background context you want to provide?
The paginator is part of a larger effort championed by @lessarderic and @mweser 
#### What are the relevant tickets?
[DDF-3034](https://codice.atlassian.net/browse/DDF-3034)
#### Screenshots (if appropriate)
#### Checklist:
- [X ] Update / Add Unit Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
