### PR TITLE
DDF-3169 Adds alerts for failover log failure

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -23,7 +23,10 @@
         <PaxOsgi name="osgi-platformLogging"
                  filter="org.codice.ddf.platform.logging.LoggingService"/>
 
-        <PaxOsgi name="osgi-all" filter="*"/>
+        <PaxOsgi name="osgi-adminAlertAppender"
+                 filter="ddf.security.common.audit.LogFailoverAlertAppender"/>
+
+        <PaxOsgi name="osgi-karafConsole" filter="VmLogAppender"/>
 
         <Syslog name="syslog" facility="AUTH" host="localhost" protocol="UDP" port="514"/>
 
@@ -75,6 +78,7 @@
         <Failover name="securityFailover" primary="securityMain">
             <Failovers>
                 <AppenderRef ref="securityBackup"/>
+                <AppenderRef ref="osgi-adminAlertAppender"/>
             </Failovers>
         </Failover>
 
@@ -146,7 +150,8 @@
 
         <Root level="info">
             <AppenderRef ref="out"/>
-            <AppenderRef ref="osgi-all"/>
+            <AppenderRef ref="osgi-karafConsole"/>
+            <AppenderRef ref="osgi-platformLogging"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -31,7 +31,8 @@ log4j2.pattern = %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} 
 # Root logger
 log4j2.rootLogger.level = INFO
 log4j2.rootLogger.appenderRef.out.ref = out
-log4j2.rootLogger.appenderRef.osgi-all.ref = osgi-all
+log4j2.rootLogger.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
+log4j2.rootLogger.appenderRef.osgi-karafConsole.ref = osgi-karafConsole
 
 # Loggers configuration
 
@@ -106,10 +107,10 @@ log4j2.appender.osgi-platformLogging.type = PaxOsgi
 log4j2.appender.osgi-platformLogging.name = osgi-platformLogging
 log4j2.appender.osgi-platformLogging.filter = org.codice.ddf.platform.logging.LoggingService
 
-# osgi-all
-log4j2.appender.osgi-all.type = PaxOsgi
-log4j2.appender.osgi-all.name = osgi-all
-log4j2.appender.osgi-all.filter = *
+# osgi-karafConsole
+log4j2.appender.osgi-karafConsole.type = PaxOsgi
+log4j2.appender.osgi-karafConsole.name = osgi-karafConsole
+log4j2.appender.osgi-karafConsole.filter = VmLogAppender
 
 # syslog
 log4j2.appender.syslog.type = Syslog
@@ -196,5 +197,3 @@ log4j2.appender.artemis.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.artemis.policies.size.size = 20MB
 log4j2.appender.artemis.strategy.type = DefaultRolloverStrategy
 log4j2.appender.artemis.strategy.max = 10
-
-# Setting custom configurations using log:set from the console will append those configurations below this line

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -140,6 +140,16 @@
             <artifactId>platform-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>alerts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -189,7 +199,8 @@
                             httpcore,
                             google-http-client,
                             opensaml-soap-impl,
-                            common-system
+                            common-system,
+                            alerts
                         </Embed-Dependency>
                         <Export-Package>
                             ddf.security*;version=${project.version}

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/common/audit/LogFailoverAlertAppender.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/common/audit/LogFailoverAlertAppender.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.common.audit;
+
+import static org.apache.commons.lang.Validate.notNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.codice.ddf.system.alerts.NoticePriority;
+import org.codice.ddf.system.alerts.SystemNotice;
+import org.joda.time.DateTime;
+import org.ops4j.pax.logging.spi.PaxAppender;
+import org.ops4j.pax.logging.spi.PaxLoggingEvent;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventAdmin;
+
+public final class LogFailoverAlertAppender implements PaxAppender {
+
+    private final EventAdmin eventAdmin;
+
+    private DateTime lastUpdated;
+
+    private HashSet<String> details = new HashSet<>(Arrays.asList(
+            "Writing to the backup audit log has failed. This could occur if there are insufficient permissions to write to the log directory, a full disk, or the primary or backup log configurations are incorrect."));
+
+    public LogFailoverAlertAppender(EventAdmin eventAdmin) {
+        notNull(eventAdmin, "eventAdmin may not be null");
+        this.eventAdmin = eventAdmin;
+    }
+
+    @Override
+    public void doAppend(PaxLoggingEvent event) {
+        if (lastUpdated == null) {
+            lastUpdated = DateTime.now();
+        } else if (DateTime.now()
+                .isBefore(lastUpdated.plusSeconds(5))) {
+            // don't spam the admin console when multiple log messages come in at once
+            return;
+        }
+
+        SystemNotice notice = new SystemNotice(LogFailoverAlertAppender.class.toString(),
+                NoticePriority.CRITICAL,
+                "Audit Logging Failure",
+                details);
+        eventAdmin.postEvent(new Event(SystemNotice.SYSTEM_NOTICE_BASE_TOPIC.concat("audit"),
+                notice.getProperties()));
+        lastUpdated = DateTime.now();
+    }
+}

--- a/platform/security/platform-security-core-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/platform-security-core-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="adminAlertAppender" class="ddf.security.common.audit.LogFailoverAlertAppender">
+        <argument ref="eventAdmin"/>
+    </bean>
+
+    <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
+
+    <service id="AdminAlertAppenderService" ref="adminAlertAppender"
+             interface="org.ops4j.pax.logging.spi.PaxAppender">
+        <service-properties>
+            <entry key="org.ops4j.pax.logging.appender.name"
+                   value="ddf.security.common.audit.LogFailoverAlertAppender"/>
+        </service-properties>
+    </service>
+
+</blueprint>


### PR DESCRIPTION
#### What does this PR do?
Alerts admins when failover logging fails. 

_Original PR_ : 
[DDF-2912 Implemented System Administrator Alerts](https://github.com/codice/ddf/pull/1829) by @emmberk 
_Changes_: 
Log4j2 formatting is different from Log4j
Had to add in a time check to the appender because of how fast the logs come in

_Must be built using_ : 
[DDF 3128 Add Decanter and alert/solr appenders base for future expansion](https://github.com/codice/ddf/pull/2130) by @clockard 
[DDF 3143 Update alerting in the admin UI](https://github.com/codice/ddf/pull/2141) by @clockard 

#### Who is reviewing it? 
@emmberk @clockard @ahoffer @josephthweatt 

#### Choose 2 committers to review/merge the PR. 
@clockard
@figliold 

#### How should this be tested? (List steps with links to updated documentation)
Follow the directions here: https://github.com/codice/ddf/pull/2131
but while configuring the log4j2.config.xml config, also configure the failover appender look like the following:
```
        <Failover name="securityFailover" primary="securityMain">
            <Failovers>
                <AppenderRef ref="osgi-adminAlertAppender"/>
            </Failovers>
        </Failover>
```
This will make it so when a failover occurs it will not use the failover file and will immediately use the alerter. Ensure that an alert appears on the admin console once the disk is full and the main audit log has failed. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
