### PR TITLE
DDF-3143 Fix alerting for configuration dialogs.

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/Alerts.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/Alerts.view.js
@@ -17,9 +17,10 @@ define([
         'marionette',
         'text!templates/alerts.handlebars',
         'icanhaz',
-        'jquery'
+        'jquery',
+        'underscore'
     ],
-    function (Marionette, alertsTemplate, ich, $) {
+    function (Marionette, alertsTemplate, ich, $, _) {
 
         ich.addTemplate('alertsTemplate', alertsTemplate);
 
@@ -45,8 +46,18 @@ define([
             },
             serializeData: function () {
                 var json = this.model.toJSON();
+                json.showChevron = true;
+                json.details = _.map(json.details, function(val){
+                    if(val.message !== undefined){
+                        json.showChevron = false;
+                        return val.message;
+                    }
+                    return val;
+                });
                 json.collapseId = 'alertCollapse_' + parseInt((Math.random() * Math.pow(2, 32)), 10);
                 switch (this.model.get('priority')) {
+                    case 1:
+                    case'1':
                     case 2:
                     case'2':
                         json.level = 'info';
@@ -60,7 +71,7 @@ define([
                         json.level = 'danger';
                         break;
                     default:
-                        json.level = 'info';
+                        json.level = 'danger';
                         break;
                 }
                 return json;

--- a/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/alerts.handlebars
@@ -16,9 +16,11 @@
         <h4 class="panel-title clearfix">
             <i class="fa {{#is level "info"}}fa-info-circle{{else}}fa-exclamation-triangle{{/is}}"></i>
             {{title}}
-            <button type="button" class="btn btn-link dismiss">
-                Dismiss
-            </button>
+            {{#if id}}
+                <button type="button" class="btn btn-link dismiss">
+                    Dismiss
+                </button>
+            {{/if}}
             {{#notEmpty details}}
                 <button type="button" class="btn btn-link details" data-toggle="collapse" data-parent=".accordion" data-target="#{{collapseId}}">
                     {{details-button-action}} details
@@ -28,17 +30,23 @@
     </div>
     <div class="panel-collapse collapse {{collapse}} collapseAlerts" id="{{collapseId}}">
         <table class="alert-details-table">
-            <tr>
-                <td><i class="fa fa-exclamation-triangle"></i></td>
-                <td><i>Dismiss this alert at your own risk. This alert may be repopulated if the issue persists.</i></td>
-            </tr>
-            <tr>
-                <td><i class="fa fa-chevron-circle-right"></i></td>
-                <td>Host: {{hostName}} ({{hostAddress}})</td>
-            </tr>
-            {{#each details}}
+            {{#if id}}
+                <tr>
+                    <td><i class="fa fa-exclamation-triangle"></i></td>
+                    <td><i>Dismiss this alert at your own risk. This alert may be repopulated if the
+                        issue persists.</i></td>
+                </tr>
                 <tr>
                     <td><i class="fa fa-chevron-circle-right"></i></td>
+                    <td>Host: {{hostName}} ({{hostAddress}})</td>
+                </tr>
+            {{/if}}
+
+            {{#each details}}
+                <tr>
+                    {{#if ../showChevron}}
+                        <td><i class="fa fa-chevron-circle-right"></i></td>
+                    {{/if}}
                     <td>{{this}}</td>
                 </tr>
             {{/each}}


### PR DESCRIPTION
#### What does this PR do?
Fixes alerting for configurations dialogs in admin ui
#### Who is reviewing it? 
@emmberk @mcalcote  
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and enter and save an invalid configuration (Platform->Configuration->Metrics Reporting->Metrics Max Threshold = asdf). Verify that the alert you receive doesn't show the dismiss button or the host name. It should look something like
![screen shot 2017-08-07 at 10 10 09 am](https://user-images.githubusercontent.com/5248090/29037652-5395a75c-7b59-11e7-88cd-a100b2273cf7.png)

Export error should look something like
![screen shot 2017-08-07 at 10 13 21 am](https://user-images.githubusercontent.com/5248090/29037665-687f79ea-7b59-11e7-86bc-7f129300dc04.png)

Verify that the admin-ui level alerting still works as before. See testing steps on https://github.com/codice/ddf/pull/2141
#### Any background context you want to provide?
Alerting was updated a few weeks ago but the invalid configuration aspect wasn't handled.
#### What are the relevant tickets?
[DDF-3143](https://codice.atlassian.net/browse/DDF-3143)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
