### PR TITLE
DDF-3028 - updated CertificateCommand and CertNew script to support s…

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
@@ -1,5 +1,5 @@
 REM Usage:
-REM   CertNew.sh [-cn <cn>|-dn <dn>] [-san <tag:name,tag:name,...>]
+REM   CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]
 REM
 REM where:
 REM <cn> represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
@@ -18,8 +18,6 @@ REM Create new certificate and certificate chain signed by Demo Certificate Auth
 REM The new certificate chain and private key are installed in the keystore.
 REM The alias will be the same as the common name.
 REM The localhost key will be deleted from the keystore.
-REM If no arguments specified on the command line, `hostname -f` is used as the
-REM the common-name for the certificate.
 REM Adds the specified subject alternative names if any.
 REM
 REM NOTE: Execute from the <DDF_HOME>/etc/certs directory.

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
@@ -1,5 +1,6 @@
+@echo off
 REM Usage:
-REM   CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]
+REM   CertNew.sh (-cn <cn>|-dn <dn>) [-san "<tag:name,tag:name,...>"]
 REM
 REM where:
 REM <cn> represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
@@ -22,8 +23,6 @@ REM Adds the specified subject alternative names if any.
 REM
 REM NOTE: Execute from the <DDF_HOME>/etc/certs directory.
 REM NOTE: Defaults to Java Keystore file type.
-
-@echo off
 
 REM This next line captures the output of the dir command and stores it in a variable
 for /f "delims=" %%a in ('dir /S /B ..\..\security-certificate-generator*.jar') do @set JARFILE=%%a

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
@@ -1,12 +1,26 @@
-REM Usage: CertNew -cn some.computer.com
-REM    or  CertNew -dn "cn=some.computer.com,o=some company,ou=some department"
-REM The first usage creates a certificate with a subject/common name of some.computer.com.
-REM The second usage creates a certificate with the FQDN provided and extracts the common name
+REM Usage:
+REM   CertNew.sh [-cn <cn>|-dn <dn>] [-san <tag:name,tag:name,...>]
+REM
+REM where:
+REM <cn> represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+REM <dn> represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+REM <tag:name,tag:name,...> represents optional subject alternative names to be added to the generated certificate
+REM    (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names
+REM    is similar to the OpenSSL X509 configuration format. Supported tags are:
+REM      email - email subject
+REM      URI - uniformed resource identifier
+REM      RID - registered id
+REM      DNS - hostname
+REM      IP - ip address (V4 or V6)
+REM      dirName - directory name
 REM
 REM Create new certificate and certificate chain signed by Demo Certificate Authority.
 REM The new certificate chain and private key are installed in the keystore.
 REM The alias will be the same as the common name.
 REM The localhost key will be deleted from the keystore.
+REM If no arguments specified on the command line, `hostname -f` is used as the
+REM the common-name for the certificate.
+REM Adds the specified subject alternative names if any.
 REM
 REM NOTE: Execute from the <DDF_HOME>/etc/certs directory.
 REM NOTE: Defaults to Java Keystore file type.

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
@@ -37,13 +37,14 @@ fi
 if [[ $1 && $2 ]]; then
     PARAM1="$1"
     PARAM2="$2"
+    shift
+    shift
 else
     PARAM1="-cn"
     PARAM2="$(hostname -f)"
 fi
-
 echo "--IGNORE SLF4J ERRORS"--
-$(java -Djavax.net.ssl.keyStore="$KEYFILE" -Djavax.net.ssl.keyStorePassword="$PASSWORD" -Djavax.net.ssl.keyStoreType="$KEYTYPE" -jar "$JARFILE" "$PARAM1" "$PARAM2")
+$(java -Djavax.net.ssl.keyStore="$KEYFILE" -Djavax.net.ssl.keyStorePassword="$PASSWORD" -Djavax.net.ssl.keyStoreType="$KEYTYPE" -jar "$JARFILE" "$PARAM1" "$PARAM2" "$@")
 
 
 if [[ $? == 0 ]]; then

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.sh
@@ -1,16 +1,31 @@
 #! /bin/bash 
 #
 # Usage:
-#   CertNew.sh
-#   CertNew.sh -cn <common-name>
-#   CertNew.sh -dn <distinguished name>
+#   CertNew.sh [-cn <cn>|-dn <dn>] [-san <tag:name,tag:name,...>]
+#
+# where:
+# <cn> represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+# <dn> represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+# <tag:name,tag:name,...> represents optional subject alternative names to be added to the generated certificate
+#    (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names
+#    is similar to the OpenSSL X509 configuration format. Supported tags are:
+#      email - email subject
+#      URI - uniformed resource identifier
+#      RID - registered id
+#      DNS - hostname
+#      IP - ip address (V4 or V6)
+#      dirName - directory name
 #
 # Create new certificate and certificate chain signed by Demo Certificate Authority.  
 # The new certificate chain and private key are installed in the keystore.
 # The alias will be the same as the common name.
 # The localhost key will be deleted from the keystore.
 # If no arguments specified on the command line, `hostname -f` is used as the
-# the  the common-name for the certificate.
+# the common-name for the certificate.
+# Adds the specified subject alternative names if any.
+#
+# NOTE: Execute from the <DDF_HOME>/etc/certs directory.
+# NOTE: Defaults to Java Keystore file type.
 
 #Assume script is in <DDF>/etc/certs/ directory
 cd `dirname $0`

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -83,7 +83,7 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
+`sh CertNew.sh [-cn <cn>|-dn <dn>] [-san <tag:name,tag:name,...>]`
 
 where:
 
@@ -97,6 +97,7 @@ where:
 ** `IP` - ip address (V4 or V6)
 ** `dirName` - directory name
 
+If no arguments specified on the command line, `hostname -f` is used as the common-name for the certificate.
 ****
 
 .Windows Demo CA Script

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -83,28 +83,47 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh <FQDN>`
+`sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
+
+where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+
+* `email`
+* `URI` - uniformed resource identifier
+* `RID` - registered id
+* `DNS`
+* `IP` - ip address (V4 or V6)
+* `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
+`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 .Windows Demo CA Script
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew -cn <FQDN>`
+`CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
+
+where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+
+* `email`
+* `URI` - uniformed resource identifier
+* `RID` - registered id
+* `DNS`
+* `IP` - ip address (V4 or V6)
+* `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
+`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <subject tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:
 
 * Create a new entry in the server keystore.
 * Use the hostname as the fully qualified domain name (FQDN) when creating the certificate.
+* Adds the specified subject alternative names if any
 * Use the Demo Certificate Authority to sign the certificate so that it will be trusted by the default configuration.
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -83,40 +83,40 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
+`sh CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
 
-where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where:
 
-* `email` - email subject
-* `URI` - uniformed resource identifier
-* `RID` - registered id
-* `DNS` - hostname
-* `IP` - ip address (V4 or V6)
-* `dirName` - directory name
+* `<cn>` represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+* `<dn>` represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+* `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+** `email` - email subject
+** `URI` - uniformed resource identifier
+** `RID` - registered id
+** `DNS` - hostname
+** `IP` - ip address (V4 or V6)
+** `dirName` - directory name
 
-Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
-
-`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 .Windows Demo CA Script
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
+`CertNew (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
 
-where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where:
 
-* `email` - email subject
-* `URI` - uniformed resource identifier
-* `RID` - registered id
-* `DNS` - hostname
-* `IP` - ip address (V4 or V6)
-* `dirName` - directory name
+* `<cn>` represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+* `<dn>` represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+* `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+** `email` - email subject
+** `URI` - uniformed resource identifier
+** `RID` - registered id
+** `DNS` - hostname
+** `IP` - ip address (V4 or V6)
+** `dirName` - directory name
 
-Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
-
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -123,7 +123,7 @@ The `CertNew` scripts:
 
 * Create a new entry in the server keystore.
 * Use the hostname as the fully qualified domain name (FQDN) when creating the certificate.
-* Adds the specified subject alternative names if any
+* Adds the specified subject alternative names if any.
 * Use the Demo Certificate Authority to sign the certificate so that it will be trusted by the default configuration.
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -85,12 +85,12 @@ For *NIX, use the `CertNew.sh` script.
 
 `sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
 
-where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
 
-* `email`
+* `email` - email subject
 * `URI` - uniformed resource identifier
 * `RID` - registered id
-* `DNS`
+* `DNS` - hostname
 * `IP` - ip address (V4 or V6)
 * `dirName` - directory name
 
@@ -105,18 +105,18 @@ For Windows, use the `CertNew.cmd` script.
 
 `CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
 
-where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
 
-* `email`
+* `email` - email subject
 * `URI` - uniformed resource identifier
 * `RID` - registered id
-* `DNS`
+* `DNS` - hostname
 * `IP` - ip address (V4 or V6)
 * `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <subject tag:name,tag:name,...>]`
+`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -104,7 +104,7 @@ If no arguments specified on the command line, `hostname -f` is used as the comm
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
+`CertNew (-cn <cn>|-dn <dn>) [-san "<tag:name,tag:name,...>"]`
 
 where:
 

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -80,12 +80,12 @@ For *NIX, use the `CertNew.sh` script.
 
 `sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
 
-where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
 
-* `email`
+* `email` - email subject
 * `URI` - uniformed resource identifier
 * `RID` - registered id
-* `DNS`
+* `DNS` - hostname
 * `IP` - ip address (V4 or V6)
 * `dirName` - directory name
 
@@ -100,18 +100,18 @@ For Windows, use the `CertNew.cmd` script.
 
 `CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
 
-where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
 
-* `email`
+* `email` - email subject
 * `URI` - uniformed resource identifier
 * `RID` - registered id
-* `DNS`
+* `DNS` - hostname
 * `IP` - ip address (V4 or V6)
 * `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <subject tag:name,tag:name,...>]`
+`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -78,40 +78,40 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
+`sh CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
 
-where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where:
 
-* `email` - email subject
-* `URI` - uniformed resource identifier
-* `RID` - registered id
-* `DNS` - hostname
-* `IP` - ip address (V4 or V6)
-* `dirName` - directory name
+* `<cn>` represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+* `<dn>` represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+* `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+** `email` - email subject
+** `URI` - uniformed resource identifier
+** `RID` - registered id
+** `DNS` - hostname
+** `IP` - ip address (V4 or V6)
+** `dirName` - directory name
 
-Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
-
-`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 .Windows Demo CA Script
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
+`CertNew (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
 
-where `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+where:
 
-* `email` - email subject
-* `URI` - uniformed resource identifier
-* `RID` - registered id
-* `DNS` - hostname
-* `IP` - ip address (V4 or V6)
-* `dirName` - directory name
+* `<cn>` represents a fully qualified common name (e.g. "<FQDN>", where <FQDN> could be something like cluster.yoyo.com)
+* `<dn>` represents a distinguished name as a comma-delimited string (e.g. "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>")
+* `<tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate (e.g. "DNS:<FQDN>,DNS:node1.<FQDN>,DNS:node2.<FQDN>"). The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+** `email` - email subject
+** `URI` - uniformed resource identifier
+** `RID` - registered id
+** `DNS` - hostname
+** `IP` - ip address (V4 or V6)
+** `dirName` - directory name
 
-Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
-
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -99,7 +99,7 @@ If no arguments specified on the command line, `hostname -f` is used as the comm
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
+`CertNew (-cn <cn>|-dn <dn>) [-san "<tag:name,tag:name,...>"]`
 
 where:
 

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -118,7 +118,7 @@ The `CertNew` scripts:
 
 * Create a new entry in the server keystore.
 * Use the hostname as the fully qualified domain name (FQDN) when creating the certificate.
-* Adds the specified subject alternative names if any
+* Adds the specified subject alternative names if any.
 * Use the Demo Certificate Authority to sign the certificate so that it will be trusted by the default configuration.
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -78,28 +78,47 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh <FQDN>`
+`sh CertNew.sh <FQDN> [-san <tag:name,tag:name,...>]`
+
+where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+
+* `email`
+* `URI` - uniformed resource identifier
+* `RID` - registered id
+* `DNS`
+* `IP` - ip address (V4 or V6)
+* `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
+`sh CertNew.sh -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <tag:name,tag:name,...>]`
 ****
 
 .Windows Demo CA Script
 ****
 For Windows, use the `CertNew.cmd` script.
 
-`CertNew -cn <FQDN>`
+`CertNew -cn <FQDN> [-san <tag:name,tag:name,...>]`
+
+where `<subject tag:name,tag:name,...>` represents optional subject alternative names to be added to the generated certificate. The format for subject alternative names is similar to the OpenSSL X509 configuration format. Supported tags are:
+
+* `email`
+* `URI` - uniformed resource identifier
+* `RID` - registered id
+* `DNS`
+* `IP` - ip address (V4 or V6)
+* `dirName` - directory name
 
 Alternatively, a distinguished name can be provided to the script with a comma-delimited string.
 
-`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>"`
+`CertNew -dn "c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>" [-san <subject tag:name,tag:name,...>]`
 ****
 
 The `CertNew` scripts:
 
 * Create a new entry in the server keystore.
 * Use the hostname as the fully qualified domain name (FQDN) when creating the certificate.
+* Adds the specified subject alternative names if any
 * Use the Demo Certificate Authority to sign the certificate so that it will be trusted by the default configuration.
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -78,7 +78,7 @@ To use the scripts, run them out of the `<INSTALL_HOME>/etc/certs` directory.
 
 For *NIX, use the `CertNew.sh` script.
 
-`sh CertNew.sh (-cn <cn>|-dn <dn>) [-san <tag:name,tag:name,...>]`
+`sh CertNew.sh [-cn <cn>|-dn <dn>] [-san <tag:name,tag:name,...>]`
 
 where:
 
@@ -92,6 +92,7 @@ where:
 ** `IP` - ip address (V4 or V6)
 ** `dirName` - directory name
 
+If no arguments specified on the command line, `hostname -f` is used as the common-name for the certificate.
 ****
 
 .Windows Demo CA Script

--- a/platform/security/certificate/security-certificate-generator/pom.xml
+++ b/platform/security/certificate/security-certificate-generator/pom.xml
@@ -73,6 +73,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateAuthority.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateAuthority.java
@@ -20,6 +20,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import org.apache.commons.lang.Validate;
+import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -58,13 +59,17 @@ public class CertificateAuthority {
     }
 
     public KeyStore.PrivateKeyEntry sign(CertificateSigningRequest csr) {
-        //Converters, holders, and builders! Oh my!
-        JcaX509v3CertificateBuilder builder = csr.newCertificateBuilder(getCertificate());
-        X509CertificateHolder holder = builder.build(getContentSigner());
-        JcaX509CertificateConverter converter = newCertConverter();
         X509Certificate signedCert;
+
         try {
+            //Converters, holders, and builders! Oh my!
+            JcaX509v3CertificateBuilder builder = csr.newCertificateBuilder(getCertificate());
+            X509CertificateHolder holder = builder.build(getContentSigner());
+            JcaX509CertificateConverter converter = newCertConverter();
+
             signedCert = converter.getCertificate(holder);
+        } catch (CertIOException e) {
+            throw new CertificateGeneratorException("Could not create signed certificate.", e);
         } catch (CertificateException e) {
             throw new CertificateGeneratorException("Could not create signed certificate.",
                     e.getCause());

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -73,7 +73,7 @@ public class CertificateCommand {
         }
         if (args.length != expected) {
             throw new IllegalArgumentException(String.format(
-                    "java %s (-cn <cn>|-d <dn>) [-san <tag:name,tag:name,...>]%n%n" //
+                    "java %s (-cn <cn>|-d <dn>) [-san \"<tag:name,tag:name,...>\"]%n%n" //
                             + "where:%n"
                             + "  <cn> represents a fully qualified common name (e.g. \"<FQDN>\", where <FQDN> could be something like cluster.yoyo.com)%n"
                             + "  <dn> represents a distinguished name as a comma-delimited string (e.g. \"c=US, st=California, o=Yoyodyne, l=San Narciso, cn=<FQDN>\")%n"

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -72,7 +72,7 @@ public class CertificateCommand {
             }
         }
         if (args.length != expected) {
-            throw new RuntimeException(String.format(
+            throw new IllegalArgumentException(String.format(
                     "java %s (-cn <cn>|-d <dn>) [-san <tag:name,tag:name,...>]%n%n" //
                             + "where:%n"
                             + "  <cn> represents a fully qualified common name (e.g. \"<FQDN>\", where <FQDN> could be something like cluster.yoyo.com)%n"

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -27,9 +27,6 @@ import org.bouncycastle.asn1.x500.style.BCStyle;
 import ddf.security.SecurityConstants;
 
 public class CertificateCommand {
-
-    private static final String SAN_EXAMPLE = "-san DNS:localhost,IP:127.0.0.1";
-
     /**
      * Pass in a string to use as the common name of the certificate to be generated.
      * Exception thrown if 0 arguments or more than 2 argument (or more than 4 when -san is used).

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -18,6 +18,8 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang.Validate;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -28,66 +30,102 @@ public class CertificateCommand {
 
     /**
      * Pass in a string to use as the common name of the certificate to be generated.
-     * Exception thrown if 0 arguments or more than 1 argument.
+     * Exception thrown if 0 arguments or more than 2 argument (or 4 when -san is used).
      *
      * @param args
      */
     public static void main(String args[]) {
-        if (args.length != 2) {
-            String canonicalName = CertificateCommand.class.getCanonicalName();
-            String exCn = String.format("java %s -cn \"John Smith\"", canonicalName);
+        // try to extract -san if provided
+        int expected = 2;
+        String[] sans = null;
+        int mainIndex = 0;
 
+        if (args.length == 4) {
+            if (args[0].trim()
+                    .equalsIgnoreCase("-san")) {
+                sans = Arrays.stream(args[1].split("[,]"))
+                        .map(String::trim)
+                        .toArray(String[]::new);
+                mainIndex = 2;
+                expected = 4;
+            } else if (args[2].trim()
+                    .equalsIgnoreCase("-san")) {
+                sans = Arrays.stream(args[3].split("[,]"))
+                        .map(String::trim)
+                        .toArray(String[]::new);
+                expected = 4;
+            }
+        }
+        if (args.length != expected) {
+            String canonicalName = CertificateCommand.class.getCanonicalName();
+            String exSan = "-san DNS:localhost,IP:127.0.0.1";
+            String exCn = String.format("java %s -cn \"John Smith\"", canonicalName);
             String exDn = String.format(
                     "java %s -dn \"cn=John Whorfin, o=Yoyodyne, l=San Narciso, st=California, c=US\"",
                     canonicalName);
             String usage = String.format(
-                    "%nUsage: java %s [-cn <common name>] | [-dn <distinguished name>]%n Examples: %n%s%n%s",
-                    canonicalName, exCn, exDn);
+                    "%nUsage: java %s [-san <subject alt names>] [-cn <common name>] | [-dn <distinguished name>]%n Examples: %n%s%n%s%n%s %s%n%s %s",
+                    canonicalName,
+                    exCn,
+                    exDn,
+                    exCn,
+                    exSan,
+                    exDn,
+                    exSan);
             throw new RuntimeException(usage);
         }
-
-        if (args[0].trim()
+        if (args[mainIndex].trim()
                 .equalsIgnoreCase("-cn")) {
-            configureDemoCert(args[1].trim());
+            configureDemoCert(args[mainIndex + 1].trim(), sans);
         } else {
-            String[] dn = Arrays.stream(args[1].split("[,]"))
+            String[] dn = Arrays.stream(args[mainIndex + 1].split("[,]"))
                     .map(String::trim)
                     .toArray(String[]::new);
-            configureDemoCertWithDN(dn);
+            configureDemoCertWithDN(dn, sans);
         }
     }
 
     /**
-     * Generates new signed certificate. The input parameter is used as the certificate's common name.
+     * Generates new signed certificate. The input parameter is used as the certificate's common name
+     * and optional subject alternative names.
      * <p>
      * Postcondition is the server keystore is updated to include a private entry. The private
      * entry has the new certificate chain that connects the server to the Demo CA. The matching
      * private key is also stored in the entry.
      *
-     * @param commonName string to use as the common name in the new certificate.
+     * @param commonName      string to use as the common name in the new certificate.
+     * @param subjectAltNames names in the form {@code tag:name} (format similar to OpenSSL X509 configuration)
      * @return the string used as the common name in the new certificate
      */
-    public static String configureDemoCert(String commonName) {
+    public static String configureDemoCert(String commonName, @Nullable String[] subjectAltNames) {
         CertificateSigningRequest csr = new CertificateSigningRequest();
         csr.setCommonName(commonName);
+        if (subjectAltNames != null) {
+            csr.addSubjectAlternativeNames(subjectAltNames);
+        }
         return configureCert(commonName, csr);
     }
 
     /**
      * Generates new signed certificate. The input parameter is the full set of attributes of the
-     * distinguished name for the cert. It must include a single {@code CN} value for the common name.
+     * distinguished name for the cert and optional subject alternative names. It must include a
+     * single {@code CN} value for the common name.
      * <p>
      * Postcondition is the server keystore is updated to include a private entry. The private
      * entry has the new certificate chain that connects the server to the Demo CA. The matching
      * private key is also stored in the entry.
      *
-     * @param dn String params in the form {@code attrKey=attrVal} composing a distinguished name.
-     *           e.g. {@code configureDemoCertWithDN("cn=John Whorfin", "o=Yoyodyne", "l=San Narciso", "st=California", "c=US")}
+     * @param dn              String params in the form {@code attrKey=attrVal} composing a distinguished name.
+     *                        e.g. {@code configureDemoCertWithDN(new String[] {"cn=John Whorfin", "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"), null}
+     * @param subjectAltNames names in the form {@code tag:name} (format similar to OpenSSL X509 configuration)
      * @return the string used as the common name in the new certificate
      */
-    public static String configureDemoCertWithDN(String... dn) {
+    public static String configureDemoCertWithDN(String[] dn, @Nullable String[] subjectAltNames) {
         CertificateSigningRequest csr = new CertificateSigningRequest();
         csr.setDistinguishedName(dn);
+        if (subjectAltNames != null) {
+            csr.addSubjectAlternativeNames(subjectAltNames);
+        }
         RDN[] rdns = csr.getSubjectName()
                 .getRDNs(BCStyle.CN);
 
@@ -106,7 +144,7 @@ public class CertificateCommand {
                         .toCharArray());
     }
 
-    private static String configureCert(String commonName, CertificateSigningRequest csr) {
+    static String configureCert(String commonName, CertificateSigningRequest csr) {
         CertificateAuthority demoCa = new DemoCertificateAuthority();
         KeyStore.PrivateKeyEntry pkEntry = demoCa.sign(csr);
         KeyStoreFile ksFile = getKeyStoreFile();

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -31,7 +31,7 @@ public class CertificateCommand {
      * Pass in a string to use as the common name of the certificate to be generated.
      * Exception thrown if 0 arguments or more than 2 argument (or more than 4 when -san is used).
      * <pre>
-     * Arguments to this program are: <code>[-cn &lt;cn&gt;|-dn &lt;dn&gt;] [-san &lt;tag:name,tag:name,...&gt;]</code>
+     * Arguments to this program are: <code>(-cn &lt;cn&gt;|-dn &lt;dn&gt;) [-san &lt;tag:name,tag:name,...&gt;]</code>
      *
      * where:
      * &lt;cn&gt; represents a fully qualified common name (e.g. "&lt;FQDN&gt;", where &lt;FQDN&gt; could be something like cluster.yoyo.com)
@@ -142,7 +142,7 @@ public class CertificateCommand {
      * private key is also stored in the entry.
      *
      * @param dn String params in the form {@code attrKey=attrVal} composing a distinguished name.
-     *           e.g. {@code configureDemoCertWithDN(new String[] {"cn=John Whorfin", "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"), null}
+     *           e.g. {@code configureDemoCertWithDN(new String[] {"cn=John Whorfin", "o=Yoyodyne", "l=San Narciso", "st=California", "c=US")}
      * @return the string used as the common name in the new certificate
      */
     public static String configureDemoCertWithDN(String[] dn) {

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateCommand.java
@@ -28,9 +28,11 @@ import ddf.security.SecurityConstants;
 
 public class CertificateCommand {
 
+    private static final String SAN_EXAMPLE = "-san DNS:localhost,IP:127.0.0.1";
+
     /**
      * Pass in a string to use as the common name of the certificate to be generated.
-     * Exception thrown if 0 arguments or more than 2 argument (or 4 when -san is used).
+     * Exception thrown if 0 arguments or more than 2 argument (or more than 4 when -san is used).
      *
      * @param args
      */
@@ -58,7 +60,6 @@ public class CertificateCommand {
         }
         if (args.length != expected) {
             String canonicalName = CertificateCommand.class.getCanonicalName();
-            String exSan = "-san DNS:localhost,IP:127.0.0.1";
             String exCn = String.format("java %s -cn \"John Smith\"", canonicalName);
             String exDn = String.format(
                     "java %s -dn \"cn=John Whorfin, o=Yoyodyne, l=San Narciso, st=California, c=US\"",
@@ -69,9 +70,9 @@ public class CertificateCommand {
                     exCn,
                     exDn,
                     exCn,
-                    exSan,
+                    CertificateCommand.SAN_EXAMPLE,
                     exDn,
-                    exSan);
+                    CertificateCommand.SAN_EXAMPLE);
             throw new RuntimeException(usage);
         }
         if (args[mainIndex].trim()
@@ -144,7 +145,7 @@ public class CertificateCommand {
                         .toCharArray());
     }
 
-    static String configureCert(String commonName, CertificateSigningRequest csr) {
+    private static String configureCert(String commonName, CertificateSigningRequest csr) {
         CertificateAuthority demoCa = new DemoCertificateAuthority();
         KeyStore.PrivateKeyEntry pkEntry = demoCa.sign(csr);
         KeyStoreFile ksFile = getKeyStoreFile();

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
@@ -54,7 +54,7 @@ public class CertificateGenerator implements CertificateGeneratorMBean {
      * @return the string used as the common name in the new certificate
      */
     public String configureDemoCert(String commonName) {
-        return CertificateCommand.configureDemoCert(commonName);
+        return CertificateCommand.configureDemoCert(commonName, null);
     }
 
     public KeyStoreFile getKeyStoreFile() {

--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/PkiTools.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/PkiTools.java
@@ -266,10 +266,10 @@ public abstract class PkiTools {
      * Create an X509 general name based on the specified string which supports a format similar to
      * OpenSSL X509 configuration as: {@code tag:name} where tag can be one of:
      * <ul>
-     * <li>email</li>
+     * <li>email - email subject</li>
      * <li>URI - uniformed resource identifier</li>
      * <li>RID - registered id</li>
-     * <li>DNS</li>
+     * <li>DNS - hostname</li>
      * <li>IP - ip address (V4 or V6)</li>
      * <li>dirName - directory name</li>
      * </ul>
@@ -282,8 +282,6 @@ public abstract class PkiTools {
      */
     public static GeneralName makeGeneralName(String name) {
         Validate.isTrue(name != null, "Certificate general name cannot be null");
-
-        assert name != null;
         final int i = name.indexOf(':');
 
         Validate.isTrue(i != -1, "General name components must be in the format tag:value");

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateAuthorityTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateAuthorityTest.java
@@ -22,8 +22,10 @@ import static org.mockito.Mockito.when;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
+import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -90,6 +92,34 @@ public class CertificateAuthorityTest {
         assertThat("Expected instance of a different class",
                 newObject,
                 instanceOf(KeyStore.PrivateKeyEntry.class));
+    }
+
+    @Test(expected = CertificateGeneratorException.class)
+    public void testSignWithCertificateException() throws Exception {
+        DemoCertificateAuthority demoCa = new DemoCertificateAuthority() {
+            JcaX509CertificateConverter newCertConverter() {
+                return mockConverter;
+            }
+        };
+
+        when(csr.newCertificateBuilder(any(X509Certificate.class))).thenReturn(mockBuilder);
+        when(mockBuilder.build(any(ContentSigner.class))).thenThrow(CertificateException.class);
+
+        demoCa.sign(csr);
+    }
+
+    @Test(expected = CertificateGeneratorException.class)
+    public void testSignWithCertIOException() throws Exception {
+        DemoCertificateAuthority demoCa = new DemoCertificateAuthority() {
+            JcaX509CertificateConverter newCertConverter() {
+                return mockConverter;
+            }
+        };
+
+        when(csr.newCertificateBuilder(any(X509Certificate.class))).thenReturn(mockBuilder);
+        when(mockBuilder.build(any(ContentSigner.class))).thenThrow(CertIOException.class);
+
+        demoCa.sign(csr);
     }
 
     @Test

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
@@ -71,8 +71,6 @@ public class CertificateCommandTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private File systemKeystoreFile = null;
-
     private static void validateCertificateHasNoSan(KeyStoreFile ksf, String alias)
             throws Exception {
         final KeyStore.Entry ke = ksf.getEntry(alias);
@@ -118,7 +116,7 @@ public class CertificateCommandTest {
 
     @Before
     public void setup() throws IOException {
-        this.systemKeystoreFile = temporaryFolder.newFile("serverKeystore.jks");
+        final File systemKeystoreFile = temporaryFolder.newFile("serverKeystore.jks");
         final FileOutputStream systemKeyOutStream = new FileOutputStream(systemKeystoreFile);
         final InputStream systemKeyStream = CertificateGenerator.class.getResourceAsStream(
                 "/serverKeystore.jks");

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.certificate.generator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNamesBuilder;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.security.SecurityConstants;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CertificateCommandTest {
+    private static final String[] SANs = new String[] {"IP:1.2.3.4", "DNS:A"};
+    private static final String SANs_ARG = "IP:1.2.3.4,DNS:A";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    File systemKeystoreFile = null;
+
+    private static void validateCertificateHasNoSAN(KeyStoreFile ksf, String alias)
+            throws Exception {
+        final KeyStore.Entry ke = ksf.getEntry(alias);
+
+        assertThat(ke, instanceOf(KeyStore.PrivateKeyEntry.class));
+        final KeyStore.PrivateKeyEntry pke = (KeyStore.PrivateKeyEntry) ke;
+        final Certificate c = pke.getCertificate();
+        final X509CertificateHolder holder = new X509CertificateHolder(c.getEncoded());
+
+        MatcherAssert.assertThat("There should be no subject alternative name extension",
+                holder.getExtension(org.bouncycastle.asn1.x509.Extension.subjectAlternativeName),
+                nullValue(org.bouncycastle.asn1.x509.Extension.class));
+    }
+
+    private static void validateCertificateHasSANs(KeyStoreFile ksf, String alias)
+            throws Exception {
+        final KeyStore.Entry ke = ksf.getEntry(alias);
+
+        assertThat(ke, instanceOf(KeyStore.PrivateKeyEntry.class));
+        final KeyStore.PrivateKeyEntry pke = (KeyStore.PrivateKeyEntry) ke;
+        final Certificate c = pke.getCertificate();
+        final X509CertificateHolder holder = new X509CertificateHolder(c.getEncoded());
+        final org.bouncycastle.asn1.x509.Extension csn =
+                holder.getExtension(org.bouncycastle.asn1.x509.Extension.subjectAlternativeName);
+
+        MatcherAssert.assertThat(csn.getParsedValue()
+                        .toASN1Primitive()
+                        .getEncoded(ASN1Encoding.DER),
+                equalTo(new GeneralNamesBuilder().addName(new GeneralName(GeneralName.iPAddress,
+                        "1.2.3.4"))
+                        .addName(new GeneralName(GeneralName.dNSName, "A"))
+                        .build()
+                        .getEncoded(ASN1Encoding.DER)));
+    }
+
+    private static void validateKeyStore(String alias, boolean hasSAN) throws Exception {
+        final KeyStoreFile ksf = CertificateCommand.getKeyStoreFile();
+
+        assertThat(ksf.aliases()
+                .size(), is(2));
+        if (hasSAN) {
+            validateCertificateHasSANs(ksf, alias);
+        } else {
+            validateCertificateHasNoSAN(ksf, alias);
+        }
+    }
+
+    @Before
+    public void setup() throws IOException {
+        this.systemKeystoreFile = temporaryFolder.newFile("serverKeystore.jks");
+        final FileOutputStream systemKeyOutStream = new FileOutputStream(systemKeystoreFile);
+        final InputStream systemKeyStream = CertificateGenerator.class.getResourceAsStream(
+                "/serverKeystore.jks");
+
+        IOUtils.copy(systemKeyStream, systemKeyOutStream);
+        IOUtils.closeQuietly(systemKeyOutStream);
+        IOUtils.closeQuietly(systemKeyStream);
+
+        System.setProperty(SecurityConstants.KEYSTORE_TYPE, "jks");
+        System.setProperty(SecurityConstants.KEYSTORE_PATH, systemKeystoreFile.getAbsolutePath());
+        System.setProperty(SecurityConstants.KEYSTORE_PASSWORD, "changeit");
+    }
+
+    @Test
+    public void testConfigureDemoCertWithoutSAN() throws Exception {
+        final KeyStoreFile ksf = CertificateCommand.getKeyStoreFile();
+
+        assertThat(ksf.aliases()
+                .size(), is(2));
+        assertThat(ksf.isKey("my-fqdn"), is(false));
+
+        assertThat(CertificateCommand.configureDemoCert("my-fqdn", null), equalTo("CN=my-fqdn"));
+
+        validateKeyStore("my-fqdn", false);
+    }
+
+    @Test
+    public void testConfigureDemoCertWithSANs() throws Exception {
+        final KeyStoreFile ksf = CertificateCommand.getKeyStoreFile();
+
+        assertThat(ksf.aliases()
+                .size(), is(2));
+        assertThat(ksf.isKey("my-fqdn"), is(false));
+
+        assertThat(CertificateCommand.configureDemoCert("my-fqdn", CertificateCommandTest.SANs),
+                equalTo("CN=my-fqdn"));
+
+        validateKeyStore("my-fqdn", true);
+    }
+
+    @Test
+    public void testConfigureDemoCertWithDNAndWithoutSAN() throws Exception {
+        final KeyStoreFile ksf = CertificateCommand.getKeyStoreFile();
+
+        assertThat(ksf.aliases()
+                .size(), is(2));
+        assertThat(ksf.isKey("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"),
+                is(false));
+
+        assertThat(CertificateCommand.configureDemoCertWithDN(new String[] {"cn=John Whorfin",
+                        "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"}, null),
+                equalTo("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"));
+
+        validateKeyStore("john whorfin", false);
+    }
+
+    @Test
+    public void testConfigureDemoCertWithDNAndSANs() throws Exception {
+        final KeyStoreFile ksf = CertificateCommand.getKeyStoreFile();
+
+        assertThat(ksf.aliases()
+                .size(), is(2));
+        assertThat(ksf.isKey("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"),
+                is(false));
+
+        assertThat(CertificateCommand.configureDemoCertWithDN(new String[] {"cn=John Whorfin",
+                        "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"},
+                CertificateCommandTest.SANs),
+                equalTo("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"));
+
+        validateKeyStore("john whorfin", true);
+    }
+
+    @Test
+    public void testMainWithCNAndWithoutSAN() throws Exception {
+        CertificateCommand.main(new String[] {"-cn", "my-fqdn"});
+
+        validateKeyStore("my-fqdn", false);
+    }
+
+    @Test
+    public void testMainWithCNAndSANs() throws Exception {
+        CertificateCommand.main(new String[] {"-cn", "my-fqdn", "-san", CertificateCommandTest.SANs_ARG});
+
+        validateKeyStore("my-fqdn", true);
+    }
+
+    @Test
+    public void testMainWithCNAndSANsReversedArguments() throws Exception {
+        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-cn", "my-fqdn"});
+
+        validateKeyStore("my-fqdn", true);
+    }
+
+    @Test
+    public void testMainWithDNAndWithoutSAN() throws Exception {
+        CertificateCommand.main(new String[] {"-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+
+        validateKeyStore("john whorfin", false);
+    }
+
+    @Test
+    public void testMainWithDNAndSANs() throws Exception {
+        CertificateCommand.main(new String[] {"-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US", "-san", CertificateCommandTest.SANs_ARG});
+
+        validateKeyStore("john whorfin", true);
+    }
+
+    @Test
+    public void testMainWithDNAndSANsReversedArguments() throws Exception {
+        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+
+        validateKeyStore("john whorfin", true);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testMainWithTooFewArguments() throws Exception {
+        CertificateCommand.main(new String[] { "something" });
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testMainWithTooFewArgumentsWithSAN() throws Exception {
+        CertificateCommand.main(new String[] { "-san", CertificateCommandTest.SANs_ARG, "something" });
+    }
+}

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
@@ -44,6 +44,7 @@ import ddf.security.SecurityConstants;
 @RunWith(MockitoJUnitRunner.class)
 public class CertificateCommandTest {
     private static final String[] SANs = new String[] {"IP:1.2.3.4", "DNS:A"};
+
     private static final String SANs_ARG = "IP:1.2.3.4,DNS:A";
 
     @Rule
@@ -183,46 +184,59 @@ public class CertificateCommandTest {
 
     @Test
     public void testMainWithCNAndSANs() throws Exception {
-        CertificateCommand.main(new String[] {"-cn", "my-fqdn", "-san", CertificateCommandTest.SANs_ARG});
+        CertificateCommand.main(new String[] {"-cn", "my-fqdn", "-san",
+                CertificateCommandTest.SANs_ARG});
 
         validateKeyStore("my-fqdn", true);
     }
 
     @Test
     public void testMainWithCNAndSANsReversedArguments() throws Exception {
-        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-cn", "my-fqdn"});
+        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-cn",
+                "my-fqdn"});
 
         validateKeyStore("my-fqdn", true);
     }
 
     @Test
     public void testMainWithDNAndWithoutSAN() throws Exception {
-        CertificateCommand.main(new String[] {"-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+        CertificateCommand.main(new String[] {"-dn",
+                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
 
         validateKeyStore("john whorfin", false);
     }
 
     @Test
     public void testMainWithDNAndSANs() throws Exception {
-        CertificateCommand.main(new String[] {"-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US", "-san", CertificateCommandTest.SANs_ARG});
+        CertificateCommand.main(new String[] {"-dn",
+                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US", "-san",
+                CertificateCommandTest.SANs_ARG});
 
         validateKeyStore("john whorfin", true);
     }
 
     @Test
     public void testMainWithDNAndSANsReversedArguments() throws Exception {
-        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-dn", "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG, "-dn",
+                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
 
         validateKeyStore("john whorfin", true);
     }
 
     @Test(expected = RuntimeException.class)
     public void testMainWithTooFewArguments() throws Exception {
-        CertificateCommand.main(new String[] { "something" });
+        CertificateCommand.main(new String[] {"something"});
     }
 
     @Test(expected = RuntimeException.class)
     public void testMainWithTooFewArgumentsWithSAN() throws Exception {
-        CertificateCommand.main(new String[] { "-san", CertificateCommandTest.SANs_ARG, "something" });
+        CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANs_ARG,
+                "something"});
     }
+
+    @Test(expected = RuntimeException.class)
+    public void testMainWithTooManyArguments() throws Exception {
+        CertificateCommand.main(new String[] {"something", "wicked", "is", "coming", "to", "town"});
+    }
+
 }

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
@@ -50,7 +50,7 @@ public class CertificateCommandTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    File systemKeystoreFile = null;
+    private File systemKeystoreFile = null;
 
     private static void validateCertificateHasNoSAN(KeyStoreFile ksf, String alias)
             throws Exception {

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateCommandTest.java
@@ -48,6 +48,13 @@ public class CertificateCommandTest {
 
     private static final byte[] ENCODED_SAN_GENERAL_NAME;
 
+    private static final String[] CERTIFICATE_DN =
+            new String[] {"cn=John Whorfin", "o=Yoyodyne", "l=San Narciso", "st=California",
+                    "c=US"};
+
+    private static final String CERTIFICATE_CN =
+            "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US";
+
     static {
         try {
             ENCODED_SAN_GENERAL_NAME =
@@ -158,12 +165,10 @@ public class CertificateCommandTest {
 
         assertThat(ksf.aliases()
                 .size(), is(2));
-        assertThat(ksf.isKey("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"),
-                is(false));
+        assertThat(ksf.isKey(CertificateCommandTest.CERTIFICATE_CN), is(false));
 
-        assertThat(CertificateCommand.configureDemoCertWithDN(new String[] {"cn=John Whorfin",
-                        "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"}, null),
-                equalTo("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"));
+        assertThat(CertificateCommand.configureDemoCertWithDN(CertificateCommandTest.CERTIFICATE_DN,
+                null), equalTo(CertificateCommandTest.CERTIFICATE_CN));
 
         validateKeyStore("john whorfin", false);
     }
@@ -174,13 +179,10 @@ public class CertificateCommandTest {
 
         assertThat(ksf.aliases()
                 .size(), is(2));
-        assertThat(ksf.isKey("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"),
-                is(false));
+        assertThat(ksf.isKey(CertificateCommandTest.CERTIFICATE_CN), is(false));
 
-        assertThat(CertificateCommand.configureDemoCertWithDN(new String[] {"cn=John Whorfin",
-                        "o=Yoyodyne", "l=San Narciso", "st=California", "c=US"},
-                CertificateCommandTest.SANS),
-                equalTo("CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"));
+        assertThat(CertificateCommand.configureDemoCertWithDN(CertificateCommandTest.CERTIFICATE_DN,
+                CertificateCommandTest.SANS), equalTo(CertificateCommandTest.CERTIFICATE_CN));
 
         validateKeyStore("john whorfin", true);
     }
@@ -210,16 +212,14 @@ public class CertificateCommandTest {
 
     @Test
     public void testMainWithDnAndWithoutSan() throws Exception {
-        CertificateCommand.main(new String[] {"-dn",
-                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+        CertificateCommand.main(new String[] {"-dn", CertificateCommandTest.CERTIFICATE_CN});
 
         validateKeyStore("john whorfin", false);
     }
 
     @Test
     public void testMainWithDnAndSans() throws Exception {
-        CertificateCommand.main(new String[] {"-dn",
-                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US", "-san",
+        CertificateCommand.main(new String[] {"-dn", CertificateCommandTest.CERTIFICATE_CN, "-san",
                 CertificateCommandTest.SANS_ARG});
 
         validateKeyStore("john whorfin", true);
@@ -228,7 +228,7 @@ public class CertificateCommandTest {
     @Test
     public void testMainWithDnAndSansReversedArguments() throws Exception {
         CertificateCommand.main(new String[] {"-san", CertificateCommandTest.SANS_ARG, "-dn",
-                "CN=John Whorfin,O=Yoyodyne,L=San Narciso,ST=California,C=US"});
+                CertificateCommandTest.CERTIFICATE_CN});
 
         validateKeyStore("john whorfin", true);
     }

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
@@ -15,16 +15,33 @@ package org.codice.ddf.security.certificate.generator;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 
+import javax.security.auth.x500.X500Principal;
+
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNamesBuilder;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x509.Time;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +53,14 @@ public class CertificateSigningRequestTest {
 
     CertificateSigningRequest csr;
 
+    private static KeyPair makeKeyPair() throws Exception {
+        final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA", "SUN");
+        final SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+
+        keyGen.initialize(1024, random);
+        return keyGen.generateKeyPair();
+    }
+
     @Before
     public void setUp() {
         csr = new CertificateSigningRequest();
@@ -43,18 +68,48 @@ public class CertificateSigningRequestTest {
 
     @Test
     public void testKeys() throws Exception {
-        assertThat("CSR failed to auto-generate RSA keypair", csr.getSubjectPrivateKey(),
+        assertThat("CSR failed to auto-generate RSA keypair",
+                csr.getSubjectPrivateKey(),
                 instanceOf(PrivateKey.class));
-        assertThat("CSR failed to auto-generate RSA keypair", csr.getSubjectPublicKey(),
+        assertThat("CSR failed to auto-generate RSA keypair",
+                csr.getSubjectPublicKey(),
                 instanceOf(PublicKey.class));
         PublicKey pubKey = mock(PublicKey.class);
         PrivateKey privKey = mock(PrivateKey.class);
         KeyPair kp = new KeyPair(pubKey, privKey);
         csr.setSubjectKeyPair(kp);
-        assertThat("Unable to get mock private key", csr.getSubjectPrivateKey(),
+        assertThat("Unable to get mock private key",
+                csr.getSubjectPrivateKey(),
                 sameInstance(privKey));
-        assertThat("Unable to get mock public key", csr.getSubjectPublicKey(),
+        assertThat("Unable to get mock public key",
+                csr.getSubjectPublicKey(),
                 sameInstance(pubKey));
+    }
+
+    @Test
+    public void testAddSubjectAlternativeNames() {
+        assertThat("CSR should not have any SAN by default",
+                csr.getSubjectAlternativeNames(),
+                emptyCollectionOf(GeneralName.class));
+        csr.addSubjectAlternativeNames("IP:1.2.3.4", "DNS:A");
+        assertThat(csr.getSubjectAlternativeNames(),
+                contains(new GeneralName(GeneralName.iPAddress, "1.2.3.4"),
+                        new GeneralName(GeneralName.dNSName, "A")));
+        csr.addSubjectAlternativeNames("RID:0.2.1.4", "DNS:A");
+        assertThat(csr.getSubjectAlternativeNames(),
+                contains(new GeneralName(GeneralName.iPAddress, "1.2.3.4"),
+                        new GeneralName(GeneralName.dNSName, "A"),
+                        new GeneralName(GeneralName.registeredID, "0.2.1.4")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddSubjectAlternativeNamesWithNullList() {
+        csr.addSubjectAlternativeNames((String[]) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddSubjectAlternativeNamesWithNullEntry() {
+        csr.addSubjectAlternativeNames(null, "IP:1.2.3.4");
     }
 
     @Test
@@ -62,7 +117,8 @@ public class CertificateSigningRequestTest {
         boolean outcome = csr.getNotAfter()
                 .isAfter(csr.getNotBefore());
         assertThat("'Not after' date should never be chronologically before the 'Not before' date'",
-                outcome, equalTo(true));
+                outcome,
+                equalTo(true));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -99,7 +155,8 @@ public class CertificateSigningRequestTest {
     @Test
     public void subjectName() throws Exception {
 
-        assertThat("Subject name should never be null", true,
+        assertThat("Subject name should never be null",
+                true,
                 equalTo(csr.getSubjectName() != null));
         csr.setCommonName("test");
         String cn = csr.getSubjectName()
@@ -109,22 +166,104 @@ public class CertificateSigningRequestTest {
 
     @Test
     public void subjectFromDN() throws Exception {
-        assertThat("Subject name should never be null", true,
+        assertThat("Subject name should never be null",
+                true,
                 equalTo(csr.getSubjectName() != null));
         csr.setDistinguishedName("CN=john.smith", "O=Tardis", "o=police box", "L=London", "C=UK");
         String subjectName = csr.getSubjectName()
                 .toString();
 
-        assertThat("Subject name should contain 'cn=john.smith'", subjectName,
+        assertThat("Subject name should contain 'cn=john.smith'",
+                subjectName,
                 containsString("cn=john.smith"));
-        assertThat("Subject name should contain 'o=Tardis'", subjectName,
+        assertThat("Subject name should contain 'o=Tardis'",
+                subjectName,
                 containsString("o=Tardis"));
-        assertThat("Subject name should contain 'o=police box'", subjectName,
+        assertThat("Subject name should contain 'o=police box'",
+                subjectName,
                 containsString("o=police box"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void badSerialNumber() {
         csr.setSerialNumber(-1);
+    }
+
+    public void testNewCertificateBuilderWithoutSAN() throws Exception {
+        final DateTime start = DateTime.now()
+                .minusDays(1);
+        final DateTime end = start.plusYears(100);
+        final KeyPair kp = makeKeyPair();
+
+        csr.setSerialNumber(1);
+        csr.setNotBefore(start);
+        csr.setNotAfter(end);
+        csr.setCommonName("A");
+        csr.setSubjectKeyPair(kp);
+        final X509Certificate issuerCert = mock(X509Certificate.class);
+
+        doReturn(new X500Principal("CN=Duke, OU=JavaSoft, O=Sun Microsystems, C=US")).when(
+                issuerCert)
+                .getSubjectX500Principal();
+        final JcaX509v3CertificateBuilder builder = csr.newCertificateBuilder(issuerCert);
+        final X509CertificateHolder holder =
+                builder.build(new DemoCertificateAuthority().getContentSigner());
+
+        assertThat(holder.getSerialNumber(), equalTo(BigInteger.ONE));
+        assertThat(holder.getNotBefore(), equalTo(new Time(start.toDate()).getDate()));
+        assertThat(holder.getNotAfter(), equalTo(new Time(end.toDate()).getDate()));
+        assertThat(holder.getSubject()
+                .toString(), equalTo("cn=A"));
+        assertThat("Unable to validate public key",
+                holder.getSubjectPublicKeyInfo(),
+                equalTo(SubjectPublicKeyInfo.getInstance(kp.getPublic()
+                        .getEncoded())));
+        assertThat("There should be no subject alternative name extension",
+                holder.getExtension(org.bouncycastle.asn1.x509.Extension.subjectAlternativeName),
+                nullValue(org.bouncycastle.asn1.x509.Extension.class));
+    }
+
+    @Test
+    public void testNewCertificateBuilderWithSAN() throws Exception {
+        final DateTime start = DateTime.now()
+                .minusDays(1);
+        final DateTime end = start.plusYears(100);
+        final KeyPair kp = makeKeyPair();
+
+        csr.setSerialNumber(1);
+        csr.setNotBefore(start);
+        csr.setNotAfter(end);
+        csr.setCommonName("A");
+        csr.setSubjectKeyPair(kp);
+        csr.addSubjectAlternativeNames("IP:1.2.3.4", "DNS:A");
+        final X509Certificate issuerCert = mock(X509Certificate.class);
+
+        doReturn(new X500Principal("CN=Duke, OU=JavaSoft, O=Sun Microsystems, C=US")).when(
+                issuerCert)
+                .getSubjectX500Principal();
+        final JcaX509v3CertificateBuilder builder = csr.newCertificateBuilder(issuerCert);
+        final X509CertificateHolder holder =
+                builder.build(new DemoCertificateAuthority().getContentSigner());
+
+        assertThat(holder.getSerialNumber(), equalTo(BigInteger.ONE));
+        assertThat(holder.getNotBefore(), equalTo(new Time(start.toDate()).getDate()));
+        assertThat(holder.getNotAfter(), equalTo(new Time(end.toDate()).getDate()));
+        assertThat(holder.getSubject()
+                .toString(), equalTo("cn=A"));
+        assertThat("Unable to validate public key",
+                holder.getSubjectPublicKeyInfo(),
+                equalTo(SubjectPublicKeyInfo.getInstance(kp.getPublic()
+                        .getEncoded())));
+        final org.bouncycastle.asn1.x509.Extension csn =
+                holder.getExtension(org.bouncycastle.asn1.x509.Extension.subjectAlternativeName);
+
+        assertThat(csn.getParsedValue()
+                        .toASN1Primitive()
+                        .getEncoded(ASN1Encoding.DER),
+                equalTo(new GeneralNamesBuilder().addName(new GeneralName(GeneralName.iPAddress,
+                        "1.2.3.4"))
+                        .addName(new GeneralName(GeneralName.dNSName, "A"))
+                        .build()
+                        .getEncoded(ASN1Encoding.DER)));
     }
 }

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
@@ -189,6 +189,7 @@ public class CertificateSigningRequestTest {
         csr.setSerialNumber(-1);
     }
 
+    @Test
     public void testNewCertificateBuilderWithoutSAN() throws Exception {
         final DateTime start = DateTime.now()
                 .minusDays(1);

--- a/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
+++ b/platform/security/certificate/security-certificate-generator/src/test/java/org/codice/ddf/security/certificate/generator/CertificateSigningRequestTest.java
@@ -190,7 +190,7 @@ public class CertificateSigningRequestTest {
     }
 
     @Test
-    public void testNewCertificateBuilderWithoutSAN() throws Exception {
+    public void testNewCertificateBuilderWithoutSan() throws Exception {
         final DateTime start = DateTime.now()
                 .minusDays(1);
         final DateTime end = start.plusYears(100);
@@ -225,7 +225,7 @@ public class CertificateSigningRequestTest {
     }
 
     @Test
-    public void testNewCertificateBuilderWithSAN() throws Exception {
+    public void testNewCertificateBuilderWithSan() throws Exception {
         final DateTime start = DateTime.now()
                 .minusDays(1);
         final DateTime end = start.plusYears(100);


### PR DESCRIPTION
#### What does this PR do?
This PR add an optional argument to the certificate command to allow subject alternative names to be added to the generated certificate. Format supported on the command line is similar to the OpenSSL X509 configuration where multiple SANs can be specified separated by commas.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@Lambeaux @brjeter @lessarderic 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security/members

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@figliold
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Execute the CertNew.sh or CertNew.bat to generate a new certificate and specify a -san option with a set of subject alternative names (e.g. -san DNS:localhost,IP:127.0.0.1) then verify the certificate in the keystore is defined with the SANs specified. Also verify without using the -san option for backward compatibility.

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
