### PR TITLE
DDF-3117 Fixed the logviewer log levels from all appearing as UNKNOWN

### DIFF
--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -261,6 +261,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-logging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LogEvent.java
+++ b/platform/platform-logging/src/main/java/org/codice/ddf/platform/logging/LogEvent.java
@@ -13,15 +13,20 @@
  */
 package org.codice.ddf.platform.logging;
 
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_DEBUG;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_ERROR;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_INFO;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_TRACE;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_WARNING;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.log4j.Priority;
 import org.ops4j.pax.logging.spi.PaxLoggingEvent;
 
 /**
  * Describes a log event in the system
  */
-class LogEvent {
+public class LogEvent {
 
     private static final String BUNDLE_NAME_KEY = "bundle.name";
 
@@ -126,22 +131,22 @@ class LogEvent {
 
     private Level getLevel(int level) {
         switch (level) {
-        case Priority.ERROR_INT:
+        case LEVEL_ERROR:
             return Level.ERROR;
-        case Priority.WARN_INT:
+        case LEVEL_WARNING:
             return Level.WARN;
-        case Priority.INFO_INT:
+        case LEVEL_INFO:
             return Level.INFO;
-        case Priority.DEBUG_INT:
+        case LEVEL_DEBUG:
             return Level.DEBUG;
-        case org.apache.log4j.Level.TRACE_INT:
+        case LEVEL_TRACE:
             return Level.TRACE;
         default:
             return Level.UNKNOWN;
         }
     }
 
-    enum Level {
+    public enum Level {
         TRACE("TRACE"), 
         DEBUG("DEBUG"), 
         INFO("INFO"), 
@@ -155,7 +160,7 @@ class LogEvent {
             level = l;
         }
 
-        String getLevel() {
+        public String getLevel() {
             return level;
         }
     }

--- a/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LogEventTest.java
+++ b/platform/platform-logging/src/test/java/org/codice/ddf/platform/logging/LogEventTest.java
@@ -18,10 +18,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_DEBUG;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_ERROR;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_INFO;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_TRACE;
+import static org.ops4j.pax.logging.PaxLogger.LEVEL_WARNING;
 
 import java.util.Properties;
 
-import org.apache.log4j.Priority;
 import org.codice.ddf.platform.logging.LogEvent.Level;
 import org.junit.Test;
 import org.ops4j.pax.logging.spi.PaxLevel;
@@ -128,16 +132,16 @@ public class LogEventTest {
             @Override
             public int toInt() {
                 switch (level) {
-                case "ERROR":
-                    return Priority.ERROR_INT;
-                case "WARN":
-                    return Priority.WARN_INT;
-                case "INFO":
-                    return Priority.INFO_INT;
-                case "DEBUG":
-                    return Priority.DEBUG_INT;
-                case "TRACE":
-                    return org.apache.log4j.Level.TRACE_INT;
+                case ERROR_LEVEL:
+                    return LEVEL_ERROR;
+                case WARN_LEVEL:
+                    return LEVEL_WARNING;
+                case INFO_LEVEL:
+                    return LEVEL_INFO;
+                case DEBUG_LEVEL:
+                    return LEVEL_DEBUG;
+                case TRACE_LEVEL:
+                    return LEVEL_TRACE;
                 default:
                     return -1;
                 }


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the regression introduced by DDF-2132 that caused log entries levels to all appear as `UNKNOWN` in the logviewer.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@vinamartin @mcalcote @alexaabrd @josephthweatt @garrettfreibott 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard
@figliold
#### How should this be tested? (List steps with links to updated documentation)
Confirm that log levels show up correctly at the `/admin/logviewer/index.html` endpoint and under `System` >> `Logs` in the Admin Console.
#### Any background context you want to provide?
`pax-logging` was upgraded to 1.9.1 in Karaf 4.1.1
#### What are the relevant tickets?
[DDF-3117](https://codice.atlassian.net/browse/DDF-3117)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
