### PR TITLE
DDF-3188,3123 Improved logging in Intrigue and Historian + misc. fixes

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/operation/impl/CreateStorageResponseImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/content/operation/impl/CreateStorageResponseImpl.java
@@ -16,6 +16,8 @@ package ddf.catalog.content.operation.impl;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.content.operation.CreateStorageRequest;
@@ -31,7 +33,7 @@ public class CreateStorageResponseImpl extends ResponseImpl<CreateStorageRequest
     /**
      * Instantiates a new ResponseImpl
      *
-     * @param request    - the original request
+     * @param request the original request
      * @param properties
      */
     public CreateStorageResponseImpl(CreateStorageRequest request,
@@ -42,7 +44,7 @@ public class CreateStorageResponseImpl extends ResponseImpl<CreateStorageRequest
     /**
      * Instantiates a new ResponseImpl
      *
-     * @param request    - the original request
+     * @param request the original request
      * @param createdContentItems
      */
     public CreateStorageResponseImpl(CreateStorageRequest request,
@@ -59,5 +61,17 @@ public class CreateStorageResponseImpl extends ResponseImpl<CreateStorageRequest
     @Override
     public StorageRequest getStorageRequest() {
         return request;
+    }
+
+    @Override
+    public String toString() {
+        if (createdContentItems == null) {
+            return "CreateStorageResponseImpl{createdContentItems=null}";
+        }
+        return String.format("CreateStorageResponseImpl{createdContentItems=%s}",
+                createdContentItems.stream()
+                        .filter(Objects::nonNull)
+                        .map(Object::toString)
+                        .collect(Collectors.joining(", ", "[", "]")));
     }
 }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
@@ -117,25 +117,24 @@ public abstract class CatalogCommands extends SubjectCommands {
 
     protected StringBuilder getUserInputModifiable() throws IOException {
         int in;
-        StringBuilder builder = new StringBuilder();
+        StringBuilder input = new StringBuilder();
         while ((in = session.getKeyboard()
-                .read()) != '\r') {
-            if (in == 127) {
-                if (builder.length() > 0) {
-                    builder.deleteCharAt(builder.length() - 1);
+                .read()) != '\r' && in != '\n') {
+            if (in == 127 || in == 8) {
+                if (input.length() > 0) {
+                    input.deleteCharAt(input.length() - 1);
+                    console.print((char) 8);
+                    console.print(' ');
+                    console.print((char) 8);
                 }
-                console.print((char) 8);
-                console.print(' ');
-                console.print((char) 8);
-
             } else {
-                builder.append((char) in);
+                input.append((char) in);
                 console.print((char) in);
             }
             console.flush();
         }
         console.println();
-        return builder;
+        return input;
     }
 
     protected String getFormattedDuration(Instant start) {

--- a/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
+++ b/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
@@ -166,18 +166,15 @@ class ExportCommandSpec extends Specification {
         thrown(IllegalStateException)
     }
 
-    // TODO - Ignored until DDF-3123 has been addressed
-    @Ignore
     def "Test abort command"() {
         setup:
+        InputStream keyboardInput = new ByteArrayInputStream("n\r".getBytes('utf-8'))
+        def session = Mock(Session) {
+            getKeyboard() >> keyboardInput
+        }
         exportCommand.with {
             it.delete = true
             it.session = session
-        }
-
-        InputStream keyboardInput = new ByteArrayInputStream("n\r".getBytes('utf-8'))
-        Session session = Mock(Session) {
-            getKeyboard() >> keyboardInput
         }
 
         when:

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -214,6 +214,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
      * @return the original metacard this version represents
      * @deprecated The metacard types passed in are no longer used
      */
+    @Deprecated
     public Metacard getMetacard(List<MetacardType> types) {
         return this.getMetacard();
     }
@@ -234,6 +235,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
      * @return The original metacard this version represents
      * @deprecated The metacard types passed in are no longer used
      */
+    @Deprecated
     public static Metacard toMetacard(Metacard source, List<MetacardType> types) {
         return toMetacard(source);
     }

--- a/catalog/ui/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
+++ b/catalog/ui/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
@@ -47,10 +47,11 @@ public class ExperimentalEnumerationExtractor {
     private final List<AttributeInjector> attributeInjectors;
 
     /**
-     * @deprecated This constructor does not take into account injected attributes.
-     * The other constructor <code>ExperimentalEnumerationExtractor/3</code> should be used.
      * @param attributeValidatorRegistry
      * @param metacardTypes
+     * @deprecated This constructor does not take into account injected attributes.
+     * The other constructor {@link #ExperimentalEnumerationExtractor(AttributeValidatorRegistry, List, List)}
+     * should be used.
      */
     @Deprecated
     public ExperimentalEnumerationExtractor(AttributeValidatorRegistry attributeValidatorRegistry,
@@ -60,8 +61,8 @@ public class ExperimentalEnumerationExtractor {
 
     /**
      * @param attributeValidatorRegistry validators to build enumerations from
-     * @param metacardTypes metacard types to associate attributes with types
-     * @param attributeInjectors injected attributes
+     * @param metacardTypes              metacard types to associate attributes with types
+     * @param attributeInjectors         injected attributes
      */
     public ExperimentalEnumerationExtractor(AttributeValidatorRegistry attributeValidatorRegistry,
             List<MetacardType> metacardTypes, List<AttributeInjector> attributeInjectors) {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -170,6 +170,10 @@
         <argument>
             <reference-list interface="ddf.catalog.data.MetacardType"/>
         </argument>
+        <argument>
+            <reference-list interface="ddf.catalog.data.AttributeInjector"
+                            availability="optional"/>
+        </argument>
     </bean>
 
     <bean id="associated" class="org.codice.ddf.catalog.ui.metacard.associations.Associated">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Metacard.js
@@ -575,8 +575,9 @@ define([
                                         {
                                             type: '=',
                                             property: '"id"',
-                                            value: metacard['metacard.deleted.id'] || metacard.id
-                                        }, {
+                                            value: metacard.get('properties').get('metacard.deleted.id') || metacard.id
+                                        },
+                                        {
                                             type: '=',
                                             property: '"metacard.deleted.id"',
                                             value: metacard.id
@@ -599,7 +600,7 @@ define([
                         type: "POST",
                         url: '/search/catalog/internal/cql',
                         data: JSON.stringify(req),
-                        dataType: 'json'
+                        contentType: 'application/json'
                     }).then(this.parseRefresh.bind(this), this.handleRefreshError.bind(this));
 
                 }.bind(this), 1000);


### PR DESCRIPTION
## Please do not squash 
#### What does this PR do?
- Updated logging in Historian
- Updated logging in CqlQueryResponse
- Fixed missing implicit dependencies on Injected Attributes
- Added to string to CreateStorageResponseImpl
- Fixed CatalogCommands getUserInputModifiable
   - Accounts for Windows Systems now. 
- Removed changed assumptions in MetacardVersionImpl
   - Previously we relied on MetacardTypes not changing. However they can and do 
   change now. So we have opted to always serialize the MetacardType (but did
   add caching to prevent the serialization overhead).
- Fixed model/Metacard.js re-query on archive/restore

#### Who is reviewing it? 
anyone

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@bdeining 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3188

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
