### PR TITLE
DDF-3105 Temporarily disable CDMIT

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -383,17 +383,18 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.17</version>
-                <configuration>
-                    <systemPropertyVariables>
-                        <pax.exam.karaf.version>${karaf.version}</pax.exam.karaf.version>
-                        <component.artifactId>${artifactId}</component.artifactId>
-                        <component.version>${project.version}</component.version>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
+            <!-- FIXME DDF-3105 Add port randomization and reenable-->
+            <!--<plugin>-->
+                <!--<artifactId>maven-failsafe-plugin</artifactId>-->
+                <!--<version>2.17</version>-->
+                <!--<configuration>-->
+                    <!--<systemPropertyVariables>-->
+                        <!--<pax.exam.karaf.version>${karaf.version}</pax.exam.karaf.version>-->
+                        <!--<component.artifactId>${artifactId}</component.artifactId>-->
+                        <!--<component.version>${project.version}</component.version>-->
+                    <!--</systemPropertyVariables>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
 
             <!-- Needed if you use versionAsInProject() -->
             <plugin>


### PR DESCRIPTION
#### What does this PR do?
Disables the directory monitor component tests until #2090 adds port randomization.
#### Who is reviewing it? 
@mcalcote @AzGoalie 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic 
#### How should this be tested? (List steps with links to updated documentation)
Build catalog-core-directorymonitor and verify the component tests do not run.
#### Any background context you want to provide?
This issue was causing the tests to fail to startup on the nightlies, rendering them unstable in jenkins.
#### What are the relevant tickets?
[DDF-3105](https://codice.atlassian.net/browse/DDF-3105)
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
