### PR TITLE
DDF-3166 Add Unit Test to Ensure catalog:seed Does Not Skip Resources

### DIFF
--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.apache.commons.lang3.math.NumberUtils;
 import org.geotools.filter.text.ecql.ECQL;
 import org.junit.Before;
 import org.junit.Test;
@@ -318,14 +317,10 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
             throws Exception {
 
         mockResourceResponse();
-        QueryResponse queryResponseMock = mock(QueryResponse.class);
 
         // Populate list of mock results, sized at resource limit
         List<Result> resultsList = populateResultMockList(resourceLimit);
-        List<Result>[] queriedResultsList = mockQueryGetResults(resultsList, pageSize);
-
-        when(catalogFramework.query(any())).thenReturn(queryResponseMock);
-        when(queryResponseMock.getResults()).thenReturn(queriedResultsList[0], queriedResultsList);
+        mockQueryGetResults(resultsList, pageSize);
 
         seedCommand.resourceLimit = resourceLimit;
     }
@@ -356,7 +351,9 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
      * of thenReturn.
      * i.e. thenReturn(query1, [ query1, query2, query2 ]).
      */
-    private List<Result>[] mockQueryGetResults(List<Result> results, int pageSize) {
+    private void mockQueryGetResults(List<Result> results, int pageSize) throws Exception {
+
+        QueryResponse queryResponseMock = mock(QueryResponse.class);
 
         int queries = results.size() / pageSize;
         queries += (results.size() % pageSize > 0) ? 1 : 0;
@@ -371,6 +368,7 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
             pageArray[i + 1] = pageResults.get(j);
         }
 
-        return pageArray;
+        when(catalogFramework.query(any())).thenReturn(queryResponseMock);
+        when(queryResponseMock.getResults()).thenReturn(pageArray[0], pageArray);
     }
 }

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
@@ -222,7 +222,7 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
     @Test
     public void testDoesNotSkipResources() throws Exception {
 
-        int maxPageSize = getMaxPageSize();
+        int maxPageSize = 1000;
         int resourceLimit = maxPageSize * 2;
 
         String expected = resourceLimit + " resource download(s) started.";
@@ -312,10 +312,6 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
         public boolean matches(Object o) {
             return test.test((QueryRequest) o);
         }
-    }
-
-    private int getMaxPageSize() {
-        return NumberUtils.toInt(System.getProperty("catalog.maxPageSize"), 1000);
     }
 
     private void mockMultipleCatalogFrameworkQueries(int pageSize, int resourceLimit)

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/SeedCommandTest.java
@@ -65,9 +65,9 @@ public class SeedCommandTest extends CommandCatalogFrameworkCommon {
 
     private CatalogFramework catalogFramework;
 
-    Metacard metacardMock;
+    private Metacard metacardMock;
 
-    Result resultMock;
+    private Result resultMock;
 
     @Before
     public void setUp() throws Exception {

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -378,22 +378,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.28</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.11</minimum>
+                                            <minimum>0.19</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.15</minimum>
+                                            <minimum>0.25</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.19</minimum>
+                                            <minimum>0.27</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
#### What does this PR do?
The current implementation of the catalog:seed command takes a maximum number of resources to download and uses that number to page through the results:
https://github.com/codice/ddf/blob/088e81f76c19291ba3a6e953b25700b08bb217db/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SeedCommand.java#L115-L119
Now that   DDF-2872  has been added to address potential Solr and security problems, the number of results returned is limited to a maximum, which means that the command could skip some resources when it needs to page because of some download failures or already cached resources.

This PR added a unit test to verify that results would not be skipped.

#### Who is reviewing it? 
@mweser 
@vinamartin 
@jhunzik 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard 
@bdeining 

#### How should this be tested? (List steps with links to updated documentation)
1. Build DDF & unzip the snapshot
2. In the snapshot, modify the last line of **bin/setenv** by adding `-Dcatalog.maxPageSize=100` to `export JAVA_OPTS="`
3. Run DDF
4. Run another DDF, either on your own computer or on another, and make 200 files available for the original DDF to seed. Add the new DDF as a source to the original.
5. Run the `seed` command as follows: `seed -rl 200`
6. If successful, the program should display that 200 downloads have started.

#### What are the relevant tickets?
[DDF-3166](https://codice.atlassian.net/browse/)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
