### PR TITLE
DDF-3221 Improved support for downstream configuration of AbstractStsRealm in integration tests

### DIFF
--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -7,6 +7,15 @@ Use the `isDebugEnabled` property to force the integration test to pause during 
 mvn clean verify -DisDebugEnabled=true
 ```
 
+## Debugging Pax Exam Setup
+Pax Exam uses two JVMs: the first is used to perform Pax Exam configuration, and the second is launched by Pax Exam to perform the actual integration tests. This second JVM is the one you connect to on port 5005.
+
+As a result, if you want to debug code that is run during Pax Exam setup itself (for example, inside the `@org.ops4j.pax.exam.Configuration` configuration method), you need to startup the tests in your IDE and use a local debugger to catch Pax Exam before it spawns the second JVM process.
+
+In short:
+* Use remote debugging to debug tests themselves or anything related to production code
+* Use local debugging to debug the code that sets up and configures the testing environment
+
 ## SSH Into a Running Instance
 It is possible to SSH into a running test instance. This will allow you to use the shell to inspect the runtime state while the test probe is installed and running. The SSH port is dynamic and can be found in `target/exam/<GUID>/etc/org.apache.karaf.shell.cfg`.
 

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -497,9 +497,6 @@ public abstract class AbstractIntegrationTest {
                         RMI_SERVER_PORT.getPort()),
                 installStartupFile(getClass().getClassLoader()
                         .getResourceAsStream("hazelcast.xml"), "/etc/hazelcast.xml"),
-                installStartupFile(getClass().getClassLoader()
-                                .getResourceAsStream("ddf.security.sts.client.configuration.config"),
-                        "/etc/ddf.security.sts.client.configuration.config"),
                 KarafDistributionOption.editConfigurationFilePut(
                         "etc/ddf.security.sts.client.configuration.config",
                         "address",


### PR DESCRIPTION
#### What does this PR do?
Enables downstream projects to use custom configurations for `AbstractStsRealm` that are then properly respected during integration testing.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@brjeter @AzGoalie 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)

Manually verify that 

- If no `ddf.security.sts.client.configuration.config` file is placed in `distribution/ddf-common/src/main/resources`, then a file is automatically created inside the Pax Exam runtime folder with an `address` configuration
- If a  `ddf.security.sts.client.configuration.config` file is placed in `distribution/ddf-common/src/main/resources`, then the values used in that file, other than `address`, are respected in the version created inside the Pax Exam runtime folder. 

#### What are the relevant tickets?
[DDF-3221](https://codice.atlassian.net/browse/DDF-3221)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
