### PR TITLE
DDF-3177 Adds a process method for content metadata that takes a stream.

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/ContentMetadataExtractor.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/operation/ContentMetadataExtractor.java
@@ -13,6 +13,7 @@
  **/
 package ddf.catalog.content.operation;
 
+import java.io.InputStream;
 import java.util.Set;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -28,10 +29,22 @@ public interface ContentMetadataExtractor {
     /**
      * Parses the input string, extracting metadata from it to add to the metacard.
      *
+     * <strong>This method can have large memory effects. If you already have data in
+     * a datasource that can be streamed, consider the {@link #process(InputStream, Metacard)}
+     * overloaded method instead.</strong>
+     *
      * @param input    the content to process
      * @param metacard the incoming metacard
      */
     void process(String input, Metacard metacard);
+
+    /**
+     * Parses the input stream, extracting metadata from it to add to the metacard.
+     *
+     * @param input    the content to process
+     * @param metacard the incoming metacard
+     */
+    void process(InputStream input, Metacard metacard);
 
     /**
      * Returns the valid set of Metacard attributes that are populated by this extractor.

--- a/catalog/transformer/catalog-transformer-pdf/pom.xml
+++ b/catalog/transformer/catalog-transformer-pdf/pom.xml
@@ -157,17 +157,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.48</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -147,17 +147,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.39</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -397,9 +397,11 @@ public class TikaInputTransformer implements InputTransformer {
                         useResourceTitleAsTitle);
 
                 if (textContentHandler != null && !contentExtractors.isEmpty()) {
-                    String plainText = textContentHandler.toString();
                     for (ContentMetadataExtractor contentMetadataExtractor : contentExtractors.values()) {
-                        contentMetadataExtractor.process(plainText, metacard);
+                        try (InputStream contentStream = textContentHandlerOutStream.asByteSource()
+                                .openStream()) {
+                            contentMetadataExtractor.process(contentStream, metacard);
+                        }
                     }
                 }
             }

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -44,6 +44,7 @@ import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -194,7 +195,7 @@ public class TikaInputTransformerTest {
                 .getResourceAsStream("testPDF.pdf");
         tikaInputTransformer.addContentMetadataExtractor(serviceRefCme);
         Metacard metacard = tikaInputTransformer.transform(stream);
-        verify(cme).process(anyString(), anyObject());
+        verify(cme).process(Matchers.any(InputStream.class), anyObject());
         verify(cme).getMetacardAttributes();
         assertThat(metacard.getMetacardType()
                 .getName(), is(PDF_METACARDTYPE_NAME));


### PR DESCRIPTION
#### What does this PR do?
Updates the `ContentMetadataExtractor` with a new `process` method that can work directly with `InputStream`s.

Also updates the `TikaInputTransformer` to use this new method instead of generating Strings.  

This PR is based off the changes for DDF-3178 in #2164

#### Who is reviewing it? 
@ahoffer @rzwiefel 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@jlcsmith
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Ingest of large text files should be determined to require less heap and GC less frequently.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3177](https://codice.atlassian.net/browse/DDF-3177)
[DDF-3178](https://codice.atlassian.net/browse/DDF-3178)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
