### PR TITLE
DDF-3112 When creating a new source from the sources UI, other options show up that are not sources

### DIFF
--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
@@ -85,8 +85,6 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
 
     private List<String> excludeAsSource;
 
-    protected String serviceFilter;
-
     protected String serviceFactoryFilter;
 
     public AdminPollerServiceBean(ConfigurationAdmin configurationAdmin, org.osgi.service.cm.ConfigurationAdmin felixConfigAdmin) {
@@ -109,7 +107,6 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
 
     public void init() {
         serviceFactoryFilter = getServiceFactoryFilterProperties();
-        serviceFilter = getServiceFilterProperties();
         try {
             try {
                 mBeanServer.registerMBean(this, objectName);
@@ -257,10 +254,6 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
         return createFilter("service.factoryPid");
     }
 
-    protected String getServiceFilterProperties() {
-        return createFilter("service.pid");
-    }
-
     private String createFilter(String pidKey) {
         String includes, excludes;
         includes = (includeAsSource == null || CollectionUtils.isEmpty(includeAsSource)) ?
@@ -305,7 +298,7 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
         }
 
         protected List<Service> getMetatypes() {
-            return configurationAdmin.listServices(serviceFactoryFilter, serviceFilter);
+            return configurationAdmin.listServices(serviceFactoryFilter, ConfigurationAdmin.NO_MATCH_FILTER);
         }
 
         protected List<Configuration> getConfigurations(Metatype metatype) throws InvalidSyntaxException, IOException {

--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/AdminHelper.java
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/java/org/codice/ddf/registry/federationadmin/impl/AdminHelper.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.registry.federationadmin.impl;
 
+import static org.codice.ddf.admin.core.api.ConfigurationAdmin.NO_MATCH_FILTER;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,18 +71,19 @@ public class AdminHelper {
     }
 
     public List<Service> getMetatypes() {
-        return configAdmin.listServices(REGISTRY_FILTER, REGISTRY_FILTER);
+        return configAdmin.listServices(REGISTRY_FILTER, NO_MATCH_FILTER);
     }
 
     public List<Configuration> getConfigurations(Service metatype)
             throws InvalidSyntaxException, IOException {
-        return Arrays.asList(configurationAdmin.listConfigurations(
-                String.format("(|(%s=%s)(%s=%s%s))",
-                        ConfigurationAdmin.SERVICE_FACTORYPID,
-                        metatype.getId(),
-                        ConfigurationAdmin.SERVICE_FACTORYPID,
-                        metatype.getId(),
-                        DISABLED)));
+        Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
+                "(|(%s=%s)(%s=%s%s))",
+                ConfigurationAdmin.SERVICE_FACTORYPID,
+                metatype.getId(),
+                ConfigurationAdmin.SERVICE_FACTORYPID,
+                metatype.getId(),
+                DISABLED));
+        return configurations == null ? new ArrayList<>() : Arrays.asList(configurations);
     }
 
     public Configuration getConfiguration(ConfiguredService cs) throws IOException {

--- a/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/admin/core/api/ConfigurationAdmin.java
+++ b/platform/admin/core/admin-core-api/src/main/java/org/codice/ddf/admin/core/api/ConfigurationAdmin.java
@@ -30,6 +30,9 @@ import org.osgi.service.metatype.ObjectClassDefinition;
  */
 public interface ConfigurationAdmin {
 
+    // Used when we want a filter to match with nothing
+    String NO_MATCH_FILTER = "(service.pid=0)";
+
     /**
      * Returns the {@link Configuration} associated with the given PID
      * @param pid - service pid for the configuration

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -179,7 +179,7 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
 
             // Get ManagedServiceFactory instances
             serviceFactoryList = getServices(ManagedServiceFactory.class.getName(),
-                    serviceFilter,
+                    serviceFactoryFilter,
                     true);
 
             // Get ManagedServiceFactory Metatypes
@@ -578,9 +578,16 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
             boolean ocdRequired) throws InvalidSyntaxException {
         List<Service> serviceList = new ArrayList<>();
 
+        // service.factoryPid cannot be searched, but service.pid can be searched,
+        // and can contain a factoryPid
+        String newFilter = null;
+        if (serviceFilter != null) {
+            newFilter = serviceFilter.replace("service.factoryPid", "service.pid");
+        }
+
         // find all ManagedServiceFactories to get the factoryPIDs
         ServiceReference[] refs = this.getBundleContext()
-                .getAllServiceReferences(serviceClass, serviceFilter);
+                .getAllServiceReferences(serviceClass, newFilter);
 
         for (int i = 0; refs != null && i < refs.length; i++) {
             Object pidObject = refs[i].getProperty(SERVICE_PID);

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImplTest.java
@@ -181,7 +181,7 @@ public class ConfigurationAdminImplTest {
         when(testBundleContext.getAllServiceReferences(ManagedService.class.getName(),
                 TEST_FILTER)).thenReturn(testServRefs);
         when(testBundleContext.getAllServiceReferences(ManagedServiceFactory.class.getName(),
-                TEST_FILTER)).thenReturn(testServRefs);
+                TEST_FACT_FILTER)).thenReturn(testServRefs);
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
When creating a new source from the sources tab, other options showed up that were not sources (see attached screenshot). This PR keeps only the sources from appearing
#### Who is reviewing it?
@vinamartin 
@emmberk 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
1. Build DDF and go to the Admin UI
2. Open the Catalog application, then select the Sources tab
3. Select Add Source, verify that the only options in the **Source Type** dropdown box are sources. 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3112](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
