### PR TITLE
DDF-2132 offline install issue missing org.apache.felix.coordinator

### DIFF
--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-certificates.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-certificates.adoc
@@ -62,6 +62,8 @@ The `CertNew` scripts:
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.
 
+Once the certificate has been updated the system user will also need to be updated to have a username that matches the fully qualified domain name (FQDN). See <<_updating_system_users,Updating System Users>>.
+
 Finally, restart the ${branding} instance.
 Browse the ${admin-console} at \https://<FQDN>:8993/admin to test changes.
 

--- a/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-certificates.adoc
+++ b/distribution/docs/src/main/jdocs/content/_quickstart/quickstart-certificates.adoc
@@ -62,7 +62,7 @@ The `CertNew` scripts:
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.
 
-Once the certificate has been updated the system user will also need to be updated to have a username that matches the fully qualified domain name (FQDN). See <<_updating_system_users,Updating System Users>>.
+Once the certificate has been updated the system user and `org.codice.ddf.system.hostname` property will also need to be updated to match the FQDN. Replace localhost with the FQDN in `<INSTALL_HOME>/etc/users.properties`, `<INSTALL_HOME>/etc/users.attributes` and `<INSTALL_HOME>/etc/system.properties`.
 
 Finally, restart the ${branding} instance.
 Browse the ${admin-console} at \https://<FQDN>:8993/admin to test changes.

--- a/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
@@ -161,28 +161,28 @@ RUN_AS_USER=<${branding-lowercase}-user>
 [source,java,linenums]
 ----
 #Add the following:
-wrapper.java.additional.10=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
-wrapper.java.additional.11=-Dderby.storage.fileSyncTransactionLog=true
-wrapper.java.additional.12=-server
-wrapper.java.additional.13=-Djava.security.egd=file:/dev/./urandom
-wrapper.java.additional.14=-Dfile.encoding=UTF8
-wrapper.java.additional.15=-Dkaraf.instances=%KARAF_HOME%/instances
-wrapper.java.additional.16=-Dkaraf.restart.jvm.supported=true
-wrapper.java.additional.17=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
+wrapper.java.additional.11=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
+wrapper.java.additional.12=-Dderby.storage.fileSyncTransactionLog=true
+wrapper.java.additional.13=-server
+wrapper.java.additional.14=-Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.15=-Dfile.encoding=UTF8
+wrapper.java.additional.16=-Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.17=-Dkaraf.restart.jvm.supported=true
 wrapper.java.additional.18=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
 wrapper.java.additional.19=-XX:+UnlockDiagnosticVMOptions
 wrapper.java.additional.20=-XX:+UnsyncloadClass
 wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
 wrapper.java.additional.22=-Djava.awt.headless=true
 
-# Set the JVM min heap space as desired
-wrapper.java.additional.23=-Xms2g
-
-# Set the JVM max heap space as desired
-wrapper.java.additional.24=-Xmx4g
-
 # (Preferred) Optionally add the disable attach mechanism to prevent connections to JMX
-wrapper.java.additional.25=-XX:+DisableAttachMechanism
+wrapper.java.additional.23=-XX:+DisableAttachMechanism
+
+#Update the following
+# Initial Java Heap Size (in MB)
+wrapper.java.initmemory=2000
+
+# Maximum Java Heap Size (in MB)
+wrapper.java.maxmemory=4000
 
 ----
 +

--- a/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
@@ -155,6 +155,13 @@ to:
 RUN_AS_USER=<${branding-lowercase}-user>
 ----
 +
+. (Windows users skip to next step) (All *NIX) Edit `<${branding}_HOME>/bin/${branding-lowercase}.service`. Add LimitNOFILE to the [Service] section.
++
+.<${branding}_HOME>/bin/${branding-lowercase}.service
+----
+LimitNOFILE=6815744
+----
++
 . Set the memory in the wrapper config to match with ${branding} default memory setting.
 +
 .<${branding}_HOME>/etc/${branding-lowercase}-wrapper.conf
@@ -182,6 +189,13 @@ wrapper.java.additional.24=-XX:+DisableAttachMechanism
 
 ----
 +
+Remove or comment out `wrapper.java.maxmemory=512`:
++
+.<${branding}_HOME>/etc/${branding-lowercase}-wrapper.conf
+----
+#wrapper.java.maxmemory=512
+----
++
 . Install the wrapper startup/shutdown scripts.
 +
 *Windows*
@@ -199,6 +213,12 @@ Startup and shutdown settings can then be managed through *Services -> MMC Start
 root${at-symbol}localhost# ln -s <${branding}_HOME>/bin/${branding-lowercase}-service /etc/init.d/
 root${at-symbol}localhost# chkconfig ${branding-lowercase}-service --add
 root${at-symbol}localhost# chkconfig ${branding-lowercase}-service on
+----
++
+*Redhat 7 (systemd)*
++
+----
+root${at-symbol}localhost# systemctl enable <${branding}_HOME>/bin/${branding-lowercase}.service
 ----
 +
 *Ubuntu*

--- a/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_running/starting-intro-contents.adoc
@@ -174,15 +174,11 @@ wrapper.java.additional.20=-XX:+UnsyncloadClass
 wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
 wrapper.java.additional.22=-Djava.awt.headless=true
 
+# Set the JVM max heap space as desired
+wrapper.java.additional.23=-Xmx4g
+
 # (Preferred) Optionally add the disable attach mechanism to prevent connections to JMX
-wrapper.java.additional.23=-XX:+DisableAttachMechanism
-
-#Update the following
-# Initial Java Heap Size (in MB)
-wrapper.java.initmemory=2000
-
-# Maximum Java Heap Size (in MB)
-wrapper.java.maxmemory=4000
+wrapper.java.additional.24=-XX:+DisableAttachMechanism
 
 ----
 +

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -149,6 +149,13 @@ to:
 RUN_AS_USER=<${branding-lowercase}-user>
 ----
 +
+. (Windows users skip to next step) (All *NIX) Edit `<${branding}_HOME>/bin/${branding-lowercase}.service`. Add LimitNOFILE to the [Service] section.
++
+.<${branding}_HOME>/bin/${branding-lowercase}.service
+----
+LimitNOFILE=6815744
+----
++
 . Set the memory in the wrapper config to match with ${branding} default memory setting.
 +
 .<${branding}_HOME>/etc/${branding-lowercase}-wrapper.conf
@@ -176,6 +183,13 @@ wrapper.java.additional.24=-XX:+DisableAttachMechanism
 
 ----
 +
+Remove or comment out `wrapper.java.maxmemory=512`:
++
+.<${branding}_HOME>/etc/${branding-lowercase}-wrapper.conf
+----
+#wrapper.java.maxmemory=512
+----
++
 . Install the wrapper startup/shutdown scripts.
 +
 *Windows*
@@ -193,6 +207,12 @@ Startup and shutdown settings can then be managed through *Services -> MMC Start
 root${at-symbol}localhost# ln -s <${branding}_HOME>/bin/${branding-lowercase}-service /etc/init.d/
 root${at-symbol}localhost# chkconfig ${branding-lowercase}-service --add
 root${at-symbol}localhost# chkconfig ${branding-lowercase}-service on
+----
++
+*Redhat 7 (systemd)*
++
+----
+root${at-symbol}localhost# systemctl enable <${branding}_HOME>/bin/${branding-lowercase}.service
 ----
 +
 *Ubuntu*

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -155,28 +155,28 @@ RUN_AS_USER=<${branding-lowercase}-user>
 [source,java,linenums]
 ----
 #Add the following:
-wrapper.java.additional.10=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
-wrapper.java.additional.11=-Dderby.storage.fileSyncTransactionLog=true
-wrapper.java.additional.12=-server
-wrapper.java.additional.13=-Djava.security.egd=file:/dev/./urandom
-wrapper.java.additional.14=-Dfile.encoding=UTF8
-wrapper.java.additional.15=-Dkaraf.instances=%KARAF_HOME%/instances
-wrapper.java.additional.16=-Dkaraf.restart.jvm.supported=true
-wrapper.java.additional.17=-Djava.io.tmpdir=%KARAF_HOME%/data/tmp
+wrapper.java.additional.11=-D${ddf-branding-lowercase}.home=%KARAF_HOME%
+wrapper.java.additional.12=-Dderby.storage.fileSyncTransactionLog=true
+wrapper.java.additional.13=-server
+wrapper.java.additional.14=-Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.15=-Dfile.encoding=UTF8
+wrapper.java.additional.16=-Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.17=-Dkaraf.restart.jvm.supported=true
 wrapper.java.additional.18=-Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
 wrapper.java.additional.19=-XX:+UnlockDiagnosticVMOptions
 wrapper.java.additional.20=-XX:+UnsyncloadClass
 wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
 wrapper.java.additional.22=-Djava.awt.headless=true
 
-# Set the JVM min heap space as desired
-wrapper.java.additional.23=-Xms2g
-
-# Set the JVM max heap space as desired
-wrapper.java.additional.24=-Xmx4g
-
 # (Preferred) Optionally add the disable attach mechanism to prevent connections to JMX
-wrapper.java.additional.25=-XX:+DisableAttachMechanism
+wrapper.java.additional.23=-XX:+DisableAttachMechanism
+
+#Update the following
+# Initial Java Heap Size (in MB)
+wrapper.java.initmemory=2000
+
+# Maximum Java Heap Size (in MB)
+wrapper.java.maxmemory=4000
 
 ----
 +

--- a/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_running/starting-intro-contents.adoc
@@ -168,15 +168,11 @@ wrapper.java.additional.20=-XX:+UnsyncloadClass
 wrapper.java.additional.21=-Dderby.system.home=%KARAF_HOME%/data/derby
 wrapper.java.additional.22=-Djava.awt.headless=true
 
+# Set the JVM max heap space as desired
+wrapper.java.additional.23=-Xmx4g
+
 # (Preferred) Optionally add the disable attach mechanism to prevent connections to JMX
-wrapper.java.additional.23=-XX:+DisableAttachMechanism
-
-#Update the following
-# Initial Java Heap Size (in MB)
-wrapper.java.initmemory=2000
-
-# Maximum Java Heap Size (in MB)
-wrapper.java.maxmemory=4000
+wrapper.java.additional.24=-XX:+DisableAttachMechanism
 
 ----
 +

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -124,7 +124,7 @@ The `CertNew` scripts:
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.
 
-Once the certificate has been updated the system user will also need to be updated to have a username that matches the fully qualified domain name (FQDN). See <<_updating_system_users,Updating System Users>>.
+Once the certificate has been updated the system user and `org.codice.ddf.system.hostname` property will also need to be updated to match the FQDN. Replace localhost with the FQDN in `<INSTALL_HOME>/etc/users.properties`, `<INSTALL_HOME>/etc/users.attributes` and `<INSTALL_HOME>/etc/system.properties`.
 
 Finally, restart the ${branding} instance.
 Browse the ${admin-console} at \https://<FQDN>:8993/admin to test changes.

--- a/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/managing-certificates-contents.adoc
@@ -124,6 +124,8 @@ The `CertNew` scripts:
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.
 
+Once the certificate has been updated the system user will also need to be updated to have a username that matches the fully qualified domain name (FQDN). See <<_updating_system_users,Updating System Users>>.
+
 Finally, restart the ${branding} instance.
 Browse the ${admin-console} at \https://<FQDN>:8993/admin to test changes.
 

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -289,18 +289,16 @@
         </capability>
     </feature>
 
+    <!--NOTE: conditional and dependency=true have been removed because it caused required bundles not being included in kar -->
     <feature name="transaction" description="OSGi Transaction Manager" version="2.0">
         <details>JTA Support</details>
         <feature dependency="true">transaction-manager-geronimo</feature>
         <requirement>
             transaction-manager
         </requirement>
-        <conditional>
-            <condition>aries-blueprint</condition>
-            <bundle dependency="true">mvn:org.apache.felix/org.apache.felix.coordinator/${felix.coordinator.version}</bundle>
-            <bundle>mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/${aries.transaction.blueprint.version}</bundle>
-            <bundle>mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/${aries.transaction.blueprint.version2}</bundle>
-        </conditional>
+        <bundle>mvn:org.apache.felix/org.apache.felix.coordinator/${felix.coordinator.version}</bundle>
+        <bundle>mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/${aries.transaction.blueprint.version}</bundle>
+        <bundle>mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/${aries.transaction.blueprint.version2}</bundle>
     </feature>
     <!-- END Enterprise Features -->
 


### PR DESCRIPTION
#### What does this PR do?
Fix installing DDF with broker-app while offline.
#### Who is reviewing it? 
@emmberk 
@jrnorth 
@vinamartin 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@jaymcnallie
#### How should this be tested? (List steps with links to updated documentation)
Install broker-app on a DDF while not connected to the internet and without an .m2/repository
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
