### PR TITLE
DDF-3182 Added paging to search endpoint and config for max page size

### DIFF
--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -68,6 +68,8 @@ public class SearchController {
 
     private BayeuxServer bayeuxServer;
 
+    private int maxQueryResults = 1000;
+
     /**
      * Create a new SearchController
      *
@@ -250,5 +252,9 @@ public class SearchController {
 
     public void setNormalizationDisabled(Boolean normalizationDisabled) {
         this.normalizationDisabled = normalizationDisabled;
+    }
+
+    public int getMaxQueryResults() {
+        return maxQueryResults;
     }
 }

--- a/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ui/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -17,9 +17,9 @@
 
     <OCD name="Standard Search UI" id="org.codice.ddf.ui.search.standard.properties">
         <AD
-                description="Specifies the number of results to request from each source"
+                description="Specifies the number of results to request from each source (Max 1000)"
                 name="Result Count" id="resultCount" required="true" type="Integer"
-                default="250">
+                default="250" max="1000" min="1">
         </AD>
         <AD name="Imagery Providers" id="imageryProviders"
             required="false" type="String" cardinality="10000"

--- a/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.ui.search.standard.properties-table-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.ui.search.standard.properties-table-contents.adoc
@@ -19,7 +19,7 @@
 |Result Count
 |resultCount
 |Integer
-|Specifies the number of results to request from each source
+|Specifies the number of results to request from each source (Max 1000)
 |250
 |true
 


### PR DESCRIPTION
#### What does this PR do?
The search endpoint has been changed to enforce its own maximum page size, the user is able to configure this value. It has also been updated to make sure it properly pages if the number of results returned by the catalog framework doesn't match its own maximum page size.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mweser @emmberk @josephthweatt @vinamartin @alexaabrd 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard @lessarderic 

#### How should this be tested? (List steps with links to updated documentation)
Install a DDF, then configure the Standard Search Endpoint max results to be lower than the number of results in the catalog. Confirm the configured max is returned using the standard search ui.
Configure the max standard search results to be higher than the catalog.maxPageSize, but both lower than the number of products in the catalog. Confirm the max search results are returned, which would require paging.

#### What are the relevant tickets?
[DDF-3182](https://codice.atlassian.net/browse/DDF-3182)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
