### PR TITLE
DDF-3211 Add configuration for Intrigue to directly retrieve map tiles.

### DIFF
--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import CircularProgress from 'material-ui/CircularProgress'
 import ContentAdd from 'material-ui/svg-icons/content/add'
 import DeleteIcon from 'material-ui/svg-icons/action/delete'
+import Checkbox from 'material-ui/Checkbox'
 import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
 import Flexbox from 'flexbox-react'
@@ -121,6 +122,16 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
         value={provider.get('url') || ''}
         id='provider-url'
         floatingLabelText='Provider URL' />
+    </div>
+    <div style={{ padding: '0 16px' }}>
+      <Flexbox flex='1'>
+        <Checkbox
+          checked={typeof provider.get('proxyEnabled') === 'boolean' ? provider.get('proxyEnabled') : ''}
+          label='Proxy Imagery Provider URL'
+          onCheck={(e, value) => {
+            onUpdate(value, 'proxyEnabled')
+          }} />
+      </Flexbox>
     </div>
     <Flexbox flex='1' style={{ padding: '0 16px' }}>
       <Flexbox flex='3' style={{ marginRight: 20 }}>

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
@@ -161,6 +161,12 @@ export const validate = (providers) => {
       errors = errors.setIn([i, 'alpha'], 'Alpha too large')
     }
 
+    const proxyEnabled = layer.get('proxyEnabled')
+
+    if (typeof proxyEnabled !== 'boolean') {
+      errors = errors.setIn([i, 'proxyEnabled'], 'Proxy enabled settings needs to be true or false')
+    }
+
     const type = layer.get('type')
 
     if (type === '') {
@@ -199,6 +205,7 @@ const emptyProvider = () => {
     url: '',
     type: '',
     alpha: '',
+    proxyEnabled: true,
     parameters: {}
   }
   const buffer = JSON.stringify(layer, null, 2)

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -50,6 +50,8 @@ public class ConfigurationApplication implements SparkApplication {
 
     public static final String URL = "url";
 
+    public static final String PROXY_ENABLED = "proxyEnabled";
+
     public static final String ENDPOINT_NAME = "catalog";
 
     public static final Factory NEW_SET_FACTORY = TreeSet::new;
@@ -397,8 +399,19 @@ public class ConfigurationApplication implements SparkApplication {
         proxiedImageryProviders.clear();
         for (Map<String, Object> newImageryProvider : newImageryProviders) {
             HashMap<String, Object> map = new HashMap<>(newImageryProvider);
-            map.put(URL, SERVLET_PATH + "/" + urlToProxyMap.get(newImageryProvider.get(URL)
-                    .toString()));
+            String baseUrl = newImageryProvider.get(URL).toString();
+            boolean proxyEnabled = true;
+            Object proxyEnabledProp = newImageryProvider.get(PROXY_ENABLED);
+            if (proxyEnabledProp != null) {
+                proxyEnabled = Boolean.parseBoolean(proxyEnabledProp.toString());
+            }
+
+            if (proxyEnabled) {
+                map.put(URL,
+                        SERVLET_PATH + "/" + urlToProxyMap.get(baseUrl));
+            } else {
+                map.put(URL, baseUrl);
+            }
             proxiedImageryProviders.add(map);
         }
         imageryProviderMaps = newImageryProviders;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -62,7 +62,7 @@ public class ConfigurationApplication implements SparkApplication {
 
     private List imageryProviders = new ArrayList<>();
 
-    private List<Map> proxiedImageryProviders = new ArrayList<>();
+    private List<Map> imageryProviderUrlMaps = new ArrayList<>();
 
     private List<Map<String, Object>> imageryProviderMaps = new ArrayList<>();
 
@@ -213,7 +213,7 @@ public class ConfigurationApplication implements SparkApplication {
     }
 
     private List<Map> getConfigImageryProviders() {
-        if (proxiedImageryProviders.isEmpty()) {
+        if (imageryProviderUrlMaps.isEmpty()) {
             // @formatter:off
             return Collections.singletonList(ImmutableMap.of(
                     "type", "SI",
@@ -223,7 +223,7 @@ public class ConfigurationApplication implements SparkApplication {
                     "alpha", 1));
             // @formatter:on
         } else {
-            return proxiedImageryProviders;
+            return imageryProviderUrlMaps;
         }
     }
 
@@ -318,8 +318,8 @@ public class ConfigurationApplication implements SparkApplication {
         this.timeout = timeout;
     }
 
-    public List<Map> getProxiedImageryProviders() {
-        return proxiedImageryProviders;
+    public List<Map> getImageryProviderUrlMaps() {
+        return imageryProviderUrlMaps;
     }
 
     public String getImageryProviders() {
@@ -396,23 +396,23 @@ public class ConfigurationApplication implements SparkApplication {
                     .toString());
         }
         startImageryEndpoints(imageryProvidersToStart);
-        proxiedImageryProviders.clear();
+        imageryProviderUrlMaps.clear();
         for (Map<String, Object> newImageryProvider : newImageryProviders) {
             HashMap<String, Object> map = new HashMap<>(newImageryProvider);
-            String baseUrl = newImageryProvider.get(URL).toString();
+            String imageryProviderUrl = newImageryProvider.get(URL).toString();
             boolean proxyEnabled = true;
             Object proxyEnabledProp = newImageryProvider.get(PROXY_ENABLED);
-            if (proxyEnabledProp instanceof String) {
-                proxyEnabled = Boolean.parseBoolean((String)proxyEnabledProp);
+            if (proxyEnabledProp instanceof Boolean) {
+                proxyEnabled = (Boolean) proxyEnabledProp;
             }
 
             if (proxyEnabled) {
                 map.put(URL,
-                        SERVLET_PATH + "/" + urlToProxyMap.get(baseUrl));
+                        SERVLET_PATH + "/" + urlToProxyMap.get(imageryProviderUrl));
             } else {
-                map.put(URL, baseUrl);
+                map.put(URL, imageryProviderUrl);
             }
-            proxiedImageryProviders.add(map);
+            imageryProviderUrlMaps.add(map);
         }
         imageryProviderMaps = newImageryProviders;
     }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -402,8 +402,8 @@ public class ConfigurationApplication implements SparkApplication {
             String baseUrl = newImageryProvider.get(URL).toString();
             boolean proxyEnabled = true;
             Object proxyEnabledProp = newImageryProvider.get(PROXY_ENABLED);
-            if (proxyEnabledProp != null) {
-                proxyEnabled = Boolean.parseBoolean(proxyEnabledProp.toString());
+            if (proxyEnabledProp instanceof String) {
+                proxyEnabled = Boolean.parseBoolean((String)proxyEnabledProp);
             }
 
             if (proxyEnabled) {

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/config/ConfigurationApplicationTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/config/ConfigurationApplicationTest.java
@@ -63,7 +63,7 @@ public class ConfigurationApplicationTest {
                 "/imagery-providers.json")));
 
         // Verify
-        for (Map<String, Object> provider : configurationApplication.getProxiedImageryProviders()) {
+        for (Map<String, Object> provider : configurationApplication.getImageryProviderUrlMaps()) {
             assertTrue(provider.get(ConfigurationApplication.URL)
                     .toString()
                     .contains(PROXY_SERVER));

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -32,6 +32,9 @@ Multiple layer example: `[{"type": "AGM","url": "https://server.arcgisonline.com
 WMT example: `[{"type": "WMT","url": "http://suite.opengeo.org/geoserver/gwc/service/wmts", "layer" : "opengeo:countries", "style" : "", "format" : "image/jpeg", "tileMatrixSetID": "EPSG:4326", "tileMatrixLabels" : ['EPSG:4326:0', 'EPSG:4326:1', 'EPSG:4326:2', 'EPSG:4326:3', 'EPSG:4326:4', 'EPSG:4326:5', 'EPSG:4326:6', 'EPSG:4326:7', 'EPSG:4326:8', 'EPSG:4326:9', 'EPSG:4326:10', 'EPSG:4326:11', 'EPSG:4326:12', 'EPSG:4326:13', 'EPSG:4326:14', 'EPSG:4326:15', 'EPSG:4326:16', 'EPSG:4326:17', 'EPSG:4326:18', 'EPSG:4326:19', 'EPSG:4326:20', 'EPSG:4326:21']}]`
 
 TMS example (3d map support only): `[{"type" : "TMS", "url" : "https://cesiumjs.org/tilesets/imagery/blackmarble" }]`
+
+Note: An optional `"proxyEnabled" : "false"` can be included if the source tile server doesn't need to be proxied.
+
 |
 |false
 

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -21,7 +21,7 @@
 |String
 |List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), GE (GoogleEarth). 
 
-WMS example: `[{"type": "WMS", "url": "http://suite.opengeo.org/geoserver/gwc/service/wms", "layers" : ["opengeo:countries"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha":1, "proxyEnabled" : "true"}]`
+WMS example: `[{"type": "WMS", "url": "http://suite.opengeo.org/geoserver/gwc/service/wms", "layers" : ["opengeo:countries"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha":1, "proxyEnabled" : true}]`
 
 OSM example: `[{ "type": "OSM", "url": "http://a.tile.openstreetmap.org", "fileExtension": "png", "alpha": 1.0 }]`
 
@@ -33,7 +33,7 @@ WMT example: `[{"type": "WMT","url": "http://suite.opengeo.org/geoserver/gwc/ser
 
 TMS example (3d map support only): `[{"type" : "TMS", "url" : "https://cesiumjs.org/tilesets/imagery/blackmarble" }]`
 
-Note: An optional `"proxyEnabled" : "false"` can be included if the source tile server doesn't need to be proxied.
+Note: An optional `"proxyEnabled" : false` can be included if the source tile server doesn't need to be proxied.
 
 |
 |false

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -21,7 +21,7 @@
 |String
 |List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), GE (GoogleEarth). 
 
-WMS example: `[{"type": "WMS", "url": "http://suite.opengeo.org/geoserver/gwc/service/wms", "layers" : ["opengeo:countries"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha":1}]`
+WMS example: `[{"type": "WMS", "url": "http://suite.opengeo.org/geoserver/gwc/service/wms", "layers" : ["opengeo:countries"], "parameters": {"FORMAT": "image/png", "VERSION": "1.1.1"}, "alpha":1, "proxyEnabled" : "true"}]`
 
 OSM example: `[{ "type": "OSM", "url": "http://a.tile.openstreetmap.org", "fileExtension": "png", "alpha": 1.0 }]`
 


### PR DESCRIPTION
#### What does this PR do?
Adds a configuration option to Intrigue for map layers to be directly retrieved instead of proxied through the DDF server.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@albany551  
@andrewkfiedler  

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build and install
Configure a map layer such that the proxy is disabled for the layer and verify in Chrome developer tools or similar tool that tile requests are made directly to the configured tile server.

Example:
  [{
    "alpha": 1,
    "parameters": {},
    "type": "OSM",
    "url": "http://c.tile.openstreetmap.org",
    "proxyEnabled": "false"
  }]

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3211](https://codice.atlassian.net/browse/DDF-3211)

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
