### PR TITLE
DDF-3144 Fix removeAll command not deleting all metacards when batchSize exceeds catalog page size

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
@@ -77,7 +77,7 @@ public class RemoveAllCommand extends CatalogCommands {
 
     @Argument(name = "Batch size", description =
             "Number of Metacards to delete at a time until completion. Change this argument based on system memory and Catalog limits. "
-                    + "Must be a positive integer.", index = 0, multiValued = false, required = false)
+                    + "Must be a positive integer.\nNOTE: Batch size may not be honored given system constraints.", index = 0, multiValued = false, required = false)
     int batchSize = DEFAULT_BATCH_SIZE;
 
     @Option(name = "-e", required = false, aliases = {
@@ -189,7 +189,8 @@ public class RemoveAllCommand extends CatalogCommands {
             console.flush();
 
             // Break out if there are no more records to delete
-            if (amountDeleted < batchSize || batchSize < 1) {
+            // Prevents additional query to catalog framework
+            if (response.getResults().isEmpty()) {
                 break;
             }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes issue with RemoveAll command where not all metacards are deleted when the batchSize is greater than the page size the catalog framework uses. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@ahoffer @emanns95 @emmberk @jhunzik  @josephthweatt 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
Running a build with itests and unit tests ought to be sufficient to verify correctness.

#### Any background context you want to provide?
Catalog Framework maintains an internal page size, but not all commands function with an awareness of this. Therefore, paging has to be accounted for.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/3144)

#### Checklist:
- [x] Update / Add Unit Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
