### PR TITLE
DDF-3135 Fixed error when updating storage with only qualified content items

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -190,6 +190,10 @@ public class Historian {
                 .filter(isNotVersionNorDeleted)
                 .collect(Collectors.toList());
 
+        if (updatedMetacards.isEmpty()) {
+            return updateStorageResponse;
+        }
+
         Map<String, Metacard> originalMetacards = query(forIds(updatedMetacards.stream()
                 .map(Metacard::getId)
                 .collect(Collectors.toList())));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
@@ -240,7 +240,6 @@ public class HistorianTest {
     public void testUpdateStorageResponse()
             throws UnsupportedQueryException, SourceUnavailableException, IngestException,
             URISyntaxException, StorageException {
-
         // The metacard and updated metacard
         List<Metacard> metacards = getMetacardUpdatePair();
 
@@ -265,6 +264,24 @@ public class HistorianTest {
         assertThat(storageResponse.getUpdatedContentItems()
                 .get(0)
                 .getUri(), not(equalTo(RESOURCE_URI)));
+    }
+
+    @Test
+    public void testUpdateStorageResponseWithOnlyQualifiedContentItems()
+            throws UnsupportedQueryException, SourceUnavailableException, IngestException,
+            URISyntaxException, StorageException {
+        // Parameters for historian
+        UpdateStorageResponse storageResponse = mock(UpdateStorageResponse.class);
+        ContentItem hasQualifier = mock(ContentItem.class);
+        when(hasQualifier.getQualifier()).thenReturn("some-qualifier");
+        ContentItem anotherHasQualifier = mock(ContentItem.class);
+        when(anotherHasQualifier.getQualifier()).thenReturn("another-qualifier");
+        when(storageResponse.getUpdatedContentItems()).thenReturn(Arrays.asList(
+                hasQualifier,
+                anotherHasQualifier));
+
+        historian.version(mock(UpdateStorageRequest.class), storageResponse, mock(UpdateResponse.class));
+        verifyZeroInteractions(catalogProvider);
     }
 
     @Test
@@ -539,7 +556,6 @@ public class HistorianTest {
     }
 
     private List<Update> createUpdatedMetacardList() {
-
         List<Metacard> metacards = getMetacardUpdatePair();
         return Collections.singletonList(new UpdateImpl(metacards.get(1), metacards.get(0)));
     }


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue that was causing `UpdateStorageRequest`s to fail when the request contains only qualified content items.
#### Who is reviewing it?
@rzwiefel @peterhuffer @troymohl 
#### Select relevant component teams:
@codice/data 
#### Choose 2 committers to review/merge the PR.
@kcwire 
@clockard
#### How should this be tested? (List steps with links to updated documentation)
Confirm build succeeds.
#### Any background context you want to provide?
The asynchronous plugin API (https://github.com/codice/ddf/pull/1495) introduced motivation to submit an `UpdateStorageRequest` with only qualified content items.
#### What are the relevant tickets?
[DDF-3135](https://codice.atlassian.net/browse/DDF-3135)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
