### PR TITLE
DDF-2995 Make the catalog backup plugin uninstalled by default

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -119,7 +119,7 @@
         <bundle>mvn:ddf.catalog.core/catalog-core-sourcemetricsplugin/${project.version}</bundle>
     </feature>
 
-    <feature name="catalog-core-backupplugin" install="auto" version="${project.version}"
+    <feature name="catalog-core-backupplugin" install="manual" version="${project.version}"
              description="Catalog post ingest plug-in to backup metacards to a file system.">
         <feature prerequisite="true">catalog-app</feature>
         <bundle>mvn:ddf.catalog.core/catalog-core-backupplugin/${project.version}</bundle>

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,16 +15,16 @@
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0">
 
-    <ext:property-placeholder />
+    <ext:property-placeholder/>
 
     <bean id="executorService" class="java.util.concurrent.Executors"
           factory-method="newSingleThreadExecutor">
     </bean>
 
-
     <bean id="catalogBackupPlugin" class="ddf.catalog.backup.CatalogBackupPlugin"
           destroy-method="shutdown">
-        <cm:managed-properties persistent-id="plugin.backup" update-strategy="container-managed"/>
+        <cm:managed-properties persistent-id="ddf.catalog.backup.CatalogBackupPlugin"
+                               update-strategy="container-managed"/>
         <property name="rootBackupDir" value="${ddf.home}/data/backup"/>
         <property name="subDirLevels" value="2"/>
         <property name="terminationTimeoutSeconds" value="30"/>

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -13,13 +13,8 @@
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-    <OCD description="Backup Post-Ingest Plugin Configuration"
-         name="Backup Post-Ingest Plugin" id="plugin.backup">
-
-        <AD
-                description="Enable the Backup Ingest plugin which will write each result to a directory"
-                name="Enable Backup Plugin" id="enableBackupPlugin"
-                required="false" type="Boolean" default="true"/>
+    <OCD description="Catalog Backup Plugin Configuration"
+         name="Catalog Backup Plugin" id="plugin.backup">
 
         <AD
                 description="Root backup directory for Metacards. A relative path is relative to ddf.home."

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -14,7 +14,7 @@
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
     <OCD description="Catalog Backup Plugin Configuration"
-         name="Catalog Backup Plugin" id="plugin.backup">
+         name="Catalog Backup Plugin" id="ddf.catalog.backup.CatalogBackupPlugin">
 
         <AD
                 description="Root backup directory for Metacards. A relative path is relative to ddf.home."
@@ -28,8 +28,8 @@
 
     </OCD>
 
-    <Designate pid="plugin.backup">
-        <Object ocdref="plugin.backup"/>
+    <Designate pid="ddf.catalog.backup.CatalogBackupPlugin">
+        <Object ocdref="ddf.catalog.backup.CatalogBackupPlugin"/>
     </Designate>
 
 </metatype:MetaData>

--- a/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/managing-certificates-contents.adoc
@@ -131,14 +131,6 @@ For example:
 `127.0.0.1 <FQDN>`
 ====
 
-[NOTE]
-====
-By default, the Catalog Backup Post-Ingest Plugin is *NOT* enabled.
-To enable, the Enable Backup Plugin configuration item must be checked in the Backup Post-Ingest Plugin configuration.
-
-`Enable Backup Plugin: true`
-====
-
 .Changing Default Passwords
 [NOTE]
 ====

--- a/distribution/docs/src/main/jdocs/content/_running/ingesting-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/ingesting-contents.adoc
@@ -167,11 +167,6 @@ Therefore, whether an administrator's data store is from Oracle, Solr, or any ot
 ==== Automatic Catalog Backup
 
 To backup local catalog records, a <<_catalog_backup_plugin,Catalog Backup Plugin>> is available.
-It is disabled by default for performance reasons.
+It is not installed by default for performance reasons.
 
-It can be enabled and configured in the *${admin-console}:
-
-. Navigate to the *${admin-console}.
-. Select the *${ddf-catalog} application.
-. Select the *Configuration* tab.
-. Select the <<_catalog_backup_plugin,Backup Post-Ingest Plugin>>.
+It can be installed and configured in the *${admin-console}* (see <<_catalog_backup_plugin,Catalog Backup Plugin>> for instructions).

--- a/distribution/docs/src/main/resources/_contents/_catalog-contents/managing-catalog-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_catalog-contents/managing-catalog-contents.adoc
@@ -26,7 +26,7 @@ These configurations are available throught the ${ddf-catalog} application.
 |ID
 |Description
 
-include::{adoc-include}/_tables/conf-plugin.backup-table-contents.adoc[]
+include::{adoc-include}/_tables/conf-ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc[]
 
 include::{adoc-include}/_tables/conf-OpenSearchSource-table-contents.adoc[]
 

--- a/distribution/docs/src/main/resources/_contents/_plugins/catalog-backup-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/catalog-backup-plugin-contents.adoc
@@ -4,15 +4,22 @@ The Catalog Backup Plugin is used to enable data backup of the catalog and the m
 
 ===== Installing the Catalog Backup Plugin
 
-The Catalog Backup Plugin is installed by default with a standard installation in the ${ddf-catalog} application.
+The Catalog Backup Plugin is not installed by default with a standard installation.
+
+To install:
+
+* Navigate to the *${admin-console}*.
+* Navigate to *${ddf-catalog}* application.
+* Navigate to *Features* tab.
+* Install the *catalog-core-backupplugin* feature.
 
 ===== Configuring the Catalog Backup Plugin
 
 To configure the Catalog Backup Plugin:
 
 . Navigate to the *${admin-console}*.
-. Select ${ddf-catalog} application.
+. Select *${ddf-catalog}* application.
 . Select *Configuration* tab.
-. Select *Backup Post-Ingest Plugin*.
+. Select *Catalog Backup Plugin*.
 
 include::{adoc-include}/_tables/plugin.backup-table-contents.adoc[]

--- a/distribution/docs/src/main/resources/_contents/_plugins/catalog-backup-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/catalog-backup-plugin-contents.adoc
@@ -22,4 +22,4 @@ To configure the Catalog Backup Plugin:
 . Select *Configuration* tab.
 . Select *Catalog Backup Plugin*.
 
-include::{adoc-include}/_tables/plugin.backup-table-contents.adoc[]
+include::{adoc-include}/_tables/ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc[]

--- a/distribution/docs/src/main/resources/_contents/_running/ingesting-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/ingesting-contents.adoc
@@ -167,11 +167,6 @@ Therefore, whether an administrator's data store is from Oracle, Solr, or any ot
 ==== Automatic Catalog Backup
 
 To backup local catalog records, a <<_catalog_backup_plugin,Catalog Backup Plugin>> is available.
-It is disabled by default for performance reasons.
+It is not installed by default for performance reasons.
 
-It can be enabled and configured in the *${admin-console}:
-
-. Navigate to the *${admin-console}.
-. Select the *${ddf-catalog} application.
-. Select the *Configuration* tab.
-. Select the <<_catalog_backup_plugin,Backup Post-Ingest Plugin>>.
+It can be installed and configured in the *${admin-console}* (see <<_catalog_backup_plugin,Catalog Backup Plugin>> for instructions).

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -126,14 +126,6 @@ For example:
 `127.0.0.1 <FQDN>`
 ====
 
-[NOTE]
-====
-By default, the Catalog Backup Post-Ingest Plugin is *NOT* enabled.
-To enable, the Enable Backup Plugin configuration item must be checked in the Backup Post-Ingest Plugin configuration.
-
-`Enable Backup Plugin: true`
-====
-
 .Changing Default Passwords
 [NOTE]
 ====

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc
@@ -1,0 +1,3 @@
+|<<ddf.catalog.backup.CatalogBackupPlugin,Catalog Backup Plugin>>
+|ddf.catalog.backup.CatalogBackupPlugin
+|Catalog Backup Plugin Configuration

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
@@ -1,4 +1,0 @@
-|<<plugin.backup,Catalog Backup Plugin>>
-|plugin.backup
-|Catalog Backup Plugin Configuration
-

--- a/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/conf-plugin.backup-table-contents.adoc
@@ -1,4 +1,4 @@
-|<<plugin.backup,Backup Post-Ingest Plugin>>
+|<<plugin.backup,Catalog Backup Plugin>>
 |plugin.backup
-|Backup Post-Ingest Plugin Configuration
+|Catalog Backup Plugin Configuration
 

--- a/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/ddf.catalog.backup.CatalogBackupPlugin-table-contents.adoc
@@ -1,4 +1,4 @@
-.[[plugin.backup]]Catalog Backup Plugin
+.[[ddf.catalog.backup.CatalogBackupPlugin]]Catalog Backup Plugin
 [cols="1,1m,1,3,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/_contents/_tables/plugin.backup-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/plugin.backup-table-contents.adoc
@@ -1,4 +1,4 @@
-.[[plugin.backup]]Backup Post-Ingest Plugin
+.[[plugin.backup]]Catalog Backup Plugin
 [cols="1,1m,1,3,1,1" options="header"]
 |===
 
@@ -8,13 +8,6 @@
 |Description
 |Default Value
 |Required
-
-|Enable Backup Plugin
-|enableBackupPlugin
-|Boolean
-|Enable the Backup Ingest plugin which will write each result to a directory
-|true
-|false
 
 | Root backup directory path
 | rootBackupDir

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -356,10 +356,6 @@ public abstract class AbstractIntegrationTest {
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
             getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/csw?_wadl");
 
-            //currently none of the test use this feature but
-            //it generates a lot of error/warnings so turning it off
-            getServiceManager().stopFeature(false, "catalog-core-backupplugin");
-
             getServiceManager().startFeature(true, "search-ui", "search-ui-app", "catalog-ui");
             getServiceManager().waitForAllBundles();
         } catch (Exception e) {


### PR DESCRIPTION
#### What does this PR do?
Removes the `enableBackupPlugin` configuration option and leaves the catalog backup plugin uninstalled by default. Renames references to the plugin in the documentation to "Catalog Backup Plugin".

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@ahoffer 
@ryeats 
@idperez 
@ricklarsen 

#### Select relevant component teams: 
@codice/core-apis 

#### Choose 2 committers to review/merge the PR. 
@clockard 
@jaymcnallie

#### How should this be tested? (List steps with links to updated documentation)
Build DDF, start it up, and verify that the catalog backup plugin is not installed.

#### Any background context you want to provide?
Our documentation states that the plugin is not installed for performance reasons but in reality it is installed by default.

#### What are the relevant tickets?
[DDF-2995](https://codice.atlassian.net/browse/DDF-2995)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
