### PR TITLE
DDF-3161 Results displayed by Intrigue can be incomplete because the Catalog UI endpoint doesn't handle paging

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/ResultIterable.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/ResultIterable.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Result;
@@ -83,6 +87,11 @@ public class ResultIterable implements Iterable<Result> {
     @Override
     public Iterator<Result> iterator() {
         return new QueryResultIterator(queryFunction, queryRequest);
+    }
+
+    public Stream<Result> stream() {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(),
+                Spliterator.ORDERED), false);
     }
 
     private static class QueryResultIterator implements Iterator<Result> {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.io.ByteSource;
 
 import ddf.catalog.CatalogFramework;
@@ -102,6 +103,7 @@ import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.util.impl.ResultIterable;
 import ddf.security.Subject;
 import ddf.security.SubjectUtils;
 import spark.servlet.SparkApplication;
@@ -664,13 +666,13 @@ public class MetacardApplication implements SparkApplication {
                 .text(id);
 
         Filter filter = filterBuilder.allOf(historyFilter, idFilter);
-        QueryResponse response = catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter,
+        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(filter,
                 1,
                 -1,
                 SortBy.NATURAL_ORDER,
                 false,
                 TimeUnit.SECONDS.toMillis(10)), false));
-        return response.getResults();
+        return Lists.newArrayList(resultIterable);
     }
 
     private Metacard updateMetacard(String id, Metacard metacard)

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -140,6 +140,8 @@ public class MetacardApplication implements SparkApplication {
 
     private final Associated associated;
 
+    private static int pageSize = 250;
+
     public MetacardApplication(CatalogFramework catalogFramework, FilterBuilder filterBuilder,
             EndpointUtil endpointUtil, Validator validator, WorkspaceTransformer transformer,
             ExperimentalEnumerationExtractor enumExtractor,
@@ -668,7 +670,7 @@ public class MetacardApplication implements SparkApplication {
         Filter filter = filterBuilder.allOf(historyFilter, idFilter);
         ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(filter,
                 1,
-                -1,
+                pageSize,
                 SortBy.NATURAL_ORDER,
                 false,
                 TimeUnit.SECONDS.toMillis(10)), false));

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -60,6 +61,8 @@ public class Associated {
     private final EndpointUtil util;
 
     private final CatalogFramework catalogFramework;
+
+    private static int pageSize = 250;
 
     public Associated(EndpointUtil util, CatalogFramework catalogFramework) {
         this.util = util;
@@ -269,16 +272,13 @@ public class Associated {
 
         ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(filter,
                 1,
-                0,
+                pageSize,
                 SortBy.NATURAL_ORDER,
                 false,
                 TimeUnit.SECONDS.toMillis(30)), false));
-        Map<String, Metacard> results = new HashMap<>();
-        for (Result result : resultIterable) {
-            results.put(result.getMetacard()
-                    .getId(), result.getMetacard());
-        }
-        return results;
+        return resultIterable.stream()
+                .map(Result::getMetacard)
+                .collect(Collectors.toMap(Metacard::getId, Function.identity()));
     }
 
     private List<String> getRelationsToChild(Metacard parent, Metacard child) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,13 +44,13 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.federation.FederationException;
-import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.util.impl.ResultIterable;
 
 public class Associated {
 
@@ -268,17 +267,18 @@ public class Associated {
             return Collections.emptyMap();
         }
 
-        QueryResponse query = catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter,
+        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(filter,
                 1,
                 0,
                 SortBy.NATURAL_ORDER,
                 false,
                 TimeUnit.SECONDS.toMillis(30)), false));
-
-        return query.getResults()
-                .stream()
-                .map(Result::getMetacard)
-                .collect(Collectors.toMap(Metacard::getId, Function.identity()));
+        Map<String, Metacard> results = new HashMap<>();
+        for (Result result : resultIterable) {
+            results.put(result.getMetacard()
+                    .getId(), result.getMetacard());
+        }
+        return results;
     }
 
     private List<String> getRelationsToChild(Metacard parent, Metacard child) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -81,6 +81,8 @@ public class EndpointUtil {
 
     private static final String ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
+    private static int pageSize = 250;
+
     public EndpointUtil(List<MetacardType> metacardTypes, CatalogFramework catalogFramework,
             FilterBuilder filterBuilder, List<InjectableAttribute> injectableAttributes,
             AttributeRegistry attributeRegistry) {
@@ -143,17 +145,13 @@ public class EndpointUtil {
         ResultIterable resultIterable = new ResultIterable(catalogFramework,
                 new QueryRequestImpl(new QueryImpl(filter,
                         1,
-                        -1,
+                        pageSize,
                         SortBy.NATURAL_ORDER,
                         false,
                         TimeUnit.SECONDS.toMillis(10)), false));
-        Map<String, Result> results = new HashMap<>();
-        for (Result result : resultIterable) {
-            results.put(result.getMetacard()
-                    .getId(), result);
-        }
-
-        return results;
+        return resultIterable.stream()
+                .collect(Collectors.toMap(result -> result.getMetacard()
+                        .getId(), Function.identity()));
     }
 
     public Map<String, Result> getMetacards(Collection<String> ids, String tagFilter)
@@ -195,20 +193,17 @@ public class EndpointUtil {
         }
 
         Filter queryFilter = filterBuilder.anyOf(filters);
-        ResultIterable resultsIterable = new ResultIterable(catalogFramework,
+        ResultIterable resultIterable = new ResultIterable(catalogFramework,
                 new QueryRequestImpl(new QueryImpl(queryFilter,
                         1,
-                        -1,
+                        pageSize,
                         SortBy.NATURAL_ORDER,
                         false,
                         TimeUnit.SECONDS.toMillis(10)), false));
-        Map<String, Result> results = new HashMap<>();
-        for (Result result : resultsIterable) {
-            results.put(result.getMetacard()
-                    .getId(), result);
-        }
 
-        return results;
+        return resultIterable.stream()
+                .collect(Collectors.toMap(result -> result.getMetacard()
+                        .getId(), Function.identity()));
     }
 
     @SuppressWarnings("unchecked")

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -140,14 +140,13 @@ public class EndpointUtil {
                 .is()
                 .like()
                 .text(tagFilter);
-
-        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
-                filter,
-                1,
-                -1,
-                SortBy.NATURAL_ORDER,
-                false,
-                TimeUnit.SECONDS.toMillis(10)), false));
+        ResultIterable resultIterable = new ResultIterable(catalogFramework,
+                new QueryRequestImpl(new QueryImpl(filter,
+                        1,
+                        -1,
+                        SortBy.NATURAL_ORDER,
+                        false,
+                        TimeUnit.SECONDS.toMillis(10)), false));
         Map<String, Result> results = new HashMap<>();
         for (Result result : resultIterable) {
             results.put(result.getMetacard()
@@ -196,14 +195,13 @@ public class EndpointUtil {
         }
 
         Filter queryFilter = filterBuilder.anyOf(filters);
-
-        ResultIterable resultsIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
-                queryFilter,
-                1,
-                -1,
-                SortBy.NATURAL_ORDER,
-                false,
-                TimeUnit.SECONDS.toMillis(10)), false));
+        ResultIterable resultsIterable = new ResultIterable(catalogFramework,
+                new QueryRequestImpl(new QueryImpl(queryFilter,
+                        1,
+                        -1,
+                        SortBy.NATURAL_ORDER,
+                        false,
+                        TimeUnit.SECONDS.toMillis(10)), false));
         Map<String, Result> results = new HashMap<>();
         for (Result result : resultsIterable) {
             results.put(result.getMetacard()

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -148,9 +148,7 @@ public class EndpointUtil {
                 SortBy.NATURAL_ORDER,
                 false,
                 TimeUnit.SECONDS.toMillis(10)), false));
-
         Map<String, Result> results = new HashMap<>();
-
         for (Result result : resultIterable) {
             results.put(result.getMetacard()
                     .getId(), result);
@@ -198,7 +196,8 @@ public class EndpointUtil {
         }
 
         Filter queryFilter = filterBuilder.anyOf(filters);
-        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
+
+        ResultIterable resultsIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
                 queryFilter,
                 1,
                 -1,
@@ -206,10 +205,11 @@ public class EndpointUtil {
                 false,
                 TimeUnit.SECONDS.toMillis(10)), false));
         Map<String, Result> results = new HashMap<>();
-        for (Result result : resultIterable) {
+        for (Result result : resultsIterable) {
             results.put(result.getMetacard()
                     .getId(), result);
         }
+
         return results;
     }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -66,6 +66,7 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.util.impl.ResultIterable;
 
 public class EndpointUtil {
     private final List<MetacardType> metacardTypes;
@@ -134,11 +135,13 @@ public class EndpointUtil {
 
     public Map<String, Result> getMetacardsByFilter(String tagFilter)
             throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+
         Filter filter = filterBuilder.attribute(Metacard.TAGS)
                 .is()
                 .like()
                 .text(tagFilter);
-        QueryResponse queryResponse = catalogFramework.query(new QueryRequestImpl(new QueryImpl(
+
+        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
                 filter,
                 1,
                 -1,
@@ -147,10 +150,12 @@ public class EndpointUtil {
                 TimeUnit.SECONDS.toMillis(10)), false));
 
         Map<String, Result> results = new HashMap<>();
-        for (Result result : queryResponse.getResults()) {
+
+        for (Result result : resultIterable) {
             results.put(result.getMetacard()
                     .getId(), result);
         }
+
         return results;
     }
 
@@ -193,7 +198,7 @@ public class EndpointUtil {
         }
 
         Filter queryFilter = filterBuilder.anyOf(filters);
-        QueryResponse response = catalogFramework.query(new QueryRequestImpl(new QueryImpl(
+        ResultIterable resultIterable = new ResultIterable(catalogFramework, new QueryRequestImpl(new QueryImpl(
                 queryFilter,
                 1,
                 -1,
@@ -201,7 +206,7 @@ public class EndpointUtil {
                 false,
                 TimeUnit.SECONDS.toMillis(10)), false));
         Map<String, Result> results = new HashMap<>();
-        for (Result result : response.getResults()) {
+        for (Result result : resultIterable) {
             results.put(result.getMetacard()
                     .getId(), result);
         }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -1,9 +1,24 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.ddf.catalog.ui.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -17,6 +32,7 @@ import org.opengis.filter.Filter;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.InjectableAttribute;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.FederationException;
@@ -28,14 +44,9 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
 
-/**
- * Created by mweser on 7/17/17.
- */
 public class EndpointUtilTest {
 
     EndpointUtil endpointUtil;
-
-    Map<String, Result> expectedMap;
 
     List<MetacardType> metacardTypeList;
 
@@ -59,6 +70,10 @@ public class EndpointUtilTest {
 
     QueryResponse responseMock;
 
+    Metacard metacardMock;
+
+    Result resultMock;
+
     @Before
     public void setUp() throws Exception {
 
@@ -76,14 +91,13 @@ public class EndpointUtilTest {
         injectableAttributeList.add(injectableAttributeMock);
 
         attributeRegistryMock = mock(AttributeRegistry.class);
-
         filterMock = mock(Filter.class);
-
         attributeBuilderMock = mock(AttributeBuilder.class);
-
         contextualExpressionBuilderMock = mock(ContextualExpressionBuilder.class);
 
         responseMock = mock(QueryResponse.class);
+        metacardMock = mock(Metacard.class);
+        resultMock = mock(Result.class);
 
         // when
         when(filterBuilderMock.attribute(any())).thenReturn(attributeBuilderMock);
@@ -92,6 +106,9 @@ public class EndpointUtilTest {
         when(contextualExpressionBuilderMock.text(anyString())).thenReturn(filterMock);
         when(catalogFrameworkMock.query(any(QueryRequestImpl.class))).thenReturn(responseMock);
 
+        when(resultMock.getMetacard()).thenReturn(metacardMock);
+        when(metacardMock.getId()).thenReturn("MOCK METACARD");
+
         // constructor
         endpointUtil = new EndpointUtil(metacardTypeList,
                 catalogFrameworkMock,
@@ -99,22 +116,44 @@ public class EndpointUtilTest {
                 injectableAttributeList,
                 attributeRegistryMock);
 
-        // TODO: 7/17/17 Instantiate expectedMap here
     }
 
     @Test
     public void testGetMetacardsByFilterExpectAll()
             throws UnsupportedQueryException, SourceUnavailableException, FederationException {
 
-        String tagFilter = "*";
-        Map<String, Result> expected;
+        int numResults = 100;
 
-        expected = endpointUtil.getMetacardsByFilter(tagFilter);
+        // TODO: 7/17/17 Look into why tagFilter is irrelevant (might need for other test)
+        String tagFilter = "";
 
-        assertThat("Something expected", true);
+        List<Result> resultList = populateResultMockList(numResults);
+        List<Result> emptyList = populateResultMockList(0);
 
-        //verify
+        when(responseMock.getResults()).thenReturn(resultList, resultList, emptyList);
 
+        Map<String, Result> expected = endpointUtil.getMetacardsByFilter(tagFilter);
+
+        assertThat("Should return " + numResults + " results, but returned " + expected.size(),
+                expected.size() == numResults);
+
+        verify(responseMock, times(4)).getResults();
     }
 
+    private List<Result> populateResultMockList(int size) {
+
+        List<Result> resultMockList = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            resultMock = mock(Result.class);
+            metacardMock = mock(Metacard.class);
+
+            when(resultMock.getMetacard()).thenReturn(metacardMock);
+            when(metacardMock.getId()).thenReturn("MOCK METACARD " + (i + 1));
+
+            resultMockList.add(resultMock);
+        }
+
+        return resultMockList;
+    }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -1,0 +1,120 @@
+package org.codice.ddf.catalog.ui.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.InjectableAttribute;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.AttributeBuilder;
+import ddf.catalog.filter.ContextualExpressionBuilder;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+/**
+ * Created by mweser on 7/17/17.
+ */
+public class EndpointUtilTest {
+
+    EndpointUtil endpointUtil;
+
+    Map<String, Result> expectedMap;
+
+    List<MetacardType> metacardTypeList;
+
+    MetacardType metacardTypeMock;
+
+    CatalogFramework catalogFrameworkMock;
+
+    FilterBuilder filterBuilderMock;
+
+    List<InjectableAttribute> injectableAttributeList;
+
+    InjectableAttribute injectableAttributeMock;
+
+    AttributeRegistry attributeRegistryMock;
+
+    Filter filterMock;
+
+    AttributeBuilder attributeBuilderMock;
+
+    ContextualExpressionBuilder contextualExpressionBuilderMock;
+
+    QueryResponse responseMock;
+
+    @Before
+    public void setUp() throws Exception {
+
+        // mocks
+        metacardTypeList = new ArrayList<>();
+        metacardTypeMock = mock(MetacardType.class);
+        metacardTypeList.add(metacardTypeMock);
+
+        catalogFrameworkMock = mock(CatalogFramework.class);
+
+        filterBuilderMock = mock(FilterBuilder.class);
+
+        injectableAttributeList = new ArrayList<>();
+        injectableAttributeMock = mock(InjectableAttribute.class);
+        injectableAttributeList.add(injectableAttributeMock);
+
+        attributeRegistryMock = mock(AttributeRegistry.class);
+
+        filterMock = mock(Filter.class);
+
+        attributeBuilderMock = mock(AttributeBuilder.class);
+
+        contextualExpressionBuilderMock = mock(ContextualExpressionBuilder.class);
+
+        responseMock = mock(QueryResponse.class);
+
+        // when
+        when(filterBuilderMock.attribute(any())).thenReturn(attributeBuilderMock);
+        when(attributeBuilderMock.is()).thenReturn(attributeBuilderMock);
+        when(attributeBuilderMock.like()).thenReturn(contextualExpressionBuilderMock);
+        when(contextualExpressionBuilderMock.text(anyString())).thenReturn(filterMock);
+        when(catalogFrameworkMock.query(any(QueryRequestImpl.class))).thenReturn(responseMock);
+
+        // constructor
+        endpointUtil = new EndpointUtil(metacardTypeList,
+                catalogFrameworkMock,
+                filterBuilderMock,
+                injectableAttributeList,
+                attributeRegistryMock);
+
+        // TODO: 7/17/17 Instantiate expectedMap here
+    }
+
+    @Test
+    public void testGetMetacardsByFilterExpectAll()
+            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+
+        String tagFilter = "*";
+        Map<String, Result> expected;
+
+        expected = endpointUtil.getMetacardsByFilter(tagFilter);
+
+        assertThat("Something expected", true);
+
+        //verify
+
+    }
+
+}

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -30,7 +31,6 @@ import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Or;
 
@@ -41,40 +41,18 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.AttributeBuilder;
 import ddf.catalog.filter.ContextualExpressionBuilder;
 import ddf.catalog.filter.EqualityExpressionBuilder;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 
 public class EndpointUtilTest {
 
-    @InjectMocks
     EndpointUtil endpointUtil;
 
-    List<MetacardType> metacardTypeList;
-
-    MetacardType metacardTypeMock;
-
-    CatalogFramework catalogFrameworkMock;
-
     FilterBuilder filterBuilderMock;
-
-    List<InjectableAttribute> injectableAttributeList;
-
-    InjectableAttribute injectableAttributeMock;
-
-    AttributeRegistry attributeRegistryMock;
-
-    Filter filterMock;
-
-    AttributeBuilder attributeBuilderMock;
-
-    ContextualExpressionBuilder contextualExpressionBuilderMock;
 
     QueryResponse responseMock;
 
@@ -85,27 +63,32 @@ public class EndpointUtilTest {
     @Before
     public void setUp() throws Exception {
 
-        // mocks
-        metacardTypeList = new ArrayList<>();
-        metacardTypeMock = mock(MetacardType.class);
-        metacardTypeList.add(metacardTypeMock);
+        List<MetacardType> metacardTypeList = new ArrayList<>();
 
-        catalogFrameworkMock = mock(CatalogFramework.class);
+        List<InjectableAttribute> injectableAttributeList = new ArrayList<>();
+
+        // mocks
+        MetacardType metacardTypeMock = mock(MetacardType.class);
+
+        CatalogFramework catalogFrameworkMock = mock(CatalogFramework.class);
+
+        InjectableAttribute injectableAttributeMock = mock(InjectableAttribute.class);
+
+        AttributeRegistry attributeRegistryMock = mock(AttributeRegistry.class);
+
+        Filter filterMock = mock(Filter.class);
+
+        AttributeBuilder attributeBuilderMock = mock(AttributeBuilder.class);
+
+        ContextualExpressionBuilder contextualExpressionBuilderMock = mock(ContextualExpressionBuilder.class);
 
         filterBuilderMock = mock(FilterBuilder.class);
-
-        injectableAttributeList = new ArrayList<>();
-        injectableAttributeMock = mock(InjectableAttribute.class);
-        injectableAttributeList.add(injectableAttributeMock);
-
-        attributeRegistryMock = mock(AttributeRegistry.class);
-        filterMock = mock(Filter.class);
-        attributeBuilderMock = mock(AttributeBuilder.class);
-        contextualExpressionBuilderMock = mock(ContextualExpressionBuilder.class);
-
         responseMock = mock(QueryResponse.class);
         metacardMock = mock(Metacard.class);
         resultMock = mock(Result.class);
+
+        metacardTypeList.add(metacardTypeMock);
+        injectableAttributeList.add(injectableAttributeMock);
 
         // when
         when(filterBuilderMock.attribute(any())).thenReturn(attributeBuilderMock);
@@ -123,42 +106,40 @@ public class EndpointUtilTest {
                 filterBuilderMock,
                 injectableAttributeList,
                 attributeRegistryMock);
-
     }
 
     @Test
-    public void testGetMetacardsByFilterExpectAll()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    public void testGetMetacardsByFilterExpectAll() throws Exception {
 
         String tagFilter = "";
-        int numResults = 100;
+        int expected = 100;
 
-        List<Result> resultList = populateResultMockList(numResults);
+        List<Result> resultList = populateResultMockList(expected);
         List<Result> emptyList = populateResultMockList(0);
 
+        // Internal implementation detail: ResultIterable.fetchNextResults may call resultList
+        // a varying number times. emptyList is returned to express that all resources have been exhausted
         when(responseMock.getResults()).thenReturn(resultList, resultList, emptyList);
 
-        Map<String, Result> expected = endpointUtil.getMetacardsByFilter(tagFilter);
+        Map<String, Result> result = endpointUtil.getMetacardsByFilter(tagFilter);
 
-        assertThat("Should return " + numResults + " results, but returned " + expected.size(),
-                expected.size() == numResults);
+        assertThat(result.keySet(), hasSize(expected));
 
         verify(responseMock, times(4)).getResults();
     }
 
     @Test
-    public void testGetMetacardsByIdListExpectAll()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    public void testGetMetacardsByIdListExpectAll() throws Exception {
 
         String attributeName = "attr";
-        int numResults = 100;
+        int expected = 100;
 
         Filter tagFilter = mock(Filter.class);
-        List<Result> resultList = populateResultMockList(numResults, attributeName);
-        List<Result> emptyList = populateResultMockList(0, attributeName);
+        List<Result> resultList = populateResultMockList(expected, attributeName);
+        List<Result> emptyList = populateResultMockList(0);
 
         Collection<String> ids = resultList.stream()
-                .map(res -> res.getMetacard()
+                .map(result -> result.getMetacard()
                         .getId())
                 .collect(Collectors.toSet());
 
@@ -168,10 +149,9 @@ public class EndpointUtilTest {
                 .equalTo()).thenReturn(mock(EqualityExpressionBuilder.class));
         when(filterBuilderMock.anyOf(anyList())).thenReturn(mock(Or.class));
 
-        Map<String, Result> expected = endpointUtil.getMetacards(attributeName, ids, tagFilter);
+        Map<String, Result> result = endpointUtil.getMetacards(attributeName, ids, tagFilter);
 
-        assertThat("Should return " + numResults + " results, but returned " + expected.size(),
-                expected.size() == numResults);
+        assertThat(result.keySet(), hasSize(expected));
 
         verify(responseMock, times(4)).getResults();
     }
@@ -180,7 +160,7 @@ public class EndpointUtilTest {
         return populateResultMockList(size, null);
     }
 
-    // this method will give the Metacard an attribute if provided
+    // this method will return Metacards with an attribute if the attribute parameter is specified
     private List<Result> populateResultMockList(int size, String attribute) {
 
         List<Result> resultMockList = new ArrayList<>();


### PR DESCRIPTION
#### What does this PR do?
Uses ResultIterable to retrieve Metacards from the catalog. After DDF-2782, there was a possibility of a user only receiving a subset of the actual results.

#### Who is reviewing it? 
@mweser 
@emmberk 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard 
@coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
1. Build DDF and unzip
2. Before running DDF, edit the **setenv** inside **ddf-2.11.0-SNAPSHOT/bin** so that the last line reads: `export JAVA_OPTS=-"server -Dcatalog.maxPageSize=3 .......`
3. Run DDF
4. In DDF's terminal, install the Catalog UI using `feature:install catalog-ui`
5. Ingest a metacard through Catalog UI
6. Using the Catalog UI, select the metacard and expand it. In the details tab, make four changes to the title. Save after every change
7. Select the History tab, verify that there are four changes to the metacard


#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3161](https://codice.atlassian.net/browse/)
[DDF-2782](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
