### PR TITLE
DDF-3226 Removed 'Open View in New Tab' link in System->Logs in Admin UI

### DIFF
--- a/platform/admin/core/admin-core-logviewer/src/main/webapp/js/components/log-panel/log-panel.js
+++ b/platform/admin/core/admin-core-logviewer/src/main/webapp/js/components/log-panel/log-panel.js
@@ -28,16 +28,6 @@ const panelClass = () => {
   }
 }
 
-const iframeNewTab = () => {
-  if (window !== window.top) {
-    return (
-      <a href='/admin/logviewer/index.html' target='_blank' className='newTabLink'>
-        Open Viewer in New Tab
-      </a>
-    )
-  }
-}
-
 const LogPanel = connect(({ filter, logs, displaySize, expandedHash }) => ({
   filter, logs, displaySize, expandedHash
 }))(LogViewer)
@@ -45,7 +35,6 @@ const LogPanel = connect(({ filter, logs, displaySize, expandedHash }) => ({
 export default () => {
   return (
     <div>
-      {iframeNewTab()}
       <div className={panelClass()}>
         <LogPanel />
       </div>


### PR DESCRIPTION
#### What does this PR do?
Removes the link in **Admin UI -> System -> Logs** that allows the log viewer to be seen in a new tab.
#### Who is reviewing it? 
@djblue 
@vinamartin 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
1. Build and run DDF
2. Go to the Admin UI -> System -> Logs
3. Verify there is no link to open the logs in a new tab, and no issues related to these changes
#### What are the relevant tickets?
[DDF-3226](https://codice.atlassian.net/browse/)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
