### PR TITLE
DDF-2863 Added optional flag to the SecurityFilters list in the DelegateServletFilter

### DIFF
--- a/platform/platform-filter-delegate/pom.xml
+++ b/platform/platform-filter-delegate/pom.xml
@@ -114,12 +114,12 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.43</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/DelegateServletFilter.java
+++ b/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/DelegateServletFilter.java
@@ -158,17 +158,19 @@ public class DelegateServletFilter implements Filter {
 
     public void removeSecurityFilter(
             final ServiceReference<SecurityFilter> securityFilterServiceReference) {
-        final BundleContext bundleContext = getContext();
+        if (securityFilterServiceReference != null) {
+            final BundleContext bundleContext = getContext();
 
-        if (bundleContext != null) {
-            // unmark the SecurityFilter as initialized so that it can be re-initialized if the SecurityFilter is registered again
-            keysOfInitializedSecurityFilters.remove(getFilterKey(securityFilterServiceReference,
-                    bundleContext));
-            bundleContext.getService(securityFilterServiceReference)
-                    .destroy();
-        } else {
-            LOGGER.warn(
-                    "Unable to remove SecurityFilter {}. Try restarting the system or turning up logging to monitor current SecurityFilters.");
+            if (bundleContext != null) {
+                // unmark the SecurityFilter as initialized so that it can be re-initialized if the SecurityFilter is registered again
+                keysOfInitializedSecurityFilters.remove(getFilterKey(securityFilterServiceReference,
+                        bundleContext));
+                bundleContext.getService(securityFilterServiceReference)
+                        .destroy();
+            } else {
+                LOGGER.warn(
+                        "Unable to remove SecurityFilter. Try restarting the system or turning up logging to monitor current SecurityFilters.");
+            }
         }
     }
 

--- a/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/FilterInjector.java
+++ b/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/FilterInjector.java
@@ -168,8 +168,9 @@ public class FilterInjector {
 
             filterReg.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, ALL_URLS);
         } catch (IllegalStateException ise) {
-            LOGGER.warn(
-                    "Could not inject DelegateServletFilter into {} because the servlet was already initialized.",
+            LOGGER.error(
+                    "Could not inject DelegateServletFilter into {} because the servlet was already initialized. This means that SecurityFilters will not be included in {}.",
+                    refBundle.getSymbolicName(),
                     refBundle.getSymbolicName(),
                     ise);
         }

--- a/platform/platform-filter-delegate/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-filter-delegate/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
     </reference-list>
 
     <reference-list id="securityFilters" interface="org.codice.ddf.platform.filter.SecurityFilter"
-                    member-type="service-reference">
+                    member-type="service-reference" availability="optional">
         <reference-listener unbind-method="removeSecurityFilter" ref="delegateServletFilter"/>
     </reference-list>
 

--- a/platform/platform-filter-delegate/src/test/java/org/codice/ddf/platform/filter/delegate/DelegateServletFilterTest.java
+++ b/platform/platform-filter-delegate/src/test/java/org/codice/ddf/platform/filter/delegate/DelegateServletFilterTest.java
@@ -313,8 +313,6 @@ public class DelegateServletFilterTest {
     @Test
     public void testRemoveSecurityFilter() throws IOException, ServletException {
         // given
-        delegateServletFilter.init(mock(FilterConfig.class));
-
         final SecurityFilter securityFilter = mock(SecurityFilter.class);
         final MockServiceReference securityFilterServiceReference = new MockServiceReference();
         securityFilterServiceReference.setProperties(new Hashtable());
@@ -326,6 +324,11 @@ public class DelegateServletFilterTest {
 
         // then
         verify(securityFilter).destroy();
+    }
+
+    @Test
+    public void testRemoveNullSecurityFilter() throws IOException, ServletException {
+        delegateServletFilter.removeSecurityFilter(null);
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issue that restarting DDF caused some servlets to be missing the `SecurityFilter`s added in https://github.com/codice/ddf/commit/8c330bab9cf7c5e247b020beba115b60b6f66129.
#### Who is reviewing it? 
@mcalcote @Lambeaux @vinamartin 
#### Select relevant component teams:
@codice/security 
#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
#### How should this be tested? (List steps with links to updated documentation)

1. Install DDF. You shouldn't see any log messages like, 
    ```
    Bundle platform-filter-delegate/2.11.0.SNAPSHOT is waiting for dependencies...
    ```
    or
    ```
    Could not inject DelegateServletFilter into xxxxx because the servlet was already initialized.
    ```
2. Restart DDF. Again, you shouldn't see any of those log messages.
3. Confirm that ingesting from Intrigue works.
#### What are the relevant tickets?
[DDF-2863](https://codice.atlassian.net/browse/DDF-2863)
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
