### PR TITLE
DDF-3176 Disable shape editing when query editing is disabled.

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -533,24 +533,32 @@ define([
             });
         },
         drawLine: function () {
-            this.clearLocation();
-            wreqr.vent.trigger('search:drawline', this.model);
-            this.changeMode("line");
+            if (this.propertyModel.get('property').get('isEditing')) {
+                this.clearLocation();
+                wreqr.vent.trigger('search:drawline', this.model);
+                this.changeMode("line");
+            }
         },
         drawCircle: function () {
-            this.clearLocation();
-            wreqr.vent.trigger('search:drawcircle', this.model);
-            this.changeMode("circle");
+            if (this.propertyModel.get('property').get('isEditing')) {
+                this.clearLocation();
+                wreqr.vent.trigger('search:drawcircle', this.model);
+                this.changeMode("circle");
+            }
         },
         drawPolygon: function () {
-            this.clearLocation();
-            wreqr.vent.trigger('search:drawpoly', this.model);
-            this.changeMode("polygon");
+            if (this.propertyModel.get('property').get('isEditing')) {
+                this.clearLocation();
+                wreqr.vent.trigger('search:drawpoly', this.model);
+                this.changeMode("polygon");
+            }
         },
         drawBbox: function () {
-            this.clearLocation();
-            wreqr.vent.trigger('search:drawbbox', this.model);
-            this.changeMode("bbox");
+            if (this.propertyModel.get('property').get('isEditing')) {
+                this.clearLocation();
+                wreqr.vent.trigger('search:drawbbox', this.model);
+                this.changeMode("bbox");
+            }
         },
         searchByKeyword: function () {
             this.clearLocation();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -561,9 +561,11 @@ define([
             }
         },
         searchByKeyword: function () {
-            this.clearLocation();
-            this.model.set({hasKeyword: true});            
-            this.changeMode("keyword");
+            if (this.propertyModel.get('property').get('isEditing')) {
+                this.clearLocation();
+                this.model.set({hasKeyword: true});
+                this.changeMode("keyword");
+            }
         },
         onLineUnitsChanged: function () {
             this.$('#lineWidthValue').val(this.getDistanceFromMeters(this.model.get('lineWidth'), this.$('#lineUnits').val()));


### PR DESCRIPTION
#### What does this PR do?
Disables shape editing in Intrigue when query editing is disabled
#### Who is reviewing it? 
@albany551 
@bdeining 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@millerw8
@pklinef 

#### How should this be tested? (List steps with links to updated documentation)
Create a query with a shape and save.
Attempt to edit the shape definition. Switch types. Shape editing should be disabled.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3176

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
