### PR TITLE
DDF-3229 Fix intrigue endpoints from reading data infinitely

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -34,6 +34,9 @@ import org.apache.commons.collections.Factory;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.boon.json.JsonFactory;
+import org.boon.json.JsonParserFactory;
+import org.boon.json.JsonSerializerFactory;
+import org.boon.json.ObjectMapper;
 import org.codice.ddf.branding.BrandingPlugin;
 import org.codice.proxy.http.HttpProxyService;
 import org.slf4j.Logger;
@@ -126,6 +129,10 @@ public class ConfigurationApplication implements SparkApplication {
         return readOnly;
     }
 
+    private ObjectMapper objectMapper = JsonFactory.create(new JsonParserFactory(),
+            new JsonSerializerFactory().includeNulls()
+                    .includeEmpty());
+
     private boolean disableLocalCatalog = false;
 
     private boolean queryFeedbackEnabled = false;
@@ -135,6 +142,8 @@ public class ConfigurationApplication implements SparkApplication {
     private String queryFeedbackEmailBodyTemplate;
 
     private String queryFeedbackEmailDestination;
+
+    private int maximumUploadSize = 1_048_576;
 
     public List<String> getAttributeAliases() {
         return attributeAliases.entrySet()
@@ -161,6 +170,14 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setResultShow(List<String> resultShow) {
         this.resultShow = resultShow;
+    }
+
+    public void setMaximumUploadSize(int size) {
+        this.maximumUploadSize = size;
+    }
+
+    public int getMaximumUploadSize() {
+        return maximumUploadSize;
     }
 
     public void setAttributeAliases(List<String> attributeAliases) {
@@ -268,14 +285,13 @@ public class ConfigurationApplication implements SparkApplication {
 
     @Override
     public void init() {
-        get("/config", (req, res) -> this.getConfig(), JsonFactory.create()::toJson);
+        get("/config", (req, res) -> this.getConfig(), objectMapper::toJson);
 
         exception(Exception.class, (ex, req, res) -> {
             res.status(500);
             res.header(CONTENT_TYPE, APPLICATION_JSON);
             LOGGER.warn("Failed to serve request.", ex);
-            res.body(JsonFactory.create()
-                    .toJson(ImmutableMap.of("message", ex.getMessage())));
+            res.body(objectMapper.toJson(ImmutableMap.of("message", ex.getMessage())));
         });
     }
 
@@ -402,7 +418,8 @@ public class ConfigurationApplication implements SparkApplication {
         imageryProviderUrlMaps.clear();
         for (Map<String, Object> newImageryProvider : newImageryProviders) {
             HashMap<String, Object> map = new HashMap<>(newImageryProvider);
-            String imageryProviderUrl = newImageryProvider.get(URL).toString();
+            String imageryProviderUrl = newImageryProvider.get(URL)
+                    .toString();
             boolean proxyEnabled = true;
             Object proxyEnabledProp = newImageryProvider.get(PROXY_ENABLED);
             if (proxyEnabledProp instanceof Boolean) {
@@ -410,8 +427,7 @@ public class ConfigurationApplication implements SparkApplication {
             }
 
             if (proxyEnabled) {
-                map.put(URL,
-                        SERVLET_PATH + "/" + urlToProxyMap.get(imageryProviderUrl));
+                map.put(URL, SERVLET_PATH + "/" + urlToProxyMap.get(imageryProviderUrl));
             } else {
                 map.put(URL, imageryProviderUrl);
             }
@@ -507,7 +523,7 @@ public class ConfigurationApplication implements SparkApplication {
         return resultPageSize;
     }
 
-    public void setResultPageSize(Integer resultPageSize){
+    public void setResultPageSize(Integer resultPageSize) {
         this.resultPageSize = resultPageSize;
     }
 
@@ -551,7 +567,7 @@ public class ConfigurationApplication implements SparkApplication {
         return this.isEditingAllowed;
     }
 
-    public void setIsEditingAllowed(Boolean isEditingAllowed){
+    public void setIsEditingAllowed(Boolean isEditingAllowed) {
         this.isEditingAllowed = isEditingAllowed;
     }
 
@@ -653,4 +669,5 @@ public class ConfigurationApplication implements SparkApplication {
     public void setQueryFeedbackEmailDestination(String queryFeedbackEmailDestination) {
         this.queryFeedbackEmailDestination = queryFeedbackEmailDestination;
     }
+
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/EntityTooLargeException.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/EntityTooLargeException.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard;
+
+/**
+ * Exception class for a HTTP 413 status code - Entity Too Large 
+ */
+public class EntityTooLargeException extends RuntimeException {
+    private String ip;
+
+    private String userAgent;
+
+    private String url;
+
+    private int id;
+
+    public EntityTooLargeException(String ip, String userAgent, String url, int id) {
+        super();
+        this.ip = ip;
+        this.userAgent = userAgent;
+        this.url = url;
+        this.id = id;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(
+                "Client sent a request body that was too large. {ip='%s', userClient='%s', url='%s', id='0x%08X'",
+                ip,
+                userAgent,
+                url,
+                id);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getStringId() {
+        return String.format("0x%08X", id);
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -123,6 +123,7 @@
         <argument>
             <reference interface="ddf.catalog.data.AttributeRegistry" availability="optional"/>
         </argument>
+        <argument ref="configurationApplication" />
     </bean>
 
     <bean id="workspaceTransformer"
@@ -208,6 +209,7 @@
         <property name="filterAdapter" ref="filterAdapter"/>
         <property name="actionRegistry" ref="metacardActionRegistry"/>
         <property name="featureService" ref="featureService"/>
+        <property name="endpointUtil" ref="endpointUtil" />
     </bean>
 
     <bean id="feedbackApplication" class="org.codice.ddf.catalog.ui.query.FeedbackApplication">
@@ -218,6 +220,7 @@
 
         <property name="configurationApplication" ref="configurationApplication"/>
         <property name="smtpClient" ref="smtpClient"/>
+        <property name="endpointUtil" ref="endpointUtil" />
     </bean>
 
     <reference id="persistentStore" interface="org.codice.ddf.persistence.PersistentStore"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -207,6 +207,13 @@
             default=""
             required="true"/>
 
+        <AD id="maximumUploadSize"
+            name="Maximum Endpoint Upload Size"
+            description="The maximum size (in bytes) to allow per client when receiving a POST/PATCH/PUT. Note: This does not affect product upload size, just the maximum size allowed for calls from Intrigue"
+            type="Integer"
+            default="1048576"
+            required="true"/>
+
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.ui.config">

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.codice.ddf.catalog.ui.config.ConfigurationApplication;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.Filter;
@@ -78,6 +79,8 @@ public class EndpointUtilTest {
 
         AttributeBuilder attributeBuilderMock = mock(AttributeBuilder.class);
 
+        ConfigurationApplication configurationApplicationMock = mock(ConfigurationApplication.class);
+
         ContextualExpressionBuilder contextualExpressionBuilderMock = mock(
                 ContextualExpressionBuilder.class);
 
@@ -95,6 +98,7 @@ public class EndpointUtilTest {
         when(attributeBuilderMock.like()).thenReturn(contextualExpressionBuilderMock);
         when(contextualExpressionBuilderMock.text(anyString())).thenReturn(filterMock);
         when(catalogFrameworkMock.query(any(QueryRequestImpl.class))).thenReturn(responseMock);
+        when(configurationApplicationMock.getMaximumUploadSize()).thenReturn(1<<20);
 
         when(resultMock.getMetacard()).thenReturn(metacardMock);
         when(metacardMock.getId()).thenReturn("MOCK METACARD");
@@ -104,7 +108,8 @@ public class EndpointUtilTest {
                 catalogFrameworkMock,
                 filterBuilderMock,
                 injectableAttributeList,
-                attributeRegistryMock);
+                attributeRegistryMock,
+                configurationApplicationMock);
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Fixes intrigue endpoints from reading data indefinitely.
#### Who is reviewing it? 
anyone
#### Select relevant component teams: 
@codice/security 
#### Choose 2 committers to review/merge the PR. 
@clockard
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
Ensure you cannot upload to any Intrigue post/patch/put endpoint with a blob greater than 1MB in size
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3229

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
