### PR TITLE
DDF-3054 Updates geowebcache owasp suppresions

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -140,6 +140,7 @@
             gwc-web-1.5.0.war: commons-collections-3.1.jar
             gwc-web-1.5.0.war: postgresql-8.4-701.jdbc3.jar
             geowebcache-server-standalone-0.7.0.war: gwc-sqlite-1.9.1.jar
+            geowebcache-server-standalone-0.7.0.war: sqlite-jdbc-3.8.6.jar
             geowebcache-server-standalone-0.7.0.war: commons-fileupload-1.2.1.jar
         </notes>
         <cve>CVE-2016-3092</cve>
@@ -154,5 +155,6 @@
         <cve>CVE-2015-3416</cve>
         <cve>CVE-2015-3415</cve>
         <cve>CVE-2015-3414</cve>
+        <cve>CVE-2017-10989</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
#### What does this PR do?
Adds in new suppression for geowebcache which breaks the build.
A similar change was made here: https://github.com/codice/alliance/commit/6253941a70c5809a635cba12dd624d253fb86fb7

#### Who is reviewing it? 
@mcalcote @clockard @josephthweatt 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard 
@coyotesqrl 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
