### PR TITLE
DDF-3187 Fixes waitForReady to account for new fragment

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/shell.init.script
+++ b/distribution/ddf-common/src/main/resources/etc/shell.init.script
@@ -56,7 +56,7 @@ keymap "^[OB" down-line-or-search
 lna = { bundle:list -t 0 | grep -v Active };
 waitForReady = {
     while { (la | grep "DDF :: Admin :: UI" | grep "Active") isEmpty } { echo -n ". "; sleep 1 }
-    while { ("3" equals (la | grep -v "Active" | grep -c "Hosts: ") ) equals "false" } { echo -n ". "; sleep 1 }
+    while { ("4" equals (la | grep -v "Active" | grep -c "Hosts: ") ) equals "false" } { echo -n ". "; sleep 1 }
     echo ""
     echo "System Ready"
 };


### PR DESCRIPTION
#### What does this PR do?
Fixes the number of bundle fragments `waitForReady` waits for to account for the newly added `platform-crypto-provider` fragment
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)

@clockard
@coyotesqrl

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
