### PR TITLE
DDF-3223 Adds limit to attribute override size

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -13,6 +13,9 @@
  */
 package org.codice.ddf.endpoints.rest;
 
+import static ddf.catalog.data.AttributeType.AttributeFormat.BINARY;
+import static ddf.catalog.data.AttributeType.AttributeFormat.OBJECT;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,8 +23,10 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,7 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
@@ -59,6 +63,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
@@ -121,7 +126,6 @@ import ddf.mime.MimeTypeMapper;
 import ddf.mime.MimeTypeResolutionException;
 import ddf.mime.MimeTypeResolver;
 import ddf.mime.MimeTypeToTransformerMapper;
-
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
@@ -161,6 +165,8 @@ public class RESTEndpoint implements RESTService {
     private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
 
     private static final String DEFAULT_FILE_NAME = "file";
+
+    public static final int MAX_INPUT_SIZE = 65_536;
 
     private UuidGenerator uuidGenerator;
 
@@ -724,20 +730,17 @@ public class RESTEndpoint implements RESTService {
                 }
 
                 if (createInfo == null) {
-                    UpdateRequest updateRequest = new UpdateRequestImpl(id, generateMetacard(
-                            mimeType,
-                            id,
-                            message,
-                            transformerParam));
+                    UpdateRequest updateRequest = new UpdateRequestImpl(id,
+                            generateMetacard(mimeType, id, message, transformerParam));
                     catalogFramework.update(updateRequest);
                 } else {
                     UpdateStorageRequest streamUpdateRequest = new UpdateStorageRequestImpl(
                             Collections.singletonList(new IncomingContentItem(id,
-                                            createInfo.getStream(),
-                                            createInfo.getContentType(),
-                                            createInfo.getFilename(),
-                                            0,
-                                            createInfo.getMetacard())),
+                                    createInfo.getStream(),
+                                    createInfo.getContentType(),
+                                    createInfo.getFilename(),
+                                    0,
+                                    createInfo.getMetacard())),
                             null);
                     catalogFramework.update(streamUpdateRequest);
                 }
@@ -812,10 +815,10 @@ public class RESTEndpoint implements RESTService {
                 } else {
                     CreateStorageRequest streamCreateRequest = new CreateStorageRequestImpl(
                             Collections.singletonList(new IncomingContentItem(uuidGenerator,
-                                            createInfo.getStream(),
-                                            createInfo.getContentType(),
-                                            createInfo.getFilename(),
-                                            createInfo.getMetacard())),
+                                    createInfo.getStream(),
+                                    createInfo.getContentType(),
+                                    createInfo.getFilename(),
+                                    createInfo.getMetacard())),
                             null);
                     createResponse = catalogFramework.create(streamCreateRequest);
                 }
@@ -914,65 +917,79 @@ public class RESTEndpoint implements RESTService {
 
     private void parseOverrideAttributes(List<Attribute> attributes, String parsedName,
             InputStream inputStream) {
-        Optional<AttributeType.AttributeFormat> attributeFormat = metacardTypes.stream()
+        metacardTypes.stream()
                 .map(metacardType -> metacardType.getAttributeDescriptor(parsedName))
                 .filter(Objects::nonNull)
                 .findFirst()
                 .map(AttributeDescriptor::getType)
-                .map(AttributeType::getAttributeFormat);
-        attributeFormat.ifPresent(attributeFormat1 -> {
-            try {
-                switch (attributeFormat1) {
-                case XML:
-                case GEOMETRY:
-                case STRING:
-                    attributes.add(new AttributeImpl(parsedName, IOUtils.toString(inputStream)));
-                    break;
-                case BOOLEAN:
-                    attributes.add(new AttributeImpl(parsedName, Boolean.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case SHORT:
-                    attributes.add(new AttributeImpl(parsedName, Short.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case LONG:
-                    attributes.add(new AttributeImpl(parsedName, Long.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case INTEGER:
-                    attributes.add(new AttributeImpl(parsedName, Integer.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case FLOAT:
-                    attributes.add(new AttributeImpl(parsedName, Float.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case DOUBLE:
-                    attributes.add(new AttributeImpl(parsedName, Double.valueOf(IOUtils.toString(
-                            inputStream))));
-                    break;
-                case DATE:
-                    Instant instant = Instant.parse(IOUtils.toString(inputStream));
-                    if (instant == null) {
-                        break;
-                    }
-                    attributes.add(new AttributeImpl(parsedName, Date.from(instant)));
-                    break;
-                case BINARY:
-                    attributes.add(new AttributeImpl(parsedName, IOUtils.toByteArray(inputStream)));
-                    break;
-                case OBJECT:
-                    LOGGER.debug("Object type not supported for override");
-                    break;
-                }
-            } catch (IOException e) {
-                LOGGER.debug("Unable to read attribute to override", e);
-            } finally {
-                IOUtils.closeQuietly(inputStream);
+                .map(AttributeType::getAttributeFormat)
+                .ifPresent((attributeFormat) -> parseAttribute(attributes,
+                        parsedName,
+                        inputStream,
+                        attributeFormat));
+    }
+
+    private void parseAttribute(List<Attribute> attributes, String parsedName,
+            InputStream inputStream, AttributeType.AttributeFormat attributeFormat) {
+        try (InputStream is = inputStream; InputStream boundedStream = new BoundedInputStream(is,
+                MAX_INPUT_SIZE + 1)) {
+            if (attributeFormat == OBJECT) {
+                LOGGER.debug("Object type not supported for override");
+                return;
             }
 
-        });
+            byte[] bytes = IOUtils.toByteArray(boundedStream);
+            if (bytes.length > MAX_INPUT_SIZE) {
+                LOGGER.debug("Attribute length is limited to {} bytes", MAX_INPUT_SIZE);
+                return;
+            }
+
+            if (attributeFormat == BINARY) {
+                attributes.add(new AttributeImpl(parsedName, bytes));
+                return;
+            }
+
+            String attribute = new String(bytes, Charset.defaultCharset());
+
+            switch (attributeFormat) {
+            case XML:
+            case GEOMETRY:
+            case STRING:
+                attributes.add(new AttributeImpl(parsedName, attribute));
+                break;
+            case BOOLEAN:
+                attributes.add(new AttributeImpl(parsedName, Boolean.valueOf(attribute)));
+                break;
+            case SHORT:
+                attributes.add(new AttributeImpl(parsedName, Short.valueOf(attribute)));
+                break;
+            case LONG:
+                attributes.add(new AttributeImpl(parsedName, Long.valueOf(attribute)));
+                break;
+            case INTEGER:
+                attributes.add(new AttributeImpl(parsedName, Integer.valueOf(attribute)));
+                break;
+            case FLOAT:
+                attributes.add(new AttributeImpl(parsedName, Float.valueOf(attribute)));
+                break;
+            case DOUBLE:
+                attributes.add(new AttributeImpl(parsedName, Double.valueOf(attribute)));
+                break;
+            case DATE:
+                try {
+                    Instant instant = Instant.parse(attribute);
+                    attributes.add(new AttributeImpl(parsedName, Date.from(instant)));
+                } catch (DateTimeParseException e) {
+                    LOGGER.debug("Unable to parse instant '{}'", attribute, e);
+                }
+                break;
+            default:
+                LOGGER.debug("Attribute format '{}' not supported", attributeFormat);
+                break;
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Unable to read attribute to override", e);
+        }
     }
 
     private Metacard parseMetadata(String transformerParam, Metacard metacard,
@@ -1277,8 +1294,8 @@ public class RESTEndpoint implements RESTService {
             if (rangeHeader.startsWith(BYTES_EQUAL)) {
                 String tempString = rangeHeader.substring(BYTES_EQUAL.length());
                 if (tempString.contains("-")) {
-                    response = rangeHeader.substring(BYTES_EQUAL.length(), rangeHeader.lastIndexOf(
-                            "-"));
+                    response = rangeHeader.substring(BYTES_EQUAL.length(),
+                            rangeHeader.lastIndexOf("-"));
                 } else {
                     response = rangeHeader.substring(BYTES_EQUAL.length());
                 }

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/TestRestEndpoint.java
@@ -66,6 +66,8 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
+
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.content.operation.CreateStorageRequest;
 import ddf.catalog.data.BinaryContent;
@@ -349,6 +351,67 @@ public class TestRestEndpoint {
         createInfo = rest.parseAttachments(attachments, "xml");
 
         assertThat(createInfo.getMetacard().getMetadata(), equalTo("<meta>beta</meta>"));
+        assertThat(createInfo.getMetacard().getAttribute("foo"), equalTo(null));
+    }
+
+    @Test
+    public void testParseAttachmentsTooLarge()
+            throws IOException, CatalogTransformerException, SourceUnavailableException,
+            IngestException, InvalidSyntaxException, MimeTypeResolutionException,
+            URISyntaxException {
+        CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+        BundleContext bundleContext = mock(BundleContext.class);
+        Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+        ServiceReference serviceReference = mock(ServiceReference.class);
+        InputTransformer inputTransformer = mock(InputTransformer.class);
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setMetadata("Some Text Again");
+        when(inputTransformer.transform(any())).thenReturn(metacard);
+        when(bundleContext.getService(serviceReference)).thenReturn(inputTransformer);
+        serviceReferences.add(serviceReference);
+        when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)")).thenReturn(serviceReferences);
+
+        RESTEndpoint rest = new RESTEndpoint(framework) {
+            @Override
+            BundleContext getBundleContext() {
+                return bundleContext;
+            }
+        };
+        rest.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
+        MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
+        when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
+        when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
+        rest.setMimeTypeMapper(mimeTypeMapper);
+
+        addMatchingService(rest, Arrays.asList(getSimpleTransformer()));
+
+        List<Attachment> attachments = new ArrayList<>();
+        ContentDisposition contentDisposition = new ContentDisposition(
+                "form-data; name=parse.resource; filename=C:\\DDF\\metacard.txt");
+        Attachment attachment = new Attachment("parse.resource", new ByteArrayInputStream("Some Text".getBytes()), contentDisposition);
+        attachments.add(attachment);
+        ContentDisposition contentDisposition1 = new ContentDisposition(
+                "form-data; name=parse.metadata; filename=C:\\DDF\\metacard.xml");
+        Attachment attachment1 = new Attachment("parse.metadata", new ByteArrayInputStream("Some Text Again".getBytes()), contentDisposition1);
+        attachments.add(attachment1);
+
+        RESTEndpoint.CreateInfo createInfo = rest.parseAttachments(attachments, "xml");
+        assertThat(createInfo.getMetacard().getMetadata(), equalTo("Some Text Again"));
+
+        ContentDisposition contentDisposition2 = new ContentDisposition(
+                "form-data; name=metadata; filename=C:\\DDF\\metacard.xml");
+        Attachment attachment2 = new Attachment("metadata", new ByteArrayInputStream(Strings.repeat("hi", 100_000).getBytes()), contentDisposition2);
+        attachments.add(attachment2);
+
+        ContentDisposition contentDisposition3 = new ContentDisposition(
+                "form-data; name=foo; filename=C:\\DDF\\metacard.xml");
+        Attachment attachment3 = new Attachment("foo", new ByteArrayInputStream("bar".getBytes()), contentDisposition3);
+        attachments.add(attachment3);
+
+        createInfo = rest.parseAttachments(attachments, "xml");
+
+        // Ensure that the metadata was not overriden because it was too large to be parsed
+        assertThat(createInfo.getMetacard().getMetadata(), equalTo("Some Text Again"));
         assertThat(createInfo.getMetacard().getAttribute("foo"), equalTo(null));
     }
 

--- a/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor-table-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor-table-contents.adoc
@@ -1,3 +1,10 @@
+:title: Content Directory Monitor
+:id: org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor
+:type: table
+:status: published
+:application: ${ddf-catalog}
+:summary: Content Directory Monitor configurations.
+
 .[[org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor]]Catalog Content Directory Monitor
 [cols="1,1m,1,3,1,1" options="header"]
 |===


### PR DESCRIPTION
#### What does this PR do?
 - Maximum attribute data size is capped to 65,535 bytes

#### Who is reviewing it? 
@anyone
#### Select relevant component teams: 
@codice/security
#### Choose 2 committers to review/merge the PR. 
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1. Ensure you cannot override an attribute with data greater than 65,535 in size.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3223

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
