### PR TITLE
DDF-3171 Changed SystemUsage storage logic to make modal display appropriately

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
@@ -52,7 +52,12 @@ module.exports = Marionette.LayoutView.extend({
         };
     },
     handleClick: function(){
-        this.$el.trigger(CustomElements.getNamespace() + 'close-lightbox');
+        if (!user.get('user').isGuestUser() && properties.ui.systemUsageOncePerSession) {
+            var systemUsage = JSON.parse(window.sessionStorage.getItem("systemUsage"));
+            systemUsage[user.get('user').get('username')] = "true";
+            window.sessionStorage.setItem("systemUsage", JSON.stringify(systemUsage));
+         }
+         this.$el.trigger(CustomElements.getNamespace() + 'close-lightbox');
     },
     onAttach: function(){
         if (user.fetched){


### PR DESCRIPTION
#### What does this PR do?
- Makes System Usage Modal display every time for non-user login
- Makes System Usage Modal display every time for users if "once per session" is set to false
- Makes System Usage Modal display only once per browser session for users when "once per session" is set to true

#### Who is reviewing it? 
@josephthweatt @djblue @mcalcote @vinamartin @emmberk

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@clockard

#### How should this be tested? (List steps with links to updated documentation)
2. After building DDF, 
- Add system usage properties in ddf.platform.ui.config.config:
```
systemUsageEnabled=B"true"
systemUsageOncePerSession=B"false"
systemUsageMessage="Click\ acknowledge\ to\ continue"
systemUsageTitle="CONSENT\ BANNER"
```      
- OR build downstream project that already has a system usage message 

**_NOTE: the modal content will not display if quick built_**

3. Run & setup your project
4. logout 
5. direct to Intrigue
6. test user login when "once per session" is set to false
     - the modal should display at every refresh or re-direct to Intrigue
7. logout
8.  change the following line in ddf.platform.ui.config.config:
`systemUsageOncePerSession=B"true"`
9. test user login when "once per session" is set to true
     - see that the modal pops up on first access 
     - the modal should NOT display after refresh or re-direct to Intrigue
     - exiting and reentering the browser will cause the modal to display again
     - you should be able to login as X amount of users within one browser session and have to consent to the banner X amount of times
10. Test guest login - the modal should display every time just like when "once per session" is set to false

#### What are the relevant tickets?
[DDF-3171](https://codice.atlassian.net/browse/DDF-3171)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.