### PR TITLE
DDF-2132 Updated logging configuration in itests to work with log4j2

### DIFF
--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -8,14 +8,14 @@ mvn clean verify -DisDebugEnabled=true
 ```
 
 ## SSH Into a Running Instance
-It is possible to SSH into a running test instance.  This will allow you to use the shell to inspect the runtime state while the test probe is installed and running.
+It is possible to SSH into a running test instance. This will allow you to use the shell to inspect the runtime state while the test probe is installed and running. The SSH port is dynamic and can be found in `target/exam/<GUID>/etc/org.apache.karaf.shell.cfg`.
 
 ```
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 9101 admin@localhost
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 20003 admin@localhost
 ```
 
 ## Debug a Single Test
-The Pax Exam tests support Maven Surefire Plugin properties.  One useful property is the `test` property to select a single test class or method to execute.
+The Pax Exam tests support Maven Surefire Plugin properties. One useful property is the `it.test` property to select a single test class or method to execute.
 
 ```
 mvn clean verify -Dit.test=TestFederation
@@ -31,10 +31,11 @@ Use the `keepRuntimeFolder` property to keep the test container for test failure
 mvn clean verify -DkeepRuntimeFolder=true
 ```
 
-The runtime folder used during the test will be available under `target/exam/<GUID>`.  It is possible to rerun the instance and verify that all bundles (excluding the test probe) are installed and working properly.  You can also inspect the logs under `target/exam/<GUID>/data/logs`.
+The runtime folder used during the test will be available under `target/exam/<GUID>`. It is possible to rerun the instance and verify that all bundles (excluding the test probe) are installed and working properly. You can also inspect the logs under `target/exam/<GUID>/data/logs`.
 
 ## Adjusting the Log Level
-By default, itests are run at a log level of `warn` for increased performance. If you want to change the logging level, use the flag `-DitestLogLevel=<level>`. Valid levels are defined by the [SLF4J API](http://www.slf4j.org/api/org/apache/commons/logging/Log.html).
+By default, itests are run at a log level of `WARN` for increased performance.
+If you want to change the logging level, use the flags `-DitestLogLevel=<level>` or `-DsecurityLogLevel=<level>`. Valid levels are defined by the [SLF4J API](http://www.slf4j.org/api/org/apache/commons/logging/Log.html).
 
 ## Run unstable tests
 By default, all tests that include a call to `unstableTest` will not be run. To include them as part of a build, add the `-DincludeUnstableTests=true` property to the Maven command.

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AdminConfig.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AdminConfig.java
@@ -15,11 +15,9 @@ package org.codice.ddf.itests.common;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Dictionary;
 
 import javax.management.NotCompliantMBeanException;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.subject.Subject;
 import org.codice.ddf.admin.core.impl.AdminConsoleService;
 import org.codice.ddf.admin.core.impl.ConfigurationAdminImpl;
@@ -28,17 +26,6 @@ import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 public class AdminConfig {
-    public static final String LOG_CONFIG_PID = "org.ops4j.pax.logging";
-
-    public static final String LOGGER_PREFIX = "log4j.logger.";
-
-    public static final String DEFAULT_LOG_LEVEL = "WARN";
-
-    public static final String TEST_LOGLEVEL_PROPERTY = "itestLogLevel";
-
-    public static final String TEST_SECURITYLOGLEVEL_PROPERTY = "securityLogLevel";
-
-    public static final int CONFIG_WAIT_POLLING_INTERVAL = 50;
 
     private final ConfigurationAdmin configAdmin;
 
@@ -84,26 +71,5 @@ public class AdminConfig {
 
     public Configuration[] listConfigurations(String s) throws IOException, InvalidSyntaxException {
         return configAdmin.listConfigurations(s);
-    }
-
-    public void setLogLevels() throws IOException {
-        String logLevel = System.getProperty(TEST_LOGLEVEL_PROPERTY);
-        String securityLogLevel = System.getProperty(TEST_SECURITYLOGLEVEL_PROPERTY);
-
-        Configuration logConfig = configAdmin.getConfiguration(LOG_CONFIG_PID, null);
-        Dictionary<String, Object> properties = logConfig.getProperties();
-
-        properties.put(LOGGER_PREFIX + "*", DEFAULT_LOG_LEVEL);
-
-        if (!StringUtils.isEmpty(logLevel)) {
-            properties.put(LOGGER_PREFIX + "ddf", logLevel);
-            properties.put(LOGGER_PREFIX + "org.codice", logLevel);
-            if (StringUtils.isEmpty(securityLogLevel)) {
-                properties.put(LOGGER_PREFIX + "ddf.security.expansion.impl.RegexExpansion", logLevel);
-                properties.put(LOGGER_PREFIX + "ddf.security.service.impl.AbstractAuthorizingRealm", logLevel);
-            }
-        }
-
-        logConfig.update(properties);
     }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestEmbeddedSolr.java
@@ -66,7 +66,6 @@ public class TestEmbeddedSolr extends AbstractIntegrationTest {
     public void beforeExam() throws Exception {
         try {
             basePort = getBasePort();
-            getAdminConfig().setLogLevels();
             getServiceManager().waitForRequiredApps(getDefaultRequiredApps());
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -58,7 +58,6 @@ public class TestSolrCommands extends AbstractIntegrationTest {
         try {
             waitForSystemReady();
             basePort = getBasePort();
-            getAdminConfig().setLogLevels();
             getServiceManager().waitForRequiredApps(getDefaultRequiredApps());
             getServiceManager().waitForAllBundles();
             getCatalogBundle().waitForCatalogProvider();


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a regression from the Karaf upgrade to 4.1.1 that caused the `itestLogLevel` itest property to no longer work.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@mackncheesiest @Lambeaux @alexaabrd @josephthweatt @idperez 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@clockard
#### How should this be tested? (List steps with links to updated documentation)

- Confirm that the `itestLogLevel` and `securityLogLevel` itest properties work as expected. See `distribution/test/itest/README.md`.
- Test itests on downstream projects.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2132](https://codice.atlassian.net/browse/DDF-2132)
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
