### PR TITLE
DDF-3170 Require users to push OK button on System Usage Modal to exit

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/Modal.js
+++ b/platform/admin/ui/src/main/webapp/js/views/Modal.js
@@ -41,7 +41,10 @@ function (Marionette) {
         },
 
         show: function () {
-            this.$el.modal('show');
+            this.$el.modal({
+                backdrop: 'static',
+                keyboard: false
+            });
         },
 
         hide: function () {


### PR DESCRIPTION
#### What does this PR do?
Forces users to click OK to dismiss System Usage modal
#### Who is reviewing it? 
@vinamartin 
@emmberk 
@josephthweatt 
@mcalcote 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@clockard
#### How should this be tested? (List steps with links to updated documentation)
When System Usage modal appears in the ADMIN console, attempt to click everywhere besides OK and see that you can only click OK to dismiss the Modal. 
#### What are the relevant tickets?
[DDF-3170](https://codice.atlassian.net/browse/)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
