### PR TITLE
DDF-3225 Improve performance of XStreamPathConverter

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
@@ -175,6 +175,41 @@ public class TestXstreamPathConverter {
         assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
         assertThat(converter.doBasicPathsMatch(path1, path1), is(true));
         assertThat(converter.doBasicPathsMatch(path2, path2), is(true));
+
+        path1 = new Path("/a/b/c[2]/@asdf");
+        path2 = new Path("/a/b/c");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(true));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
+
+        path1 = new Path("/a/b/c/@asdf");
+        path2 = new Path("/a/b/c");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(true));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
+
+        path1 = new Path("/a/b[2]/c[5]/@hello");
+        path2 = new Path("/a/b[2]/c[7]/@goodbye");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(true));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
+
+        path1 = new Path("/a/b[2]/c/@hello");
+        path2 = new Path("/a/b[2]/c/@goodbye");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(true));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
+
+        path1 = new Path("/a/b/c/def");
+        path2 = new Path("/a/b/c/def");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(true));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(true));
+
+        path1 = new Path("/a/b/c/def");
+        path2 = new Path("/a/b/c/deg");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(false));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(false));
+
+        path1 = new Path("/c/b/a");
+        path2 = new Path("/a/b/c");
+        assertThat(converter.doBasicPathsMatch(path1, path2), is(false));
+        assertThat(converter.doBasicPathsMatch(path2, path1), is(false));
     }
 
     private void assertRepeatedElements(String xml) throws XMLStreamException {


### PR DESCRIPTION
#### What does this PR do?
Migrates the path matching done in XStreamPathMatcher away from using regular expression matching, in favor of considerably more performant character array processing. This change has resulted in about a 5x increase in performance, with ingest taking around 18.5% of the time previously recorded. I've also added a few unit test assertions to ensure the path matching is behaving as expected in edge cases.

The old code was considerably more readable, but I've done my best to keep this code relatively maintainable, despite its lower-level, by adding explanatory javadoc, and extracting the more complicated portions of the comparison to helper methods. I'm definitely open to any suggestions that would improve readability.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@brianfelix @mackncheesiest @glenhein 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
@codice/io 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.
If we're looking to confirm performance improvements, we can ingest a large data set using a transformer that uses XStreamPathMatcher on current master and compare it to the performance on this PR build.

#### What are the relevant tickets?
[DDF-3225](https://codice.atlassian.net/browse/DDF-3225)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
