### PR TITLE
DDF-3069 Fix service reference in geocoder plugin

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,7 +48,11 @@
       <argument ref="geoCoderFactory"/>
     </bean>
 
-    <bean id="geoCoder" class="org.codice.ddf.spatial.geocoder.GazetteerGeoCoder"/>
+    <reference id="geoEntryQueryable" availability="mandatory" interface="org.codice.ddf.spatial.geocoding.GeoEntryQueryable"/>
+
+    <bean id="geoCoder" class="org.codice.ddf.spatial.geocoder.GazetteerGeoCoder">
+        <property name="geoEntryQueryable" ref="geoEntryQueryable"/>
+    </bean>
     <service ref="geoCoder" interface="org.codice.ddf.spatial.geocoder.GeoCoder"/>
 
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
I left out a service reference on the GeoCoder bean when I rearranged its underlying interfaces for the keyword search feature.
Currently this causes an NPE when you import a document and the GeoCoder plugin gets used to find the country code based on the document's location data.

#### Who is reviewing it? 
@bdeining 
@troymohl 

#### Choose 2 committers to review/merge the PR. 
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Ingest document(s) with location data and check that they are properly geo-located.
Ensure that there aren't any NPEs in the Karaf log.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3069