### PR TITLE
DDF-3180 Add temporal query support to Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.js
@@ -177,7 +177,7 @@ define([
                     calculatedType = 'textarea';
                     break;
                 case 'BOOLEAN':
-                    calculatedType = 'boolean'
+                    calculatedType = 'boolean';
                     break;
                 case 'LONG':
                 case 'DOUBLE':

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.hbs
@@ -22,7 +22,7 @@
              data-help="Take casing of characters into account when searching by free text.">
 
         </div>
-        <div class="basic-time-details" data-help="Search based on absolute
+        <div class="basic-time-details" data-help="Search based on absolute or relative
     time of the created, modified, or effective date.">
             <div class="basic-time">
 
@@ -38,6 +38,14 @@
 
                 </div>
                 <div class="between-before">
+
+                </div>
+            </div>
+            <div class="basic-time-relative">
+                <div class="relative-value">
+
+                </div>
+                <div class="relative-unit">
 
                 </div>
             </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.less
@@ -18,6 +18,7 @@
     .basic-time-before,
     .basic-time-after,
     .basic-time-between,
+    .basic-time-relative,
     .basic-location-specific,
     .basic-type-specific {
       display: none;
@@ -96,6 +97,15 @@
   .editor-properties {
 
     .basic-time-between {
+      display: block;
+    }
+  }
+}
+
+@{customElementNamespace}query-basic.is-timeRange-relative {
+  .editor-properties {
+
+    .basic-time-relative {
       display: block;
     }
   }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -28,39 +28,40 @@ define([
     'component/singletons/metacard-definitions',
     'component/singletons/sources-instance',
     'js/CQLUtils',
-    'component/query-settings/query-settings.view'
+    'component/query-settings/query-settings.view',
+    'moment'
 ], function (Marionette, _, $, template, CustomElements, store, DropdownModel,
              QuerySrcView, PropertyView, Property, cql, metacardDefinitions, sources,
-            CQLUtils, QuerySettingsView) {
+             CQLUtils, QuerySettingsView, moment) {
 
-    function isNested(filter){
+    function isNested(filter) {
         var nested = false;
-        filter.filters.forEach(function(subfilter){
+        filter.filters.forEach(function (subfilter) {
             nested = nested || subfilter.filters;
         });
         return nested;
     }
 
-    function isTypeLimiter(filter){
+    function isTypeLimiter(filter) {
         var typesFound = {};
-        filter.filters.forEach(function(subfilter){
+        filter.filters.forEach(function (subfilter) {
             typesFound[CQLUtils.getProperty(subfilter)] = true;
         });
         typesFound = Object.keys(typesFound);
-        return (typesFound.length === 2) && (typesFound.indexOf('metadata-content-type') >= 0) && 
-            (typesFound.indexOf('datatype') >=0);
+        return (typesFound.length === 2) && (typesFound.indexOf('metadata-content-type') >= 0) &&
+            (typesFound.indexOf('datatype') >= 0);
     }
 
-    function isAnyDate(filter){
-        var propertiesToCheck = ['created','modified','effective', 'metacard.created', 'metacard.modified'];
+    function isAnyDate(filter) {
+        var propertiesToCheck = ['created', 'modified', 'effective', 'metacard.created', 'metacard.modified'];
         var typesFound = {};
         var valuesFound = {};
-        if (filter.filters.length === propertiesToCheck.length){
-            filter.filters.forEach(function(subfilter){
+        if (filter.filters.length === propertiesToCheck.length) {
+            filter.filters.forEach(function (subfilter) {
                 typesFound[subfilter.type] = true;
                 valuesFound[subfilter.value] = true;
                 var indexOfType = propertiesToCheck.indexOf(CQLUtils.getProperty(subfilter));
-                if (indexOfType >= 0){
+                if (indexOfType >= 0) {
                     propertiesToCheck.splice(indexOfType, 1);
                 }
             });
@@ -69,43 +70,43 @@ define([
         return false;
     }
 
-    function translateFilterToBasicMap(filter){
+    function translateFilterToBasicMap(filter) {
         var propertyValueMap = {};
         var downConversion = false;
 
         if (filter.filters && isAnyDate(filter)) {
-           propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
-           if (propertyValueMap['anyDate'].filter(function(existingFilter){
-                   return existingFilter.type === filter.filters[0].type;
-               }).length === 0) {
-               propertyValueMap['anyDate'].push(filter.filters[0]);
-           }
+            propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
+            if (propertyValueMap['anyDate'].filter(function (existingFilter) {
+                    return existingFilter.type === filter.filters[0].type;
+                }).length === 0) {
+                propertyValueMap['anyDate'].push(filter.filters[0]);
+            }
         }
 
-        if (filter.filters){
-            filter.filters.forEach(function(filter){
-               if (!filter.filters){
-                   propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];
-                   if (propertyValueMap[CQLUtils.getProperty(filter)].filter(function(existingFilter){
-                           return existingFilter.type === filter.type;
-                       }).length === 0) {
-                       propertyValueMap[CQLUtils.getProperty(filter)].push(filter);
-                   }
-               } else if (!isNested(filter) && isAnyDate(filter)) {
-                   propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
-                   if (propertyValueMap['anyDate'].filter(function(existingFilter){
-                           return existingFilter.type === filter.filters[0].type;
-                       }).length === 0) {
-                       propertyValueMap['anyDate'].push(filter.filters[0]);
-                   }
-               } else if (!isNested(filter) && isTypeLimiter(filter)){
-                   propertyValueMap[CQLUtils.getProperty(filter.filters[0])] = propertyValueMap[CQLUtils.getProperty(filter.filters[0])] || [];
-                   filter.filters.forEach(function(subfilter){
-                       propertyValueMap[CQLUtils.getProperty(filter.filters[0])].push(subfilter);
-                   });
-               } else {
-                   downConversion = true;
-               }
+        if (filter.filters) {
+            filter.filters.forEach(function (filter) {
+                if (!filter.filters) {
+                    propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];
+                    if (propertyValueMap[CQLUtils.getProperty(filter)].filter(function (existingFilter) {
+                            return existingFilter.type === filter.type;
+                        }).length === 0) {
+                        propertyValueMap[CQLUtils.getProperty(filter)].push(filter);
+                    }
+                } else if (!isNested(filter) && isAnyDate(filter)) {
+                    propertyValueMap['anyDate'] = propertyValueMap['anyDate'] || [];
+                    if (propertyValueMap['anyDate'].filter(function (existingFilter) {
+                            return existingFilter.type === filter.filters[0].type;
+                        }).length === 0) {
+                        propertyValueMap['anyDate'].push(filter.filters[0]);
+                    }
+                } else if (!isNested(filter) && isTypeLimiter(filter)) {
+                    propertyValueMap[CQLUtils.getProperty(filter.filters[0])] = propertyValueMap[CQLUtils.getProperty(filter.filters[0])] || [];
+                    filter.filters.forEach(function (subfilter) {
+                        propertyValueMap[CQLUtils.getProperty(filter.filters[0])].push(subfilter);
+                    });
+                } else {
+                    downConversion = true;
+                }
             });
         } else {
             propertyValueMap[CQLUtils.getProperty(filter)] = propertyValueMap[CQLUtils.getProperty(filter)] || [];
@@ -120,8 +121,7 @@ define([
     return Marionette.LayoutView.extend({
         template: template,
         tagName: CustomElements.register('query-basic'),
-        modelEvents: {
-        },
+        modelEvents: {},
         events: {
             'click .editor-edit': 'edit',
             'click .editor-cancel': 'cancel',
@@ -137,15 +137,16 @@ define([
             basicTimeAfter: '.basic-time-after',
             basicTimeBetweenBefore: '.between-before',
             basicTimeBetweenAfter: '.between-after',
+            basicTimeRelativeValue: '.relative-value',
+            basicTimeRelativeUnit: '.relative-unit',
             basicLocation: '.basic-location',
             basicLocationSpecific: '.basic-location-specific',
             basicType: '.basic-type',
             basicTypeSpecific: '.basic-type-specific'
         },
-        ui: {
-        },
+        ui: {},
         filter: undefined,
-        onBeforeShow: function(){
+        onBeforeShow: function () {
             var translationToBasicMap = translateFilterToBasicMap(cql.simplify(cql.read(this.model.get('cql'))));
             this.filter = translationToBasicMap.propertyValueMap;
             this.handleDownConversion(translationToBasicMap.downConversion);
@@ -156,6 +157,7 @@ define([
             this.setupTimeBefore();
             this.setupTimeAfter();
             this.setupTimeBetween();
+            this.setupTimeRelative();
             this.setupLocation();
             this.setupLocationInput();
             this.setupType();
@@ -167,21 +169,21 @@ define([
             this.handleTimeRangeValue();
             this.handleLocationValue();
             this.handleTypeValue();
-            if (this.model._cloneOf === undefined){
+            if (this.model._cloneOf === undefined) {
                 this.edit();
             } else {
                 this.turnOffEdit();
             }
         },
-        setupSettings: function(){
+        setupSettings: function () {
             this.basicSettings.show(new QuerySettingsView({
                 model: this.model
             }))
         },
-        setupTypeSpecific: function(){
+        setupTypeSpecific: function () {
             var currentValue = [];
-            if (this.filter['metadata-content-type']){
-                currentValue = _.uniq(this.filter['metadata-content-type'].map(function(subfilter){
+            if (this.filter['metadata-content-type']) {
+                currentValue = _.uniq(this.filter['metadata-content-type'].map(function (subfilter) {
                     return subfilter.value;
                 }));
             }
@@ -190,11 +192,11 @@ define([
                     enumFiltering: true,
                     showValidationIssues: false,
                     enumMulti: true,
-                    enum: sources.toJSON().reduce(function(enumArray, source){
-                        source.contentTypes.forEach(function(contentType){
-                            if (contentType.value && (enumArray.filter(function(option){
+                    enum: sources.toJSON().reduce(function (enumArray, source) {
+                        source.contentTypes.forEach(function (contentType) {
+                            if (contentType.value && (enumArray.filter(function (option) {
                                     return option.value === contentType.value;
-                                }).length === 0)){
+                                }).length === 0)) {
                                 enumArray.push({
                                     label: contentType.name,
                                     value: contentType.value
@@ -202,20 +204,20 @@ define([
                             }
                         });
                         return enumArray;
-                    }, metacardDefinitions.enums.datatype ? metacardDefinitions.enums.datatype.map(function(value){
-                       return {
+                    }, metacardDefinitions.enums.datatype ? metacardDefinitions.enums.datatype.map(function (value) {
+                        return {
                             label: value,
                             value: value
-                       };
+                        };
                     }) : []),
                     value: [currentValue],
                     id: 'Types'
                 })
             }));
         },
-        setupType: function(){
+        setupType: function () {
             var currentValue = 'any';
-            if (this.filter['metadata-content-type']){
+            if (this.filter['metadata-content-type']) {
                 currentValue = 'specific'
             }
             this.basicType.show(new PropertyView({
@@ -225,16 +227,16 @@ define([
                     radio: [{
                         label: 'Any',
                         value: 'any'
-                    },{
+                    }, {
                         label: 'Specific',
                         value: 'specific'
                     }]
                 })
             }));
         },
-        setupLocation: function(){
+        setupLocation: function () {
             var currentValue = 'any';
-            if (this.filter.anyGeo){
+            if (this.filter.anyGeo) {
                 currentValue = 'specific'
             }
             this.basicLocation.show(new PropertyView({
@@ -244,16 +246,16 @@ define([
                     radio: [{
                         label: 'Anywhere',
                         value: 'any'
-                    },{
+                    }, {
                         label: 'Somewhere Specific',
                         value: 'specific'
                     }]
                 })
             }));
         },
-        setupLocationInput: function(){
+        setupLocationInput: function () {
             var currentValue = '';
-            if (this.filter.anyGeo){
+            if (this.filter.anyGeo) {
                 currentValue = this.filter.anyGeo[0];
             }
             this.basicLocationSpecific.show(new PropertyView({
@@ -264,31 +266,32 @@ define([
                 })
             }));
         },
-        handleTypeValue: function(){
+        handleTypeValue: function () {
             var type = this.basicType.currentView.model.getValue()[0];
             this.$el.toggleClass('is-type-any', type === 'any');
             this.$el.toggleClass('is-type-specific', type === 'specific');
         },
-        handleLocationValue: function(){
+        handleLocationValue: function () {
             var location = this.basicLocation.currentView.model.getValue()[0];
             this.$el.toggleClass('is-location-any', location === 'any');
             this.$el.toggleClass('is-location-specific', location === 'specific');
         },
-        handleTimeRangeValue: function(){
+        handleTimeRangeValue: function () {
             var timeRange = this.basicTime.currentView.model.getValue()[0];
             this.$el.toggleClass('is-timeRange-any', timeRange === 'any');
             this.$el.toggleClass('is-timeRange-before', timeRange === 'before');
             this.$el.toggleClass('is-timeRange-after', timeRange === 'after');
             this.$el.toggleClass('is-timeRange-between', timeRange === 'between');
+            this.$el.toggleClass('is-timeRange-relative', timeRange === 'relative');
         },
-        setupTimeBefore: function(){
+        setupTimeBefore: function () {
             var currentBefore = '';
             var currentAfter = '';
             if (this.filter.anyDate) {
-                this.filter.anyDate.forEach(function(subfilter){
-                    if (subfilter.type === 'BEFORE'){
+                this.filter.anyDate.forEach(function (subfilter) {
+                    if (subfilter.type === 'BEFORE') {
                         currentBefore = subfilter.value;
-                    } else {
+                    } else if (subfilter.type === 'AFTER') {
                         currentAfter = subfilter.value;
                     }
                 });
@@ -302,14 +305,14 @@ define([
                 })
             }));
         },
-        setupTimeAfter: function(){
+        setupTimeAfter: function () {
             var currentBefore = '';
             var currentAfter = '';
             if (this.filter.anyDate) {
-                this.filter.anyDate.forEach(function(subfilter){
-                    if (subfilter.type === 'BEFORE'){
+                this.filter.anyDate.forEach(function (subfilter) {
+                    if (subfilter.type === 'BEFORE') {
                         currentBefore = subfilter.value;
-                    } else {
+                    } else if (subfilter.type === 'AFTER') {
                         currentAfter = subfilter.value;
                     }
                 });
@@ -323,14 +326,14 @@ define([
                 })
             }));
         },
-        setupTimeBetween: function(){
+        setupTimeBetween: function () {
             var currentBefore = '';
             var currentAfter = '';
             if (this.filter.anyDate) {
-                this.filter.anyDate.forEach(function(subfilter){
-                    if (subfilter.type === 'BEFORE'){
+                this.filter.anyDate.forEach(function (subfilter) {
+                    if (subfilter.type === 'BEFORE') {
                         currentBefore = subfilter.value;
-                    } else {
+                    } else if (subfilter.type === 'AFTER') {
                         currentAfter = subfilter.value;
                     }
                 });
@@ -352,38 +355,109 @@ define([
                 })
             }));
         },
-        setupTimeInput: function(){
+        setupTimeRelative: function () {
+            var currentLast = 1;
+            var currentUnit = '';
+            if (this.filter.anyDate) {
+                this.filter.anyDate.forEach(function (subfilter) {
+                    if (subfilter.type === '=') {
+                        var durationISO = subfilter.value.substring(9, subfilter.value.length - 1);
+                        var duration = moment.duration(durationISO);
+
+                        if (duration.minutes() > 0) {
+                            currentLast = duration.asMinutes();
+                            currentUnit = 'm';
+                        } else if (duration.hours() > 0) {
+                            currentLast = duration.asHours();
+                            currentUnit = 'h';
+                        } else if (duration.weeks() > 0) {
+                            currentLast = duration.asWeeks();
+                            currentUnit = 'w';
+                        } else if (duration.days() > 0) {
+                            currentLast = duration.asDays();
+                            currentUnit = 'd';
+                        } else if (duration.months() > 0) {
+                            currentLast = duration.asMonths();
+                            currentUnit = 'M';
+                        } else if (duration.years() > 0) {
+                            currentLast = duration.asYears();
+                            currentUnit = 'y';
+                        }
+                    }
+                });
+            }
+            this.basicTimeRelativeValue.show(new PropertyView({
+                model: new Property({
+                    value: [currentLast],
+                    id: 'Last',
+                    placeholder: 'Limit searches to between the present and this time.',
+                    type: 'INTEGER'
+                })
+            }));
+            this.basicTimeRelativeUnit.show(new PropertyView({
+                model: new Property({
+                    value: [currentUnit || 'h'],
+                    enum: [{
+                        label: 'Minutes',
+                        value: 'm'
+                    }, {
+                        label: 'Hours',
+                        value: 'h'
+                    }, {
+                        label: 'Days',
+                        value: 'd'
+                    }, {
+                        label: 'Weeks',
+                        value: 'w'
+                    }, {
+                        label: 'Months',
+                        value: 'M'
+
+                    }, {
+                        label: 'Years',
+                        value: 'y'
+                    }],
+                    id: 'Unit'
+                })
+            }))
+        },
+        setupTimeInput: function () {
             var currentValue = 'any';
             if (this.filter.anyDate) {
                 if (this.filter.anyDate.length > 1) {
                     currentValue = 'between'
-                } else if(this.filter.anyDate[0].type === 'AFTER') {
+                } else if (this.filter.anyDate[0].type === 'AFTER') {
                     currentValue = 'after'
-                } else {
+                } else if (this.filter.anyDate[0].type === 'BEFORE') {
                     currentValue = 'before'
+                } else {
+                    currentValue = 'relative';
                 }
             }
             this.basicTime.show(new PropertyView({
                 model: new Property({
                     value: [currentValue],
                     id: 'Time Range',
-                    radio: [{
+                    enum: [{
                         label: 'Any',
                         value: 'any'
-                    },{
+                    }, {
                         label: 'After',
                         value: 'after'
-                    },{
+                    }, {
                         label: 'Before',
                         value: 'before'
                     }, {
                         label: 'Between',
                         value: 'between'
+                    }, {
+                        label: 'Relative',
+                        value: 'relative'
                     }]
                 })
             }));
         },
-        setupTextMatchInput: function(){
+        setupTextMatchInput: function () {
             this.basicTextMatch.show(new PropertyView({
                 model: new Property({
                     value: [this.filter.anyText && this.filter.anyText[0].type === 'LIKE' ? 'LIKE' : 'ILIKE'],
@@ -392,14 +466,14 @@ define([
                     radio: [{
                         label: 'Yes',
                         value: 'LIKE'
-                    },{
+                    }, {
                         label: 'No',
                         value: 'ILIKE'
                     }]
                 })
             }));
         },
-        setupTextInput: function(){
+        setupTextInput: function () {
             this.basicText.show(new PropertyView({
                 model: new Property({
                     value: [this.filter.anyText ? this.filter.anyText[0].value : ''],
@@ -408,46 +482,46 @@ define([
                 })
             }));
         },
-        turnOnLimitedWidth: function(){
-            this.regionManager.forEach(function(region){
-                if (region.currentView && region.currentView.turnOnLimitedWidth){
+        turnOnLimitedWidth: function () {
+            this.regionManager.forEach(function (region) {
+                if (region.currentView && region.currentView.turnOnLimitedWidth) {
                     region.currentView.turnOnLimitedWidth();
                 }
             });
         },
-        turnOffEdit: function(){
-            this.regionManager.forEach(function(region){
-                if (region.currentView && region.currentView.turnOffEditing){
+        turnOffEdit: function () {
+            this.regionManager.forEach(function (region) {
+                if (region.currentView && region.currentView.turnOffEditing) {
                     region.currentView.turnOffEditing();
                 }
             });
         },
-        edit: function(){
+        edit: function () {
             this.$el.addClass('is-editing');
-            this.regionManager.forEach(function(region){
-                if (region.currentView && region.currentView.turnOnEditing){
+            this.regionManager.forEach(function (region) {
+                if (region.currentView && region.currentView.turnOnEditing) {
                     region.currentView.turnOnEditing();
                 }
             });
-            var tabable =  _.filter(this.$el.find('[tabindex], input, button'), function(element){
+            var tabable = _.filter(this.$el.find('[tabindex], input, button'), function (element) {
                 return element.offsetParent !== null;
             });
-            if (tabable.length > 0){
+            if (tabable.length > 0) {
                 $(tabable[0]).focus();
             }
         },
-        cancel: function(){
-            if (this.model._cloneOf === undefined){
+        cancel: function () {
+            if (this.model._cloneOf === undefined) {
                 store.resetQuery();
             } else {
                 this.$el.removeClass('is-editing');
                 this.onBeforeShow();
             }
         },
-        handleDownConversion: function(downConversion){
+        handleDownConversion: function (downConversion) {
             this.$el.toggleClass('is-down-converted', downConversion);
-        },  
-        save: function(){
+        },
+        save: function () {
             this.$el.removeClass('is-editing');
             this.basicSettings.currentView.saveToModel();
 
@@ -458,12 +532,12 @@ define([
             });
             store.saveQuery();
         },
-        constructFilter: function(){
+        constructFilter: function () {
             var filters = [];
 
             var timeRange = this.basicTime.currentView.model.getValue()[0];
-            var timeBefore, timeAfter;
-            switch(timeRange){
+            var timeBefore, timeAfter, timeLast, timeUnit;
+            switch (timeRange) {
                 case 'before':
                     timeBefore = this.basicTimeBefore.currentView.model.getValue()[0];
                     break;
@@ -474,8 +548,12 @@ define([
                     timeBefore = this.basicTimeBetweenBefore.currentView.model.getValue()[0];
                     timeAfter = this.basicTimeBetweenAfter.currentView.model.getValue()[0];
                     break;
+                case 'relative':
+                    timeLast = Math.floor(this.basicTimeRelativeValue.currentView.model.getValue()[0]);
+                    timeUnit = this.basicTimeRelativeUnit.currentView.model.getValue()[0];
+                    break;
             }
-            if (timeBefore){
+            if (timeBefore) {
                 var timeFilter = {
                     type: 'OR',
                     filters: [
@@ -488,7 +566,7 @@ define([
                 };
                 filters.push(timeFilter);
             }
-            if (timeAfter){
+            if (timeAfter) {
                 var timeFilter = {
                     type: 'OR',
                     filters: [
@@ -501,22 +579,36 @@ define([
                 };
                 filters.push(timeFilter);
             }
+            if (timeLast) {
+                var duration = 'RELATIVE(' + moment.duration(timeLast, timeUnit).toISOString() + ')';
+                var timeDuration = {
+                    type: 'OR',
+                    filters: [
+                        CQLUtils.generateFilter('=', 'created', duration),
+                        CQLUtils.generateFilter('=', 'modified', duration),
+                        CQLUtils.generateFilter('=', 'effective', duration),
+                        CQLUtils.generateFilter('=', 'metacard.created', duration),
+                        CQLUtils.generateFilter('=', 'metacard.modified', duration)
+                    ]
+                };
+                filters.push(timeDuration);
+            }
 
             var locationSpecific = this.basicLocation.currentView.model.getValue()[0];
             var location = this.basicLocationSpecific.currentView.model.getValue()[0];
             var locationFilter = CQLUtils.generateFilter(undefined, 'anyGeo', location);
-            if (locationSpecific === 'specific' && locationFilter){
+            if (locationSpecific === 'specific' && locationFilter) {
                 filters.push(locationFilter);
             }
 
             var types = this.basicType.currentView.model.getValue()[0];
             var typesSpecific = this.basicTypeSpecific.currentView.model.getValue()[0];
-            if (types === 'specific' && typesSpecific.length !== 0){
+            if (types === 'specific' && typesSpecific.length !== 0) {
                 var typeFilter = {
                     type: 'OR',
-                    filters: typesSpecific.map(function(specificType){
+                    filters: typesSpecific.map(function (specificType) {
                         return CQLUtils.generateFilter('ILIKE', 'metadata-content-type', specificType);
-                    }).concat(typesSpecific.map(function(specificType){
+                    }).concat(typesSpecific.map(function (specificType) {
                         return CQLUtils.generateFilter('ILIKE', 'datatype', specificType);
                     }))
                 };

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -365,7 +365,7 @@ define([
                         currentLast = duration.match(/\d+/);
 
                         currentUnit = currentUnit.toLowerCase();
-                        if (duration.indexOf('T') === -1 && currentUnit === 'M') {
+                        if (duration.indexOf('T') === -1 && currentUnit === 'm') {
                             //must capitalize months
                             currentUnit = currentUnit.toUpperCase();
                         }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -28,11 +28,10 @@ define([
     'component/singletons/metacard-definitions',
     'component/singletons/sources-instance',
     'js/CQLUtils',
-    'component/query-settings/query-settings.view',
-    'moment'
+    'component/query-settings/query-settings.view'
 ], function (Marionette, _, $, template, CustomElements, store, DropdownModel,
              QuerySrcView, PropertyView, Property, cql, metacardDefinitions, sources,
-             CQLUtils, QuerySettingsView, moment) {
+             CQLUtils, QuerySettingsView) {
 
     function isNested(filter) {
         var nested = false;
@@ -366,7 +365,7 @@ define([
                         currentLast = duration.match(/\d+/);
 
                         currentUnit = currentUnit.toLowerCase();
-                        if(duration.indexOf('T') === -1 && currentUnit === 'M') {
+                        if (duration.indexOf('T') === -1 && currentUnit === 'M') {
                             //must capitalize months
                             currentUnit = currentUnit.toUpperCase();
                         }
@@ -563,15 +562,22 @@ define([
                 filters.push(timeFilter);
             }
             if (timeLast) {
-                var duration = 'RELATIVE(' + moment.duration(timeLast, timeUnit).toISOString() + ')';
+                var duration;
+                if (timeUnit === 'm' || timeUnit === 'h') {
+                    duration = "PT" + timeLast + timeUnit.toUpperCase();
+                } else {
+                    duration = "P" + timeLast + timeUnit.toUpperCase();
+                }
+
+                var relativeFunction = 'RELATIVE(' + duration + ')';
                 var timeDuration = {
                     type: 'OR',
                     filters: [
-                        CQLUtils.generateFilter('=', 'created', duration),
-                        CQLUtils.generateFilter('=', 'modified', duration),
-                        CQLUtils.generateFilter('=', 'effective', duration),
-                        CQLUtils.generateFilter('=', 'metacard.created', duration),
-                        CQLUtils.generateFilter('=', 'metacard.modified', duration)
+                        CQLUtils.generateFilter('=', 'created', relativeFunction),
+                        CQLUtils.generateFilter('=', 'modified', relativeFunction),
+                        CQLUtils.generateFilter('=', 'effective', relativeFunction),
+                        CQLUtils.generateFilter('=', 'metacard.created', relativeFunction),
+                        CQLUtils.generateFilter('=', 'metacard.modified', relativeFunction)
                     ]
                 };
                 filters.push(timeDuration);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -361,24 +361,14 @@ define([
             if (this.filter.anyDate) {
                 this.filter.anyDate.forEach(function (subfilter) {
                     if (subfilter.type === '=') {
-                        var durationISO = subfilter.value.substring(9, subfilter.value.length - 1);
-                        var duration = moment.duration(durationISO);
+                        var duration = subfilter.value.substring(9, subfilter.value.length - 1).match(/(T?\d+)./)[0];
+                        currentUnit = duration.substring(duration.length - 1, duration.length);
+                        currentLast = duration.match(/\d+/);
 
-                        if (duration.minutes() > 0) {
-                            currentLast = duration.asMinutes();
-                            currentUnit = 'm';
-                        } else if (duration.hours() > 0) {
-                            currentLast = duration.asHours();
-                            currentUnit = 'h';
-                        }else if (duration.days() > 0) {
-                            currentLast = duration.asDays();
-                            currentUnit = 'd';
-                        } else if (duration.months() > 0) {
-                            currentLast = duration.asMonths();
-                            currentUnit = 'M';
-                        } else if (duration.years() > 0) {
-                            currentLast = duration.asYears();
-                            currentUnit = 'y';
+                        currentUnit = currentUnit.toLowerCase();
+                        if(duration.indexOf('T') === -1 && currentUnit === 'M') {
+                            //must capitalize months
+                            currentUnit = currentUnit.toUpperCase();
                         }
                     }
                 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -370,10 +370,7 @@ define([
                         } else if (duration.hours() > 0) {
                             currentLast = duration.asHours();
                             currentUnit = 'h';
-                        } else if (duration.weeks() > 0) {
-                            currentLast = duration.asWeeks();
-                            currentUnit = 'w';
-                        } else if (duration.days() > 0) {
+                        }else if (duration.days() > 0) {
                             currentLast = duration.asDays();
                             currentUnit = 'd';
                         } else if (duration.months() > 0) {
@@ -407,12 +404,8 @@ define([
                         label: 'Days',
                         value: 'd'
                     }, {
-                        label: 'Weeks',
-                        value: 'w'
-                    }, {
                         label: 'Months',
                         value: 'M'
-
                     }, {
                         label: 'Years',
                         value: 'y'

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -13,8 +13,11 @@
 /*jshint bitwise: false*/
 define([
     'js/cql',
-    'component/singletons/metacard-definitions'
-], function (cql, metacardDefinitions) {
+    'component/singletons/metacard-definitions',
+    'js/Common'
+], function (cql, metacardDefinitions, Common) {
+
+    var specialDelimiter = Common.undefined;
 
     return {
         sanitizeForCql: function (text) {
@@ -23,7 +26,7 @@ define([
         //we should probably regex this or find a better way, but for now this works
         sanitizeGeometryCql: function (cqlString) {
             return cqlString.split("'POLYGON((").join("POLYGON((").split("))'").join("))")
-                .split("'POINT(").join("POINT(").split(")'").join(")")
+                .split("'POINT(").join("POINT(").replace(/(POINT\([-0-9. ]*\))/g, '$1' + specialDelimiter).split(")"+specialDelimiter+"'").join(")")
                 .split("'LINESTRING(").join("LINESTRING(").split("))'").join("))");
         },
         getProperty: function (filter) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.js
@@ -41,6 +41,7 @@ define([
             BEFORE: /^BEFORE/i,
             AFTER: /^AFTER/i,
             DURING: /^DURING/i,
+            RELATIVE: /^'RELATIVE\([A-Za-z0-9.]*\)'/i,
             TIME: new RegExp('^' + timePatter.source),
             TIME_PERIOD: new RegExp('^' + timePatter.source + '/' + timePatter.source),
             GEOMETRY: function (text) {
@@ -76,7 +77,7 @@ define([
             PROPERTY: ['COMPARISON', 'BETWEEN', 'COMMA', 'IS_NULL', 'BEFORE', 'AFTER', 'DURING'],
             BETWEEN: ['VALUE'],
             IS_NULL: ['END'],
-            COMPARISON: ['VALUE', 'BOOLEAN'],
+            COMPARISON: ['RELATIVE', 'VALUE', 'BOOLEAN'],
             COMMA: ['GEOMETRY', 'VALUE', 'UNITS', 'PROPERTY'],
             VALUE: ['LOGICAL', 'COMMA', 'RPAREN', 'END'],
             BOOLEAN: ['RPAREN'],
@@ -89,7 +90,8 @@ define([
             AFTER: ['TIME'],
             DURING: ['TIME_PERIOD'],
             TIME: ['LOGICAL', 'RPAREN', 'END'],
-            TIME_PERIOD: ['LOGICAL', 'RPAREN', 'END']
+            TIME_PERIOD: ['LOGICAL', 'RPAREN', 'END'],
+            RELATIVE: ['RPAREN']
         },
 
         precedence = {
@@ -187,6 +189,7 @@ define([
                 case "VALUE":
                 case "TIME":
                 case "TIME_PERIOD":
+                case "RELATIVE":
                 case "BOOLEAN":
                     postfix.push(tok);
                     break;
@@ -371,6 +374,8 @@ define([
                         type: tok.type,
                         value: tok.text
                     };
+                case "RELATIVE":
+                    return tok.text.substring(1, tok.text.length -1);
                 default:
                     return tok.text;
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.spec.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai'
+import cql from './cql'
+
+describe('tokenize', () => {
+    it('test relative function parsing', () => {
+        const cqlString = `(("created" = 'RELATIVE(P0DT0H5M)') OR ("modified" = 'RELATIVE(P0DT0H5M)') OR ("effective" = 'RELATIVE(P0DT0H5M)') OR ("metacard.created" = 'RELATIVE(P0DT0H5M)') OR ("metacard.modified" = 'RELATIVE(P0DT0H5M)'))`;
+        const result = cql.simplify(cql.read(cqlString));
+        const filters = result.filters;
+
+        expect(filters).to.be.an('array');
+        expect(filters, 'Result does not have the proper number of filters').to.have.lengthOf(5);
+
+        filters.forEach(e => {
+            switch(e.property) {
+                case "\"metacard.modified\"":
+                case "\"metacard.created\"":
+                case "\"modified\"":
+                case "\"created\"":
+                case "\"effective\"":
+                    expect(e.value, 'Unexpected filter value.').to.equal("RELATIVE(P0DT0H5M)");
+                    expect(e.type, 'Unexpected filter operator.').to.equal("=");
+                    break;
+                default:
+                    expect.fail(0, 1, 'Unexpected filters present');
+            }
+        });
+    })
+});

--- a/catalog/ui/catalog-ui-search/webpack/config/ci.js
+++ b/catalog/ui/catalog-ui-search/webpack/config/ci.js
@@ -10,7 +10,7 @@ var config =  merge.smart(base, {
     node: {
         __filename: true
     },
-    entry: glob.sync('src/main/webapp/component/**/*.spec.js*', {
+    entry: glob.sync('src/main/webapp/**/*.spec.js*', {
             cwd: path.resolve(__dirname, '../../')
         }).map(function (spec) { return path.resolve(spec) }),
     output: {

--- a/catalog/ui/catalog-ui-search/webpack/config/test.js
+++ b/catalog/ui/catalog-ui-search/webpack/config/test.js
@@ -5,10 +5,15 @@ var ci = require('./ci');
 
 module.exports = merge.smart(ci, {
     entry: [
-        'webpack-hot-middleware/client?path=/__webpack_hmr_test',
-        'webpack/hot/only-dev-server',
         'stack-source-map/register'
     ],
+    devServer: {
+        progress: true,
+        historyApiFallback: true,
+        inline: true,
+        hot: true,
+        port: 8181
+    },
     plugins: [
         new webpack.HotModuleReplacementPlugin()
     ]


### PR DESCRIPTION
#### What does this PR do?
Adds support to Intrigue for creating relative temporal queries that can be saved and will always perform the temporal search relative to the time of the search execution.

#### Who is reviewing it? 
@AzGoalie 
@jhunzik 
@ahoffer 
@mweser 
@djblue 
@rzwiefel 
@ryeats 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Start up a DDF and ingest a product. Perform a relative temporal query that will both include and exclude the product and verify the metacard is present or not. Try waiting 3-4 minutes after ingesting and perform a `last 1 minute` query to verify no results and a `last 1 hour` query to verify results.

#### What are the relevant tickets?
[DDF-3180](https://codice.atlassian.net/browse/DDF-3180)
#### Screenshots (if appropriate)
![relative_temporal_button](https://user-images.githubusercontent.com/12501737/29196064-fb3f9ac8-7de6-11e7-89dd-53e9e6cf27eb.PNG)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
