### PR TITLE
DDF-3173 Added support for cleaning up XML declarations in getCswInsertRequest iTest utility

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/csw/CswTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/csw/CswTestCommons.java
@@ -162,8 +162,17 @@ public class CswTestCommons {
     }
 
     public static String getCswInsertRequest(String typeName, String record) {
-        return getFileContent(CSW_REQUEST_RESOURCE_PATH + "/CswInsertRequest",
+        String cswStr = getFileContent(CSW_REQUEST_RESOURCE_PATH + "/CswInsertRequest",
                 ImmutableMap.of("typeName", typeName, "record", record));
+        if (cswStr.lastIndexOf("<?xml") > 0) {
+            String header = "";
+            if (cswStr.indexOf("<?xml") == 0) {
+                header = cswStr.substring(0, cswStr.indexOf("?>") + 2);
+                cswStr = cswStr.substring(cswStr.indexOf("?>") + 2);
+            }
+            cswStr = header + cswStr.replaceAll("<\\?xml.*\\?>", "");
+        }
+        return cswStr;
     }
 
     public static String getMetacardIdFromCswInsertResponse(Response response)

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -458,6 +458,14 @@ public class TestCatalog extends AbstractIntegrationTest {
                 .post(CSW_PATH.getUrl());
     }
 
+    private Response ingestXmlWithHeaderMetacard() {
+        return given().header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+                .body(getCswInsertRequest("xml",
+                        getFileContent(XML_RECORD_RESOURCE_PATH + "/SimpleXmlMetacard",
+                                ImmutableMap.of("uri", "http://example.com"))))
+                .post(CSW_PATH.getUrl());
+    }
+
     @Test
     public void testCswIngest() {
         Response response = ingestCswRecord();
@@ -574,6 +582,25 @@ public class TestCatalog extends AbstractIntegrationTest {
             fail("Could not retrieve the ingested record's ID from the response.");
         }
 
+    }
+
+    @Test
+    public void testCswXmlWithHeaderIngest() {
+        Response response = ingestXmlWithHeaderMetacard();
+
+        response.then()
+                .body(hasXPath("//TransactionResponse/TransactionSummary/totalInserted", is("1")),
+                        hasXPath("//TransactionResponse/TransactionSummary/totalUpdated", is("0")),
+                        hasXPath("//TransactionResponse/TransactionSummary/totalDeleted", is("0")),
+                        hasXPath("//TransactionResponse/InsertResult/BriefRecord/title",
+                                is("myXmlTitle")),
+                        hasXPath("//TransactionResponse/InsertResult/BriefRecord/BoundingBox"));
+
+        try {
+            CatalogTestCommons.deleteMetacardUsingCswResponseId(response);
+        } catch (IOException | XPathExpressionException e) {
+            fail("Could not retrieve the ingested record's ID from the response.");
+        }
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Adds support for files with XML header declarations to CswTestCommons.getCswInsertRequest

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@brianfelix @glenhein @emanns95 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/test

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build for verification that no regressions were introduced

#### Any background context you want to provide?
In its current state, an XML file with the header gets substituted into the CSW insert request along with the header, and the parsing logic throws an exception because an XML header occurs somewhere other than at the start of the file.

#### What are the relevant tickets?
[DDF-3173](https://codice.atlassian.net/browse/DDF-3173)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
