### PR TITLE
DDF-3036 Fix NPE caused by looking up properties on disabled configurations

### DIFF
--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
@@ -183,12 +183,16 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
                 if (configs != null) {
                     for (Configuration config : configs) {
                         ConfigurationDetails source = new ConfigurationDetailsImpl();
-
-                        boolean disabled = config.getPid()
-                                .endsWith(ConfigurationStatus.DISABLED_EXTENSION);
-                        source.setId(config.getPid());
+                        String pid = config.getPid();
+                        String fPid = config.getFactoryPid();
+                        boolean disabled = pid.endsWith(ConfigurationStatus.DISABLED_EXTENSION);
+                        if (fPid != null) {
+                            disabled = disabled
+                                    || fPid.endsWith(ConfigurationStatus.DISABLED_EXTENSION);
+                        }
+                        source.setId(pid);
                         source.setEnabled(!disabled);
-                        source.setFactoryPid(config.getFactoryPid());
+                        source.setFactoryPid(fPid);
 
                         if (!disabled) {
                             source.setName(helper.getName(config));

--- a/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
+++ b/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.shiro.util.CollectionUtils;
+import org.codice.ddf.admin.core.api.ConfigurationStatus;
 import org.codice.ddf.admin.core.api.Metatype;
 import org.codice.ddf.admin.core.api.Service;
 import org.codice.ddf.admin.core.impl.ServiceImpl;
@@ -125,7 +126,7 @@ public class AdminPollerTest {
         List<Map<String, Object>> configurations = (List) sources.get(1)
                 .get("configurations");
 
-        assertThat(configurations, hasSize(1));
+        assertThat(configurations, hasSize(2));
         Map<String, Object> configurationMap = configurations.get(0);
         assertThat(configurationMap, hasKey("operation_actions"));
         assertThat(configurationMap, hasKey("report_actions"));
@@ -167,7 +168,18 @@ public class AdminPollerTest {
                 dict.put("service.pid", CONFIG_PID);
                 dict.put("service.factoryPid", FPID);
                 when(config.getProperties()).thenReturn(dict);
-                when(helper.getConfigurations(any(Metatype.class))).thenReturn(CollectionUtils.asList(config),
+                Configuration config2 = mock(Configuration.class);
+                when(config2.getPid()).thenReturn(
+                        CONFIG_PID + ConfigurationStatus.DISABLED_EXTENSION);
+                when(config2.getFactoryPid()).thenReturn(
+                        FPID + ConfigurationStatus.DISABLED_EXTENSION);
+                Dictionary<String, Object> dict2 = new Hashtable<>();
+                dict2.put("service.pid", CONFIG_PID + ConfigurationStatus.DISABLED_EXTENSION);
+                dict2.put("service.factoryPid", FPID + ConfigurationStatus.DISABLED_EXTENSION);
+                when(config2.getProperties()).thenReturn(dict);
+                when(helper.getConfigurations(any(Metatype.class))).thenReturn(CollectionUtils.asList(
+                        config,
+                        config2),
                         null);
 
                 // Mock out the sources


### PR DESCRIPTION
#### What does this PR do?
Fixes a npe by checking if the service or factory pid contains _disabled
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@vinamartin @josephthweatt @mcalcote 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Startup DDF and add a secondary local node with a federation service and a couple of endpoints. 
Verify that it shows up in the sources tab with the endpoint types you added. Check the log and verify that there isn't any log message that look like `10:53:56,144 | INFO  | tp1725158859-118 | admin-poller-service | Error getting source info: null`

#### What are the relevant tickets?
[DDF-3036](https://codice.atlassian.net/browse/DDF-3036)

#### Checklist:
- [X] Update / Add Unit Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
