### PR TITLE
DDF-2132 Fixed tech debt in featuresBoot in org.apache.karaf.feature.cfg

### DIFF
--- a/distribution/ddf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/ddf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -57,9 +57,6 @@ featuresRepositories= \
 # to work for the current feature files included in DDF and in the itests. This configuration change
 # to the DDF featuresBoot was made in the Karaf upgrade to 4.1.1.
 #
-# NOTE: Ending the featuresBoot list with a ')' results in a parsing error in Karaf's
-# BootFeaturesInstaller. This is why the current list of featuresBoot ends with a comma.
-#
 # TODO DDF-3072 Investigate improvements of this configuration.
 featuresBoot= \
  (kernel), \
@@ -67,7 +64,7 @@ featuresBoot= \
  (platform-app), \
  (security-services-app), \
  (admin-app, \
- admin-modules-installer),
+ admin-modules-installer)
 
 #
 # Defines if the boot features are started in asynchronous mode (in a dedicated thread)


### PR DESCRIPTION
#### What does this PR do?
This PR removed the extra comma that was added to the end of the `featuresBoot` list in the `org.apache.karaf.feature.cfg` file because it is no longer needed.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mcalcote @vinamartin @alexaabrd @josephthweatt 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
- itests
- `/bin/ddf` script
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2132](https://codice.atlassian.net/browse/DDF-2132)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
