### PR TITLE
DDF-3069 Fix loading issues for catalog-ui-search

### DIFF
--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -18,6 +18,7 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <feature name="catalog-ui" install="auto" version="${project.version}" description="Catalog UI">
+        <feature prerequisite="true">spatial-app</feature>
         <feature prerequisite="true">camel-http</feature>
         <feature prerequisite="true">search-ui-app</feature>
         <configfile finalname="/etc/org.codice.ddf.catalog.ui.config.config" override="false">


### PR DESCRIPTION
#### What does this PR do?
Catalog-search-ui has an implicit dependency on the spatial-app, which can cause it to fail during installation if it is initialized first. 

This change declares the spatial-app feature as a dependency of the catalog-ui feature.

#### Who is reviewing it? 
@bdeining 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR. 
@millerw8
@pklinef

#### How should this be tested? (List steps with links to updated documentation)

Installation with standard profile should complete successfully - both spatial-app and catalog search ui should be installed.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3069

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
