### PR TITLE
DDF-3210 Updated Catalog Taxonomy to support new DCMI-defined types

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/constants/core/DataType.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/constants/core/DataType.java
@@ -15,22 +15,30 @@ package ddf.catalog.data.types.constants.core;
 
 /**
  * These are the allowed values for the attribute Core#DATATYPE.
- *
- * Based on Dublin Core (http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-type) and extended to include other DDF supported types.
+ * <p>
+ * These generic type(s) of the resource include the Dublin Core Metadata Initiative DCMI Type
+ * Vocabulary (http://dublincore.org/documents/dcmi-type-vocabulary/) and are extended to include
+ * other DDF supported types. DCMI Type term labels are included here, as opposed to term names.
  */
 public enum DataType {
 
+    // DCMI type vocabulary labels
     COLLECTION("Collection"), //
     DATASET("Dataset"), //
     EVENT("Event"), //
     IMAGE("Image"), //
     INTERACTIVE_RESOURCE("Interactive Resource"), //
+    MOVING_IMAGE("Moving Image"), //
+    PHYSICAL_OBJECT("Physical Object"), //
     SERVICE("Service"), //
     SOFTWARE("Software"), //
     SOUND("Sound"), //
+    STILL_IMAGE("Still Image"), //
     TEXT("Text"), //
-    VIDEO("Video"), //
-    DOCUMENT("Document");
+
+    // other DDF-supported type labels
+    DOCUMENT("Document"), //
+    VIDEO("Video");
 
     private final String value;
 

--- a/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
@@ -10,9 +10,12 @@
           "Event",
           "Image",
           "Interactive Resource",
+          "Moving Image",
+          "Physical Object",
           "Service",
           "Software",
           "Sound",
+          "Still Image",
           "Text",
           "Video",
           "Document"

--- a/distribution/docs/src/main/resources/_contents/_data/core-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/core-attributes-table-contents.adoc
@@ -41,7 +41,7 @@
 |metadata
 |Additional XML metadata describing the resource.
 |XML
-|A valid XML string per RFC 4825 (must be well-formed but not necessarily schema-compliant).
+|A valid XML string per RFC 4825 (must be well-formed but not necessarily schema-compliant)
 |
 
 |location
@@ -84,7 +84,7 @@ __Coordinates must be in *lon-lat* coordinate order__
 |resource-size
 |Size in bytes of resource.
 |String
-|Although this type cannot be changed for legacy reasons, its value should always be a parseable whole number.
+|Although this type cannot be changed for legacy reasons, its value should always be a parseable whole number
 |
 
 |thumbnail
@@ -127,13 +127,13 @@ __Coordinates must be in *lon-lat* coordinate order__
 |language
 |The language(s) of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#language[Dublin Core language].
 |List of Strings
-|Alpha-3 language code(s) per ISO_639-2.
+|Alpha-3 language code(s) per ISO_639-2
 |
 
 |resource.derived-download-url
 |Download URL(s) for accessing the derived formats for the metacard resource.
 |List of Strings
-|Valid URL(s) per RFC 2396.
+|Valid URL(s) per RFC 2396
 |
 
 |resource.derived-uri
@@ -143,10 +143,10 @@ __Coordinates must be in *lon-lat* coordinate order__
 |
 
 |datatype
-|The generic type(s) of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-type[Dublin Core terms-type] and extended to include other DDF supported types.
+|The generic type(s) of the resource including the http://dublincore.org/documents/dcmi-type-vocabulary/[Dublin Core terms-type] and extended to include other ${ddf-branding}-supported types. DCMI Type term labels are expected here, as opposed to term names.
 |List of Strings
-|Collection, Dataset, Event, Image, Interactive Resource, Service, Software, Sound, Text, Video, Document.
-|
+|`Collection`, `Dataset`, `Event`, `Image`, `Interactive Resource`, `Moving Image`, `Physical Object`, `Service`, `Software`, `Sound`, `Still Image`, `Text`, `Document`, and/or `Video`
+|`Video`
 
 |===
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds the missing dataypes from http://dublincore.org/documents/dcmi-type-vocabulary/ to the Core Attributes.
#### Who is reviewing it? 
@brendan-hofmann @vinamartin @mcalcote 
#### Select relevant component teams: 
@codice/data 
#### Choose 2 committers to review/merge the PR.
@clockard
@jlcsmith 
#### How should this be tested? (List steps with links to updated documentation)
Ingest records with the added datatypes (`Moving Image`, `Physical Object`, and `Still Image`), and confirm that there is no `datatype has an invalid value` validation error.
#### What are the relevant tickets?
[DDF-3210](https://codice.atlassian.net/browse/DDF-3210)
#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/29184551-7506b5e8-7dbb-11e7-83d8-f8a5514df4a4.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
