### PR TITLE
DDF-3122 Let MetacardValidityMarkerPlugin save validation errors and …

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
@@ -89,17 +89,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
@@ -169,15 +169,20 @@ public class MetacardValidityMarkerPluginTest {
             throws StopProcessingException, PluginExecutionException {
         metacardValidators.add(getMockPassingValidator());
         CreateRequest request = getMockCreateRequest();
-        Metacard m1 = request.getMetacards().get(0);
+        Metacard m1 = request.getMetacards()
+                .get(0);
 
         Set<String> tags = m1.getTags();
         tags.add(INVALID_TAG);
         m1.setAttribute(new AttributeImpl(Metacard.TAGS, new ArrayList<String>(tags)));
 
         CreateRequest filteredRequest = plugin.process(request);
-        assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(VALID_TAG));
-        assertThat(filteredRequest.getMetacards().get(0).getTags(), not(hasItem(INVALID_TAG)));
+        assertThat(filteredRequest.getMetacards()
+                .get(0)
+                .getTags(), hasItem(VALID_TAG));
+        assertThat(filteredRequest.getMetacards()
+                .get(0)
+                .getTags(), not(hasItem(INVALID_TAG)));
     }
 
     @Test
@@ -185,15 +190,20 @@ public class MetacardValidityMarkerPluginTest {
             throws StopProcessingException, PluginExecutionException, ValidationException {
         metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings());
         CreateRequest request = getMockCreateRequest();
-        Metacard m1 = request.getMetacards().get(0);
+        Metacard m1 = request.getMetacards()
+                .get(0);
 
         Set<String> tags = m1.getTags();
         tags.add(VALID_TAG);
         m1.setAttribute(new AttributeImpl(Metacard.TAGS, new ArrayList<String>(tags)));
 
         CreateRequest filteredRequest = plugin.process(request);
-        assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(INVALID_TAG));
-        assertThat(filteredRequest.getMetacards().get(0).getTags(), not(hasItem(VALID_TAG)));
+        assertThat(filteredRequest.getMetacards()
+                .get(0)
+                .getTags(), hasItem(INVALID_TAG));
+        assertThat(filteredRequest.getMetacards()
+                .get(0)
+                .getTags(), not(hasItem(VALID_TAG)));
     }
 
     @Test
@@ -225,6 +235,46 @@ public class MetacardValidityMarkerPluginTest {
         metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings());
         verifyCreate(getMockCreateRequest(), expectError, expectWarning, INVALID_TAG);
         verifyUpdate(getMockUpdateRequest(), expectError, expectWarning, INVALID_TAG);
+    }
+
+    @Test
+    public void testPreExistingMetacardErrors()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        metacardValidators.add(getMockPassingValidator());
+
+        CreateRequestImpl request = new CreateRequestImpl(metacardsWithPreExistingAttributes(true,
+                false), PROPERTIES, DESTINATIONS);
+        verifyCreate(request, expectError, expectNone, INVALID_TAG);
+    }
+
+    @Test
+    public void testPreExistingMetacardWarnings()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        metacardValidators.add(getMockPassingValidator());
+
+        CreateRequestImpl request = new CreateRequestImpl(metacardsWithPreExistingAttributes(false,
+                true), PROPERTIES, DESTINATIONS);
+        verifyCreate(request, expectNone, expectWarning, INVALID_TAG);
+    }
+
+    @Test
+    public void testPreExistingMetacardErrorsAndWarnings()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        metacardValidators.add(getMockPassingValidator());
+
+        CreateRequestImpl request = new CreateRequestImpl(metacardsWithPreExistingAttributes(true,
+                true), PROPERTIES, DESTINATIONS);
+        verifyCreate(request, expectError, expectWarning, INVALID_TAG);
+    }
+
+    @Test
+    public void testPreExistingMetacardErrorsAndWarningsNoDuplicates()
+            throws ValidationException, StopProcessingException, PluginExecutionException {
+        metacardValidators.add(getMockFailingValidatorWithErrorsAndWarnings());
+
+        CreateRequestImpl request = new CreateRequestImpl(metacardsWithPreExistingAttributes(true,
+                true), PROPERTIES, DESTINATIONS);
+        verifyCreate(request, expectError, expectWarning, INVALID_TAG);
     }
 
     @Test
@@ -400,6 +450,26 @@ public class MetacardValidityMarkerPluginTest {
         MetacardImpl metacard = new MetacardImpl();
         metacard.setTitle(title);
         return metacard;
+    }
+
+    private List<Metacard> metacardsWithPreExistingAttributes(boolean error, boolean warning) {
+        Metacard metacard1 = metacardWithTitle(FIRST);
+        Metacard metacard2 = metacardWithTitle(SECOND);
+        AttributeImpl attribute;
+
+        if (error) {
+            attribute = new AttributeImpl(Validation.VALIDATION_ERRORS, SAMPLE_ERROR);
+            metacard1.setAttribute(attribute);
+            metacard2.setAttribute(attribute);
+        }
+
+        if (warning) {
+            attribute = new AttributeImpl(Validation.VALIDATION_WARNINGS, SAMPLE_WARNING);
+            metacard1.setAttribute(attribute);
+            metacard2.setAttribute(attribute);
+        }
+
+        return Lists.newArrayList(metacard1, metacard2);
     }
 
     private CreateRequest getMockCreateRequest() {


### PR DESCRIPTION
…warnings stored prior to calling validate method

#### What does this PR do?
The validate method in MetacardValidityMarkerPlugin currently adds validation errors and validation warnings to metacard attributes using a new ArrayList. This causes pre-existing attributes of the same name to be overwritten. The validate method should instead add to the existing attributes to prevent errors and warnings from getting lost.

#### Who is reviewing it?
@emmberk 
@clockard 
@emanns95 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@lessarderic 
#### How should this be tested? (List steps with links to updated documentation)
1. Build DDF
2. Build a downstream project that will create a validation error or warning before the metacard is validated.
3. Verify that metacards with invalid information or structuring will hold their respective validation issues.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3122](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
