### PR TITLE
DDF-3220 Disable local catalog searching from Intrigue.

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -124,6 +124,8 @@ public class ConfigurationApplication implements SparkApplication {
         return readOnly;
     }
 
+    private boolean disableLocalCatalog = false;
+
     private boolean queryFeedbackEnabled = false;
 
     private String queryFeedbackEmailSubjectTemplate;
@@ -253,6 +255,7 @@ public class ConfigurationApplication implements SparkApplication {
         config.put("scheduleFrequencyList", scheduleFrequencyList);
         config.put("isEditingAllowed", isEditingAllowed);
         config.put("isCacheDisabled", isCacheDisabled);
+        config.put("disableLocalCatalog", disableLocalCatalog);
         config.put("queryFeedbackEnabled", queryFeedbackEnabled);
         config.put("queryFeedbackEmailSubjectTemplate", queryFeedbackEmailSubjectTemplate);
         config.put("queryFeedbackEmailBodyTemplate", queryFeedbackEmailBodyTemplate);
@@ -600,6 +603,14 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setExternalAuthentication(Boolean isExternalAuthentication) {
         this.isExternalAuthentication = isExternalAuthentication;
+    }
+
+    public boolean isDisableLocalCatalog() {
+        return disableLocalCatalog;
+    }
+
+    public void setDisableLocalCatalog(boolean disableLocalCatalog) {
+        this.disableLocalCatalog = disableLocalCatalog;
     }
 
     public void setQueryFeedbackEnabled(boolean queryFeedbackEnabled) {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -173,6 +173,12 @@
             default="25"
             required="true"/>
 
+        <AD id="disableLocalCatalog"
+            name="Disable Local Catalog"
+            description="Disables queries to the local catalog"
+            type="Boolean"
+            default="false" />
+
         <AD id="queryFeedbackEnabled"
             name="Enable Query Feedback"
             description="Enable the query comments option."

--- a/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
@@ -108,7 +108,11 @@ define(function (require) {
         },
         isFeedbackRestricted: function(){
             return !this.queryFeedbackEnabled;
+        },
+        isDisableLocalCatalog: function(){
+            return this.disableLocalCatalog;
         }
+
     };
 
     return properties.init();

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -193,6 +193,14 @@ TMS example (3d map support only): `[{"type" : "TMS", "url" : "https://cesiumjs.
 |25
 |true
 
+|Disable Local Catalog
+|disableLocalCatalog
+|Boolean
+|Disables querying the local catalog from UI only.
+|false
+|true
+
+
 |Enable Query Feedback
 |queryFeedbackEnabled
 |Boolean


### PR DESCRIPTION
#### What does this PR do?
Disables searching the local catalog from Intrigue. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka  
@albany551  

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Install DDF
Configure Catalog UI Search and check `Disable Local Catalog`
Configure a local source (e.g. CSW)
Ingest some data via CSW
Launch Intrigue and create a new search. Select providers. 
Verify that `ddf.distribution` or similar is not present but the CSW source is.

#### Any background context you want to provide?
This allows integrators to use Intrigue while providing separate middleware for query.

#### What are the relevant tickets?
[DDF-3220](https://codice.atlassian.net/browse/DDF-3220)

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
