### PR TITLE
DDF-3071 Update CswCqlTextFilter to work with ECQL keyword restrictions

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/ECQLMapperVisitor.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/ECQLMapperVisitor.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.csw.catalog.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The ECQL.toCql method doesn't escape (double quote) all reserved words which causes
+ * problems when then using ECQL.toFilter on cql that has one of those key words as a property name.
+ * This visitor creates a new filter with those keywords quoted so ECQL.toFilter will work.
+ */
+public class ECQLMapperVisitor extends PropertyMapperVisitor {
+    private static Map<String, String> ecqlMappings;
+
+    static {
+        ecqlMappings = new HashMap<>();
+        ecqlMappings.put("id", "\"id\"");
+        ecqlMappings.put("text", "\"text\"");
+        ecqlMappings.put("temporal", "\"temporal\"");
+        ecqlMappings.put("between", "\"between\"");
+        ecqlMappings.put("spatial", "\"spatial\"");
+    }
+
+    public ECQLMapperVisitor() {
+        super(ecqlMappings);
+    }
+}

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyMapperVisitor.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyMapperVisitor.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.csw.catalog.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.expression.PropertyName;
+
+/**
+ * This Visitor creates a new Filter with the PropertyNames remapped
+ * as defined in the passed in Map. If a given property name doesn't
+ * exist in the map it remains unchanged.
+ * For example if you pass in a map with key->key1 value->key2 and run
+ * it on a filter like `key1 = 10 AND key3 = 20` the resulting filter will be `key2 = 10 AND key3 = 20`
+ */
+public class PropertyMapperVisitor extends DuplicatingFilterVisitor {
+    private Map<String, String> mappings = new HashMap<>();
+
+    public PropertyMapperVisitor(Map<String, String> mappings) {
+        this.mappings.putAll(mappings);
+    }
+
+    @Override
+    public Object visit(PropertyName expression, Object extraData) {
+        if (expression == null) {
+            return null;
+        }
+
+        String name = expression.getPropertyName();
+
+        return getFactory(extraData).property(mappings.getOrDefault(name, name));
+    }
+}

--- a/catalog/spatial/csw/spatial-csw-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyMapperVisitorTest.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyMapperVisitorTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.csw.catalog.common;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.filter.AttributeExpression;
+import org.geotools.filter.FilterFactoryImpl;
+import org.junit.Test;
+import org.opengis.filter.expression.PropertyName;
+
+import ddf.catalog.filter.impl.PropertyNameImpl;
+
+public class PropertyMapperVisitorTest {
+
+    @Test
+    public void testPropertyMapperVisit() {
+        Map<String, String> map = new HashMap<>();
+        map.put("prop", "newProp");
+        PropertyMapperVisitor mapper = new PropertyMapperVisitor(map);
+        PropertyName propertyName = new PropertyNameImpl("prop");
+        AttributeExpression exp = (AttributeExpression) mapper.visit(propertyName,
+                new FilterFactoryImpl());
+        assertThat(exp.getPropertyName(), equalTo("newProp"));
+    }
+
+    @Test
+    public void testPropertyMapperVisitNullProperty() {
+        Map<String, String> map = new HashMap<>();
+        PropertyMapperVisitor mapper = new PropertyMapperVisitor(map);
+
+        AttributeExpression exp = (AttributeExpression) mapper.visit((PropertyName) null,
+                new FilterFactoryImpl());
+        assertThat(exp, nullValue());
+    }
+
+    @Test
+    public void testPropertyMapperVisitPassThrough() {
+        Map<String, String> map = new HashMap<>();
+        map.put("prop", "newProp");
+        PropertyMapperVisitor mapper = new PropertyMapperVisitor(map);
+        PropertyName propertyName = new PropertyNameImpl("myprop");
+        AttributeExpression exp = (AttributeExpression) mapper.visit(propertyName,
+                new FilterFactoryImpl());
+        assertThat(exp.getPropertyName(), equalTo("myprop"));
+    }
+}

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswCqlTextFilter.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/CswCqlTextFilter.java
@@ -24,6 +24,8 @@ import javax.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.codice.ddf.spatial.ogc.csw.catalog.common.ECQLMapperVisitor;
+import org.geotools.filter.FilterFactoryImpl;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.filter.v1_1.OGCConfiguration;
 import org.geotools.xml.Parser;
@@ -33,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import ddf.catalog.source.UnsupportedQueryException;
-
 import net.opengis.filter.v_1_1_0.FilterType;
 
 /**
@@ -78,7 +79,9 @@ public final class CswCqlTextFilter {
             StringReader reader = new StringReader(marshalFilterType(filterType));
             Object parsedFilter = parser.parse(reader);
             if (parsedFilter instanceof Filter) {
-                Filter filterToCql = (Filter) parsedFilter;
+                Filter filter = (Filter) parsedFilter;
+                Filter filterToCql = (Filter) filter.accept(new ECQLMapperVisitor(),
+                        new FilterFactoryImpl());
                 LOGGER.debug("Filter to Convert to CQL => {}", filterToCql);
                 String cql = ECQL.toCQL(filterToCql);
                 LOGGER.debug("Generated CQL from Filter => {}", cql);


### PR DESCRIPTION
#### What does this PR do?
Update CswCqlTextFilter to work with ECQL keyword restrictions. The PropertyMapperVisitor/ECQLMapperVisitor were added to accomplish this.
#### Who is reviewing it? 
@kcrowe01 @emmberk @vinamartin @AzGoalie 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)

@coyotesqrl
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Install two DDF with registry with certs (dev=true). Create a connection from one to the other via the remote registry tab using all the default options. Verify that the node you are connecting to gets the sending node entry in the Node Information tab. Once this is verified go back to the remote registries tab and open up the registry connection. Turn off the auto push option. Verify that the node you are connected to no longer has the sending node in the Node Information tab (It could take a few seconds for it to be removed).
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3071](https://codice.atlassian.net/browse/DDF-3071)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
