### PR TITLE
DDF-3179 UndeliveredMessagesMbean operations can be executed regardless of the system hostname value

### DIFF
--- a/broker/broker-undelivered-messages-ui/src/main/java/org/codice/ddf/broker/ui/UndeliveredMessages.java
+++ b/broker/broker-undelivered-messages-ui/src/main/java/org/codice/ddf/broker/ui/UndeliveredMessages.java
@@ -35,7 +35,6 @@ import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,9 +219,10 @@ public class UndeliveredMessages implements UndeliveredMessagesMBean {
 
     private ObjectName createArtemisObjectName(String address, String queue) {
         try {
-            return new ObjectName("org.apache.activemq.artemis:broker=\"" + SystemBaseUrl.getHost()
-                    + "\",component=addresses,address=\"" + address
-                    + "\",subcomponent=queues,routing-type=\"anycast\",queue=\"" + queue + "\"");
+            return new ObjectName(
+                    "org.apache.activemq.artemis:broker=\"artemis\",component=addresses,address=\""
+                            + address + "\",subcomponent=queues,routing-type=\"anycast\",queue=\""
+                            + queue + "\"");
         } catch (MalformedObjectNameException e) {
             LOGGER.warn(
                     "Unable to create the Artemis ObjectName, with the given the address: {}, and "

--- a/broker/broker-undelivered-messages-ui/src/test/java/org/codice/ddf/broker/ui/UndeliveredMessagesTest.java
+++ b/broker/broker-undelivered-messages-ui/src/test/java/org/codice/ddf/broker/ui/UndeliveredMessagesTest.java
@@ -35,7 +35,6 @@ import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,9 +55,9 @@ public class UndeliveredMessagesTest {
     private static final String RETRY_MESSAGE = "retryMessage";
 
     private final ObjectName objectName = new ObjectName(
-            "org.apache.activemq.artemis:broker=\"" + SystemBaseUrl.getHost()
-                    + "\",component=addresses,address=\"" + ADDRESS
-                    + "\",subcomponent=queues,routing-type=\"anycast\",queue=\"" + QUEUE + "\"");
+            "org.apache.activemq.artemis:broker=\"artemis\",component=addresses,address=\""
+                    + ADDRESS + "\",subcomponent=queues,routing-type=\"anycast\",queue=\"" + QUEUE
+                    + "\"");
 
     private UndeliveredMessages undeliveredMessagesService;
 

--- a/distribution/ddf-common/src/main/resources/etc/artemis-backup.xml
+++ b/distribution/ddf-common/src/main/resources/etc/artemis-backup.xml
@@ -14,7 +14,7 @@
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
     <core xmlns="urn:activemq:core">
-
+        <name>artemis</name>
         <addresses>
             <address name="DLQ">
                 <anycast>

--- a/distribution/ddf-common/src/main/resources/etc/artemis.xml
+++ b/distribution/ddf-common/src/main/resources/etc/artemis.xml
@@ -14,7 +14,7 @@
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
     <core xmlns="urn:activemq:core">
-
+        <name>artemis</name>
         <addresses>
             <address name="DLQ">
                 <anycast>

--- a/distribution/sdk/artemis-sandbox/pom.xml
+++ b/distribution/sdk/artemis-sandbox/pom.xml
@@ -55,7 +55,45 @@
             <artifactId>artemis-jms-client</artifactId>
             <version>${artemis.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.4.2</version>
+        </dependency>
     </dependencies>
-
-
 </project>


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug that would prevent the UndeliveredMessagesMbean from being registered if the system hostname was not localhost. For more Information see: https://codice.atlassian.net/browse/DDF-3179

-Changed the Artemis broker name to "artemis"
-The Artemis ObjectName created in the UndeliveredMessagesMbean now uses "artemis" as the broker name instead of the system hostname
-Added missing dependencies to fix sdk example routes
#### Who is reviewing it? 
@ryeats 
@harrison-tarr 
@jrnorth 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@jaymcnallie
#### How should this be tested? (List steps with links to updated documentation)
-Run a full build, all itests should pass.
-Change the system hostname to something other than "localhost", verify the UndeliveredMessagesMbean is registered (no errors should show up in the logs)
-Use a client to send messages to the DLQ, and verify messages can be displayed in the UndeliveredMessages UI.
#### What are the relevant tickets?
[DDF-3179](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
