### PR TITLE
DDF-3073 Adds failover log back to logging config

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -12,7 +12,7 @@
  *
  **/
 -->
-<Configuration status="WARN">
+<Configuration status="FATAL">
     <Properties>
         <Property name="log-pattern">%-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id}
             - %X{bundle.name} - %X{bundle.version} | %m%n
@@ -61,11 +61,8 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
 
-        <!--TODO DDF-3073
-        The karaf upgrade from 4.0.7 to 4.1.1 introduced a bug with the log4j2 failover
-        appender: "ERROR appender Failover has no parameter that matches element Failovers". See
-        https://issues.apache.org/jira/browse/LOG4J2-1163.-->
-        <!--<RollingFile name="securityBackup" append="true" ignoreExceptions="false"
+        <!-- It is recommended to change the default directory of this log file -->
+        <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
                      fileName="${sys:karaf.data}/log/securityBackup.log"
                      filePattern="${sys:karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
             <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
@@ -73,13 +70,13 @@
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>
             <DefaultRolloverStrategy max="10"/>
-        </RollingFile>-->
+        </RollingFile>
 
-        <!--<Failover name="securityFailover" primary="securityMain">
+        <Failover name="securityFailover" primary="securityMain">
             <Failovers>
                 <AppenderRef ref="securityBackup"/>
             </Failovers>
-        </Failover>-->
+        </Failover>
 
         <RollingFile name="solr" append="true"
                      fileName="${sys:karaf.data}/log/solr.log"
@@ -104,15 +101,13 @@
 
     <Loggers>
         <Logger name="securityLogger" level="info" additivity="false">
-            <!--<AppenderRef ref="securityFailover"/>-->
-            <AppenderRef ref="securityMain"/>
+            <AppenderRef ref="securityFailover"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
         <Logger name="org.apache.karaf.jaas.modules.audit" level="info" additivity="false">
-            <!--<AppenderRef ref="securityFailover"/>-->
-            <AppenderRef ref="securityMain"/>
+            <AppenderRef ref="securityFailover"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -18,8 +18,10 @@
 ################################################################################
 
 # In order to switch to the xml-style configuration for Log4j2 in ${karaf.etc}/log4j2.config.xml, 
-# uncomment the following line and remove all the configuration beneath it. This change has not been 
+# uncomment the following line and remove all the configuration beneath it. This change has not been
 # made default because the xml-style configuration causes log entries to be missing from the itests.
+# However, because failover logging capabilities are only available for the xml-style configuration,
+# this step is required for security hardening.
 #
 # org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml
 
@@ -37,8 +39,6 @@ log4j2.rootLogger.appenderRef.osgi-all.ref = osgi-all
 log4j2.logger.securityLogger.name = securityLogger
 log4j2.logger.securityLogger.level = INFO
 log4j2.logger.securityLogger.additivity = false
-# TODO DDF-3073 (see note below)
-#log4j2.logger.securityLogger.appenderRef.securityFailover.ref = securityFailover
 log4j2.logger.securityLogger.appenderRef.securityMain.ref = securityMain
 log4j2.logger.securityLogger.appenderRef.syslog.ref = syslog
 log4j2.logger.securityLogger.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
@@ -47,8 +47,6 @@ log4j2.logger.securityLogger.appenderRef.osgi-platformLogging.ref = osgi-platfor
 log4j2.logger.org_apache_karaf_jaas_modules_audit.name = org.apache.karaf.jaas.modules.audit
 log4j2.logger.org_apache_karaf_jaas_modules_audit.level = INFO
 log4j2.logger.org_apache_karaf_jaas_modules_audit.additivity = false
-# TODO DDF-3073 (see note below)
-#log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.securityFailover.ref = securityFailover
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.securityMain.ref = securityMain
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
@@ -169,33 +167,6 @@ log4j2.appender.securityMain.policies.size.size = 20MB
 log4j2.appender.securityMain.strategy.type = DefaultRolloverStrategy
 log4j2.appender.securityMain.strategy.max = 10
 
-# TODO DDF-3073
-# The karaf upgrade from 4.0.7 to 4.1.1 introduced a bug with the log4j2 failover appender: "ERROR
-# appender Failover has no parameter that matches element Failovers". See
-# https://issues.apache.org/jira/browse/LOG4J2-1163.
-
-## securityBackup
-#log4j2.appender.securityBackup.type = RollingFile
-#log4j2.appender.securityBackup.name = securityBackup
-#log4j2.appender.securityBackup.fileName = ${karaf.data}/log/securityBackup.log
-#log4j2.appender.securityBackup.filePattern = ${karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz
-#log4j2.appender.securityBackup.append = true
-#log4j2.appender.securityBackup.ignoreExceptions = false
-#log4j2.appender.securityBackup.layout.type = PatternLayout
-#log4j2.appender.securityBackup.layout.pattern = [%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n
-#log4j2.appender.securityBackup.policies.type = Policies
-#log4j2.appender.securityBackup.policies.size.type = SizeBasedTriggeringPolicy
-#log4j2.appender.securityBackup.policies.size.size = 20MB
-#log4j2.appender.securityBackup.strategy.type = DefaultRolloverStrategy
-#log4j2.appender.securityBackup.strategy.max = 10
-
-## securityFailover
-#log4j2.appender.securityFailover.type = Failover
-#log4j2.appender.securityFailover.name = securityFailover
-#log4j2.appender.securityFailover.primary = securityMain
-#log4j2.appender.securityFailover.failovers.type = Failovers
-#log4j2.appender.securityFailover.failovers.appenderRef.securityBackup.ref = securityBackup
-
 # solr
 log4j2.appender.solr.type = RollingFile
 log4j2.appender.solr.name = solr
@@ -223,3 +194,5 @@ log4j2.appender.artemis.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.artemis.policies.size.size = 20MB
 log4j2.appender.artemis.strategy.type = DefaultRolloverStrategy
 log4j2.appender.artemis.strategy.max = 10
+
+# Setting custom configurations using log:set from the console will append those configurations below this line

--- a/distribution/docs/src/main/jdocs/content/_configuring/auditing-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/auditing-contents.adoc
@@ -36,17 +36,18 @@ The security audit logging function does not have any configuration for audit re
 The logs themselves could be used to generate such reports outside the scope of ${branding}.
 ====
 
-//TODO DDF-3073 Implement a fallback auditing option, update and uncomment this documentation section
-////
 ===== Enabling Fallback Audit Logging
 
 * *{hardening-step}*
 
 In the event the system is unable to write to the `security.log` file, ${branding} must be configured to fall back to report the error in the application log:
 
+* edit `<INSTALL_HOME>/etc/org.ops4j.pax.logging.cfg`
+** uncomment the line (remove the `#` from the beginning of the line) for `log4j2` (`org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml`)
+** delete all subsequent lines
 * edit `<INSTALL_HOME>/etc/log4j2.config.xml`
-* find the entry for the `securityBackup` appender. (see example)
-* change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
+** find the entry for the `securityBackup` appender. (see example)
+** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
 
 .`securityBackup` Appender Before
 [source,xml,linenums]
@@ -63,4 +64,9 @@ In the event the system is unable to write to the `security.log` file, ${brandin
                      fileName="${sys:karaf.data}/log/<NEW_FILE_NAME>"
                      filePattern="${sys:karaf.data}/log/<NEW_FILE_NAME>-%d{yyyy-MM-dd-HH}-%i.log.gz">
 ----
-////
+
+[WARNING]
+====
+If the system is unable to write to the `security.log` file on system startup, fallback logging will be unavailable.
+Verify that the `security.log` file is properly configured and contains logs before configuring a fall back.
+====

--- a/distribution/docs/src/main/resources/_contents/_securing/auditing-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/auditing-contents.adoc
@@ -31,17 +31,18 @@ The security audit logging function does not have any configuration for audit re
 The logs themselves could be used to generate such reports outside the scope of ${branding}.
 ====
 
-//TODO DDF-3073 Implement a fallback auditing option, update and uncomment this documentation section
-////
 ===== Enabling Fallback Audit Logging
 
 * *{hardening-step}*
 
 In the event the system is unable to write to the `security.log` file, ${branding} must be configured to fall back to report the error in the application log:
 
+* edit `<INSTALL_HOME>/etc/org.ops4j.pax.logging.cfg`
+** uncomment the line (remove the `#` from the beginning of the line) for `log4j2` (`org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml`)
+** delete all subsequent lines
 * edit `<INSTALL_HOME>/etc/log4j2.config.xml`
-* find the entry for the `securityBackup` appender. (see example)
-* change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
+** find the entry for the `securityBackup` appender. (see example)
+** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
 
 .`securityBackup` Appender Before
 [source,xml,linenums]
@@ -58,4 +59,9 @@ In the event the system is unable to write to the `security.log` file, ${brandin
                      fileName="${sys:karaf.data}/log/<NEW_FILE_NAME>"
                      filePattern="${sys:karaf.data}/log/<NEW_FILE_NAME>-%d{yyyy-MM-dd-HH}-%i.log.gz">
 ----
-////
+
+[WARNING]
+====
+If the system is unable to write to the `security.log` file on system startup, fallback logging will be unavailable.
+Verify that the `security.log` file is properly configured and contains logs before configuring a fall back.
+====


### PR DESCRIPTION
#### What does this PR do?
Adds failover log back to logging configuration.
With the Karaf upgrade, there is an issue with the pax logging configuration that makes it unavailable to use through our default configuration, however, when using the log4j2.config.xml file failover seems to be functional (though errors populate the log). 

#### Who is reviewing it? 
@emmberk 
@Lambeaux 
@josephthweatt 
@pklinef 
@coyotesqrl 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)

- Create a disk image and mount it (Here's an example of how to do so on a mac: https://support.apple.com/kb/PH22247?locale=en_US&viewlocale=en_US)
- Unzip the DDF
- Configure the DDF's logging configuration per the documentation and setup the `securityMain` appender to write to a log file inside of the disk image
- Start up the DDF 
- Verify logs are written to the security log inside the disk image
- Begin to fill up the disk image (for instance: http://www.skorks.com/2010/03/how-to-quickly-generate-a-large-file-on-the-command-line-with-linux/)
- Verify that when the disk is full, the security backup log is written to

#### What are the relevant tickets?
[DDF-3073](https://codice.atlassian.net/browse/DDF-3073)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
