### PR TITLE
DDF-3136 Fixed default threadpool size in the ProcessingFramework

### DIFF
--- a/catalog/async/catalog-async-processingframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/async/catalog-async-processingframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,14 +15,12 @@
            xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]"/>
+    <ext:property-placeholder/>
 
     <!-- ProcessingFramework -->
     <bean id="processingFramework"
           class="org.codice.ddf.catalog.async.processingframework.impl.InMemoryProcessingFramework"
           destroy-method="cleanUp">
-        <cm:managed-properties persistent-id="ddf.catalog.CatalogFrameworkImpl"
-                               update-strategy="container-managed"/>
         <argument ref="catalogFramework"/>
         <argument ref="threadPool"/>
         <property name="postProcessPlugins" ref="postProcessPlugins"/>
@@ -34,8 +32,7 @@
     <!-- ThreadPool -->
     <bean id="threadPool" class="java.util.concurrent.Executors"
           factory-method="newFixedThreadPool">
-        <argument value="1"/>
-        <!--<argument value="$[org.codice.ddf.system.threadPoolSize]"/>-->
+        <argument value="${org.codice.ddf.system.threadPoolSize}"/>
     </bean>
 
     <!-- ProcessPlugins -->


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a typo that set the threadpool size in the InMemoryProcessingFramework to 1 instead of `${org.codice.ddf.system.threadPoolSize}`.
#### Who is reviewing it? 
@peterhuffer @troymohl 
#### Choose 2 committers to review/merge the PR. 
@clockard
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
Confirm that the `catalog-async-inmemory` feature can be installed without any issues.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3136](https://codice.atlassian.net/browse/DDF-3136)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
