### PR TITLE
DDF-3148 Deleting configs in ConfigAdmin also deletes the corresponding files in etc

### DIFF
--- a/platform/admin/admin-app/pom.xml
+++ b/platform/admin/admin-app/pom.xml
@@ -197,5 +197,10 @@
             <artifactId>admin-configuration-passwordencryption</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configuration-configinstaller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/platform/admin/admin-app/src/main/resources/features.xml
+++ b/platform/admin/admin-app/src/main/resources/features.xml
@@ -19,7 +19,9 @@
     <feature name="admin-core" install="manual" version="${project.version}"
              description="Administration Tools">
         <feature prerequisite="true">security-services-app</feature>
-        <bundle dependency="true">mvn:commons-collections/commons-collections/${commons-collections.version}</bundle>
+        <bundle dependency="true">
+            mvn:commons-collections/commons-collections/${commons-collections.version}
+        </bundle>
         <bundle>mvn:ddf.admin.core/admin-core-configpolicy/${project.version}</bundle>
         <bundle>mvn:ddf.admin.core/admin-core-api/${project.version}</bundle>
         <bundle>mvn:ddf.admin.core/admin-core-jolokia/${project.version}</bundle>
@@ -30,7 +32,7 @@
         <bundle>mvn:ddf.admin.core/admin-core-insecuredefaults/${project.version}</bundle>
         <bundle>mvn:ddf.admin.core/admin-core-impl/${project.version}</bundle>
         <!--Shut off password encryption to circumvent the config admin issue-->
-        <bundle>mvn:ddf.admin/admin-configuration-passwordencryption/${project.version}</bundle>
+        <!--<bundle>mvn:ddf.admin/admin-configuration-passwordencryption/${project.version}</bundle>-->
     </feature>
 
     <feature name="admin-ui" install="manual" version="${project.version}"

--- a/platform/admin/admin-app/src/main/resources/features.xml
+++ b/platform/admin/admin-app/src/main/resources/features.xml
@@ -29,6 +29,7 @@
         <bundle>mvn:ddf.admin.core/admin-core-appservice/${project.version}</bundle>
         <bundle>mvn:ddf.admin.core/admin-core-insecuredefaults/${project.version}</bundle>
         <bundle>mvn:ddf.admin.core/admin-core-impl/${project.version}</bundle>
+        <!--Shut off password encryption to circumvent the config admin issue-->
         <bundle>mvn:ddf.admin/admin-configuration-passwordencryption/${project.version}</bundle>
     </feature>
 
@@ -97,6 +98,12 @@
         <bundle>mvn:ddf.admin/admin-configurator-impl/${project.version}</bundle>
     </feature>
 
+    <feature name="admin-config-installer" install="manual" version="${project.version}"
+             description="Synchronizes config admin with the etc directory">
+        <feature prerequisite="true">admin-configurator</feature>
+        <bundle>mvn:ddf.admin/admin-configuration-configinstaller/${project.version}</bundle>
+    </feature>
+
     <feature name="admin-app" install="auto" version="${project.version}"
              description="Administration application for installation and management.\nIncludes the Admin UI and the underlying application service that supports the user interface.\nThe Admin UI provides contains modules allowing the administrator to install/remove applications and their dependencies and to access configuration pages to customize and tailor system services and properties.\nThe application service provides the supporting operations allowing the Admin UI to add, remove, start, stop, and obtain status information about all applications on the system.::Admin">
         <feature prerequisite="true">security-services-app</feature>
@@ -104,5 +111,6 @@
         <feature>admin-ui</feature>
         <feature>admin-core-migration-commands</feature>
         <feature>admin-configurator</feature>
+        <feature>admin-config-installer</feature>
     </feature>
 </features>

--- a/platform/admin/admin-configuration-configinstaller/pom.xml
+++ b/platform/admin/admin-configuration-configinstaller/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>admin</artifactId>
+        <groupId>ddf.admin</groupId>
+        <version>2.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>DDF :: Admin :: Configuration Installer</name>
+    <artifactId>admin-configuration-configinstaller</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-actions-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>jsr305</Embed-Dependency>
+                        <Export-Package />
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.85</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/platform/admin/admin-configuration-configinstaller/pom.xml
+++ b/platform/admin/admin-configuration-configinstaller/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>jsr305</artifactId>
             <version>3.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/ConfigurationInstaller.java
+++ b/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/ConfigurationInstaller.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.configuration;
+
+import static org.osgi.service.cm.ConfigurationEvent.CM_DELETED;
+import static org.osgi.service.cm.ConfigurationEvent.CM_UPDATED;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.ConfiguratorFactory;
+import org.codice.ddf.admin.configurator.Operation;
+import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.configurator.Result;
+import org.codice.ddf.internal.admin.configurator.actions.ConfigActions;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.SynchronousConfigurationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Addresses shortcomings of the Felix {@code ConfigInstaller} with our own implementation that properly
+ * syncs the etc directory using the {@code felix.fileinstall.filename} property.
+ *
+ * @see #handleUpdate(ConfigurationEvent)
+ * @see #handleDelete(ConfigurationEvent)
+ */
+public class ConfigurationInstaller implements SynchronousConfigurationListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationInstaller.class);
+
+    private final ConfigurationAdmin configurationAdmin;
+
+    private final ConfiguratorFactory configuratorFactory;
+
+    private final ConfigActions configActions;
+
+    private final Map<String, File> pidFileMap;
+
+    public ConfigurationInstaller(ConfigurationAdmin configurationAdmin,
+            ConfiguratorFactory configuratorFactory, ConfigActions configActions) {
+        this.configurationAdmin = configurationAdmin;
+        this.pidFileMap = new ConcurrentHashMap<>();
+
+        this.configuratorFactory = configuratorFactory;
+        this.configActions = configActions;
+    }
+
+    /**
+     * @return a read-only map of configuration pids to felix file install properties.
+     */
+    Map<String, File> getPidFileMap() {
+        return Collections.unmodifiableMap(pidFileMap);
+    }
+
+    public void init() throws IOException, InvalidSyntaxException {
+        Configuration[] configs = configurationAdmin.listConfigurations(null);
+        if (configs == null) {
+            return;
+        }
+        pidFileMap.putAll(Arrays.stream(configs)
+                .map(FelixConfig::new)
+                .filter(config -> config.getFelixFile() != null)
+                .collect(Collectors.toMap(FelixConfig::getPid, FelixConfig::getFelixFile,
+                        // API guarantees no duplicates in production but itests violate this.
+                        // Workaround is to shut off admin-configuration-passwordencryption.
+                        (file1, file2) -> file2)));
+    }
+
+    @Override
+    public void configurationEvent(ConfigurationEvent event) {
+        String pid = event.getPid();
+        switch (event.getType()) {
+        case CM_UPDATED:
+            LOGGER.debug("Handling update for pid {}", pid);
+            handleUpdate(event);
+            break;
+        case CM_DELETED:
+            LOGGER.debug("Handling delete for pid {}", pid);
+            handleDelete(event);
+            break;
+        default:
+            LOGGER.debug("Unknown configuration event type, taking no action for pid {}", pid);
+        }
+    }
+
+    /**
+     * Sync the config files in etc when an update occurs. There are five cases, which will be
+     * denoted using a 2-tuple combination of variables: (felixFileOriginal, felixFileNew) --> Explanation
+     * <p>
+     * (null, null) --> (1) Felix file prop wasn't tracked and is still not tracked. We don't need to
+     * do anything, and we further guarantee that beyond this point, one variable must not be null.
+     * <p>
+     * (null, X) --> (2) New config with a new felix file prop to track. The config's presence in
+     * etc was previously not being tracked by the system.
+     * <p>
+     * (Y, null) --> (3) Felix file prop no longer being tracked, delete the config file and remove it
+     * from the map. We need to account for this in the event Felix itself destroys the property for
+     * reasons beyond our concern. We do not own this property. Felix does.
+     * <p>
+     * (Y, X) --> (4) Felix file prop updated, delete config file and update map. Essentially this means
+     * Felix moved where it was tracking the file.
+     * <p>
+     * (Y, Y) --> (5) Felix file prop did not change, do nothing. This is the happy path.
+     *
+     * @param event the configuration event for which an update is needed
+     */
+    private void handleUpdate(ConfigurationEvent event) {
+        Configuration configuration = getConfiguration(event);
+        if (configuration == null) {
+            LOGGER.debug("Configuration was null for pid {}", event.getPid());
+            return;
+        }
+
+        FelixConfig felixConfig = new FelixConfig(configuration);
+        String pid = felixConfig.getPid();
+        File felixFileNew = felixConfig.getFelixFile();
+        File felixFileOriginal = pidFileMap.get(pid);
+
+        // Config not tracked and will not be tracked? (1)
+        if (felixFileOriginal == null && felixFileNew == null) {
+            LOGGER.debug("Was not tracked and will not track pid {}", pid);
+            return;
+        }
+
+        boolean filePropChanged = felixConfig.filePropChanged(felixFileOriginal);
+
+        // Felix file prop did not change? (5)
+        if (filePropChanged) {
+            // Felix file prop updated? (4)
+            if (felixFileOriginal != null) {
+                LOGGER.debug("Felix filename prop changed, deleting file for pid {}", pid);
+                try {
+                    performOperation(configActions.delete(felixFileOriginal.toPath()));
+                } catch (IllegalArgumentException | ConfiguratorException e) {
+                    LOGGER.debug("Problem deleting config file: ", e);
+                }
+                // Felix file prop no longer being tracked? (3)
+                if (felixFileNew == null) {
+                    LOGGER.debug("No longer tracking file for pid {}", pid);
+                    pidFileMap.remove(pid);
+                    // In this case, we want to skip writing
+                    return;
+                }
+            }
+
+            // Let's write, because the prop is either new (2) or needs updating (4)
+            try {
+                felixConfig.setFelixFile();
+                pidFileMap.put(pid, felixFileNew);
+                LOGGER.debug("Tracking pid {}", pid);
+            } catch (IOException e) {
+                LOGGER.error("Could not set felix file name, error writing to config admin: ", e);
+            }
+        }
+
+        // Check actual dictionary values (hash) in case a rewrite to disk is necessary
+    }
+
+    /**
+     * Remove config files from etc when a delete occurs but only if felix is tracking the file.
+     *
+     * @param event the configuration event for which a delete is needed
+     */
+    private void handleDelete(ConfigurationEvent event) {
+        String pid = event.getPid();
+        File felixFileOriginal = pidFileMap.remove(pid);
+        if (felixFileOriginal != null) {
+            LOGGER.debug("Deleting file because config was deleted for pid {}", pid);
+            try {
+                performOperation(configActions.delete(felixFileOriginal.toPath()));
+            } catch (IllegalArgumentException | ConfiguratorException e) {
+                LOGGER.debug("Problem deleting config file: ", e);
+            }
+        }
+    }
+
+    private void performOperation(Operation operation) {
+        Configurator configurator = configuratorFactory.getConfigurator();
+        configurator.add(operation);
+        OperationReport report = configurator.commit("Synchronizing the etc directory");
+        if (report.containsFailedResults()) {
+            LOGGER.error("One or more file operations failed, see debug logs for more info");
+            if (LOGGER.isDebugEnabled()) {
+                report.getFailedResults()
+                        .stream()
+                        .map(Result::getError)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .map(Exception.class::cast)
+                        .forEach(e -> LOGGER.debug("Failed file operation: ", e));
+            }
+        }
+    }
+
+    private Configuration getConfiguration(ConfigurationEvent configurationEvent) {
+        try {
+            return configurationAdmin.getConfiguration(configurationEvent.getPid(), null);
+        } catch (IOException e) {
+            LOGGER.debug("Problem reading from config admin: ", e);
+            return null;
+        }
+    }
+}

--- a/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/FelixConfig.java
+++ b/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/FelixConfig.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.configuration;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Dictionary;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import org.osgi.service.cm.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class for enabling functional constructs with {@link Configuration}s and exposes the
+ * felix.fileinstall.filename property, if it exists, as a {@link File}.
+ */
+public class FelixConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FelixConfig.class);
+
+    private static final String FELIX_FILENAME_PROP = "felix.fileinstall.filename";
+
+    private final Configuration config;
+
+    private File felixFile;
+
+    FelixConfig(Configuration config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Configuration can't be null");
+        }
+        this.config = config;
+        this.felixFile = extractFelixFileInstallProp(config);
+    }
+
+    /**
+     * @return the pid for this configuration.
+     */
+    String getPid() {
+        return config.getPid();
+    }
+
+    /**
+     * @return the File object pointing to the this configuration on disk.
+     */
+    @Nullable
+    File getFelixFile() {
+        return felixFile;
+    }
+
+    /**
+     * Sets the felix file name using the default technique from the config repo, using .config in
+     * case complex data structures are present.
+     *
+     * @throws IOException if updating config admin fails
+     */
+    void setFelixFile() throws IOException {
+        setFelixFile(createFelixFileName(config));
+    }
+
+    /**
+     * Sets the felix file name to the provided {@link File} argument.
+     *
+     * @param file
+     * @throws IOException
+     */
+    private void setFelixFile(File file) throws IOException {
+        Dictionary<String, Object> propsWithFelixFileName = config.getProperties();
+        propsWithFelixFileName.put(FELIX_FILENAME_PROP, file.getAbsolutePath());
+        config.update(propsWithFelixFileName);
+
+        this.felixFile = file;
+    }
+
+    /**
+     * Determine if the felix.fileinstall.filename property changed.
+     *
+     * @param original file location to compare to the current file location poitned to by this
+     *                 config.
+     * @return False if the file locations by absolute path are identical. True otherwise.
+     */
+    boolean filePropChanged(File original) {
+        return !Objects.equals(felixFile, original);
+    }
+
+    private File extractFelixFileInstallProp(Configuration config) {
+        if (config.getProperties() == null) {
+            LOGGER.debug("Config properties are null, they may have just been created");
+            return null;
+        }
+        Object felixConfigFileName = config.getProperties()
+                .get(FELIX_FILENAME_PROP);
+        if (felixConfigFileName == null) {
+            LOGGER.debug("Felix filename prop not found for pid {}", config.getPid());
+            return null;
+        }
+        return createFileFromFelixProp(felixConfigFileName);
+    }
+
+    /**
+     * Code adopted from Karaf's Config Repository Impl:
+     * https://github.com/apache/karaf/blob/master/config/src/main/java/org/apache/karaf/config/core/impl/
+     * ConfigRepositoryImpl.java#L101-L114
+     */
+    private File createFileFromFelixProp(Object felixConfigFileName) {
+        try {
+            if (felixConfigFileName instanceof URL) {
+                return new File(((URL) felixConfigFileName).toURI());
+            }
+            if (felixConfigFileName instanceof URI) {
+                return new File((URI) felixConfigFileName);
+            }
+            if (felixConfigFileName instanceof String) {
+                return new File(new URL((String) felixConfigFileName).toURI());
+            }
+        } catch (URISyntaxException | MalformedURLException e) {
+            LOGGER.debug(
+                    "Was expecting a correctly formatted URL or URI for felix file name [{}], but got: {}",
+                    felixConfigFileName,
+                    e);
+            return null;
+        }
+        LOGGER.debug("Unexpected type for felix file name: {}", felixConfigFileName.getClass());
+        return null;
+    }
+
+    /**
+     * Code adopted from config repo
+     */
+    private File createFelixFileName(Configuration configuration) {
+        final String fpid = configuration.getFactoryPid();
+        final String bname;
+
+        if (fpid != null) {
+            final String alias = UUID.randomUUID()
+                    .toString()
+                    .replaceAll("-", "");
+            bname = format("%s-%s", fpid, alias);
+        } else {
+            bname = configuration.getPid();
+        }
+
+        String ddfHome = System.getProperty("ddf.home");
+        if (ddfHome == null) {
+            throw new IllegalStateException("DDF_HOME not set");
+        }
+
+        return Paths.get(ddfHome, "etc", bname + ".config")
+                .toFile();
+    }
+}

--- a/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/FelixConfig.java
+++ b/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/FelixConfig.java
@@ -72,7 +72,7 @@ public class FelixConfig {
      * Sets the felix file name using the default technique from the config repo, using .config in
      * case complex data structures are present.
      *
-     * @throws IOException if updating config admin fails
+     * @throws IOException if an error occurs persisting to config admin.
      */
     void setFelixFile() throws IOException {
         setFelixFile(createFelixFileName(config));
@@ -81,12 +81,14 @@ public class FelixConfig {
     /**
      * Sets the felix file name to the provided {@link File} argument.
      *
-     * @param file
-     * @throws IOException
+     * @param file the file to use for the felix file name property.
+     * @throws IOException if an error occurs persisting to config admin.
      */
-    private void setFelixFile(File file) throws IOException {
+    void setFelixFile(File file) throws IOException {
         Dictionary<String, Object> propsWithFelixFileName = config.getProperties();
-        propsWithFelixFileName.put(FELIX_FILENAME_PROP, file.getAbsolutePath());
+        propsWithFelixFileName.put(FELIX_FILENAME_PROP,
+                file.toURI()
+                        .toString());
         config.update(propsWithFelixFileName);
 
         this.felixFile = file;

--- a/platform/admin/admin-configuration-configinstaller/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/admin-configuration-configinstaller/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <reference id="configAdmin"
+               interface="org.osgi.service.cm.ConfigurationAdmin"
+               availability="mandatory"/>
+
+    <reference id="configuratorFactory"
+               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
+               availability="mandatory"/>
+
+    <reference id="configActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.ConfigActions"
+               availability="mandatory"/>
+
+    <bean id="configInstaller" class="org.codice.ddf.admin.configuration.ConfigurationInstaller"
+          init-method="init">
+        <argument ref="configAdmin"/>
+        <argument ref="configuratorFactory"/>
+        <argument ref="configActions"/>
+    </bean>
+
+    <service ref="configInstaller" interface="org.osgi.service.cm.ConfigurationListener"/>
+
+</blueprint>

--- a/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/ConfigurationInstallerTest.java
+++ b/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/ConfigurationInstallerTest.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.configuration;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.osgi.service.cm.ConfigurationEvent.CM_DELETED;
+import static org.osgi.service.cm.ConfigurationEvent.CM_UPDATED;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfiguratorFactory;
+import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.internal.admin.configurator.actions.ConfigActions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationInstallerTest {
+    private static final String FELIX_FILENAME_PROP = "felix.fileinstall.filename";
+
+    // Will be tracked in the installer's map after init()
+    private static final String PID_001 = "001";
+
+    // Will NOT be tracked in the installer's map after init()
+    private static final String PID_002 = "002";
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private ConfiguratorFactory configuratorFactory;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Configurator configurator;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private ConfigActions configActions;
+
+    @Mock
+    private Configuration configuration;
+
+    @Mock
+    private ConfigurationAdmin configurationAdmin;
+
+    @Mock
+    private ConfigurationEvent configurationEvent;
+
+    private ConfigurationInstaller installer;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File fileA;
+
+    private File fileB;
+
+    @Before
+    public void before() throws Exception {
+        when(configuratorFactory.getConfigurator()).thenReturn(configurator);
+        when(configurator.commit(anyString())).thenAnswer(i -> {
+            fileB.delete();
+            return mock(OperationReport.class);
+        });
+
+        when(configurationEvent.getType()).thenReturn(CM_UPDATED);
+        fileA = temporaryFolder.newFile();
+        fileB = temporaryFolder.newFile();
+
+        Configuration mockConfig1b = createMockConfig(PID_001, fileB.toURI());
+        Configuration mockConfig2 = createMockConfig(PID_002, null);
+
+        Configuration[] configs = new Configuration[] {mockConfig1b, mockConfig2};
+        when(configurationAdmin.listConfigurations(null)).thenReturn(configs);
+
+        installer = new ConfigurationInstaller(configurationAdmin,
+                configuratorFactory,
+                configActions);
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        installer.init();
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), hasSize(1));
+        assertThat(pidFileMap.get(PID_001), is(fileB));
+    }
+
+    @Test
+    public void testInitWhenListConfigsReturnsNull() throws Exception {
+        when(configurationAdmin.listConfigurations(anyString())).thenReturn(null);
+        installer.init();
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), is(empty()));
+    }
+
+    @Test
+    public void testUpdatedEventNotTrackingWontTrack() throws Exception {
+        configuration = createMockConfig(PID_002, null);
+
+        when(configurationEvent.getPid()).thenReturn(PID_002);
+        when(configurationAdmin.getConfiguration(PID_002, null)).thenReturn(configuration);
+
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), hasSize(1));
+        assertThat(pidFileMap.get(PID_001), is(fileB));
+        // Not tracking and won't track, so filesystem should not have changed
+        assertThat(fileB.exists(), is(true));
+    }
+
+    @Test
+    public void testUpdatedEventPropChanged() throws Exception {
+        configuration = createMockConfig(PID_001, fileA.toURI());
+
+        when(configurationEvent.getPid()).thenReturn(PID_001);
+        when(configurationAdmin.getConfiguration(PID_001, null)).thenReturn(configuration);
+
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), hasSize(1));
+        assertThat(pidFileMap.get(PID_001), is(fileA));
+        assertThat(fileB.exists(), is(false));
+    }
+
+    @Test
+    public void testUpdatedEventPropChangedDoneTracking() throws Exception {
+        configuration = createMockConfig(PID_001, null);
+
+        when(configurationEvent.getPid()).thenReturn(PID_001);
+        when(configurationAdmin.getConfiguration(PID_001, null)).thenReturn(configuration);
+
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), is(empty()));
+        assertThat(fileB.exists(), is(false));
+    }
+
+    @Test
+    public void testUpdatedEventPropAdded() throws Exception {
+        configuration = createMockConfig(PID_002, fileA.toURI());
+
+        when(configurationEvent.getPid()).thenReturn(PID_002);
+        when(configurationAdmin.getConfiguration(PID_002, null)).thenReturn(configuration);
+
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+
+        Map<String, File> pidFileMap = installer.getPidFileMap();
+        assertThat(pidFileMap.entrySet(), hasSize(2));
+        assertThat(pidFileMap.get(PID_001), is(fileB));
+        assertThat(pidFileMap.get(PID_002), is(fileA));
+    }
+
+    @Test
+    public void testUpdatedEventConfigNull() throws Exception {
+        when(configurationAdmin.getConfiguration(anyString(), anyString())).thenReturn(null);
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+        verifyZeroInteractions(configuratorFactory, configurator, configActions);
+    }
+
+    @Test
+    public void testUpdatedEventConfigThrowsIOException() throws Exception {
+        when(configurationAdmin.getConfiguration(anyString(),
+                anyString())).thenThrow(IOException.class);
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+        verifyZeroInteractions(configuratorFactory, configurator, configActions);
+    }
+
+    @Test
+    public void testDeletedEvent() throws Exception {
+        when(configurationEvent.getType()).thenReturn(CM_DELETED);
+        when(configurationEvent.getPid()).thenReturn(PID_001);
+        installer.init();
+        installer.configurationEvent(configurationEvent);
+        assertThat(installer.getPidFileMap()
+                .entrySet(), is(empty()));
+        assertThat(fileB.exists(), is(false));
+    }
+
+    private Configuration createMockConfig(String pid, Object path) {
+        Dictionary<String, Object> props = new Hashtable<>();
+        if (path != null) {
+            props.put(FELIX_FILENAME_PROP, path);
+        }
+        Configuration mockConfig = mock(Configuration.class);
+        when(mockConfig.getPid()).thenReturn(pid);
+        when(mockConfig.getProperties()).thenReturn(props);
+        return mockConfig;
+    }
+}

--- a/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/ConfigurationInstallerTest.java
+++ b/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/ConfigurationInstallerTest.java
@@ -151,23 +151,8 @@ public class ConfigurationInstallerTest {
 
         Map<String, File> pidFileMap = installer.getPidFileMap();
         assertThat(pidFileMap.entrySet(), hasSize(1));
-        assertThat(pidFileMap.get(PID_001), is(fileA));
-        assertThat(fileB.exists(), is(false));
-    }
-
-    @Test
-    public void testUpdatedEventPropChangedDoneTracking() throws Exception {
-        configuration = createMockConfig(PID_001, null);
-
-        when(configurationEvent.getPid()).thenReturn(PID_001);
-        when(configurationAdmin.getConfiguration(PID_001, null)).thenReturn(configuration);
-
-        installer.init();
-        installer.configurationEvent(configurationEvent);
-
-        Map<String, File> pidFileMap = installer.getPidFileMap();
-        assertThat(pidFileMap.entrySet(), is(empty()));
-        assertThat(fileB.exists(), is(false));
+        assertThat(pidFileMap.get(PID_001), is(fileB));
+        assertThat(fileB.exists(), is(true));
     }
 
     @Test

--- a/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/FelixConfigTest.java
+++ b/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/FelixConfigTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.configuration;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.service.cm.Configuration;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FelixConfigTest {
+    private static final String FELIX_FILENAME_PROP = "felix.fileinstall.filename";
+
+    private static final String MALFORMED_URL = "htp:/www.google.com";
+
+    private static final String URL_BUT_NOT_URI = "http:// ";
+
+    private static final Dictionary<String, Object> PROPS_NO_FELIX = new Hashtable<>();
+
+    private static final Dictionary<String, Object> PROPS_WITH_FELIX = new Hashtable<>();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    public File temporaryFile;
+
+    @Mock
+    private Configuration configuration;
+
+    private FelixConfig felixConfig;
+
+    @BeforeClass
+    public static void beforeClass() {
+        PROPS_NO_FELIX.put("prop1", "value1");
+        PROPS_NO_FELIX.put("prop2", "value2");
+        PROPS_WITH_FELIX.put("prop1", "value1");
+        PROPS_WITH_FELIX.put("prop2", "value2");
+    }
+
+    @Before
+    public void before() throws Exception {
+        temporaryFile = temporaryFolder.newFile();
+        when(configuration.getProperties()).thenReturn(PROPS_WITH_FELIX);
+    }
+
+    @Test
+    public void testExtractFelixPropWhenPropMapNull() {
+        when(configuration.getProperties()).thenReturn(null);
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+
+    @Test
+    public void testExtractFelixPropWhenFelixPropNotFound() {
+        when(configuration.getProperties()).thenReturn(PROPS_NO_FELIX);
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+
+    @Test
+    public void testFileFromURL() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP,
+                temporaryFile.toURI()
+                        .toURL());
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(notNullValue()));
+        assertThat(felixConfig.getFelixFile(), is(temporaryFile));
+    }
+
+    @Test
+    public void testFileFromURI() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, temporaryFile.toURI());
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(notNullValue()));
+        assertThat(felixConfig.getFelixFile(), is(temporaryFile));
+    }
+
+    @Test
+    public void testFileFromString() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, "file:" + temporaryFile.getAbsolutePath());
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(notNullValue()));
+        assertThat(felixConfig.getFelixFile(), is(temporaryFile));
+    }
+
+    @Test
+    public void testFileFromURLwithBadURISyntax() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, new URL(URL_BUT_NOT_URI));
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+
+    @Test
+    public void testFileFromMalformedURLstring() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, MALFORMED_URL);
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+
+    @Test
+    public void testFileFromStringWithBadURISyntax() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, URL_BUT_NOT_URI);
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+
+    @Test
+    public void testFileFromUnexpectedType() throws Exception {
+        PROPS_WITH_FELIX.put(FELIX_FILENAME_PROP, new Object());
+        felixConfig = new FelixConfig(configuration);
+        assertThat(felixConfig.getFelixFile(), is(nullValue()));
+    }
+}

--- a/platform/admin/configurator/admin-configurator-actions-api/src/main/java/org/codice/ddf/internal/admin/configurator/actions/ConfigActions.java
+++ b/platform/admin/configurator/admin-configurator-actions-api/src/main/java/org/codice/ddf/internal/admin/configurator/actions/ConfigActions.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.internal.admin.configurator.actions;
+
+/**
+ * Property operations adapted for
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface ConfigActions extends PropertyActions {
+}

--- a/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigOperation.java
+++ b/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigOperation.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator.impl;
+
+import static org.codice.ddf.admin.configurator.impl.ConfigValidator.validateConfigPath;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+import org.codice.ddf.admin.configurator.Result;
+import org.codice.ddf.internal.admin.configurator.actions.ConfigActions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transactional handler for persisting config file changes.
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public abstract class ConfigOperation implements Operation<Void> {
+    public static class Actions implements ConfigActions {
+        @Override
+        public Operation<Void> create(Path configFile, Map<String, String> configs)
+                throws ConfiguratorException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConfigOperation delete(Path propFile) throws ConfiguratorException {
+            validateConfigPath(propFile);
+            return new ConfigOperation.DeleteHandler(propFile);
+        }
+
+        @Override
+        public Operation<Void> update(Path configFile, Map<String, String> configs,
+                boolean keepIfNotPresent) throws ConfiguratorException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getProperties(Path propFile) throws ConfiguratorException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigOperation.class);
+
+    final File configFile;
+
+    private ConfigOperation(Path configFilePath) {
+        this.configFile = configFilePath.toFile();
+    }
+
+    /**
+     * Transactional handler for deleting config files
+     */
+    private static class DeleteHandler extends ConfigOperation {
+        private DeleteHandler(Path configFile) {
+            super(configFile);
+        }
+
+        @Override
+        public Result<Void> commit() throws ConfiguratorException {
+            boolean deleted = configFile.delete();
+            if (!deleted) {
+                LOGGER.debug("Problem deleting properties file {}", configFile);
+            }
+            return ResultImpl.pass();
+        }
+
+        @Override
+        public Result<Void> rollback() throws ConfiguratorException {
+            return ResultImpl.rollback();
+        }
+    }
+}

--- a/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigValidator.java
+++ b/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigValidator.java
@@ -39,6 +39,46 @@ class ConfigValidator {
         }
     }
 
+    private static void protectHomeDir(Path target) {
+        String ddfHomeProp = System.getProperty("ddf.home");
+        validateString(ddfHomeProp, "No value set for system property ddf.home");
+
+        Path ddfHomePath = Paths.get(ddfHomeProp);
+        if (!target.startsWith(ddfHomePath)) {
+            throw new IllegalArgumentException(String.format(
+                    "File [%s] is not beneath ddf home directory [%s]",
+                    target.toString(),
+                    ddfHomePath.toString()));
+        }
+
+        if (target.getParent()
+                .equals(ddfHomePath)) {
+            throw new IllegalArgumentException("Invalid attempt to edit file in ddf.home directory");
+        }
+    }
+
+    private static void protectEtcDir(Path target) {
+        if (target.getParent()
+                .endsWith("etc")) {
+            throw new IllegalArgumentException(
+                    "Invalid attempt to edit system file in /etc directory");
+        }
+    }
+
+    static void validateConfigPath(Path configFile) {
+        if (configFile == null) {
+            throw new IllegalArgumentException("Null path provided");
+        }
+
+        String fileExtension = Files.getFileExtension(configFile.toString());
+        if (!(fileExtension.equalsIgnoreCase("cfg") || fileExtension.equalsIgnoreCase("config"))) {
+            throw new IllegalArgumentException(String.format("%s is not a configuration file",
+                    configFile.toString()));
+        }
+
+        protectHomeDir(configFile);
+    }
+
     static void validatePropertiesPath(Path propFile) {
         if (propFile == null) {
             throw new IllegalArgumentException("Null path provided");
@@ -51,25 +91,7 @@ class ConfigValidator {
                     propFile.toString()));
         }
 
-        String ddfHomeProp = System.getProperty("ddf.home");
-        validateString(ddfHomeProp, "No value set for system property ddf.home");
-
-        Path ddfHomePath = Paths.get(ddfHomeProp);
-        if (!propFile.startsWith(ddfHomePath)) {
-            throw new IllegalArgumentException(String.format("File [%s] is not beneath ddf home directory [%s]",
-                    propFile.toString(),
-                    ddfHomePath.toString()));
-        }
-
-        if (propFile.getParent()
-                .equals(ddfHomePath)) {
-            throw new IllegalArgumentException("Invalid attempt to edit file in ddf.home directory");
-        }
-
-        if (propFile.getParent()
-                .endsWith("etc")) {
-            throw new IllegalArgumentException(
-                    "Invalid attempt to edit system file in /etc directory");
-        }
+        protectHomeDir(propFile);
+        protectEtcDir(propFile);
     }
 }

--- a/platform/admin/configurator/admin-configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/configurator/admin-configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,6 +43,10 @@
         <bean class="org.codice.ddf.admin.configurator.impl.PropertyOperation.Actions"/>
     </service>
 
+    <service interface="org.codice.ddf.internal.admin.configurator.actions.ConfigActions">
+        <bean class="org.codice.ddf.admin.configurator.impl.ConfigOperation.Actions"/>
+    </service>
+
     <service interface="org.codice.ddf.internal.admin.configurator.actions.ServiceReader">
         <bean class="org.codice.ddf.admin.configurator.impl.ServiceReaderImpl"/>
     </service>

--- a/platform/admin/pom.xml
+++ b/platform/admin/pom.xml
@@ -31,6 +31,7 @@
         <module>modules</module>
         <module>admin-configuration-passwordencryption</module>
         <module>admin-app</module>
+        <module>admin-configuration-configinstaller</module>
     </modules>
     <build>
         <plugins>


### PR DESCRIPTION
#### What does this PR do?
Provides a SynchronousConfigurationListener that will delete config files in etc if the config in config admin was deleted as well. Also takes into consideration inconsistent management of the felix file install property. Should that property fail to be tracked, the file in etc is removed as well. 

#### Who is reviewing it? 
@paouelle @brjeter @oconnormi 
@coyotesqrl (for configurator changes)
@beyelerb (for admin team)

#### Select relevant component teams: 
Admin Team (not yet created on GH)

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold 
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Delete some configurations from the admin UI that have corresponding files in etc and ensure the files are deleting along with them. 
Known issue: In the admin UI you may  need to delete a configuration twice for it to truly be gone. 

#### Any background context you want to provide?
This change is a necessary fix to support an import/export HA cluster setup strategy along with third party configuration management tools such as Puppet. 

#### What are the relevant tickets?
[DDF-3148](https://codice.atlassian.net/browse/DDF-3148)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
