### PR TITLE
DDF-3191 Intrigue incorrectly adds wildcards to all queries by default

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -73,7 +73,7 @@ define([
         var propertyValueMap = {};
         var downConversion = false;
 
-        if (filter.filters && isAnyDate(filter)) {
+        if (filter.filters !== null && isAnyDate(filter)) {
            propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
            if (propertyValueMap['anyDate'].filter(function(existingFilter){
                    return existingFilter.type === filter.filters[0].type;
@@ -82,7 +82,7 @@ define([
            }
         }
 
-        if (filter.filters){
+        if (filter.filters !== null){
             filter.filters.forEach(function(filter){
                if (filter.filters === null){
                    propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -84,7 +84,7 @@ define([
 
         if (filter.filters){
             filter.filters.forEach(function(filter){
-               if (!filter.filters){
+               if (filter.filters === null){
                    propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];
                    if (propertyValueMap[CQLUtils.getProperty(filter)].filter(function(existingFilter){
                            return existingFilter.type === filter.type;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -73,7 +73,7 @@ define([
         var propertyValueMap = {};
         var downConversion = false;
 
-        if (filter.filters !== null && isAnyDate(filter)) {
+        if (filter.filters && isAnyDate(filter)) {
            propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
            if (propertyValueMap['anyDate'].filter(function(existingFilter){
                    return existingFilter.type === filter.filters[0].type;
@@ -82,9 +82,9 @@ define([
            }
         }
 
-        if (filter.filters !== null){
+        if (filter.filters){
             filter.filters.forEach(function(filter){
-               if (filter.filters === null){
+               if (!filter.filters){
                    propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];
                    if (propertyValueMap[CQLUtils.getProperty(filter)].filter(function(existingFilter){
                            return existingFilter.type === filter.type;
@@ -524,12 +524,9 @@ define([
             }
 
             var text = this.basicText.currentView.model.getValue()[0];
+            text = text === "" ? '*' : text;
 
-            if (filters.length == 0) {
-                text = '*'
-            }
-
-            if (text !== "") {
+            if (filters.length == 0 || text !== '*') {
                 var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
                 filters.unshift(CQLUtils.generateFilter(matchCase, 'anyText', text));
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -526,7 +526,7 @@ define([
             var text = this.basicText.currentView.model.getValue()[0];
             text = text === "" ? '*' : text;
 
-            if (filters.length == 0 || text !== '*') {
+            if (filters.length === 0 || text !== '*') {
                 var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
                 filters.unshift(CQLUtils.generateFilter(matchCase, 'anyText', text));
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -72,6 +72,16 @@ define([
     function translateFilterToBasicMap(filter){
         var propertyValueMap = {};
         var downConversion = false;
+
+        if (filter.filters && isAnyDate(filter)) {
+           propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
+           if (propertyValueMap['anyDate'].filter(function(existingFilter){
+                   return existingFilter.type === filter.filters[0].type;
+               }).length === 0) {
+               propertyValueMap['anyDate'].push(filter.filters[0]);
+           }
+        }
+
         if (filter.filters){
             filter.filters.forEach(function(filter){
                if (!filter.filters){
@@ -451,11 +461,6 @@ define([
         constructFilter: function(){
             var filters = [];
 
-            var text = this.basicText.currentView.model.getValue()[0];
-            text = text === "" ? '*' : text;
-            var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
-            filters.push(CQLUtils.generateFilter(matchCase, 'anyText', text));
-
             var timeRange = this.basicTime.currentView.model.getValue()[0];
             var timeBefore, timeAfter;
             switch(timeRange){
@@ -516,6 +521,17 @@ define([
                     }))
                 };
                 filters.push(typeFilter)
+            }
+
+            var text = this.basicText.currentView.model.getValue()[0];
+
+            if (filters.length == 0) {
+                text = '*'
+            }
+
+            if (text !== "") {
+                var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
+                filters.unshift(CQLUtils.generateFilter(matchCase, 'anyText', text));
             }
 
             return {


### PR DESCRIPTION
#### What does this PR do?
The intrigue UI always adds a wildcard contextual parameter. There does not appear to be any way to perform a strictly temporal or location-based search.

This PR makes it so that the wildcard is only in the query when no other specifications have been given.

#### Who is reviewing it? 
@djblue 
@emmberk 
@rzwiefel 
@vinamartin 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler 
@clockard
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)
1. Build & run DDF. Install the catalog commands through admin.
2. Go to intrigue and create the following searches:

    - An empty search with no parameters specified. When you save this search, you should see the text field with a wildcard (*) in its place
    - A temporal search. Only specify the time range of the search. Here, the text field should be blank.
    - A type search. Only specify the type of information you are expecting. Again, the text field should be blank.

#### What are the relevant tickets?
[DDF-3191](https://codice.atlassian.net/browse/)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
