### PR TITLE
DDF-3172 bad.files and bad.file.extensions in system.properties is not being respected

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -103,7 +103,7 @@ public class OperationsMetacardSupport {
                                 "Could not copy bytes of content message.  Message was NULL.");
                     }
 
-                    if (!InputValidation.isFileNameClientSideVulnerable(fileName)) {
+                    if (!InputValidation.isFileNameClientSideSafe(fileName)) {
                         throw new IngestException("Ignored filename found.");
                     }
 
@@ -133,7 +133,7 @@ public class OperationsMetacardSupport {
                 String mimeTypeRaw = contentItem.getMimeTypeRawData();
                 mimeTypeRaw = guessMimeType(mimeTypeRaw, fileName, tmpPath);
 
-                if (!InputValidation.isMimeTypeClientSideVulnerable(mimeTypeRaw)) {
+                if (!InputValidation.isMimeTypeClientSideSafe(mimeTypeRaw)) {
                     throw new IngestException("Unsupported mime type.");
                 }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -103,7 +103,7 @@ public class OperationsMetacardSupport {
                                 "Could not copy bytes of content message.  Message was NULL.");
                     }
 
-                    if (!InputValidation.checkForClientSideVulnerableFileName(fileName)) {
+                    if (!InputValidation.isFileNameClientSideVulnerable(fileName)) {
                         throw new IngestException("Ignored filename found.");
                     }
 
@@ -133,7 +133,7 @@ public class OperationsMetacardSupport {
                 String mimeTypeRaw = contentItem.getMimeTypeRawData();
                 mimeTypeRaw = guessMimeType(mimeTypeRaw, fileName, tmpPath);
 
-                if (!InputValidation.checkForClientSideVulnerableMimeType(mimeTypeRaw)) {
+                if (!InputValidation.isMimeTypeClientSideVulnerable(mimeTypeRaw)) {
                     throw new IngestException("Unsupported mime type.");
                 }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -94,15 +94,20 @@ public class OperationsMetacardSupport {
         for (ContentItem contentItem : incomingContentItems) {
             try {
                 Path tmpPath = null;
+                String fileName;
                 long size;
                 try (InputStream inputStream = contentItem.getInputStream()) {
+                    fileName = contentItem.getFilename();
                     if (inputStream == null) {
                         throw new IngestException(
                                 "Could not copy bytes of content message.  Message was NULL.");
                     }
 
-                    String sanitizedFilename =
-                            InputValidation.sanitizeFilename(contentItem.getFilename());
+                    if (!InputValidation.checkForClientSideVulnerableFileName(fileName)) {
+                        throw new IngestException("Ignored filename found.");
+                    }
+
+                    String sanitizedFilename = InputValidation.sanitizeFilename(fileName);
                     tmpPath = Files.createTempFile(FilenameUtils.getBaseName(sanitizedFilename),
                             FilenameUtils.getExtension(sanitizedFilename));
                     Files.copy(inputStream, tmpPath, StandardCopyOption.REPLACE_EXISTING);
@@ -126,13 +131,20 @@ public class OperationsMetacardSupport {
                     throw new IngestException("Could not copy bytes of content message.", e);
                 }
                 String mimeTypeRaw = contentItem.getMimeTypeRawData();
-                mimeTypeRaw = guessMimeType(mimeTypeRaw, contentItem.getFilename(), tmpPath);
+                mimeTypeRaw = guessMimeType(mimeTypeRaw, fileName, tmpPath);
 
                 if (!InputValidation.checkForClientSideVulnerableMimeType(mimeTypeRaw)) {
                     throw new IngestException("Unsupported mime type.");
                 }
 
-                String fileName = updateFileExtension(mimeTypeRaw, contentItem.getFilename());
+                // If any sanitization was done, rename file name to sanitized file name.
+                if (!InputValidation.sanitizeFilename(fileName)
+                        .equals(fileName)) {
+                    fileName = InputValidation.sanitizeFilename(fileName);
+                } else {
+                    fileName = updateFileExtension(mimeTypeRaw, fileName);
+                }
+
                 Metacard metacard = metacardFactory.generateMetacard(mimeTypeRaw,
                         contentItem.getId(),
                         fileName,
@@ -140,7 +152,9 @@ public class OperationsMetacardSupport {
                 metacardMap.put(metacard.getId(), metacard);
 
                 ContentItem generatedContentItem = new ContentItemImpl(metacard.getId(),
-                        StringUtils.isNotEmpty(contentItem.getQualifier()) ? contentItem.getQualifier() : "",
+                        StringUtils.isNotEmpty(contentItem.getQualifier()) ?
+                                contentItem.getQualifier() :
+                                "",
                         com.google.common.io.Files.asByteSource(tmpPath.toFile()),
                         mimeTypeRaw,
                         fileName,

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportSpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/OperationsMetacardSupportSpec.groovy
@@ -40,6 +40,7 @@ class OperationsMetacardSupportTest extends Specification {
         System.setProperty("bad.files", "")
         System.setProperty("bad.file.extensions", "bad,worse")
         System.setProperty("bad.mime.types", "badmime,worsemime")
+        System.setProperty("ignore.files", "")
 
         mimeTypeMapper = Mock(MimeTypeMapper)
         mimeTransMapper = Mock(MimeTypeToTransformerMapper)

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -264,6 +264,8 @@ public class CatalogFrameworkImplTest {
                 ".exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht");
         System.setProperty("bad.mime.types",
                 "text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile");
+        System.setProperty("ignore.files", ".DS_Store,Thumbs.db");
+
         // Setup
         /*
          * Prepare to capture the ResourceResponse argument passed into

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
@@ -545,6 +545,7 @@ public class FanoutCatalogFrameworkTest {
         System.setProperty("bad.files", "none");
         System.setProperty("bad.file.extensions", "none");
         System.setProperty("bad.mime.types", "none");
+        System.setProperty("ignore.files", "");
 
         CreateOperations createOperations = new CreateOperations(frameworkProperties,
                 queryOperations,

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -122,13 +122,13 @@ jdk.tls.ephemeralDHKeySize=matched
 # Files uploaded with these bad file extensions or names will have their file names sanitized
 # before being saved
 bad.file.extensions=.exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht,.tmp
-bad.files=crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db
+bad.files=crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt
 
 # Files uploaded matching these mime types will be excluded from being stored
 bad.mime.types=text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile
 
 # Files uploaded matching these file names will be excluded from being stored
-ignore.files=.DS_Store
+ignore.files=.DS_Store,Thumbs.db
 
 #
 # Basic Authentication

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -127,6 +127,8 @@ bad.files=crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passw
 # Files uploaded matching these mime types will be excluded from being stored
 bad.mime.types=text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile
 
+# Files uploaded matching these file names will be excluded from being stored
+ignore.files=.DS_Store
 
 #
 # Basic Authentication

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
@@ -372,8 +372,7 @@ nfs.conf,
 ftpd.conf,
 ntp.conf,
 web.config,
-robots.txt,
-Thumbs.db
+robots.txt
 |Yes
 
 |Mime types flagged as potentially dangerous to external clients
@@ -393,7 +392,8 @@ application/x-msmetafile
 |ignore.files
 |String
 |Files uploaded with these file names will be rejected from the upload
-|.DS_Store
+|.DS_Store,
+Thumbs.db
 |Yes
 
 6+^h|[[SolrProperties]]Solr Catalog Provider Properties

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
@@ -372,7 +372,8 @@ nfs.conf,
 ftpd.conf,
 ntp.conf,
 web.config,
-robots.txt
+robots.txt,
+Thumbs.db
 |Yes
 
 |Mime types flagged as potentially dangerous to external clients
@@ -386,6 +387,13 @@ application/x-shellscript,
 text/scriptlet,
 application/x-msdownload,
 application/x-msmetafile
+|Yes
+
+|File names flagged as potentially dangerous to external clients
+|ignore.files
+|String
+|Files uploaded with these file names will be rejected from the upload
+|.DS_Store
 |Yes
 
 6+^h|[[SolrProperties]]Solr Catalog Provider Properties

--- a/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/configuring-global-settings-contents.adoc
@@ -283,6 +283,8 @@ The interval is measured in seconds.
 |bad.file.extensions
 |String
 |Files uploaded with these bad file extensions will have their file names sanitized before being saved
+
+E.g. sample_file.exe will be renamed to sample_file.bin upon ingest
 |.exe,
 .jsp,
 .html,
@@ -360,6 +362,8 @@ The interval is measured in seconds.
 |bad.files
 |String
 |Files uploaded with these bad file names will have their file names sanitized before being saved
+
+E.g. crossdomain.xml will be renamed to file.bin upon ingest
 |crossdomain.xml,
 clientaccesspolicy.xml,
 .htaccess,

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
@@ -384,7 +384,8 @@ application/x-msmetafile
 |ignore.files
 |String
 |Files uploaded with these names will be rejected from the upload
-|.DS_Store
+|.DS_Store,
+Thumbs.db
 |Yes
 
 6+^h|[[SolrProperties]]Solr Catalog Provider Properties

--- a/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_configuring/configuring-global-settings-contents.adoc
@@ -271,6 +271,8 @@ The interval is measured in seconds.
 |bad.file.extensions
 |String
 |Files uploaded with these bad file extensions will have their file names sanitized before being saved
+
+E.g. sample_file.exe will be renamed to sample_file.bin upon ingest
 |.exe,
 .jsp,
 .html,
@@ -348,6 +350,8 @@ The interval is measured in seconds.
 |bad.files
 |String
 |Files uploaded with these bad file names will have their file names sanitized before being saved
+
+E.g. crossdomain.xml will be renamed to file.bin upon ingest
 |crossdomain.xml,
 clientaccesspolicy.xml,
 .htaccess,
@@ -374,6 +378,13 @@ application/x-shellscript,
 text/scriptlet,
 application/x-msdownload,
 application/x-msmetafile
+|Yes
+
+|File names flagged as potentially dangerous to external clients
+|ignore.files
+|String
+|Files uploaded with these names will be rejected from the upload
+|.DS_Store
 |Yes
 
 6+^h|[[SolrProperties]]Solr Catalog Provider Properties

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -2351,59 +2351,59 @@ public class TestCatalog extends AbstractIntegrationTest {
         deleteMetacard(id);
     }
 
-	@Test
-	public void testIngestSanitizationBadFile() throws Exception {
-		// DDF-3172 bad.files and bad.file.extensions in system.properties is not being respected
+    @Test
+    public void testIngestSanitizationBadFile() throws Exception {
+        // DDF-3172 bad.files and bad.file.extensions in system.properties is not being respected
 
-		// setup
-		String fileName = "robots.txt";    // filename in bad.files
-		File tmpFile = createTemporaryFile(fileName, IOUtils.toInputStream("Test"));
+        // setup
+        String fileName = "robots.txt";    // filename in bad.files
+        File tmpFile = createTemporaryFile(fileName, IOUtils.toInputStream("Test"));
 
-		// ingest
-		String id = given().multiPart(tmpFile)
-				.expect()
-				.log()
-				.headers()
-				.statusCode(HttpStatus.SC_CREATED)
-				.when()
-				.post(REST_PATH.getUrl())
-				.getHeader("id");
+        // ingest
+        String id = given().multiPart(tmpFile)
+                .expect()
+                .log()
+                .headers()
+                .statusCode(HttpStatus.SC_CREATED)
+                .when()
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
 
-		// query - check if sanitized properly
-		getOpenSearch("xml", null, null, "q=*").log()
-				.all()
-				.assertThat()
-				.body(hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value",
-						is("file.bin")));
+        // query - check if sanitized properly
+        getOpenSearch("xml", null, null, "q=*").log()
+                .all()
+                .assertThat()
+                .body(hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value",
+                        is("file.bin")));
 
-		// clean up
-		deleteMetacard(id);
-	}
+        // clean up
+        deleteMetacard(id);
+    }
 
-	@Test
-	public void testIngestSanitizationBadExtension() throws Exception {
-		// DDF-3172 bad.files and bad.file.extensions in system.properties is not being respected
+    @Test
+    public void testIngestSanitizationBadExtension() throws Exception {
+        // DDF-3172 bad.files and bad.file.extensions in system.properties is not being respected
 
-		// setup
-		String fileName = "bad_file.cgi";      // file extension in bad.file.extensions
-		File tmpFile = createTemporaryFile(fileName, IOUtils.toInputStream("Test"));
+        // setup
+        String fileName = "bad_file.cgi";      // file extension in bad.file.extensions
+        File tmpFile = createTemporaryFile(fileName, IOUtils.toInputStream("Test"));
 
-		// ingest
-		String id = given().multiPart(tmpFile)
-				.expect()
-				.log()
-				.headers()
-				.statusCode(HttpStatus.SC_CREATED)
-				.when()
-				.post(REST_PATH.getUrl())
-				.getHeader("id");
+        // ingest
+        String id = given().multiPart(tmpFile)
+                .expect()
+                .log()
+                .headers()
+                .statusCode(HttpStatus.SC_CREATED)
+                .when()
+                .post(REST_PATH.getUrl())
+                .getHeader("id");
 
-		// query - check if sanitized properly
-		getOpenSearch("xml", null, null, "q=*").log()
-				.all()
-				.assertThat()
-				.body(hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value",
-						is("bad_file.bin")));
+        // query - check if sanitized properly
+        getOpenSearch("xml", null, null, "q=*").log()
+                .all()
+                .assertThat()
+                .body(hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value",
+                        is("bad_file.bin")));
 
         // clean up
         deleteMetacard(id);

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -70,6 +70,12 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.16.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
@@ -95,7 +95,7 @@ public class InputValidation {
      * @param mimetype
      * @return true if the mime type is acceptable
      */
-    public static boolean isMimeTypeClientSideVulnerable(String mimetype) {
+    public static boolean isMimeTypeClientSideSafe(String mimetype) {
         mimetype = mimetype.toLowerCase();
         for (String type : BAD_MIME_TYPES) {
             if (mimetype.contains(type)) {
@@ -112,7 +112,7 @@ public class InputValidation {
      * @param filename
      * @return true if the filename is acceptable
      */
-    public static boolean isFileNameClientSideVulnerable(String filename) {
+    public static boolean isFileNameClientSideSafe(String filename) {
         filename = filename.toLowerCase();
         for (String ignoreFile : IGNORE_FILES) {
             if (ignoreFile.contains(filename)) {

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
@@ -95,7 +95,7 @@ public class InputValidation {
      * @param mimetype
      * @return true if the mime type is acceptable
      */
-    public static boolean checkForClientSideVulnerableMimeType(String mimetype) {
+    public static boolean isMimeTypeClientSideVulnerable(String mimetype) {
         mimetype = mimetype.toLowerCase();
         for (String type : BAD_MIME_TYPES) {
             if (mimetype.contains(type)) {
@@ -112,7 +112,7 @@ public class InputValidation {
      * @param filename
      * @return true if the filename is acceptable
      */
-    public static boolean checkForClientSideVulnerableFileName(String filename) {
+    public static boolean isFileNameClientSideVulnerable(String filename) {
         filename = filename.toLowerCase();
         for (String ignoreFile : IGNORE_FILES) {
             if (ignoreFile.contains(filename)) {

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/InputValidation.java
@@ -31,14 +31,22 @@ public class InputValidation {
     private static final String DEFAULT_FILE = "file" + DEFAULT_EXTENSION;
 
     private static final List<String> BAD_FILES = Arrays.asList(System.getProperty("bad.files")
+            .toLowerCase()
             .split(","));
 
-    private static final List<String> BAD_FILE_EXTENSIONS = Arrays.asList(
-            System.getProperty("bad.file.extensions")
-                    .split(","));
+    private static final List<String> BAD_FILE_EXTENSIONS = Arrays.asList(System.getProperty(
+            "bad.file.extensions")
+            .toLowerCase()
+            .split(","));
 
-    private static final List<String> BAD_MIME_TYPES = Arrays.asList(
-            System.getProperty("bad.mime.types")
+    private static final List<String> BAD_MIME_TYPES = Arrays.asList(System.getProperty(
+            "bad.mime.types")
+            .toLowerCase()
+            .split(","));
+
+    private static final List<String> IGNORE_FILES =
+            Arrays.asList(System.getProperty("ignore.files")
+                    .toLowerCase()
                     .split(","));
 
     private static final Pattern BAD_CHAR_PATTERN = Pattern.compile("[^a-z0-9.-]");
@@ -97,4 +105,22 @@ public class InputValidation {
         }
         return true;
     }
+
+    /**
+     * Checks for filenames that have been disallowed by the system.
+     *
+     * @param filename
+     * @return true if the filename is acceptable
+     */
+    public static boolean checkForClientSideVulnerableFileName(String filename) {
+        filename = filename.toLowerCase();
+        for (String ignoreFile : IGNORE_FILES) {
+            if (ignoreFile.contains(filename)) {
+                LOGGER.debug("Filename {} is flagged as client side vulnerable.", ignoreFile);
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -19,8 +19,10 @@ import static org.junit.Assert.assertTrue;
 
 import static junit.framework.TestCase.assertFalse;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 
 public class InputValidationTest {
 
@@ -52,16 +54,24 @@ public class InputValidationTest {
 
     private static final String IGNORE_FILE_KNOWN_GOOD = "valid_ddms_record.xml";
 
-    @Before
-    public void setup() {
-        System.setProperty("bad.files",
-                "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db");
-        System.setProperty("bad.file.extensions",
-                ".exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht");
-        System.setProperty("bad.mime.types",
-                "text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile");
-        System.setProperty("ignore.files", ".DS_Store");
-    }
+    @ClassRule
+    public static final ProvideSystemProperty badFilesSystemProperties = new ProvideSystemProperty(
+            "bad.files",
+            "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db");
+
+    @ClassRule
+    public static final ProvideSystemProperty badFileExtenstionsSystemProperties =
+            new ProvideSystemProperty("bad.file.extensions",
+                    ".exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht");
+
+    @ClassRule
+    public static final ProvideSystemProperty badMimeTypesSystemProperties =
+            new ProvideSystemProperty("bad.mime.types",
+                    "text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile");
+
+    @ClassRule
+    public static final ProvideSystemProperty ignoreFilesSystemProperties =
+            new ProvideSystemProperty("ignore.files", ".DS_Store");
 
     @Test
     public void testSanitizeFilenameBad() {
@@ -126,8 +136,8 @@ public class InputValidationTest {
 
     @Test
     public void testCheckForClientSideVulnerableFileNameGood() {
-        boolean result = InputValidation.checkForClientSideVulnerableFileName(
-                IGNORE_FILE_KNOWN_GOOD);
+        boolean result =
+                InputValidation.checkForClientSideVulnerableFileName(IGNORE_FILE_KNOWN_GOOD);
         assertTrue(result);
     }
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -114,14 +114,14 @@ public class InputValidationTest {
     }
 
     @Test
-    public void testCheckForClientSideVulnerableMimeTypeBad() {
-        boolean result = InputValidation.isMimeTypeClientSideVulnerable(BAD_MIME);
+    public void testIsMimeTypeClientSideSafeMimeTypeBad() {
+        boolean result = InputValidation.isMimeTypeClientSideSafe(BAD_MIME);
         assertFalse(result);
     }
 
     @Test
-    public void testCheckForClientSideVulnerableMimeTypeGood() {
-        boolean result = InputValidation.isMimeTypeClientSideVulnerable(GOOD_MIME);
+    public void testIsMimeTypeClientSideSafeMimeTypeGood() {
+        boolean result = InputValidation.isMimeTypeClientSideSafe(GOOD_MIME);
         assertTrue(result);
     }
 
@@ -134,21 +134,21 @@ public class InputValidationTest {
     }
 
     @Test
-    public void testCheckForClientSideVulnerableFileNameBad() {
-        boolean result = InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE);
+    public void testIsFileNameClientSideSafeFileNameBad() {
+        boolean result = InputValidation.isFileNameClientSideSafe(IGNORE_FILE);
         assertFalse(result);
     }
 
     @Test
-    public void testCheckForClientSideVulnerableFileNameBadCaseInsensitive() {
+    public void testIsFileNameClientSideSafeFileNameBadCaseInsensitive() {
         boolean result =
-                InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_CASE_INSENSITIVE);
+                InputValidation.isFileNameClientSideSafe(IGNORE_FILE_CASE_INSENSITIVE);
         assertFalse(result);
     }
 
     @Test
-    public void testCheckForClientSideVulnerableFileNameGood() {
-        boolean result = InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_KNOWN_GOOD);
+    public void testIsFileNameClientSideSafeFileNameGood() {
+        boolean result = InputValidation.isFileNameClientSideSafe(IGNORE_FILE_KNOWN_GOOD);
         assertTrue(result);
     }
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -76,31 +76,41 @@ public class InputValidationTest {
     @Test
     public void testSanitizeFilenameBad() {
         String sanitizedName = InputValidation.sanitizeFilename(BAD_FILE);
-        assertThat(sanitizedName, is(SANI_BAD_FILE));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(SANI_BAD_FILE));
     }
 
     @Test
     public void testSanitizeFilenameBad1() {
         String sanitizedName = InputValidation.sanitizeFilename(BAD_FILE1);
-        assertThat(sanitizedName, is(SANI_BAD_FILE1));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(SANI_BAD_FILE1));
     }
 
     @Test
     public void testSanitizeFilenameBad2() {
         String sanitizedName = InputValidation.sanitizeFilename(BAD_FILE2);
-        assertThat(sanitizedName, is(DEFAULT_FILE));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(DEFAULT_FILE));
     }
 
     @Test
     public void testSanitizeFilenameGood() {
         String sanitizedName = InputValidation.sanitizeFilename(GOOD_FILE);
-        assertThat(sanitizedName, is(GOOD_FILE));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(GOOD_FILE));
     }
 
     @Test
     public void testSanitizeFilenameKnownBad() {
         String sanitizedName = InputValidation.sanitizeFilename(KNOWN_BAD_FILE);
-        assertThat(sanitizedName, is(DEFAULT_FILE));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(DEFAULT_FILE));
     }
 
     @Test
@@ -118,7 +128,9 @@ public class InputValidationTest {
     @Test
     public void testSanitizeFilenameKnownBadCaseInsensitive() {
         String sanitizedName = InputValidation.sanitizeFilename(BAD_FILE3);
-        assertThat(sanitizedName, is(DEFAULT_FILE));
+        assertThat("Actual sanitized filename does not match expected output.",
+                sanitizedName,
+                is(DEFAULT_FILE));
     }
 
     @Test
@@ -129,15 +141,14 @@ public class InputValidationTest {
 
     @Test
     public void testCheckForClientSideVulnerableFileNameBadCaseInsensitive() {
-        boolean result = InputValidation.isFileNameClientSideVulnerable(
-                IGNORE_FILE_CASE_INSENSITIVE);
+        boolean result =
+                InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_CASE_INSENSITIVE);
         assertFalse(result);
     }
 
     @Test
     public void testCheckForClientSideVulnerableFileNameGood() {
-        boolean result =
-                InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_KNOWN_GOOD);
+        boolean result = InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_KNOWN_GOOD);
         assertTrue(result);
     }
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -32,7 +32,7 @@ public class InputValidationTest {
 
     private static final String BAD_FILE2 = ".";
 
-    private static final String BAD_FILE3 = "thumbs.db";
+    private static final String BAD_FILE3 = "robots.TXT";
 
     private static final String SANI_BAD_FILE = "myfile.bin.bin.unk";
 
@@ -57,7 +57,7 @@ public class InputValidationTest {
     @ClassRule
     public static final ProvideSystemProperty badFilesSystemProperties = new ProvideSystemProperty(
             "bad.files",
-            "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db");
+            "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt");
 
     @ClassRule
     public static final ProvideSystemProperty badFileExtenstionsSystemProperties =
@@ -71,7 +71,7 @@ public class InputValidationTest {
 
     @ClassRule
     public static final ProvideSystemProperty ignoreFilesSystemProperties =
-            new ProvideSystemProperty("ignore.files", ".DS_Store");
+            new ProvideSystemProperty("ignore.files", ".DS_Store,Thumbs.db");
 
     @Test
     public void testSanitizeFilenameBad() {
@@ -105,13 +105,13 @@ public class InputValidationTest {
 
     @Test
     public void testCheckForClientSideVulnerableMimeTypeBad() {
-        boolean result = InputValidation.checkForClientSideVulnerableMimeType(BAD_MIME);
+        boolean result = InputValidation.isMimeTypeClientSideVulnerable(BAD_MIME);
         assertFalse(result);
     }
 
     @Test
     public void testCheckForClientSideVulnerableMimeTypeGood() {
-        boolean result = InputValidation.checkForClientSideVulnerableMimeType(GOOD_MIME);
+        boolean result = InputValidation.isMimeTypeClientSideVulnerable(GOOD_MIME);
         assertTrue(result);
     }
 
@@ -123,13 +123,13 @@ public class InputValidationTest {
 
     @Test
     public void testCheckForClientSideVulnerableFileNameBad() {
-        boolean result = InputValidation.checkForClientSideVulnerableFileName(IGNORE_FILE);
+        boolean result = InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE);
         assertFalse(result);
     }
 
     @Test
     public void testCheckForClientSideVulnerableFileNameBadCaseInsensitive() {
-        boolean result = InputValidation.checkForClientSideVulnerableFileName(
+        boolean result = InputValidation.isFileNameClientSideVulnerable(
                 IGNORE_FILE_CASE_INSENSITIVE);
         assertFalse(result);
     }
@@ -137,7 +137,7 @@ public class InputValidationTest {
     @Test
     public void testCheckForClientSideVulnerableFileNameGood() {
         boolean result =
-                InputValidation.checkForClientSideVulnerableFileName(IGNORE_FILE_KNOWN_GOOD);
+                InputValidation.isFileNameClientSideVulnerable(IGNORE_FILE_KNOWN_GOOD);
         assertTrue(result);
     }
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -30,6 +30,8 @@ public class InputValidationTest {
 
     private static final String BAD_FILE2 = ".";
 
+    private static final String BAD_FILE3 = "thumbs.db";
+
     private static final String SANI_BAD_FILE = "myfile.bin.bin.unk";
 
     private static final String SANI_BAD_FILE1 = "bin.bin";
@@ -44,14 +46,21 @@ public class InputValidationTest {
 
     private static final String BAD_MIME = "text/html";
 
+    private static final String IGNORE_FILE = ".DS_Store";
+
+    private static final String IGNORE_FILE_CASE_INSENSITIVE = ".dS_sTorE";
+
+    private static final String IGNORE_FILE_KNOWN_GOOD = "valid_ddms_record.xml";
+
     @Before
     public void setup() {
         System.setProperty("bad.files",
-                "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt");
+                "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt,Thumbs.db");
         System.setProperty("bad.file.extensions",
                 ".exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht");
         System.setProperty("bad.mime.types",
                 "text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile");
+        System.setProperty("ignore.files", ".DS_Store");
     }
 
     @Test
@@ -93,6 +102,32 @@ public class InputValidationTest {
     @Test
     public void testCheckForClientSideVulnerableMimeTypeGood() {
         boolean result = InputValidation.checkForClientSideVulnerableMimeType(GOOD_MIME);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testSanitizeFilenameKnownBadCaseInsensitive() {
+        String sanitizedName = InputValidation.sanitizeFilename(BAD_FILE3);
+        assertThat(sanitizedName, is(DEFAULT_FILE));
+    }
+
+    @Test
+    public void testCheckForClientSideVulnerableFileNameBad() {
+        boolean result = InputValidation.checkForClientSideVulnerableFileName(IGNORE_FILE);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCheckForClientSideVulnerableFileNameBadCaseInsensitive() {
+        boolean result = InputValidation.checkForClientSideVulnerableFileName(
+                IGNORE_FILE_CASE_INSENSITIVE);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCheckForClientSideVulnerableFileNameGood() {
+        boolean result = InputValidation.checkForClientSideVulnerableFileName(
+                IGNORE_FILE_KNOWN_GOOD);
         assertTrue(result);
     }
 }

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/InputValidationTest.java
@@ -55,22 +55,22 @@ public class InputValidationTest {
     private static final String IGNORE_FILE_KNOWN_GOOD = "valid_ddms_record.xml";
 
     @ClassRule
-    public static final ProvideSystemProperty badFilesSystemProperties = new ProvideSystemProperty(
+    public static final ProvideSystemProperty BAD_FILES_SYSTEM_PROPERTIES = new ProvideSystemProperty(
             "bad.files",
             "crossdomain.xml,clientaccesspolicy.xml,.htaccess,.htpasswd,hosts,passwd,group,resolv.conf,nfs.conf,ftpd.conf,ntp.conf,web.config,robots.txt");
 
     @ClassRule
-    public static final ProvideSystemProperty badFileExtenstionsSystemProperties =
+    public static final ProvideSystemProperty BAD_FILE_EXTENSTIONS_SYSTEM_PROPERTIES =
             new ProvideSystemProperty("bad.file.extensions",
                     ".exe,.jsp,.html,.js,.php,.phtml,.php3,.php4,.php5,.phps,.shtml,.jhtml,.pl,.py,.cgi,.msi,.com,.scr,.gadget,.application,.pif,.hta,.cpl,.msc,.jar,.kar,.bat,.cmd,.vb,.vbs,.vbe,.jse,.ws,.wsf,.wsc,.wsh,.ps1,.ps1xml,.ps2,.ps2xml,.psc1,.psc2,.msh,.msh1,.msh2,.mshxml,.msh1xml,.msh2xml,.scf,.lnk,.inf,.reg,.dll,.vxd,.cpl,.cfg,.config,.crt,.cert,.pem,.jks,.p12,.p7b,.key,.der,.csr,.jsb,.mhtml,.mht,.xhtml,.xht");
 
     @ClassRule
-    public static final ProvideSystemProperty badMimeTypesSystemProperties =
+    public static final ProvideSystemProperty BAD_MIME_TYPES_SYSTEM_PROPERTIES =
             new ProvideSystemProperty("bad.mime.types",
                     "text/html,text/javascript,text/x-javascript,application/x-shellscript,text/scriptlet,application/x-msdownload,application/x-msmetafile");
 
     @ClassRule
-    public static final ProvideSystemProperty ignoreFilesSystemProperties =
+    public static final ProvideSystemProperty IGNORE_FILES_SYSTEM_PROPERTIES =
             new ProvideSystemProperty("ignore.files", ".DS_Store,Thumbs.db");
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
- Fix the issue where mime type improperly used the original filename and overwrote the sanitized filename.
- Fix a bug where if `files.bad`, `files.bad.extension` in `system.properties` contained any capitalization, to-be sanitized files would not be properly identified
- Minor refactoring of `generateMetacardAndContentItems()`
- Add ability to ignore files (`ignore.files` in `system.properties`)
- Update documentation as needed


#### Who is reviewing it? 
@ahoffer 
@brendan-hofmann 
@emanns95 
@AzGoalie 
@jhunzik 
@mweser 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison
#### How should this be tested? (List steps with links to updated documentation)

1. Build ddf
2. Add a  dummy filename to `ignore.files` in `etc/system.properties`
3. Stand up ddf
4. Ingest the attached test files
5. `crossdomain.xml` and `thUmbs.db` will be successfully ingested as `file.bin`
6. `bad_file.cgi` will be successfully ingested as `bad_file.bin`
7. Try to ingest a file with that filename added in step 2. It will not be successful

[DDF-3172.TestFiles.zip](https://github.com/codice/ddf/files/1180825/DDF-3172.TestFiles.zip)

#### Any background context you want to provide?

#### What are the relevant tickets?
DDF-2151
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
