### PR TITLE
DDF-3167 Changes the timing for the IdP server & client initialization of metadata.

### DIFF
--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
@@ -21,21 +21,21 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.xml.stream.XMLStreamException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.wss4j.common.ext.WSSecurityException;
-import org.opensaml.saml.common.SAMLException;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.opensaml.security.credential.UsageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ddf.security.samlp.MetadataConfigurationParser;
 
 public class IdpMetadata {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdpMetadata.class);
 
     private static final String SAML_2_0_PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol";
 
@@ -53,18 +53,18 @@ public class IdpMetadata {
 
     private String encryptionCertificate;
 
-    private Map<String, EntityDescriptor> entryDescriptions = new ConcurrentHashMap<>();
+    private String metadata;
+
+    private AtomicReference<Map<String, EntityDescriptor>> entryDescriptions =
+            new AtomicReference<>();
 
     private String singleLogoutBinding;
 
     private String singleLogoutLocation;
 
-    public void setMetadata(String metadata)
-            throws WSSecurityException, XMLStreamException, SAMLException, IOException {
-        MetadataConfigurationParser metadataConfigurationParser = new MetadataConfigurationParser(
-                Collections.singletonList(metadata),
-                ed -> entryDescriptions.put(ed.getEntityID(), ed));
-        entryDescriptions.putAll(metadataConfigurationParser.getEntryDescriptions());
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+        entryDescriptions.getAndSet(null);
     }
 
     private void initSingleSignOn() {
@@ -162,13 +162,39 @@ public class IdpMetadata {
     }
 
     private EntityDescriptor getEntityDescriptor() {
-        Set<Map.Entry<String, EntityDescriptor>> entries = entryDescriptions.entrySet();
+        Map<String, EntityDescriptor> edMap = entryDescriptions.get();
+        if (edMap == null) {
+            try {
+                edMap = parseMetadata();
+            } catch (IOException e) {
+                LOGGER.debug("Error parsing SSO metadata", e);
+                return null;
+            }
+
+            boolean updated = entryDescriptions.compareAndSet(null, edMap);
+            if (!updated) {
+                LOGGER.debug("Safe but concurrent update to serviceProviders map; using processed value");
+            }
+        }
+
+        Set<Map.Entry<String, EntityDescriptor>> entries = edMap.entrySet();
         if (!entries.isEmpty()) {
             return entries.iterator()
                     .next()
                     .getValue();
         }
         return null;
+    }
+
+    private Map<String, EntityDescriptor> parseMetadata() throws IOException {
+        final Map<String, EntityDescriptor> processMap = new ConcurrentHashMap<>();
+        MetadataConfigurationParser metadataConfigurationParser = //
+                new MetadataConfigurationParser(Collections.singletonList(metadata),
+                        ed -> processMap.put(ed.getEntityID(), ed));
+
+        processMap.putAll(metadataConfigurationParser.getEntryDescriptions());
+
+        return processMap;
     }
 
     public IDPSSODescriptor getDescriptor() {

--- a/platform/security/idp/security-idp-server/pom.xml
+++ b/platform/security/idp/security-idp-server/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-idp-server</artifactId>
-    <name>DDF :: Security :: IDP :: Server</name>
+    <name>DDF :: Security :: IdP :: Server</name>
     <packaging>bundle</packaging>
     <dependencies>
         <dependency>

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/MetadataConfigurationParser.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/MetadataConfigurationParser.java
@@ -26,7 +26,9 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang.StringUtils;
@@ -45,6 +47,7 @@ import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.util.ExponentialBackOff;
@@ -127,40 +130,21 @@ public class MetadataConfigurationParser {
             }
             PropertyResolver propertyResolver = new PropertyResolver(entityDescription);
             HttpTransport httpTransport = new NetHttpTransport();
-            HttpRequest httpRequest = httpTransport.createRequestFactory()
-                    .buildGetRequest(new GenericUrl(propertyResolver.getResolvedString()));
-            httpRequest.setUnsuccessfulResponseHandler(new HttpBackOffUnsuccessfulResponseHandler(
-                    new ExponentialBackOff()).setBackOffRequired(
-                    HttpBackOffUnsuccessfulResponseHandler.BackOffRequired.ALWAYS));
-            httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()));
-            ListeningExecutorService service =
-                    MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
-            ListenableFuture<HttpResponse> httpResponseFuture =
-                    service.submit(httpRequest::execute);
 
-            Futures.addCallback(httpResponseFuture, new FutureCallback<HttpResponse>() {
-                @Override
-                public void onSuccess(HttpResponse httpResponse) {
-                    if (httpResponse != null) {
-                        try {
-                            String parsedResponse = httpResponse.parseAsString();
-                            buildEntityDescriptor(parsedResponse);
-                        } catch (IOException e) {
-                            LOGGER.info("Unable to parse metadata from: {}",
-                                    httpResponse.getRequest()
-                                            .getUrl()
-                                            .toString(),
-                                    e);
-                        }
-                    }
-                }
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ListeningExecutorService service = MoreExecutors.listeningDecorator(executor);
 
-                @Override
-                public void onFailure(Throwable throwable) {
-                    LOGGER.info("Unable to retrieve metadata.", throwable);
+            addHttpCallback(propertyResolver, httpTransport, service, executor);
+            try {
+                if (!service.isShutdown() && !service.awaitTermination(30, TimeUnit.SECONDS)) {
+                    LOGGER.debug("Executor service shutdown timed out");
                 }
-            });
-            service.shutdown();
+            } catch (InterruptedException e) {
+                LOGGER.debug("Problem shutting down executor", e);
+                service.shutdown();
+                Thread.currentThread()
+                        .interrupt();
+            }
         } else if (entityDescription.startsWith(FILE + System.getProperty("ddf.home"))) {
             String pathStr = StringUtils.substringAfter(entityDescription, FILE);
             Path path = Paths.get(pathStr);
@@ -182,6 +166,57 @@ public class MetadataConfigurationParser {
                 updateCallback.accept(entityDescriptor);
             }
         }
+    }
+
+    private void addHttpCallback(PropertyResolver propertyResolver, HttpTransport httpTransport,
+            ListeningExecutorService service, ExecutorService executor) throws IOException {
+        HttpRequest httpRequest = generateHttpRequest(propertyResolver, httpTransport);
+        ListenableFuture<HttpResponse> httpResponseFuture = service.submit(httpRequest::execute);
+
+        FutureCallback<HttpResponse> callback = getHttpResponseFutureCallback(service);
+        Futures.addCallback(httpResponseFuture, callback, executor);
+    }
+
+    private HttpRequest generateHttpRequest(PropertyResolver propertyResolver,
+            HttpTransport httpTransport) throws IOException {
+        HttpRequest httpRequest = httpTransport.createRequestFactory()
+                .buildGetRequest(new GenericUrl(propertyResolver.getResolvedString()));
+
+        httpRequest.setUnsuccessfulResponseHandler(new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setBackOffRequired(
+                HttpBackOffUnsuccessfulResponseHandler.BackOffRequired.ALWAYS));
+        httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()));
+
+        return httpRequest;
+    }
+
+    private FutureCallback<HttpResponse> getHttpResponseFutureCallback(
+            ListeningExecutorService service) {
+        return new FutureCallback<HttpResponse>() {
+            @Override
+            public void onSuccess(HttpResponse httpResponse) {
+                if (httpResponse != null
+                        && httpResponse.getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+                    try {
+                        String parsedResponse = httpResponse.parseAsString();
+                        buildEntityDescriptor(parsedResponse);
+                        service.shutdown();
+                    } catch (IOException e) {
+                        LOGGER.info("Unable to parse metadata from: {}",
+                                httpResponse.getRequest()
+                                        .getUrl()
+                                        .toString(),
+                                e);
+                    }
+                } else {
+                    LOGGER.warn("No/bad response; re-submitting request");
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                LOGGER.info("Unable to retrieve metadata.", throwable);
+            }
+        };
     }
 
     private EntityDescriptor readEntityDescriptor(Reader reader) {

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/MetadataConfigurationParserTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/MetadataConfigurationParserTest.java
@@ -90,14 +90,16 @@ public class MetadataConfigurationParserTest {
         assertThat("Callback was not invoked", invoked.get());
     }
 
-    private void metadataFolderEntities(Consumer<EntityDescriptor> updateCallback) throws Exception {
+    private void metadataFolderEntities(Consumer<EntityDescriptor> updateCallback)
+            throws Exception {
         System.setProperty("ddf.home",
                 descriptorPath.getParent()
                         .getParent()
                         .getParent()
                         .toString());
         MetadataConfigurationParser metadataConfigurationParser = new MetadataConfigurationParser(
-                Collections.emptyList(), updateCallback);
+                Collections.emptyList(),
+                updateCallback);
         Map<String, EntityDescriptor> entities = metadataConfigurationParser.getEntryDescriptions();
 
         assertThat(entities.size(), is(1));
@@ -117,7 +119,8 @@ public class MetadataConfigurationParserTest {
 
     private void metadataFile(Consumer<EntityDescriptor> updateCallback) throws IOException {
         MetadataConfigurationParser metadataConfigurationParser = new MetadataConfigurationParser(
-                Collections.singletonList("file:" + descriptorPath.toString()), updateCallback);
+                Collections.singletonList("file:" + descriptorPath.toString()),
+                updateCallback);
         Map<String, EntityDescriptor> entities = metadataConfigurationParser.getEntryDescriptions();
 
         assertThat(entities.size(), is(1));
@@ -137,7 +140,8 @@ public class MetadataConfigurationParserTest {
 
     private void metadataString(Consumer<EntityDescriptor> updateCallback) throws IOException {
         MetadataConfigurationParser metadataConfigurationParser = new MetadataConfigurationParser(
-                Collections.singletonList(IOUtils.toString(descriptorPath.toUri())), updateCallback);
+                Collections.singletonList(IOUtils.toString(descriptorPath.toUri())),
+                updateCallback);
         Map<String, EntityDescriptor> entities = metadataConfigurationParser.getEntryDescriptions();
 
         assertThat(entities.size(), is(1));
@@ -181,6 +185,7 @@ public class MetadataConfigurationParserTest {
         doAnswer(invocationOnMock -> {
             HttpResponse response = (HttpResponse) invocationOnMock.getArguments()[1];
             response.setEntity(new StringEntity(message));
+            response.setStatusCode(200);
             return null;
         }).when(handler)
                 .handle(any(), any(), any());


### PR DESCRIPTION
#### What does this PR do?
Previously, these operations occurred on injection of the metadata locators. That led to an intermittent timing issue, as the two bundles cross-query HTTP endpoints. Now, they execute the queries and parse the data once, on initial access. This allows both services to be fully initialized before any queries are executed.

This change also includes some minor cleanup to the `MetadataConfigurationParser` class. That cleanup had been associated with an earlier approach to resolving the timing issue and is not necessary; however, it does make for smaller, more concise methods.

#### Who is reviewing it? 
@rzwiefel @tbatie @oconnormi 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@pklinef
@stustison

#### How should this be tested? (List steps with links to updated documentation)
As this resolves an intermittent problem, any definitive test is going to be difficult to manage. Some environments have proven to be more likely to demonstrate the issue than others based on speed/performance of equipment. The best way to test this is to repeatedly unzip, startup, and then attempt to login to the admin console. On my laptop, it would fail within fewer than six iterations. On other machines, it might take more successful login attempts to increase testing confidence.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3167](https://codice.atlassian.net/browse/DDF-3167)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
