### PR TITLE
DDF-3159 Add proxy http login

### DIFF
--- a/catalog/ui/catalog-ui-search/webpack/config/dev.js
+++ b/catalog/ui/catalog-ui-search/webpack/config/dev.js
@@ -8,6 +8,25 @@ var resolve = function (place) {
     return path.resolve(__dirname, '../../', place)
 };
 
+var handleProxyRes = function (proxyRes, req, res) {
+    // remove so we can still login in through http
+    delete proxyRes.headers['x-xss-protection'];
+    var cookie = proxyRes.headers['set-cookie'];
+    if (cookie !== undefined) {
+        // force the cookie to be insecure since the proxy is over http
+        proxyRes.headers['set-cookie'] = cookie[0].replace(new RegExp(/;\w?Secure/), '')
+    }
+};
+
+var proxyConfig = function (target) {
+    return {
+        target: target,
+        secure: false,
+        changeOrigin: true,
+        onProxyRes: handleProxyRes
+    }
+};
+
 module.exports = merge.smart(base, {
     devServer: {
         progress: true,
@@ -16,21 +35,9 @@ module.exports = merge.smart(base, {
         hot: true,
         contentBase: [resolve('./node_modules/cesium/Build/'), resolve('/src/main/webapp/')],
         proxy: {
-            '/search/catalog/**': {
-                target: 'https://localhost:8993',
-                secure: false,
-                changeOrigin: true
-            },
-            '/services/**': {
-                target: 'https://localhost:8993',
-                secure: false,
-                changeOrigin: true
-            },
-            '/styles/**': {
-                target: 'https://localhost:8993/search/catalog',
-                secure: false,
-                changeOrigin: true
-            }
+            '/search/catalog/**': proxyConfig('https://localhost:8993'),
+            '/services/**': proxyConfig('https://localhost:8993'),
+            '/styles/**': proxyConfig('https://localhost:8993/search/catalog')
         }
     },
     entry: [


### PR DESCRIPTION
#### What does this PR do?
Bring back the ability to log in while using the webpack dev proxy.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@djblue @SmithJosh 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining
#### How should this be tested? (List steps with links to updated documentation)
Install DDF. Run `npm start`. In a fresh session, go to `http://localhost:8080` and verify you can login.
#### What are the relevant tickets?
[DDF-3159](https://codice.atlassian.net/browse/DDF-3159)
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
