### PR TITLE
DDF-3116 Fixes bugs with catalog:dump when transform fails

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -215,12 +215,11 @@ public class DumpCommand extends CqlCommands {
                         Metacard metacard = result.getMetacard();
                         try {
                             exportMetacard(dumpDir, metacard);
+                            printStatus(resultCount.incrementAndGet());
                         } catch (IOException | CatalogTransformerException e) {
                             transformationFailed = true;
                             LOGGER.debug("Failed to dump metacard {}", metacard.getId(), e);
-                            executorService.shutdownNow();
                         }
-                        printStatus(resultCount.incrementAndGet());
                     }
                     if (transformationFailed) {
                         LOGGER.info(
@@ -276,14 +275,14 @@ public class DumpCommand extends CqlCommands {
         } else {
             BinaryContent binaryContent;
             if (metacard != null) {
-                try (FileOutputStream fos = new FileOutputStream(getOutputFile(dumpLocation,
-                        metacard))) {
-                    for (MetacardTransformer transformer : transformers) {
-                        binaryContent = transformer.transform(metacard, new HashMap<>());
-                        if (binaryContent != null) {
+                for (MetacardTransformer transformer : transformers) {
+                    binaryContent = transformer.transform(metacard, new HashMap<>());
+                    if (binaryContent != null) {
+                        try (FileOutputStream fos = new FileOutputStream(getOutputFile(dumpLocation,
+                                metacard))) {
                             fos.write(binaryContent.getByteArray());
-                            break;
                         }
+                        break;
                     }
                 }
             }
@@ -314,7 +313,7 @@ public class DumpCommand extends CqlCommands {
         console.flush();
     }
 
-    private List<MetacardTransformer> getTransformers() {
+    protected List<MetacardTransformer> getTransformers() {
         ServiceReference[] refs = null;
         try {
             refs = bundleContext.getAllServiceReferences(MetacardTransformer.class.getName(),


### PR DESCRIPTION
#### What does this PR do?
-Prevents DDF from shutting down when transform fails
-Changes counter to correctly display the results that were dumped (Prints out 0 file(s) dumped in 0 seconds when a failure happens)
-Does not create a blank file when transform fails

#### Who is reviewing it? 
@emmberk @bdeining @kcrowe01 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
Ingest some data that is known not to be transformable using one of the transformers. 
Run the `catalog:dump` command with the transformer option and give it a transformer that will fail. Verify that the DDF doesn't shut down, no files are written to the dump location, and a message saying 0 files were dumped is printed to the console. 

#### What are the relevant tickets?
[DDF-3116](https://codice.atlassian.net/browse/DDF-3116)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
