### PR TITLE
DDF-3118 Fix resource retrieval by uri.

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/ResourceOperationsSpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/ResourceOperationsSpec.groovy
@@ -34,7 +34,7 @@ import spock.lang.Unroll
 
 import java.util.concurrent.ExecutorService
 
-class ResourceOperationsTest extends Specification {
+class ResourceOperationsSpec extends Specification {
     private FrameworkProperties frameworkProperties
     private QueryOperations queryOperations
     private OperationsSecuritySupport opsSecurity


### PR DESCRIPTION
 #### What does this PR do?
Fixes resource retrieval by uri when the uri has a fragment. 
Also refactored getResourceInfo method to address sonarqube findings

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @mcalcote 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3118](https://codice.atlassian.net/browse/DDF-3118)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
