### PR TITLE
DDF-3197 Disable the felix file installer and manually sync etc with config admin

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/custom.properties
+++ b/distribution/ddf-common/src/main/resources/etc/custom.properties
@@ -55,7 +55,8 @@ org.apache.karaf.security.providers=org.bouncycastle.jce.provider.BouncyCastlePr
 #
 # This property is true by default in Karaf 4.1.1, but it is included here anyway to stay consistent
 # if the default is changed in future upgrades.
-felix.fileinstall.enableConfigSave=true
+# Currently set to false since we have our own config installer now.
+felix.fileinstall.enableConfigSave=false
 
 #
 # Extra packages appended after standard packages

--- a/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/FelixConfigTest.java
+++ b/platform/admin/admin-configuration-configinstaller/src/test/java/org/codice/ddf/admin/configuration/FelixConfigTest.java
@@ -186,7 +186,7 @@ public class FelixConfigTest {
                 temporaryFile.toURI()
                         .toString());
         felixConfig = new FelixConfig(configuration);
-        felixConfig.setFelixFile();
+        felixConfig.generateDefaultFelixFile();
         File felixFile = felixConfig.getFelixFile();
         assertThat(felixFile, is(notNullValue()));
         assertThat(felixFile.getName(), is("pid.config"));
@@ -199,7 +199,7 @@ public class FelixConfigTest {
                 temporaryFile.toURI()
                         .toString());
         felixConfig = new FelixConfig(configuration);
-        felixConfig.setFelixFile();
+        felixConfig.generateDefaultFelixFile();
         File felixFile = felixConfig.getFelixFile();
         assertThat(felixFile, is(notNullValue()));
         assertThat(felixFile.getName(), matchesPattern("factoryPid-[a-z0-9]++.config"));

--- a/platform/admin/configurator/admin-configurator-actions-api/src/main/java/org/codice/ddf/internal/admin/configurator/actions/ConfigActions.java
+++ b/platform/admin/configurator/admin-configurator-actions-api/src/main/java/org/codice/ddf/internal/admin/configurator/actions/ConfigActions.java
@@ -13,10 +13,59 @@
  **/
 package org.codice.ddf.internal.admin.configurator.actions;
 
+import java.nio.file.Path;
+import java.util.Dictionary;
+
+import org.codice.ddf.admin.configurator.ConfiguratorException;
+import org.codice.ddf.admin.configurator.Operation;
+
 /**
- * Property operations adapted for
+ * Config operations adapted for the Configurator API.
+ * <p>
  * <b> This code is experimental. While this interface is functional and tested, it may change or be
  * removed in a future version of the library. </b>
  */
-public interface ConfigActions extends PropertyActions {
+public interface ConfigActions {
+    /**
+     * Creates a handler for persisting config file changes to a new config file.
+     *
+     * @param configFile the config file to be created
+     * @param configs    dictionary of key:value pairs to be written to the config file
+     * @return instance of this class
+     * @throws ConfiguratorException if an error occurs creating the operator
+     */
+    Operation<Void> create(Path configFile, Dictionary<String, Object> configs)
+            throws ConfiguratorException;
+
+    /**
+     * Creates a handler for deleting a config file.
+     *
+     * @param configFile the config file to be deleted
+     * @return instance of this class
+     * @throws ConfiguratorException if an error occurs creating the operator
+     */
+    Operation<Void> delete(Path configFile) throws ConfiguratorException;
+
+    /**
+     * Creates a handler for persisting config file changes to an existing config file.
+     *
+     * @param configFile       the config file to be updated
+     * @param configs          dictionary of key:value pairs to be written to the config file
+     * @param keepIfNotPresent if true, any keys in the current config file that are not in the
+     *                         {@code configs} map will be left with their initial values; if false, they
+     *                         will be removed from the file
+     * @return instance of this class
+     * @throws ConfiguratorException if an error occurs creating the operator
+     */
+    Operation<Void> update(Path configFile, Dictionary<String, Object> configs,
+            boolean keepIfNotPresent) throws ConfiguratorException;
+
+    /**
+     * Gets the current key:value pairs set in the given config file.
+     *
+     * @param propFile the config file to query
+     * @return the current set of key:value pairs
+     * @throws ConfiguratorException if there is an error reading the state
+     */
+    Dictionary<String, Object> getProperties(Path propFile) throws ConfiguratorException;
 }

--- a/platform/admin/configurator/admin-configurator-impl/pom.xml
+++ b/platform/admin/configurator/admin-configurator-impl/pom.xml
@@ -38,6 +38,15 @@
             <artifactId>admin-configurator-actions-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.io</groupId>
+            <artifactId>platform-io-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>ddf.admin.core</groupId>
@@ -86,6 +95,9 @@
                             !org.codice.ddf.admin.configurator.impl.*,
                             *
                         </Import-Package>
+                        <Embed-Dependency>
+                            platform-util
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigOperation.java
+++ b/platform/admin/configurator/admin-configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigOperation.java
@@ -16,15 +16,26 @@ package org.codice.ddf.admin.configurator.impl;
 import static org.codice.ddf.admin.configurator.impl.ConfigValidator.validateConfigPath;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Path;
-import java.util.Map;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Hashtable;
 
 import org.codice.ddf.admin.configurator.ConfiguratorException;
 import org.codice.ddf.admin.configurator.Operation;
 import org.codice.ddf.admin.configurator.Result;
 import org.codice.ddf.internal.admin.configurator.actions.ConfigActions;
+import org.codice.ddf.platform.io.internal.PersistenceStrategy;
+import org.codice.ddf.platform.util.SortedServiceList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Files;
 
 /**
  * Transactional handler for persisting config file changes.
@@ -34,27 +45,50 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ConfigOperation implements Operation<Void> {
     public static class Actions implements ConfigActions {
+        private final SortedServiceList<PersistenceStrategy> strategies;
+
+        /**
+         * {@link SortedServiceList} implements {@link java.util.List} using generic parameter
+         * <code>&lt;T&gt;</code> and not a concrete type, so the ctor cannot be matched by the
+         * blueprint container if we did <code>SortedServiceList&lt;PersistenceStrategy&gt;</code>
+         * <p>
+         * See https://issues.apache.org/jira/browse/ARIES-960
+         */
+        public Actions(SortedServiceList strategies) {
+            this.strategies = strategies;
+        }
+
         @Override
-        public Operation<Void> create(Path configFile, Map<String, String> configs)
+        public Operation<Void> create(Path configPath, Dictionary<String, Object> configs)
                 throws ConfiguratorException {
-            throw new UnsupportedOperationException();
+            validateConfigPath(configPath);
+            return new ConfigOperation.CreateHandler(configPath,
+                    configs,
+                    getAppropriateStrategy(configPath, strategies));
         }
 
         @Override
-        public ConfigOperation delete(Path propFile) throws ConfiguratorException {
-            validateConfigPath(propFile);
-            return new ConfigOperation.DeleteHandler(propFile);
+        public ConfigOperation delete(Path configPath) throws ConfiguratorException {
+            validateConfigPath(configPath);
+            return new ConfigOperation.DeleteHandler(configPath,
+                    getAppropriateStrategy(configPath, strategies));
         }
 
         @Override
-        public Operation<Void> update(Path configFile, Map<String, String> configs,
+        public Operation<Void> update(Path configPath, Dictionary<String, Object> configs,
                 boolean keepIfNotPresent) throws ConfiguratorException {
-            throw new UnsupportedOperationException();
+            validateConfigPath(configPath);
+            return new ConfigOperation.UpdateHandler(configPath,
+                    configs,
+                    keepIfNotPresent,
+                    getAppropriateStrategy(configPath, strategies));
         }
 
         @Override
-        public Map<String, String> getProperties(Path propFile) throws ConfiguratorException {
-            throw new UnsupportedOperationException();
+        public Dictionary<String, Object> getProperties(Path configPath)
+                throws ConfiguratorException {
+            validateConfigPath(configPath);
+            return readConfig(configPath.toFile(), getAppropriateStrategy(configPath, strategies));
         }
     }
 
@@ -62,30 +96,193 @@ public abstract class ConfigOperation implements Operation<Void> {
 
     final File configFile;
 
-    private ConfigOperation(Path configFilePath) {
+    final Dictionary<String, Object> configs;
+
+    final PersistenceStrategy strategy;
+
+    private ConfigOperation(Path configFilePath, Dictionary<String, Object> configs,
+            PersistenceStrategy strategy) {
         this.configFile = configFilePath.toFile();
+        this.configs = configs;
+        this.strategy = strategy;
+    }
+
+    private static PersistenceStrategy getAppropriateStrategy(Path path,
+            SortedServiceList<PersistenceStrategy> strategies) {
+
+        String ext = Files.getFileExtension(path.toString());
+        if (ext == null || ext.isEmpty()) {
+            throw new ConfiguratorException("Provided path has invalid file extension");
+        }
+
+        return strategies.stream()
+                .filter(s -> s.getExtension()
+                        .equals(ext))
+                .findFirst()
+                .orElseThrow(() -> new ConfiguratorException(
+                        "No suitable strategy to persist config"));
+    }
+
+    private static Dictionary<String, Object> readConfig(File configFile,
+            PersistenceStrategy strategy) {
+        try (InputStream inputStream = new FileInputStream(configFile)) {
+            return strategy.read(inputStream);
+        } catch (IOException e) {
+            throw new ConfiguratorException("Problem reading config: ", e);
+        }
+    }
+
+    private static void createConfig(File configFile, PersistenceStrategy strategy,
+            Dictionary<String, Object> configs) throws IOException {
+        boolean created = configFile.createNewFile();
+        if (!created) {
+            LOGGER.debug("Config file already exists: {}", configFile.getAbsolutePath());
+        }
+        try (OutputStream outputStream = new FileOutputStream(configFile)) {
+            strategy.write(outputStream, configs);
+        }
+    }
+
+    /**
+     * Transactional handler for creating config files
+     */
+    private static class CreateHandler extends ConfigOperation {
+        private CreateHandler(Path configFile, Dictionary<String, Object> configs,
+                PersistenceStrategy strategy) {
+            super(configFile, configs, strategy);
+        }
+
+        @Override
+        public Result<Void> commit() throws ConfiguratorException {
+            try {
+                createConfig(configFile, strategy, configs);
+                return ResultImpl.pass();
+            } catch (IOException e) {
+                return ResultImpl.fail(new ConfiguratorException("Error creating config: ", e));
+            }
+        }
+
+        /**
+         * If a config was created on top of an already existing file, a successful rollback would
+         * cause the file to be deleted, which was NOT precisely the state the system was in before.
+         * The caller is responsible for invoking the appropriate operation knowing full well the
+         * rollback consequences.
+         */
+        @Override
+        public Result<Void> rollback() throws ConfiguratorException {
+            boolean deleted = configFile.delete();
+            if (!deleted) {
+                LOGGER.debug("Problem deleting properties file {}", configFile);
+                return ResultImpl.rollbackFail(new ConfiguratorException(
+                        "Problem deleting properties file " + configFile));
+            }
+            return ResultImpl.rollback();
+        }
+
+        @Override
+        public String toString() {
+            return "Creating config " + configFile.getAbsolutePath();
+        }
     }
 
     /**
      * Transactional handler for deleting config files
      */
     private static class DeleteHandler extends ConfigOperation {
-        private DeleteHandler(Path configFile) {
-            super(configFile);
+        private Dictionary<String, Object> originalConfigs;
+
+        private DeleteHandler(Path configFile, PersistenceStrategy strategy) {
+            super(configFile, null, strategy);
+            this.originalConfigs = new Hashtable<>();
         }
 
         @Override
         public Result<Void> commit() throws ConfiguratorException {
+            originalConfigs = readConfig(configFile, strategy);
             boolean deleted = configFile.delete();
             if (!deleted) {
                 LOGGER.debug("Problem deleting properties file {}", configFile);
+                return ResultImpl.fail(new ConfiguratorException(
+                        "Problem deleting properties file " + configFile));
             }
             return ResultImpl.pass();
         }
 
         @Override
         public Result<Void> rollback() throws ConfiguratorException {
-            return ResultImpl.rollback();
+            try {
+                createConfig(configFile, strategy, originalConfigs);
+                return ResultImpl.rollback();
+            } catch (IOException e) {
+                return ResultImpl.rollbackFail(new ConfiguratorException("Error creating config: ",
+                        e));
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Deleting config " + configFile.getAbsolutePath();
+        }
+    }
+
+    /**
+     * Transactional handler for updating config files
+     */
+    private static class UpdateHandler extends ConfigOperation {
+        private final boolean keepIfNotPresent;
+
+        private Dictionary<String, Object> originalConfigs;
+
+        private UpdateHandler(Path configFile, Dictionary<String, Object> configs,
+                boolean keepIfNotPresent, PersistenceStrategy strategy) {
+            super(configFile, configs, strategy);
+            this.keepIfNotPresent = keepIfNotPresent;
+            this.originalConfigs = new Hashtable<>();
+        }
+
+        @Override
+        public Result<Void> commit() throws ConfiguratorException {
+            Dictionary<String, Object> configsToWrite = new Hashtable<>();
+            originalConfigs = readConfig(configFile, strategy);
+
+            if (keepIfNotPresent) {
+                putAll(originalConfigs, configsToWrite);
+            }
+            putAll(configs, configsToWrite);
+
+            try {
+                FileOutputStream outputStream = new FileOutputStream(configFile);
+                strategy.write(outputStream, configsToWrite);
+                return ResultImpl.pass();
+            } catch (IOException e) {
+                return ResultImpl.fail(new ConfiguratorException("Error writing config: ", e));
+            }
+        }
+
+        @Override
+        public Result<Void> rollback() throws ConfiguratorException {
+            try {
+                FileOutputStream outputStream = new FileOutputStream(configFile);
+                strategy.write(outputStream, originalConfigs);
+                return ResultImpl.rollback();
+            } catch (IOException e) {
+                return ResultImpl.rollbackFail(new ConfiguratorException("Error writing config: ",
+                        e));
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Updating config " + configFile.getAbsolutePath();
+        }
+
+        private static void putAll(Dictionary<String, Object> source,
+                Dictionary<String, Object> target) {
+            Enumeration keys = source.keys();
+            while (keys.hasMoreElements()) {
+                String key = (String) keys.nextElement();
+                target.put(key, source.get(key));
+            }
         }
     }
 }

--- a/platform/admin/configurator/admin-configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/configurator/admin-configurator-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,6 +14,14 @@
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
+    <bean id="strategiesBean" class="org.codice.ddf.platform.util.SortedServiceList"/>
+    <reference-list id="strategiesRefList"
+                    interface="org.codice.ddf.platform.io.internal.PersistenceStrategy"
+                    availability="optional">
+        <reference-listener ref="strategiesBean" bind-method="bindPlugin"
+                            unbind-method="unbindPlugin"/>
+    </reference-list>
+
     <service interface="org.codice.ddf.admin.configurator.ConfiguratorFactory">
         <service-properties>
             <entry key="type" value="txact"/>
@@ -44,7 +52,9 @@
     </service>
 
     <service interface="org.codice.ddf.internal.admin.configurator.actions.ConfigActions">
-        <bean class="org.codice.ddf.admin.configurator.impl.ConfigOperation.Actions"/>
+        <bean class="org.codice.ddf.admin.configurator.impl.ConfigOperation.Actions">
+            <argument ref="strategiesBean"/>
+        </bean>
     </service>
 
     <service interface="org.codice.ddf.internal.admin.configurator.actions.ServiceReader">

--- a/platform/io/platform-io-impl/pom.xml
+++ b/platform/io/platform-io-impl/pom.xml
@@ -20,7 +20,9 @@
         <groupId>ddf.platform</groupId>
         <version>2.11.0-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
 
     <groupId>ddf.platform.io</groupId>
     <artifactId>platform-io-impl</artifactId>
@@ -60,6 +62,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            org.apache.felix.utils
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/io/platform-io-internal-api/pom.xml
+++ b/platform/io/platform-io-internal-api/pom.xml
@@ -20,7 +20,9 @@
         <groupId>ddf.platform</groupId>
         <version>2.11.0-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
 
     <groupId>ddf.platform.io</groupId>
     <artifactId>platform-io-internal-api</artifactId>

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -112,6 +112,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.io</groupId>
+            <artifactId>platform-io-internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.io</groupId>
+            <artifactId>platform-io-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.metrics.reporting</groupId>
             <artifactId>metrics-reporting</artifactId>
             <version>${project.version}</version>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -1030,6 +1030,12 @@
         <bundle>mvn:ddf.platform.error/platform-error-impl/${project.version}</bundle>
     </feature>
 
+    <feature name="io" install="manual" version="${project.version}"
+             description="Internal tools for general purpose IO functions">
+        <bundle dependency="true">mvn:ddf.platform.io/platform-io-internal-api/${project.version}</bundle>
+        <bundle>mvn:ddf.platform.io/platform-io-impl/${project.version}</bundle>
+    </feature>
+
     <feature name="parser-xml" install="manual" version="${project.version}"
              description="Platform JAXB support.">
         <bundle>mvn:ddf.platform/platform-parser-api/${project.version}</bundle>
@@ -1110,6 +1116,7 @@
         <feature>solr</feature>
         <feature>persistence-core</feature>
         <feature>error</feature>
+        <feature>io</feature>
         <feature>parser-xml</feature>
         <feature>landing-page</feature>
         <feature>platform-filter-response</feature>

--- a/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/SortedServiceList.java
+++ b/platform/util/platform-util/src/main/java/org/codice/ddf/platform/util/SortedServiceList.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>
  * It is an implementation of {@link java.util.List} but is backed by a sorted {@link java.util.TreeMap} of
- * <@link ServiceReference, T> where the {@link org.osgi.framework.ServiceReference} objects are what is used to maintain the
+ * <@link ServiceReference, T> where the {@link org.osgi.framework.ServiceReference} objects are used to maintain the
  * list order but the objects passed by this {@link java.util.List} to clients are the actual service objects
  * and not the service references.
  * </p>


### PR DESCRIPTION
#### What does this PR do?
Disables the felix file installer, which writes config admin changes back to `etc`, so we can enable our own installer that correctly supports writing **and** deleting. 

**NOTE**: Unit test changes are pending first round of feedback. 

#### Who is reviewing it? 
@paouelle 
@brjeter 
@oconnormi 
@dannythk 
@vinamartin 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Start up DDF with defaults for everything. 
Keep the logs tailed throughout this process to catch any infinite config loops. 

1. Setup various configs, both singleton-type and factory-type configurations. 
✅  Verify a config in `etc` gets created for each config created using the UI

2. Delete one or two configs using the UI
✅  Verify their corresponding files in `etc` get deleted as well

3. Delete one or two configs in `etc` and refresh the admin UI
✅  Verify the configs no longer show up in the admin UI

4. Shutdown the system, delete one or two configs in `etc`, and reboot the system
✅  Verify the configs no longer show up in the admin UI

#### Any background context you want to provide?
Highly available systems that are configured using the UI before being switched to a proper solution such as Puppet will need this kind of coherency between `etc` and the bundle cache. Also, this will be a necessary plugin point for encrypting passwords found in the `etc` directory. 

#### What are the relevant tickets?
##### This ticket:
[DDF-3197](https://codice.atlassian.net/browse/DDF-3197)
##### To be done after:
[DDF-3185](https://codice.atlassian.net/browse/DDF-3185)
##### Prereq's already done:
[DDF-3186](https://codice.atlassian.net/browse/DDF-3186)
[DDF-3148](https://codice.atlassian.net/browse/DDF-3148)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
