### PR TITLE
DDF-3231 Fix ConnectedSources in CachingFederationStrategy

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
@@ -337,7 +337,7 @@ public class CachingFederationStrategyTest {
     }
 
     @Test
-    public void testFederateDuplicateSources() throws Exception {
+    public void testConnectedSources() throws Exception {
         Query mockQ = new QueryImpl(mock(NullFilterImpl.class),
                 2,
                 2,
@@ -358,8 +358,9 @@ public class CachingFederationStrategyTest {
 
         strategy.federate(sources, fedQueryRequest);
 
+        // Make sure both sources get called even though they have the same name
         verify(sources.get(0), atLeastOnce()).query(any(QueryRequest.class));
-        verify(sources.get(1), times(0)).query(any(QueryRequest.class));
+        verify(sources.get(1), atLeastOnce()).query(any(QueryRequest.class));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Fixes CachingFederationStrategy so connected sources aren't filtered out as duplicates.
#### Who is reviewing it? 
@mcalcote @vinamartin 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)

@bdeining
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and add a confluence connected source. 
Upload a product to the local DDF.
Perform a search and verify you get results back from both the local catalog and the confluence source. (Note: The results will all show as from the local source so you will need to look at some other attribute on the results to verify where they came from)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3231](https://codice.atlassian.net/browse/DDF-3231)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
