### PR TITLE
DDF-2304 Fix InsecureDefaultsCollector.getTruststorePath

### DIFF
--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsCollector.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/InsecureDefaultsCollector.java
@@ -241,7 +241,7 @@ public class InsecureDefaultsCollector implements Runnable {
     }
 
     private String getTruststorePath() {
-        return new AbsolutePathResolver(TRUSTSTORE_SYSTEM_PROPERTY).getPath();
+        return new AbsolutePathResolver(System.getProperty(TRUSTSTORE_SYSTEM_PROPERTY)).getPath();
     }
 
     private String getTruststorePassword() {


### PR DESCRIPTION
#### What does this PR do?
Fix InsecureDefaultsCollector.getTruststorePath
#### Who is reviewing it? 
@tbatie @vinamartin 

#### Choose 2 committers to review/merge the PR. 
@bdeining
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and verify that the insecure defaults alert doesn't contain any detail message about not being able to load a keystore/truststore.

#### What are the relevant tickets?
[DDF-2304](https://codice.atlassian.net/browse/DDF-2304)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
