### PR TITLE
DDF-3146 Add Threadpool to Jetty Configuration

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -50,3 +50,15 @@ org.ops4j.pax.web.ssl.protocols.included=${https.protocols}
 
 # Excluded SSL/TLS Protocols
 org.ops4j.pax.web.ssl.protocols.excluded=SSLv3,TLSv1
+
+#######################################
+# Jetty Server ThreadPool Settings
+#######################################
+
+# ThreadPool settings should be adjusted according to the system's hardware.
+# Increase the max threads in systems with greater processing power.
+# Decrease the max threads in systems with less processing power.
+# Adjust the system's heap size in order to handle a greater number of threads
+org.ops4j.pax.web.server.maxThreads=300
+org.ops4j.pax.web.server.minThreads=10
+org.ops4j.pax.web.server.idleTimeout=60000

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-from-admin-console.contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-from-admin-console.contents.adoc
@@ -1,0 +1,10 @@
+:title: Configuring Jetty ThreadPool Settings From ${admin-console}
+:type: configuringAdminConsole
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 151
+
+=== Configuring Jetty ThreadPool Settings From ${admin-console}
+
+${branding} does not support changing Jetty ThreadPool settings from the ${admin-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-from-command-console.contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-from-command-console.contents.adoc
@@ -1,0 +1,10 @@
+:title: Configuring Jetty ThreadPool Settings From ${command-console}
+:type: configuringCommandConsole
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 061
+
+=== Configuring Jetty ThreadPool Settings From ${command-console}
+
+${branding} does not support changing ThreadPool settings from the ${command-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-settings-config-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-jetty-threadpool-settings-config-contents.adoc
@@ -1,0 +1,14 @@
+:title: Configuring Jetty ThreadPool Settings From Configuration Files
+:type: configuringConfigFile
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 111
+
+=== Configuring Jetty ThreadPool Settings From Configuration Files
+
+To prevent resource shortages in the event of concurrent requests, ${branding} allows configuring Jetty ThreadPool settings to specify the minimum and maximum available threads.
+
+. The settings can be changed at `etc/org.ops4j.pax.web.cfg` under Jetty Server ThreadPool Settings
+. Specify the maximum thread amount with `org.ops4j.pax.web.server.maxThreads`
+. Specify the minimum thread amount with `org.ops4j.pax.web.server.minThreads`
+. Specify the allotted time for a thread to complete with `org.ops4j.pax.web.server.idleTimeout`

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-from-admin-console.contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-from-admin-console.contents.adoc
@@ -1,0 +1,10 @@
+:title: Configuring Jetty ThreadPool Settings From ${admin-console}
+:type: configuringAdminConsole
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 151
+
+=== Configuring Jetty ThreadPool Settings From ${admin-console}
+
+${branding} does not support changing Jetty ThreadPool settings from the ${admin-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-from-command-console.contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-from-command-console.contents.adoc
@@ -1,0 +1,10 @@
+:title: Configuring Jetty ThreadPool Settings From ${command-console}
+:type: configuringCommandConsole
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 061
+
+=== Configuring Jetty ThreadPool Settings From ${command-console}
+
+${branding} does not support changing ThreadPool settings from the ${command-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-settings-config-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-jetty-threadpool-settings-config-contents.adoc
@@ -1,0 +1,14 @@
+:title: Configuring Jetty ThreadPool Settings From Configuration Files
+:type: configuringConfigFile
+:status: published
+:summary: Configuring jetty thread pools.
+:order: 111
+
+=== Configuring Jetty ThreadPool Settings From Configuration Files
+
+To prevent resource shortages in the event of concurrent requests, ${branding} allows configuring Jetty ThreadPool settings to specify the minimum and maximum available threads.
+
+. The settings can be changed at `etc/org.ops4j.pax.web.cfg` under Jetty Server ThreadPool Settings
+. Specify the maximum thread amount with `org.ops4j.pax.web.server.maxThreads`
+. Specify the minimum thread amount with `org.ops4j.pax.web.server.minThreads`
+. Specify the allotted time for a thread to complete with `org.ops4j.pax.web.server.idleTimeout`

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-from-admin-console.contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-from-admin-console.contents.adoc
@@ -1,0 +1,5 @@
+
+=== Configuring Jetty ThreadPool Settings From ${admin-console}
+
+${branding} does not support changing Jetty ThreadPool settings from the ${admin-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-from-command-console.contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-from-command-console.contents.adoc
@@ -1,0 +1,5 @@
+
+=== Configuring Jetty ThreadPool Settings From ${command-console}
+
+${branding} does not support changing Jetty ThreadPool settings from the ${command-console}.
+See <<_configuring_jetty_threadpool_settings_from_configuration_files,Configuring Jetty ThreadPool Settings From Configuration Files>>.

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-settings-config-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-threadpool-settings-config-contents.adoc
@@ -1,0 +1,9 @@
+
+=== Configuring Jetty ThreadPool Settings From Configuration Files
+
+To prevent resource shortages in the event of concurrent requests, ${branding} allows configuring Jetty ThreadPool settings to specify the minimum and maximum available threads.
+
+. The settings can be changed at `etc/org.ops4j.pax.web.cfg` under Jetty Server ThreadPool Settings
+. Specify the maximum thread amount with `org.ops4j.pax.web.server.maxThreads`
+. Specify the minimum thread amount with `org.ops4j.pax.web.server.minThreads`
+. Specify the allotted time for a thread to complete with `org.ops4j.pax.web.server.idleTimeout`

--- a/distribution/docs/src/main/resources/documentation.adoc
+++ b/distribution/docs/src/main/resources/documentation.adoc
@@ -103,6 +103,8 @@ include::{adoc-include}/_securing/hardening-checklist-contents.adoc[]
 
 include::{adoc-include}/_securing/managing-certificates-contents.adoc[]
 
+include::{adoc-include}/_configuring/configuring-jetty-threadpool-settings-config-contents.adoc[]
+
 === Configuring from the ${admin-console}
 
 include::{adoc-include}/_configuring/admin-console-intro-contents.adoc[]
@@ -140,6 +142,8 @@ include::{adoc-include}/_securing/auditing-contents.adoc[]
 
 include::{adoc-include}/_configuring/configuring-landing-page-contents.adoc[]
 
+include::{adoc-include}/_configuring/configuring-jetty-threadpool-from-admin-console.contents.adoc[]
+
 === Configuring from the ${command-console}
 
 include::{adoc-include}/_configuring/command-console-intro-contents.adoc[]
@@ -155,6 +159,8 @@ include::{adoc-include}/_solr-contents/configuring-solr-from-command-console.ado
 include::{adoc-include}/_configuring/standalone-sts-contents.adoc[]
 
 include::{adoc-include}/_securing/hardening-solr-index-contents.adoc[]
+
+include::{adoc-include}/_configuring/configuring-jetty-threadpool-from-command-console.contents.adoc[]
 
 === Configuring from Configuration Files
 

--- a/platform/platform-paxweb-jettyconfig/src/main/resources/jetty.xml
+++ b/platform/platform-paxweb-jettyconfig/src/main/resources/jetty.xml
@@ -31,7 +31,7 @@
  under the License.
 -->
 <!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//
-DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+DTD Configure//EN" "http://jetty.mortbay.org/configure_9_0.dtd">
 
 <Configure class="org.eclipse.jetty.server.Server">
 
@@ -60,6 +60,5 @@ DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
             </New>
         </Set>
     </Ref>
-
 
 </Configure>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <findbugs.version>3.0.1</findbugs.version>
         <commons-codec.version>1.10</commons-codec.version>
         <spring.version>4.3.5.RELEASE</spring.version>
-        <jetty.version>9.2.19.v20160908</jetty.version>
+        <jetty.version>9.3.14.v20161028</jetty.version>
         <pax.cdi.version>0.12.0</pax.cdi.version>
         <validation.version>1.1.0.Final</validation.version>
         <commons-configuration.version>1.10</commons-configuration.version>


### PR DESCRIPTION
DDF-3146 Updated the version of Jetty in the root pom

#### What does this PR do?
**platform-paxweb-jettyconfig** should have a threadpool to handle multiple concurrent updates without causing a resource shortage. Currently, concurrent updates can cause user applications to function slowly or not at all.

This PR changes the ThreadPool's minimum & maximum threads as well as the idle timeout time (see org.ops4j.pax.web.cfg).

#### Who is reviewing it? 
@ricklarsen 
@emmberk 
@rzwiefel 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard 
@stustison 
#### How should this be tested?
The issue can be tested by running the **concurrent_updates_test.py** script [provided here](https://codice.atlassian.net/secure/attachment/18000/concurrent_updates_test.py). Before running you will need to run `pip3 install urllib3`. Run the script with python3 and note the output. The output should be:

- Approximately 20 seconds
- 400 results
- 100% success rate

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3146](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
