### PR TITLE
DDF-3103 Downgrade Marionette to 2.4.5 to avoid Windows build issue

### DIFF
--- a/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/src/main/webapp/main.js
+++ b/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/src/main/webapp/main.js
@@ -22,7 +22,7 @@ require.config({
 
         underscore: 'underscore/1.8.3/underscore-min',
 
-        'backbone.marionette': 'marionette/2.4.7/lib/backbone.marionette.min',
+        'backbone.marionette': 'marionette/2.4.5/lib/backbone.marionette.min',
 
         modelbinder: 'backbone.modelbinder/1.1.0/Backbone.ModelBinder',
 

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/main.js
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/src/main/webapp/main.js
@@ -22,7 +22,7 @@ require.config({
 
         underscore: 'underscore/1.8.3/underscore-min',
 
-        'backbone.marionette': 'marionette/2.4.7/lib/backbone.marionette.min',
+        'backbone.marionette': 'marionette/2.4.5/lib/backbone.marionette.min',
 
         modelbinder: 'backbone.modelbinder/1.1.0/Backbone.ModelBinder',
 

--- a/catalog/spatial/geocoding/spatial-geocoding-admin-module/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-admin-module/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/main/webapp/main.js
+++ b/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/main/webapp/main.js
@@ -22,7 +22,7 @@ require.config({
 
         underscore: 'underscore/1.8.3/underscore-min',
 
-        'backbone.marionette': 'marionette/2.4.7/lib/backbone.marionette.min',
+        'backbone.marionette': 'marionette/2.4.5/lib/backbone.marionette.min',
 
         modelbinder: 'backbone.modelbinder/1.1.0/Backbone.ModelBinder',
 

--- a/catalog/spatial/geowebcache/geowebcache-admin-plugin/pom.xml
+++ b/catalog/spatial/geowebcache/geowebcache-admin-plugin/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/spatial/geowebcache/geowebcache-admin-plugin/src/main/webapp/main.js
+++ b/catalog/spatial/geowebcache/geowebcache-admin-plugin/src/main/webapp/main.js
@@ -22,7 +22,7 @@ require.config({
 
         underscore: 'underscore/1.8.3/underscore-min',
 
-        'backbone.marionette': 'marionette/2.4.7/lib/backbone.marionette.min',
+        'backbone.marionette': 'marionette/2.4.5/lib/backbone.marionette.min',
 
         // application
         application: 'js/application',

--- a/catalog/ui/search-ui/standard/pom.xml
+++ b/catalog/ui/search-ui/standard/pom.xml
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/ui/search-ui/standard/src/main/webapp/main.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/main.js
@@ -32,7 +32,7 @@ require.config({
         backboneundo: 'Backbone.Undo/0.2.5/Backbone.Undo',
         poller: 'backbone-poller/1.1.3/backbone.poller',
         underscore: 'lodash/3.7.0/lodash.min',
-        marionette: 'marionette/2.4.7/lib/backbone.marionette.min',
+        marionette: 'marionette/2.4.5/lib/backbone.marionette.min',
         'Backbone.ModelBinder': 'backbone.modelbinder/1.1.0/Backbone.ModelBinder.min',
         collectionbinder: 'backbone.modelbinder/1.1.0/Backbone.CollectionBinder.min',
 

--- a/platform/admin/modules/admin-security-certificate-ui/pom.xml
+++ b/platform/admin/modules/admin-security-certificate-ui/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>marionette</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/platform/admin/modules/admin-security-certificate-ui/src/main/webapp/main.js
+++ b/platform/admin/modules/admin-security-certificate-ui/src/main/webapp/main.js
@@ -25,7 +25,7 @@ require.config({
         backbone: 'backbone/1.1.2/backbone',
         backboneassociations: 'backbone-associations/0.6.2/backbone-associations-min',
         underscore: 'underscore/1.8.3/underscore-min',
-        marionette: 'marionette/2.4.7/lib/backbone.marionette',
+        marionette: 'marionette/2.4.5/lib/backbone.marionette',
         // TODO test combining
         modelbinder: 'backbone.modelbinder/1.1.0/Backbone.ModelBinder.min',
         collectionbinder: 'backbone.modelbinder/1.1.0/Backbone.CollectionBinder.min',


### PR DESCRIPTION
#### What does this PR do?
The 2.4.7 Marionette webjar added a wildcard to its pom.xml for its backbone dependency, which breaks windows builds. This downgrades all Marionette webjars to 2.4.5, which doesn't have a wildcard.

#### Who is reviewing it? 
@djblue 
@brendan-hofmann 
@emanns95 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Build should succeed.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3103

