### PR TITLE
DDF-3119 Add deleted tag for exclude version cards filter

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.Constants;
+import ddf.catalog.core.versioning.DeletedMetacard;
 import ddf.catalog.core.versioning.MetacardVersion;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -658,10 +659,16 @@ public class QueryOperations extends DescribableImpl {
     private Filter getNonVersionTagsFilter() {
         return frameworkProperties.getFilterBuilder()
                 .not(frameworkProperties.getFilterBuilder()
-                        .attribute(Metacard.TAGS)
-                        .is()
-                        .like()
-                        .text(MetacardVersion.VERSION_TAG));
+                        .anyOf(frameworkProperties.getFilterBuilder()
+                                        .attribute(Metacard.TAGS)
+                                        .is()
+                                        .like()
+                                        .text(MetacardVersion.VERSION_TAG),
+                                frameworkProperties.getFilterBuilder()
+                                        .attribute(Metacard.TAGS)
+                                        .is()
+                                        .like()
+                                        .text(DeletedMetacard.DELETED_TAG)));
     }
 
     static class QuerySources {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -656,7 +656,7 @@ public class QueryOperations extends DescribableImpl {
         return ids;
     }
 
-    private Filter getNonVersionTagsFilter() {
+    protected Filter getNonVersionTagsFilter() {
         return frameworkProperties.getFilterBuilder()
                 .not(frameworkProperties.getFilterBuilder()
                         .anyOf(frameworkProperties.getFilterBuilder()


### PR DESCRIPTION
#### What does this PR do?
`QueryOperations.getNonVersionTagsFilter` did not include the "deleted" metacard-tag used by versioning metacards for deletions. This resulted in consecutive delete requests on a resource removing the versioning metacard. Adding the "deleted" metacard-tag to the filter should prevent those metacards from being included in the DeleteOperation's query request and getting deleted.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@rzwiefel 
@AzGoalie 
@mweser 
@codymacdonald 
@jhunzik 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/data

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
Full build


#### What are the relevant tickets?
[DDF-3119](https://codice.atlassian.net/browse/DDF-3119)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
