### PR TITLE
DDF 3199 Update RegistryStore to ensure availability only when connected to a registry

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePollerRunner.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/SourcePollerRunner.java
@@ -159,7 +159,10 @@ public class SourcePollerRunner implements Runnable {
         LOGGER.debug("Unbinding source [{}]", source);
         if (source != null) {
             sources.remove(source);
-            sourceStatusThreadLocks.remove(cachedSources.remove(getSourceKey(source)));
+            CachedSource cachedSource = cachedSources.remove(getSourceKey(source));
+            if (cachedSource != null) {
+                sourceStatusThreadLocks.remove(cachedSource);
+            }
         }
     }
 

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -666,6 +666,10 @@ public abstract class AbstractCswSource extends MaskableImpl
         return filteredConfiguration;
     }
 
+    protected AvailabilityCommand getAvailabilityCommand() {
+        return new CswSourceAvailabilityCommand();
+    }
+
     protected void setupAvailabilityPoll() {
         LOGGER.debug("Setting Availability poll task for {} minute(s) on Source {}",
                 cswSourceConfiguration.getPollIntervalMinutes(),
@@ -674,7 +678,7 @@ public abstract class AbstractCswSource extends MaskableImpl
         if (availabilityPollFuture == null || availabilityPollFuture.isCancelled()) {
             if (availabilityTask == null) {
                 availabilityTask = new AvailabilityTask(interval,
-                        new CswSourceAvailabilityCommand(),
+                        getAvailabilityCommand(),
                         cswSourceConfiguration.getId());
             } else {
                 // Any run of the polling operation should trigger the task to run
@@ -1648,7 +1652,7 @@ public abstract class AbstractCswSource extends MaskableImpl
         return msg;
     }
 
-    private void availabilityChanged(boolean isAvailable) {
+    protected void availabilityChanged(boolean isAvailable) {
 
         if (isAvailable) {
             LOGGER.debug("CSW source {} is available.", cswSourceConfiguration.getId());

--- a/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
+++ b/catalog/spatial/registry/registry-api-impl/src/test/java/org/codice/ddf/registry/api/impl/TestRegistryStore.java
@@ -45,6 +45,7 @@ import org.codice.ddf.parser.xml.XmlParser;
 import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.registry.schemabindings.helper.MetacardMarshaller;
+import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityCommand;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.Csw;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswAxisOrder;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
@@ -424,6 +425,26 @@ public class TestRegistryStore {
 
         verify(filterBuilder).attribute(captor.capture());
         assertThat(captor.getValue(), is("id"));
+    }
+
+    @Test
+    public void testAvailableCommandNoIdentityNode() throws Exception {
+        AvailabilityCommand command = registryStore.getAvailabilityCommand();
+        assertThat(command.isAvailable(), is(false));
+    }
+
+    @Test
+    public void testAvailableCommandQueryException() throws Exception {
+        AvailabilityCommand command = registryStore.getAvailabilityCommand();
+        queryResults = null;
+        assertThat(command.isAvailable(), is(false));
+    }
+
+    @Test
+    public void testAvailableCommand() throws Exception {
+        AvailabilityCommand command = registryStore.getAvailabilityCommand();
+        queryResults.add(new ResultImpl(getDefaultMetacard()));
+        assertThat(command.isAvailable(), is(true));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Update RegistryStore to ensure availability only when connected to a registry.
Also updated SourcePollerRunner.unbind() method to protect against NPEs.

#### Who is reviewing it? 
@mcalcote @emmberk @vinamartin 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 

@bdeining
@figliold
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Install two DDF and install the registry app. For DDF A create a secondary node and then delete the identity node using the command `catalog:remove -p --cql "title like 'DDF-A'"` where DDF-A is the name of DDF A's identity node. On DDF B create a remote registry connection to DDF A and verify that the remote registry never shows up as available. Using bundle start/stop from the console, stop and restart the bundle registry-federation-admin-service-impl on DDF A. This should recreate the identity node. DDF B remote registry connection should show available within 5 minutes.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3199](https://codice.atlassian.net/browse/DDF-3199)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
