### PR TITLE
DDF-2979 Apply attribute overrides in CDM updates

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
@@ -13,13 +13,24 @@
  **/
 package ddf.catalog.impl.operations;
 
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.collections.MapUtils;
+
 import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 
@@ -38,7 +49,9 @@ public class OverrideAttributesSupport {
             Metacard currentMetacard = metacardMap.get(contentItem.getId());
             Metacard overrideMetacard = contentItem.getMetacard();
 
-            Metacard updatedMetacard = overrideMetacard(currentMetacard, overrideMetacard, false,
+            Metacard updatedMetacard = overrideMetacard(currentMetacard,
+                    overrideMetacard,
+                    false,
                     false);
 
             metacardMap.put(contentItem.getId(), updatedMetacard);
@@ -63,13 +76,80 @@ public class OverrideAttributesSupport {
         otherMetacard.getMetacardType()
                 .getAttributeDescriptors()
                 .stream()
-                .map(attributeDescriptor -> otherMetacard.getAttribute(
-                        attributeDescriptor.getName()))
+                .map(attributeDescriptor -> otherMetacard.getAttribute(attributeDescriptor.getName()))
                 .filter(Objects::nonNull)
                 .filter(attribute -> !attribute.getName()
                         .equals(Metacard.ID))
                 .filter(attribute -> !onlyFillNull
                         || metacard.getAttribute(attribute.getName()) == null)
                 .forEach(metacard::setAttribute);
+    }
+
+    public static void applyAttributeOverridesToMetacardMap(
+            Map<String, Serializable> attributeOverrideMap, Map<String, Metacard> metacardMap) {
+
+        if (MapUtils.isEmpty(attributeOverrideMap) || MapUtils.isEmpty(metacardMap)) {
+            return;
+        }
+
+        metacardMap.values()
+                .forEach(metacard -> attributeOverrideMap.keySet()
+                        .stream()
+                        .map(attributeName -> metacard.getMetacardType()
+                                .getAttributeDescriptor(attributeName))
+                        .filter(Objects::nonNull)
+                        .map(ad -> overrideAttributeValue(ad,
+                                attributeOverrideMap.get(ad.getName())))
+                        .filter(Objects::nonNull)
+                        .forEach(metacard::setAttribute));
+    }
+
+    private static AttributeImpl overrideAttributeValue(AttributeDescriptor attributeDescriptor,
+            Serializable overrideValue) {
+        List<Serializable> newValue = new ArrayList<>();
+        for (Object o : overrideValue instanceof List ?
+                (List) overrideValue :
+                Collections.singletonList(overrideValue)) {
+            try {
+                String override = String.valueOf(o);
+                switch (attributeDescriptor.getType()
+                        .getAttributeFormat()) {
+                case INTEGER:
+                    newValue.add(Integer.parseInt(override));
+                    break;
+                case FLOAT:
+                    newValue.add(Float.parseFloat(override));
+                    break;
+                case DOUBLE:
+                    newValue.add(Double.parseDouble(override));
+                    break;
+                case SHORT:
+                    newValue.add(Short.parseShort(override));
+                    break;
+                case LONG:
+                    newValue.add(Long.parseLong(override));
+                    break;
+                case DATE:
+                    Calendar calendar = DatatypeConverter.parseDateTime(override);
+                    newValue.add(calendar.getTime());
+                    break;
+                case BOOLEAN:
+                    newValue.add(Boolean.parseBoolean(override));
+                    break;
+                case BINARY:
+                    newValue.add(override.getBytes(Charset.forName("UTF-8")));
+                    break;
+                case OBJECT:
+                case STRING:
+                case GEOMETRY:
+                case XML:
+                    newValue.add(override);
+                    break;
+                }
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return new AttributeImpl(attributeDescriptor.getName(), newValue);
     }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -737,6 +737,14 @@ public class UpdateOperations {
 
     private UpdateStorageRequest applyAttributeOverrides(UpdateStorageRequest updateStorageRequest,
             Map<String, Metacard> metacardMap) {
+        Map<String, Serializable> attributeOverrideHeaders =
+                (HashMap<String, Serializable>) updateStorageRequest.getProperties()
+                        .get(Constants.ATTRIBUTE_OVERRIDES_KEY);
+        OverrideAttributesSupport.applyAttributeOverridesToMetacardMap(attributeOverrideHeaders,
+                metacardMap);
+        updateStorageRequest.getProperties()
+                .remove(Constants.ATTRIBUTE_OVERRIDES_KEY);
+
         OverrideAttributesSupport.overrideAttributes(updateStorageRequest.getContentItems(),
                 metacardMap);
         return updateStorageRequest;

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/CreateOperationsSpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/CreateOperationsSpec.groovy
@@ -29,12 +29,12 @@ class CreateOperationsTest extends Specification {
     def 'test single and multivalued attribute overrides'() {
         def descriptorImpl = new AttributeDescriptorImpl("foo", true, true, true, true, BasicTypes.STRING_TYPE)
         when:
-        AttributeImpl single = createOperations.overrideAttributeValue(descriptorImpl, (Serializable) Arrays.asList("bar"))
+        AttributeImpl single = OverrideAttributesSupport.overrideAttributeValue(descriptorImpl, (Serializable) Arrays.asList("bar"))
         then:
         single.getValues().size() == 1
         single.getValues().contains("bar")
         when:
-        AttributeImpl multi = createOperations.overrideAttributeValue(descriptorImpl, (Serializable) Arrays.asList("bar", "baz"))
+        AttributeImpl multi = OverrideAttributesSupport.overrideAttributeValue(descriptorImpl, (Serializable) Arrays.asList("bar", "baz"))
         then:
         multi.getValues().size() == 2
         multi.getValues().contains("bar")

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
@@ -16,7 +16,10 @@ package ddf.catalog.impl.operations;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -24,15 +27,49 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.content.data.impl.ContentItemImpl;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 
 public class OverrideAttributesSupportTest {
+
+    private static final String OVERRIDDEN_STRING = "Overridden description.";
+
+    private static final short OVERRIDDEN_SHORT = 123;
+
+    private static final float OVERRIDDEN_FLOAT = 123.456f;
+
+    private static final double OVERRIDDEN_DOUBLE = 123.456;
+
+    private static final DateTime OVERRIDDEN_DATE = new DateTime("2004-04-12T13:20:00");
+
+    private static final boolean OVERRIDDEN_BOOLEAN = true;
+
+    private static final String SHORT_ATTR = "shortAttr";
+
+    private static final String INT_ATTR = "intAttr";
+
+    private static final String LONG_ATTR = "longAttr";
+
+    private static final String FLOAT_ATTR = "floatAttr";
+
+    private static final String DOUBLE_ATTR = "doubleAttr";
+
+    private static final String DATE_ATTR = "dateAttr";
+
+    private static final String STRING_ATTR = "stringAttr";
+
+    private static final String BOOLEAN_ATTR = "boolAttr";
 
     @Test
     public void testOverrideAttributesBasic() throws URISyntaxException {
@@ -123,7 +160,9 @@ public class OverrideAttributesSupportTest {
         overrideMetacard.setResourceURI(new URI("content:newstuff"));
 
         Metacard updatedMetacard = OverrideAttributesSupport.overrideMetacard(metacard,
-                overrideMetacard, true, false);
+                overrideMetacard,
+                true,
+                false);
 
         assertThat(updatedMetacard.getMetadata(), is("updated"));
         assertThat(updatedMetacard.getTitle(), is("updated"));
@@ -150,7 +189,9 @@ public class OverrideAttributesSupportTest {
         overrideMetacard.setResourceURI(new URI("content:newstuff"));
 
         Metacard updatedMetacard = OverrideAttributesSupport.overrideMetacard(metacard,
-                overrideMetacard, false, false);
+                overrideMetacard,
+                false,
+                false);
 
         assertThat(updatedMetacard.getMetadata(), is("updated"));
         assertThat(updatedMetacard.getTitle(), is("updated"));
@@ -210,5 +251,112 @@ public class OverrideAttributesSupportTest {
                 .toString(), is("content:stuff"));
         assertThat(metacardMap.get("original")
                 .getId(), is("original"));
+    }
+
+    @Test
+    public void testApplyAttributeOverridesToMetacardMap() throws Exception {
+        Map<String, Metacard> metacardMap = createMetacardMap();
+        Map<String, Serializable> attributeMap = createAttributeMap();
+
+        OverrideAttributesSupport.applyAttributeOverridesToMetacardMap(attributeMap, metacardMap);
+
+        metacardMap.values()
+                .forEach(metacard -> assertAttributesOverridden(metacard));
+    }
+
+    private void assertAttributesOverridden(Metacard metacard) {
+        assertThat(metacard.getAttribute(STRING_ATTR)
+                .getValue(), is(OVERRIDDEN_STRING));
+        assertThat(metacard.getAttribute(SHORT_ATTR)
+                .getValue(), is(OVERRIDDEN_SHORT));
+        assertThat(metacard.getAttribute(INT_ATTR)
+                .getValue(), is(Integer.valueOf(OVERRIDDEN_SHORT)));
+        assertThat(metacard.getAttribute(LONG_ATTR)
+                .getValue(), is(Long.valueOf(OVERRIDDEN_SHORT)));
+        assertThat(metacard.getAttribute(FLOAT_ATTR)
+                .getValue(), is(OVERRIDDEN_FLOAT));
+        assertThat(metacard.getAttribute(DOUBLE_ATTR)
+                .getValue(), is(OVERRIDDEN_DOUBLE));
+        assertThat(metacard.getAttribute(DATE_ATTR)
+                .getValue(), is(OVERRIDDEN_DATE.toDate()));
+        assertThat(metacard.getAttribute(BOOLEAN_ATTR)
+                .getValue(), is(OVERRIDDEN_BOOLEAN));
+    }
+
+    private Map<String, Serializable> createAttributeMap() {
+        return new ImmutableMap.Builder<String, Serializable>().put(STRING_ATTR, OVERRIDDEN_STRING)
+                .put(SHORT_ATTR, OVERRIDDEN_SHORT)
+                .put(INT_ATTR, OVERRIDDEN_SHORT)
+                .put(LONG_ATTR, OVERRIDDEN_SHORT)
+                .put(FLOAT_ATTR, OVERRIDDEN_FLOAT)
+                .put(DOUBLE_ATTR, OVERRIDDEN_DOUBLE)
+                .put(DATE_ATTR, OVERRIDDEN_DATE)
+                .put(BOOLEAN_ATTR, OVERRIDDEN_BOOLEAN)
+                .build();
+    }
+
+    private Map<String, Metacard> createMetacardMap() {
+        MetacardType mockMetacardType = mock(MetacardType.class);
+        doReturn(new AttributeDescriptorImpl(SHORT_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.SHORT_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(SHORT_ATTR);
+        doReturn(new AttributeDescriptorImpl(INT_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(INT_ATTR);
+        doReturn(new AttributeDescriptorImpl(LONG_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.LONG_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(LONG_ATTR);
+        doReturn(new AttributeDescriptorImpl(FLOAT_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.FLOAT_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(FLOAT_ATTR);
+        doReturn(new AttributeDescriptorImpl(DOUBLE_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DOUBLE_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(DOUBLE_ATTR);
+        doReturn(new AttributeDescriptorImpl(DATE_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(DATE_ATTR);
+        doReturn(new AttributeDescriptorImpl(STRING_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(STRING_ATTR);
+        doReturn(new AttributeDescriptorImpl(BOOLEAN_ATTR,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE)).when(mockMetacardType)
+                .getAttributeDescriptor(BOOLEAN_ATTR);
+
+        Metacard metacard1 = new MetacardImpl(mockMetacardType);
+        Metacard metacard2 = new MetacardImpl(mockMetacardType);
+
+        return ImmutableMap.of("1234", metacard1, "0987", metacard2);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes attribute overrides to make them applied on content directory monitor file monitored file updates.

#### Who is reviewing it? 
@brendan-hofmann 
@gordocanchola 
@AzGoalie 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
@clockard 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1. Ingest a file with an attribute override set. (ie contact.creator-name)
2. Modify the file, including a value that will change the overridden attribute (ie a metacard with contact.creator-name set to something else)
3. Let the CDM update the metacard and verify that the attribute is still overridden

#### Any background context you want to provide?
Original PR: https://github.com/codice/ddf/pull/1953

#### What are the relevant tickets?
[DDF-2979](https://codice.atlassian.net/browse/DDF-2979)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
