### PR TITLE
DDF-3216 add the ability to attach notes to workspace queries

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteAttributes.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteAttributes.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.notes;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class NoteAttributes implements MetacardType {
+
+  private static final Set<AttributeDescriptor> DESCRIPTORS;
+
+  private static final String NAME = "note";
+
+  static {
+    Set<AttributeDescriptor> descriptors = new HashSet<>();
+    descriptors.add(
+        new AttributeDescriptorImpl(
+            NoteConstants.PARENT_ID,
+            true /* indexed */,
+            true /* stored */,
+            true /* tokenized */,
+            false /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    descriptors.add(
+        new AttributeDescriptorImpl(
+            NoteConstants.COMMENT,
+            true /* indexed */,
+            true /* stored */,
+            true /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS = Collections.unmodifiableSet(descriptors);
+  }
+
+  @Override
+  public Set<AttributeDescriptor> getAttributeDescriptors() {
+    return DESCRIPTORS;
+  }
+
+  @Override
+  public AttributeDescriptor getAttributeDescriptor(String name) {
+    for (AttributeDescriptor attributeDescriptor : DESCRIPTORS) {
+      if (attributeDescriptor.getName().equals(name)) {
+        return attributeDescriptor;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteConstants.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteConstants.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.notes;
+
+import ddf.catalog.data.Metacard;
+
+public final class NoteConstants {
+
+  /**
+   * The metacard ID of the parent object. Uses original taxonomy to preserve backwards
+   * compatibility.
+   */
+  public static final String PARENT_ID = Metacard.RELATED;
+
+  /** A comment against a result. */
+  public static final String COMMENT = "ext.note.result-comment";
+
+  private NoteConstants() {}
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteMetacard.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteMetacard.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.notes;
+
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
+
+public class NoteMetacard extends MetacardImpl {
+
+  private static final MetacardType TYPE = new NoteMetacardType();
+
+  /**
+   * @param id The parent ID of the note
+   * @param user the owner of the note
+   * @param comment The comment itself
+   */
+  public NoteMetacard(final String id, final String user, final String comment) {
+    super(TYPE);
+    this.setAttribute(NoteConstants.PARENT_ID, id);
+    this.setAttribute(Core.METACARD_OWNER, user);
+    this.setAttribute(NoteConstants.COMMENT, comment);
+    this.setAttribute(Core.METACARD_TAGS, "note");
+    this.setAttribute(Core.DESCRIPTION, "Note for a Metacard with ID " + id);
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteMetacardType.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteMetacardType.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.notes;
+
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.SecurityAttributes;
+import java.util.Arrays;
+
+public class NoteMetacardType extends MetacardTypeImpl {
+  public NoteMetacardType() {
+    super("resource-note", Arrays.asList(new NoteAttributes(), new SecurityAttributes()));
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteUtil.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.notes;
+
+import static ddf.catalog.util.impl.ResultIterable.resultIterable;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortBy;
+
+public class NoteUtil {
+
+  private static final int PAGE_SIZE = 250;
+
+  private final FilterBuilder filterBuilder;
+
+  private final CatalogFramework catalogFramework;
+
+  public NoteUtil(FilterBuilder filterBuilder, CatalogFramework catalogFramework) {
+    this.filterBuilder = filterBuilder;
+    this.catalogFramework = catalogFramework;
+  }
+
+  /**
+   * Extracts the data required by the user from the note {@link Metacard} object. If any required
+   * fields are null the return object will also be null.
+   *
+   * @param metacard - the metacard object to abstract response data from
+   * @return map of the response note fields or null
+   */
+  @Nullable
+  public Map<String, String> getResponseNote(Metacard metacard) {
+    Map<String, String> requiredAttributes = new HashMap<>();
+    if (metacard.getId() != null) {
+      requiredAttributes.put("id", metacard.getId());
+    } else {
+      return null;
+    }
+    if (metacard.getAttribute(NoteConstants.PARENT_ID) != null) {
+      requiredAttributes.put(
+          "parent", (String) metacard.getAttribute(NoteConstants.PARENT_ID).getValue());
+    } else {
+      return null;
+    }
+    if (metacard.getCreatedDate() != null) {
+      requiredAttributes.put("created", metacard.getCreatedDate().toString());
+    }
+    if (metacard.getModifiedDate() != null) {
+      requiredAttributes.put("modified", metacard.getModifiedDate().toString());
+    }
+    if (metacard.getAttribute(NoteConstants.COMMENT) != null) {
+      requiredAttributes.put(
+          "note", (String) metacard.getAttribute(NoteConstants.COMMENT).getValue());
+    } else {
+      return null;
+    }
+    if (metacard.getAttribute(Core.METACARD_OWNER) != null) {
+      requiredAttributes.put(
+          "owner", (String) metacard.getAttribute(Core.METACARD_OWNER).getValue());
+    } else {
+      return null;
+    }
+    return requiredAttributes;
+  }
+
+  /**
+   * Returns all associated metacards given two relatable attributes.
+   *
+   * @param primaryFilterAttribute The primary attribute to search against
+   * @param secondaryFilterAttribute The secondary attribute to search against
+   * @param primaryAttributeValue A primary attribute value
+   * @param secondaryAttributeValue A secondary attribute value
+   * @return A set of metacards, filtered by the given attributes and it's values
+   * @throws UnsupportedQueryException Error
+   * @throws SourceUnavailableException Error
+   * @throws FederationException Error
+   */
+  public List<Metacard> getAssociatedMetacardsByTwoAttributes(
+      String primaryFilterAttribute,
+      String secondaryFilterAttribute,
+      String primaryAttributeValue,
+      String secondaryAttributeValue)
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+
+    Filter idFilter =
+        filterBuilder.attribute(primaryFilterAttribute).is().equalTo().text(primaryAttributeValue);
+    Filter tagsFilter =
+        filterBuilder
+            .attribute(secondaryFilterAttribute)
+            .is()
+            .equalTo()
+            .text(secondaryAttributeValue);
+    Filter filter = filterBuilder.allOf(idFilter, tagsFilter);
+
+    return resultIterable(
+            catalogFramework,
+            new QueryRequestImpl(
+                new QueryImpl(
+                    filter,
+                    1,
+                    PAGE_SIZE,
+                    SortBy.NATURAL_ORDER,
+                    true,
+                    TimeUnit.SECONDS.toMillis(10)),
+                false))
+        .stream()
+        .map(Result::getMetacard)
+        .collect(Collectors.toList());
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -69,6 +69,15 @@
         <argument ref="eventAdmin"/>
     </bean>
 
+    <bean id="noteMetacardType" class="org.codice.ddf.catalog.ui.metacard.notes.NoteMetacardType"/>
+
+    <service ref="noteMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="ddf.metacard.NoteMetacardType"/>
+            <entry key="id" value="resource-note"/>
+        </service-properties>
+    </service>
+
     <service interface="ddf.catalog.plugin.PreIngestPlugin">
         <ref component-id="workspacePreIngestPlugin" />
     </service>
@@ -137,13 +146,17 @@
         <argument ref="configurationApplication" />
     </bean>
 
+    <bean id="noteUtil" class="org.codice.ddf.catalog.ui.metacard.notes.NoteUtil">
+        <argument ref="filterBuilder"/>
+        <argument ref="catalogFramework"/>
+    </bean>
+
     <bean id="workspaceTransformer"
           class="org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceTransformer">
         <argument ref="catalogFramework"/>
         <argument ref="inputTransformer"/>
         <argument ref="endpointUtil"/>
     </bean>
-
 
     <bean id="validator" class="org.codice.ddf.catalog.ui.metacard.validation.Validator">
         <argument>
@@ -212,6 +225,7 @@
         <argument ref="csvQueryResponseTransformer" />
         <argument ref="attributeRegistry" />
         <argument ref="configurationApplication" />
+        <argument ref="noteUtil" />
     </bean>
 
     <bean id="queryApplication" class="org.codice.ddf.catalog.ui.query.QueryApplication">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.collection.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.collection.js
@@ -1,4 +1,3 @@
-{{!--
 /**
  * Copyright (c) Codice Foundation
  *
@@ -10,13 +9,10 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
- --}}
-<div class="if-editing">
-    <textarea class="ta-enabled" id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
-</div>
-<div class="if-viewing">
-    <textarea class="ta-disabled" disabled id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
-    <button class="ta-expand"><i class="fa fa-ellipsis-h"></i></button>
-</div>
+/*global require*/
+var Backbone = require('backbone');
+var AnnotationModel = require('./annotation');
+
+module.exports = Backbone.Collection.extend({
+    model: AnnotationModel
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.collection.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.collection.view.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+var childView = require('./annotation.view');
+var Marionette = require('marionette');
+var CustomElements = require('js/CustomElements');
+
+module.exports = Marionette.CollectionView.extend({
+    childView: childView,
+    _options: undefined,
+    initialize: function(options) {
+        this._options = options;
+    },
+    childViewOptions: function() {
+        return {
+            selectionInterface: this._options.selectionInterface,
+            parent: this._options.parent
+        };
+    },
+    tagName: CustomElements.register('annotation-collection'),
+    onAddChild: function(childView){
+    },
+    turnOnEditing: function() {
+        this.$el.toggleClass('is-editing', true);
+        this.children.forEach(function(childView) {
+            childView.turnOnEditing();
+        });
+    },
+    turnOffEditing: function() {
+        this.$el.toggleClass('is-editing', false);
+        this.children.forEach(function(childView) {
+            childView.turnOffEditing();
+        });
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.hbs
@@ -1,0 +1,44 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+
+<div class="annotation-editor-btns">
+    <button class="annotation-edit is-button">
+        <span class="fa fa-pencil"></span>
+    </button>
+    <button class="annotation-remove is-button">
+        <span class="fa fa-trash"></span>
+    </button>
+</div>
+<div class="annotation-content">
+</div>
+<div class="editor-footer">
+    <button class="footer-cancel is-negative">
+        <span class="fa fa-times"></span>
+        <span>
+            Cancel
+        </span>
+    </button>
+    <button class="footer-save is-positive">
+        <span class="fa fa-floppy-o"></span>
+        <span>
+            Save
+        </span>
+    </button>
+    <button class="footer-delete is-negative">
+        <span class="fa fa-minus"></span>
+        <span>
+            Delete
+        </span>
+    </button>
+</div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.js
@@ -1,4 +1,3 @@
-{{!--
 /**
  * Copyright (c) Codice Foundation
  *
@@ -10,13 +9,18 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
- --}}
-<div class="if-editing">
-    <textarea class="ta-enabled" id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
-</div>
-<div class="if-viewing">
-    <textarea class="ta-disabled" disabled id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
-    <button class="ta-expand"><i class="fa fa-ellipsis-h"></i></button>
-</div>
+/*global require*/
+var Backbone = require('backbone');
+
+module.exports = Backbone.Model.extend({
+    defaults: function () {
+        return {
+            id: undefined,
+            parent: undefined,
+            created: undefined,
+            modified: undefined,
+            annotation: undefined,
+            owner: undefined
+        };
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.less
@@ -1,0 +1,79 @@
+@{customElementNamespace}annotation {
+  display: block;
+  position: relative;
+  white-space: nowrap;
+  > .annotation-editor-btns {
+    display: none;
+  }
+  > .annotation-content {
+    text-align: left;
+  }
+  > .editor-footer {
+    white-space: nowrap;
+    .inlineBlockDisplay(button);
+    .footer-cancel,
+    .footer-save,
+    .footer-delete {
+      display: none;
+      width: ~'calc(50% - 15px)';
+    }
+    .footer-cancel {
+      margin-left: 10px;
+    }
+  }
+}
+
+@{customElementNamespace}annotation.is-editing {
+  .customElement;
+
+  > .editor-footer {
+    .footer-cancel,
+    .footer-save {
+      display: inline-block;
+      width: ~'calc(50% - 20px)';
+    }
+    .footer-cancel {
+      margin-right: 5px;
+    }
+  }
+  .annotation-edit {
+    color: #428442;
+  }
+}
+
+@{customElementNamespace}annotation.is-deleting {
+  .customElement;
+
+  > .editor-footer {
+    .footer-cancel,
+    .footer-delete {
+      display: inline-block;
+    }
+    .footer-cancel {
+      margin-right: 5px;
+    }
+  }
+  .annotation-remove {
+    color: #8a423c;
+  }
+}
+
+@{customElementNamespace}annotation.is-modifiable {
+  .customElement;
+  > .annotation-editor-btns {
+    display: block;
+    position: relative;
+    float: right;
+    top: 5px;
+    right: 25px;
+    z-index: 1000;
+  }
+
+}
+
+@{customElementNamespace}annotation:not(.is-editing) {
+  > .annotation-content .annotation-parent,
+  > .annotation-content .annotation-child {
+    display: none;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+var template = require('./annotation.hbs');
+var $ = require('jquery');
+var _ = require('underscore');
+var Marionette = require('marionette');
+var CustomElements = require('js/CustomElements');
+var Common = require('js/Common');
+var PropertyView = require("component/property/property.view");
+var Property = require("component/property/property");
+var LoadingCompanionView = require("component/loading-companion/loading-companion.view");
+var userInstance = require('component/singletons/user-instance');
+var announcement = require('component/announcement');
+
+
+module.exports = Marionette.LayoutView.extend({
+    tagName: CustomElements.register('annotation'),
+    template: template,
+    regions: {
+        annotationContent: '> .annotation-content'
+    },
+    events: {
+        'click .annotation-remove': 'toggleDeleting',
+        'click .annotation-edit': 'toggleEditing',
+        'click .footer-cancel': 'handleCancel',
+        'click .footer-save': 'handleEdit',
+        'click .footer-delete': 'handleDelete'
+    },
+    initialize: function (options) {
+        this._useremail = userInstance.get("user").get("email");
+        this._parent = options.parent;
+    },
+    handleDelete: function () {
+        LoadingCompanionView.beginLoading(this);
+        $.ajax({
+            url: '/search/catalog/internal/annotations/' + this.model.id,
+            method: 'DELETE',
+            contentType: 'application/json'
+        }).always(function (response) {
+            setTimeout(function () {
+                this.handleDeleteResponse(response);
+                LoadingCompanionView.endLoading(this);
+            }.bind(this), 1000);
+        }.bind(this));
+    },
+    handleDeleteResponse: function (response) {
+        if (response.responseType === "success") {
+            this.model.collection.remove(this.model);
+            announcement.announce({
+                title: 'Success!',
+                message: "Annotation Deleted!",
+                type: 'success'
+            });
+        } else {
+            announcement.announce({
+                title: 'Error!',
+                message: "Could not delete annotation: " + response.response,
+                type: 'error'
+            });
+        }
+    },
+    handleCancel: function () {
+        if (this.$el.hasClass("is-editing")) {
+            this.turnOffEditing();
+        }
+        if (this.$el.hasClass("is-deleting")) {
+            this.turnOffDeleting();
+        }
+    },
+    onBeforeShow: function () {
+        this.showannotationContent();
+        this.turnOffEditing();
+        this.canModify();
+    },
+    turnOnEditing: function () {
+        this.turnOffDeleting();
+        this.annotationContent.currentView.turnOnEditing();
+        this.$el.toggleClass('is-editing', true);
+    },
+    turnOnDeleting: function () {
+        this.turnOffEditing();
+        this.$el.toggleClass('is-deleting', true);
+    },
+    turnOffEditing: function () {
+        this.annotationContent.currentView.turnOffEditing();
+        this.$el.toggleClass('is-editing', false);
+    },
+    toggleEditing: function () {
+        if (this.$el.hasClass("is-editing")) {
+            this.turnOffEditing();
+        } else {
+            this.turnOnEditing();
+        }
+    },
+    canModify: function () {
+        this.$el.toggleClass('is-modifiable',
+            this._useremail === this.model.attributes.owner);
+    },
+    toggleDeleting: function () {
+        if (this.$el.hasClass("is-deleting")) {
+            this.turnOffDeleting();
+        } else {
+            this.turnOnDeleting();
+        }
+    },
+    turnOffDeleting: function () {
+        this.$el.toggleClass('is-deleting', false);
+    },
+    handleEdit: function () {
+        var requestData = {};
+        requestData.note = this.annotationContent.currentView.model.get('value')[0];
+        LoadingCompanionView.beginLoading(this);
+        $.ajax({
+            url: '/search/catalog/internal/annotations/' + this.model.id,
+            method: 'PUT',
+            data: JSON.stringify(requestData),
+            contentType: 'application/json'
+        }).always(function (response) {
+            setTimeout(function () {
+                this.handleEditResponse(response);
+                LoadingCompanionView.endLoading(this);
+            }.bind(this), 1000);
+        }.bind(this));
+        LoadingCompanionView.endLoading(this);
+        this.turnOffEditing();
+    },
+    handleEditResponse: function (response) {
+        if (response.responseType === "success") {
+            var annotation = JSON.parse(response.response);
+            this.model.attributes.annotation = annotation.note;
+            this.$el.find('textarea').text(annotation.note);
+
+            announcement.announce({
+                title: 'Success!',
+                message: "Annotation Updated!",
+                type: 'success'
+            });
+        } else {
+            announcement.announce({
+                title: 'Error!',
+                message: "Could not update annotation: " + response.response,
+                type: 'error'
+            });
+        }
+    },
+    showannotationContent: function () {
+        this.annotationContent.show(new PropertyView({
+            model: new Property({
+                value: [this.model.attributes.annotation],
+                id: 'annotation-' + this.model.attributes.id,
+                label: this.model.attributes.owner + ' - ' + this.model.attributes.created,
+                type: 'TEXTAREA'
+            })
+        }));
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -80,10 +80,12 @@
 @import 'property/property';
 @import 'value/value';
 @import 'multivalue/multivalue';
+@import 'query-annotations/query-annotations';
 @import 'query-advanced/query-advanced';
 @import 'query-item/query-item';
 @import 'query-settings/query-settings';
 @import 'query-src/query-src';
+@import 'annotation/annotation';
 @import 'dropdown/query-src/dropdown.query-src.less';
 @import 'notifications/notifications';
 @import 'dropdown/notifications/dropdown.notifications.less';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/textarea/input-textarea.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/textarea/input-textarea.less
@@ -1,4 +1,7 @@
 @{customElementNamespace}input.is-textarea {
+    .if-overflow {
+        display:none;
+    }
     .if-editing {
         position: relative;
     }
@@ -6,13 +9,48 @@
     textarea {
         line-height: normal;
         padding: 6px 10px 5px 10px;
-        width: 100% !important;
-        min-height: 100px;
-        max-height: 400px;
+      width: 100%;
+        max-height:400px;
+        min-height:100px;
         color: @text-color;
         background: @medium-lighten-inherited-background-color;
         .is-input;
+
     }
+
+    textarea:disabled {
+        background-color: #2e2e33;
+      position: relative;
+      z-index: @zIndexContent;
+        border: none;
+        height:75px;
+        max-height:75px;
+        min-height:75px;
+        user-select: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex-direction: unset;
+        resize:none;
+    }
+
+    .ta-expand {
+        display:block;
+        height:20px;
+        text-align:center;
+        width:100%;
+        position:relative;
+      bottom: 30px;
+      margin-bottom: -15px;
+      z-index: @zIndexContent;
+      background-color: rgba(46, 46, 51, 0.7);
+
+      i {
+        position: relative;
+        bottom: 0;
+      }
+
+    }
+
 }
 
 @{customElementNamespace}input.is-textarea.is-editing {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/textarea/input-textarea.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/textarea/input-textarea.view.js
@@ -19,7 +19,28 @@ var InputView = require('../input.view');
 
 module.exports = InputView.extend({
     template: template,
-    getCurrentValue: function(){
+    events: {
+        'click .ta-expand': 'isOverflowing'
+    },
+    getCurrentValue: function () {
         return this.$el.find('textarea').val();
+    },
+    isOverflowing: function () {
+        var textarea = this.$el.find(".ta-disabled");
+        var scrollableHeight = textarea.prop("scrollHeight");
+        var currViewableHeight = parseInt(textarea.css("max-height"), 10);
+
+        if (this.$el.hasClass("is-expanded")) {
+            this.$el.toggleClass("is-expanded", false);
+            textarea.css("height", "75px");
+            textarea.css("max-height", "75px");
+        } else {
+            if (scrollableHeight > currViewableHeight) {
+                this.$el.toggleClass("is-expanded", true);
+                textarea.css("height", scrollableHeight + 15);
+                textarea.css("max-height", scrollableHeight + 15);
+            }
+        }
+
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.hbs
@@ -11,12 +11,19 @@
  *
  **/
  --}}
-<div class="if-editing">
-    <textarea class="ta-enabled" id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
+
+<div class="add-annotation-field">
 </div>
-<div class="if-viewing">
-    <textarea class="ta-disabled" disabled id="{{cid}}" value="{{value}}"
-              placeholder="{{property.placeholder}}" name="{{property.id}}">{{value}}</textarea>
-    <button class="ta-expand"><i class="fa fa-ellipsis-h"></i></button>
+
+<button class="add-annotation-btn is-positive">
+    <span class="fa fa-plus"></span>
+</button>
+<button class="refresh-btn is-primary">
+    <span class="fa fa-refresh"></span>
+</button>
+
+<div class="annotations-list"></div>
+
+<div class="no-annotations">
+    No annotations have been added yet!
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.less
@@ -1,0 +1,91 @@
+@query-annotations-width: ~'calc(100% - 10px)';
+@{customElementNamespace}query-annotations {
+  .customElement;
+  overflow: auto;
+
+  .no-annotations {
+    display: none;
+  }
+
+  .add-annotation-field {
+    display: inline-block;
+    width: 100%;
+    position: relative;
+  }
+
+  .add-annotation-btn {
+    position: relative;
+    display: inline-block;
+    width: ~'calc(@{query-annotations-width} - 1.5*@{minimumButtonSize})';
+    margin-left: @minimumSpacing;
+    margin-bottom: @minimumSpacing;
+  }
+
+  .refresh-btn {
+    display: inline-block;
+    width: @minimumButtonSize;
+  }
+
+  .annotations-list {
+    margin-bottom: @minimumSpacing;
+  }
+
+  ddf-property {
+    padding-bottom: 0;
+  }
+
+    .property-value {
+      width: @query-annotations-width;
+      display: block;
+      vertical-align: top;
+      position: relative;
+      z-index: 1;
+    }
+
+    .property-label {
+      text-align: left;
+      font-size: @minimumFontSize;
+      width: @query-annotations-width;
+      margin-top: -@mediumSpacing;
+    }
+  }
+
+
+  ddf-property .property-label label {
+    text-align: left;
+    vertical-align: top;
+  }
+  .if-inline {
+    display: none;
+
+    ddf-property.is-editing.is-changed:not(.is-readOnly) .property-revert {
+      display: inline;
+    }
+
+    ddf-property .property-label {
+      width: 500px;
+    }
+  }
+
+  .add-annotation-field {
+    .property-label {
+      text-align: left;
+      font-size: @minimumFontSize;
+      width: @query-annotations-width;
+      margin-top:0;
+    }
+  }
+
+@{customElementNamespace}query-annotations.has-no-annotations {
+  .no-annotations {
+    border-bottom: 1px solid rgba(255, 255, 255, @minimumOpacity);
+    border-top: 1px solid rgba(255, 255, 255, @minimumOpacity);
+    padding: @minimumSpacing;
+    text-align:center;
+    position: relative;
+    display:block;
+    margin: @minimumSpacing;
+    width: @query-annotations-width;
+  }
+}
+

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-annotations/query-annotations.view.js
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define, setTimeout*/
+define([
+    'jquery',
+    'backbone',
+    'marionette',
+    'underscore',
+    'properties',
+    'js/model/Metacard',
+    'wreqr',
+    './query-annotations.hbs',
+    'maptype',
+    'js/store',
+    'js/CustomElements',
+    'component/property/property.view',
+    'component/property/property',
+    'component/annotation/annotation.collection',
+    'component/annotation/annotation.collection.view',
+    'component/input/textarea/input-textarea.view',
+    'component/loading-companion/loading-companion.view',
+    'component/announcement'
+], function ($, Backbone, Marionette, _, properties, MetaCard, wreqr, template, maptype,
+             store, CustomElements, PropertyView, Property, AnnotationCollection, AnnotationCollectionView,
+             TextAreaView, LoadingCompanionView, announcement) {
+
+    return Marionette.LayoutView.extend({
+        setDefaultModel: function () {
+            this.model = this.selectionInterface.getSelectedResults().first();
+        },
+        template: template,
+        tagName: CustomElements.register('query-annotations'),
+        events: {
+            'click .add-annotation-btn ': 'handleCreate',
+            'click .refresh-btn ': 'handleRefresh'
+        },
+        childEvents: {
+            "annotation:add": "handleChildDelete"
+        },
+        regions: {
+            addAnnotationField: '.add-annotation-field',
+            annotationsList: '.annotations-list'
+        },
+        _annotationsCollection: undefined,
+        _annotations: undefined,
+        initialize: function (options) {
+            this.selectionInterface = options.selectionInterface || this.selectionInterface;
+            if (!options.model) {
+                this.setDefaultModel();
+            }
+        },
+        onBeforeShow: function(){
+            this.clearAnnotations();
+            this.showAddAnnotationView();
+            this.getAnnotationsForQuery();
+            this.showAnnotationsListView();
+            this.turnOnEditing();
+            this.setupListeners();
+        },
+        clearAnnotations: function () {
+            if (!this._annotationsCollection) {
+                this._annotationsCollection = new AnnotationCollection();
+            }
+            this._annotationsCollection.reset();
+        },
+        showAddAnnotationView: function() {
+            this.addAnnotationField.show(new PropertyView({
+                model: new Property({
+                    value:[''],
+                    placeholder:'enter annotation',
+                    type:'TEXTAREA',
+                    label: ''
+                })
+            }));
+        },
+        getAnnotationsForQuery: function () {
+            LoadingCompanionView.beginLoading(this);
+                $.get('/search/catalog/internal/annotations/' + this.model.get('id'))
+                    .then(function (response) {
+                        var resp = response.response;
+                        if (response.responseType === "success") {
+                            if (this.isValidResponse(resp)) {
+                                this._annotations = JSON.parse(resp);
+                                this.parseAnnotations();
+                            } else {
+                                announcement.announce({
+                                    title: 'Error!',
+                                    message: "There was an error retrieving the annotations for this item!",
+                                    type: 'error'
+                                });
+                            }
+                        }
+                        LoadingCompanionView.endLoading(this);
+                        this.checkHasAnnotations();
+                    }.bind(this));
+        },
+        showAnnotationsListView: function() {
+            this.annotationsList.show(new AnnotationCollectionView({
+                collection: this._annotationsCollection,
+                selectionInterface: this.selectionInterface,
+                parent: this.model
+            }));
+            this.annotationsList.currentView.$el.addClass("is-list");
+        },
+        setupListeners: function() {
+            this.listenTo(this._annotationsCollection, "remove", function() {
+                this.checkHasAnnotations();
+            });
+        },
+        handleRefresh: function() {
+            this.getAnnotationsForQuery();
+            announcement.announce({
+                            title: 'Success!',
+                            message: 'Updated the annotations list!',
+                            type: 'success'
+            });
+        },
+        checkHasAnnotations: function() {
+            if (this._annotationsCollection.length > 0) {
+                this.$el.toggleClass("has-no-annotations", false);
+            } else {
+                this.$el.toggleClass("has-no-annotations", true);
+            }
+        },
+        isValidResponse: function(response) {
+            return response !== "";
+        },
+        parseAnnotations: function () {
+            this.clearAnnotations();
+            this._annotations.forEach(function (annotation) {
+                this._annotationsCollection.add({
+                    id: annotation.id,
+                    parent: annotation.parent,
+                    created: annotation.created,
+                    modified: annotation.modified,
+                    annotation: annotation.note,
+                    owner:annotation.owner
+                })
+            }.bind(this));
+        },
+        clearAnnotations: function () {
+            if (!this._annotationsCollection) {
+                this._annotationsCollection = new AnnotationCollection();
+            }
+            this._annotationsCollection.reset();
+        },
+        handleCreate: function () {
+            var annotation = this.addAnnotationField.currentView.model.get('value')[0];
+            var annotationObj = {};
+            annotationObj.parent = this.model.get('id');
+            annotationObj.note = annotation;
+            annotationObj.workspace = store.getCurrentWorkspace().id;
+
+            if(annotation !== "") {
+                LoadingCompanionView.beginLoading(this);
+                $.ajax({
+                    url: '/search/catalog/internal/annotations',
+                    data: JSON.stringify(annotationObj),
+                    method: 'POST',
+                    contentType: 'application/json'
+                }).always(function(response) {
+                    var resp = response.response;
+                    setTimeout(function() {
+                        if(response.responseType === "success") {
+                            if (this.isValidResponse(resp)) {
+                                this.handlePostResponse(resp);
+                                announcement.announce({
+                                    title: 'Created!',
+                                    message: 'New annotation has been created.',
+                                    type: 'success'
+                                });
+                                this.addAnnotationField.currentView.revert();
+                            }
+                        } else {
+                            announcement.announce({
+                                title: 'Error!',
+                                message: resp,
+                                type: 'error'
+                            });
+                        }
+                        LoadingCompanionView.endLoading(this);
+                        this.checkHasAnnotations();
+
+                    }.bind(this), 1000);
+                }.bind(this));
+            } else {
+                announcement.announce({
+                    title: 'Error!',
+                    message: 'annotation was empty. Can not create!',
+                    type: 'error'
+                });
+            }
+        },
+        handlePostResponse: function(response) {
+            var annotation = JSON.parse(response);
+
+            this._annotationsCollection.add({
+                id: annotation.id,
+                parent: annotation.parent,
+                created: annotation.created,
+                modified: annotation.modified,
+                annotation: annotation.note,
+                owner: annotation.owner
+            });
+        },
+        turnOnEditing: function() {
+            this.addAnnotationField.currentView.turnOnEditing();
+        },
+        turnOffEditing: function() {
+            this.$el.toggleClass('is-editing', false);
+        }
+    });
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/query/tabs-query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/query/tabs-query.js
@@ -17,9 +17,10 @@ define([
     'component/query-settings/query-settings.view',
     'component/query-status/query-status.view',
     'component/query-schedule/query-schedule.view',
-    'component/query-editor/query-editor.view'
+    'component/query-editor/query-editor.view',
+    'component/query-annotations/query-annotations.view'
 ], function (_, Tabs, store, QuerySettingsView, QueryStatusView,
-             QueryScheduleView, QueryEditorView) {
+             QueryScheduleView, QueryEditorView, QueryAnnotationsView) {
 
     var WorkspaceContentTabs = Tabs.extend({
         defaults: {
@@ -27,7 +28,8 @@ define([
                 'Search': QueryEditorView,
                 'Settings': QuerySettingsView,
                 'Schedule': QueryScheduleView,
-                'Status': QueryStatusView
+                'Status': QueryStatusView,
+                'Annotations' : QueryAnnotationsView
             }
         },
         getAssociatedQuery: function(){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/query/tabs-query.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/query/tabs-query.less
@@ -2,7 +2,8 @@
 
   .tabs-tab[data-id=Settings],
   .tabs-tab[data-id=Schedule],
-  .tabs-tab[data-id=Status] {
+  .tabs-tab[data-id=Status],
+  .tabs-tab[data-id=Annotations] {
     display: none;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -15,6 +15,7 @@ package org.codice.ddf.catalog.ui.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -22,12 +23,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.InjectableAttribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.filter.AttributeBuilder;
 import ddf.catalog.filter.ContextualExpressionBuilder;
 import ddf.catalog.filter.EqualityExpressionBuilder;
@@ -35,7 +38,10 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -178,5 +184,39 @@ public class EndpointUtilTest {
     }
 
     return resultMockList;
+  }
+
+  @Test
+  public void testCopyAttributes() {
+
+    AttributeDescriptor firstAttributeDescriptor = mock(AttributeDescriptor.class);
+    when(firstAttributeDescriptor.getName()).thenReturn("first");
+
+    AttributeDescriptor secondAttributeDescriptor = mock(AttributeDescriptor.class);
+    when(secondAttributeDescriptor.getName()).thenReturn("second");
+
+    MetacardType metacardType = mock(MetacardType.class);
+    when(metacardType.getAttributeDescriptors())
+        .thenReturn(
+            new HashSet<>(Arrays.asList(firstAttributeDescriptor, secondAttributeDescriptor)));
+
+    String firstValue = "a";
+    String secondValue = "b";
+
+    Metacard sourceMetacard = new MetacardImpl();
+    sourceMetacard.setAttribute(new AttributeImpl(firstAttributeDescriptor.getName(), firstValue));
+    sourceMetacard.setAttribute(
+        new AttributeImpl(secondAttributeDescriptor.getName(), secondValue));
+
+    Metacard destinationMetacard = new MetacardImpl();
+
+    endpointUtil.copyAttributes(sourceMetacard, metacardType, destinationMetacard);
+
+    assertThat(
+        Collections.singletonList(firstValue),
+        is(destinationMetacard.getAttribute(firstAttributeDescriptor.getName()).getValues()));
+    assertThat(
+        Collections.singletonList(secondValue),
+        is(destinationMetacard.getAttribute(secondAttributeDescriptor.getName()).getValues()));
   }
 }

--- a/catalog/ui/catalog-ui-search/yarn.lock
+++ b/catalog/ui/catalog-ui-search/yarn.lock
@@ -5245,6 +5245,10 @@ jquery-mousewheel@~3.1.13:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
 
+jquery-ui-multiselect-widget@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui-multiselect-widget/-/jquery-ui-multiselect-widget-2.0.1.tgz#b729d89f93acba27a665053bc235e24b087c3daa"
+
 jquery-ui@1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"


### PR DESCRIPTION
ATTN: DO NOT MERGE UNTIL 2.11 IS FORKED FROM MASTER. WAIT FOR 2.12-SNAPSHOT!

#### What does this PR do?
Add the ability to attach notes to workspace queries.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@bdeining 
@troymohl 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
@andrewkfiedler 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining
#### How should this be tested? (List steps with links to updated documentation)
1) build and install
2) Create a workspace query. After the initial query has been created, there will be a new tab on the query called 'Notes'. You can add, edit and delete notes. You must be logged in as a non-guest user.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3216](https://codice.atlassian.net/browse/DDF-3216)
#### Screenshots (if appropriate)
![screen shot 2017-08-16 at 9 07 46 am](https://user-images.githubusercontent.com/17837152/29373253-7b093e92-8262-11e7-85f5-2cf957972430.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
