### PR TITLE
DDF-3184 Added a configurable option to the OpenSearchSource for parsing the response

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -306,8 +306,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             }
         } else {
             if (StringUtils.isEmpty((String) metacardId)) {
-                OpenSearchFilterVisitorObject
-                        openSearchFilterVisitorObject = (OpenSearchFilterVisitorObject) query.accept(openSearchFilterVisitor, new OpenSearchFilterVisitorObject());
+                OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+                        (OpenSearchFilterVisitorObject) query.accept(openSearchFilterVisitor,
+                                new OpenSearchFilterVisitorObject());
                 metacardId = openSearchFilterVisitorObject.getId();
             }
             restWebClient = newRestClient(query, (String) metacardId, false, subject);
@@ -403,8 +404,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             }
         }
 
-        OpenSearchFilterVisitorObject
-                openSearchFilterVisitorObject = (OpenSearchFilterVisitorObject) query.accept(openSearchFilterVisitor, new OpenSearchFilterVisitorObject());
+        OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+                (OpenSearchFilterVisitorObject) query.accept(openSearchFilterVisitor,
+                        new OpenSearchFilterVisitorObject());
 
         ContextualSearch contextualFilter = openSearchFilterVisitorObject.getContextualSearch();
 
@@ -422,9 +424,11 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             return true;
 
             // ensure that there is no search phrase - we will add our own
-        } else if ((openSearchFilterVisitorObject.getSpatialSearch() != null && contextualFilter != null
+        } else if ((openSearchFilterVisitorObject.getSpatialSearch() != null
+                && contextualFilter != null
                 && MapUtils.isEmpty(contextualFilter.getSearchPhraseMap())) || (
-                openSearchFilterVisitorObject.getSpatialSearch() != null && contextualFilter == null)) {
+                openSearchFilterVisitorObject.getSpatialSearch() != null
+                        && contextualFilter == null)) {
 
             openSearchParser.populateSearchOptions(client, queryRequest, subject, parameters);
 
@@ -954,12 +958,10 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
     private List<Metacard> processAdditionalForeignMarkups(Element element, String id) {
         List<Metacard> metacards = new ArrayList<>();
-        if (CollectionUtils.isNotEmpty(markUpSet)) {
+        if (CollectionUtils.isNotEmpty(markUpSet) && markUpSet.contains(element.getName())) {
             XMLOutputter xmlOutputter = new XMLOutputter();
-            if (markUpSet.contains(element.getName())) {
-                Metacard metacard = parseContent(xmlOutputter.outputString(element), id);
-                metacards.add(metacard);
-            }
+            Metacard metacard = parseContent(xmlOutputter.outputString(element), id);
+            metacards.add(metacard);
         }
         return metacards;
     }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,6 +39,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.TransformerException;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -49,6 +51,7 @@ import org.codice.ddf.endpoints.OpenSearch;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.geotools.filter.FilterTransformer;
 import org.jdom2.Element;
+import org.jdom2.output.XMLOutputter;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -144,6 +147,8 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     private String configurationPid;
 
     private List<String> parameters;
+
+    private Set<String> markUpSet;
 
     private String username;
 
@@ -507,12 +512,14 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
         List<Element> foreignMarkup = entry.getForeignMarkup();
         String relevance = "";
         String source = "";
+
         for (Element element : foreignMarkup) {
             if (element.getName()
                     .equals("score")) {
                 relevance = element.getContent(0)
                         .getValue();
             }
+            metacards.addAll(processAdditionalForeignMarkups(element, id));
         }
         //we currently do not support downloading content via an RSS enclosure, this support can be added at a later date if we decide to include it
         for (SyndContent content : contents) {
@@ -765,6 +772,14 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
         this.configurationPid = configurationPid;
     }
 
+    public List<String> getMarkUpSet() {
+        return new ArrayList<>(markUpSet);
+    }
+
+    public void setMarkUpSet(List<String> markUpSet) {
+        this.markUpSet = new HashSet<>(markUpSet);
+    }
+
     public List<String> getParameters() {
         return parameters;
     }
@@ -936,4 +951,17 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             client.replaceQueryParam(URL_SRC_PARAMETER, "");
         }
     }
+
+    private List<Metacard> processAdditionalForeignMarkups(Element element, String id) {
+        List<Metacard> metacards = new ArrayList<>();
+        if (CollectionUtils.isNotEmpty(markUpSet)) {
+            XMLOutputter xmlOutputter = new XMLOutputter();
+            if (markUpSet.contains(element.getName())) {
+                Metacard metacard = parseContent(xmlOutputter.outputString(element), id);
+                metacards.add(metacard);
+            }
+        }
+        return metacards;
+    }
+
 }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -81,6 +81,9 @@
                 </list>
             </property>
             <property name="resourceReader" ref="resourceReader"/>
+            <property name="markUpSet">
+                <list />
+            </property>
         </cm:managed-component>
     </cm:managed-service-factory>
     

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -49,7 +49,7 @@
 
         <AD name="Convert to BBox" id="shouldConvertToBBox" required="true"
             type="Boolean" default="true"
-            description="Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry."/>
+            description="Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry."/>
 
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"
@@ -62,6 +62,12 @@
         <AD description="Amount of time to wait for a response before timing out, in milliseconds."
             name="Receive Timeout" id="receiveTimeout"
             required="true" type="Integer" default="60000"/>
+
+        <AD name="Entry XML Element" id="markUpSet" required="false"
+            type="String"
+            default=""
+            cardinality="100"
+            description="XML Element from the Response Entry to transform into a Metacard."/>
     </OCD>
 
     <!--

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
@@ -14,6 +14,7 @@
 package ddf.catalog.source.opensearch.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
@@ -30,6 +31,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +80,8 @@ import ddf.security.encryption.EncryptionService;
  */
 public class TestOpenSearchSource {
 
+    private static final String RESOURCE_TAG = "Resource";
+
     private static final GeotoolsFilterAdapterImpl FILTER_ADAPTER = new GeotoolsFilterAdapterImpl();
 
     private static final String SAMPLE_ID = "abcdef12345678900987654321fedcba";
@@ -109,6 +113,69 @@ public class TestOpenSearchSource {
             "sort");
 
     private static FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+
+    private static InputStream getSampleAtomStreamWithForeignMarkup() {
+        String response =
+                "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:os=\"http://a9.com/-/spec/opensearch/1.1/\">\r\n"
+                        + "    <title type=\"text\">Query Response</title>\r\n"
+                        + "    <updated>2013-01-31T23:22:37.298Z</updated>\r\n"
+                        + "    <id>urn:uuid:a27352c9-f935-45f0-9b8c-5803095164bb</id>\r\n"
+                        + "    <link href=\"#\" rel=\"self\" />\r\n" + "    <author>\r\n"
+                        + "        <name>Codice</name>\r\n" + "    </author>\r\n"
+                        + "    <generator version=\"2.1.0.20130129-1341\">ddf123</generator>\r\n"
+                        + "    <os:totalResults>1</os:totalResults>\r\n"
+                        + "    <os:itemsPerPage>10</os:itemsPerPage>\r\n"
+                        + "    <os:startIndex>1</os:startIndex>\r\n"
+                        + "    <entry xmlns:relevance=\"http://a9.com/-/opensearch/extensions/relevance/1.0/\" xmlns:fs=\"http://a9.com/-/opensearch/extensions/federation/1.0/\"\r\n"
+                        + "        xmlns:georss=\"http://www.georss.org/georss\">\r\n"
+                        + "        <fs:resultSource fs:sourceId=\"ddf123\" />\r\n"
+                        + "        <relevance:score>0.19</relevance:score>\r\n"
+                        + "        <id>urn:catalog:id:ee7a161e01754b9db1872bfe39d1ea09</id>\r\n"
+                        + "        <title type=\"text\">F-15 lands in Libya; Crew Picked Up</title>\r\n"
+                        + "        <updated>2013-01-31T23:22:31.648Z</updated>\r\n"
+                        + "        <published>2013-01-31T23:22:31.648Z</published>\r\n"
+                        + "        <link href=\"http://123.45.67.123:8181/services/catalog/ddf123/ee7a161e01754b9db1872bfe39d1ea09\" rel=\"alternate\" title=\"View Complete Metacard\" />\r\n"
+                        + "        <category term=\"Resource\" />\r\n"
+                        + "        <georss:where xmlns:gml=\"http://www.opengis.net/gml\">\r\n"
+                        + "            <gml:Point>\r\n"
+                        + "                <gml:pos>32.8751900768792 13.1874561309814</gml:pos>\r\n"
+                        + "            </gml:Point>\r\n" + "        </georss:where>\r\n"
+                        + "        <Resource:Resource xmlns=\"http://sample.com/resource\" xmlns:ns5=\"http://www.w3.org/1999/xlink\" xmlns:Resource=\"http://sample.com/resource\">"
+                        + "            <ns3:metacard xmlns:ns3=\"urn:catalog:metacard\" xmlns:ns2=\"http://www.w3.org/1999/xlink\" xmlns:ns1=\"http://www.opengis.net/gml\"\r\n"
+                        + "                xmlns:ns4=\"http://www.w3.org/2001/SMIL20/\" xmlns:ns5=\"http://www.w3.org/2001/SMIL20/Language\" ns1:id=\"4535c53fc8bc4404a1d32a5ce7a29585\">\r\n"
+                        + "                <ns3:type>ddf.metacard</ns3:type>\r\n"
+                        + "                <ns3:source>ddf.distribution</ns3:source>\r\n"
+                        + "                <ns3:geometry name=\"location\">\r\n"
+                        + "                    <ns3:value>\r\n"
+                        + "                        <ns1:Point>\r\n"
+                        + "                            <ns1:pos>32.8751900768792 13.1874561309814</ns1:pos>\r\n"
+                        + "                        </ns1:Point>\r\n"
+                        + "                    </ns3:value>\r\n"
+                        + "                </ns3:geometry>\r\n"
+                        + "                <ns3:dateTime name=\"created\">\r\n"
+                        + "                    <ns3:value>2013-01-31T16:22:31.648-07:00</ns3:value>\r\n"
+                        + "                </ns3:dateTime>\r\n"
+                        + "                <ns3:dateTime name=\"modified\">\r\n"
+                        + "                    <ns3:value>2013-01-31T16:22:31.648-07:00</ns3:value>\r\n"
+                        + "                </ns3:dateTime>\r\n"
+                        + "                <ns3:stringxml name=\"metadata\">\r\n"
+                        + "                    <ns3:value>\r\n"
+                        + "                        <ns6:xml xmlns:ns6=\"urn:sample:namespace\" xmlns=\"urn:sample:namespace\">Example description.</ns6:xml>\r\n"
+                        + "                    </ns3:value>\r\n"
+                        + "                </ns3:stringxml>\r\n"
+                        + "                <ns3:string name=\"metadata-content-type-version\">\r\n"
+                        + "                    <ns3:value>myVersion</ns3:value>\r\n"
+                        + "                </ns3:string>\r\n"
+                        + "                <ns3:string name=\"metadata-content-type\">\r\n"
+                        + "                    <ns3:value>myType</ns3:value>\r\n"
+                        + "                </ns3:string>\r\n"
+                        + "                <ns3:string name=\"title\">\r\n"
+                        + "                    <ns3:value>Example title</ns3:value>\r\n"
+                        + "                </ns3:string>\r\n" + "            </ns3:metacard>\r\n"
+                        + "        </Resource:Resource>\r\n" + "    </entry>\r\n" + "</feed>";
+        return new ByteArrayInputStream(response.getBytes());
+
+    }
 
     private static InputStream getSampleAtomStream() {
         String response =
@@ -349,7 +416,7 @@ public class TestOpenSearchSource {
         Result result = results.get(0);
         Metacard metacard = result.getMetacard();
         assertThat(metacard, notNullValue());
-        assertThat(metacard.getContentTypeName(), is("Resource"));
+        assertThat(metacard.getContentTypeName(), is(RESOURCE_TAG));
     }
 
     @Test
@@ -374,7 +441,7 @@ public class TestOpenSearchSource {
         Result result = results.get(0);
         Metacard metacard = result.getMetacard();
         assertThat(metacard, notNullValue());
-        assertThat(metacard.getContentTypeName(), is("Resource"));
+        assertThat(metacard.getContentTypeName(), is(RESOURCE_TAG));
     }
 
     @Test
@@ -466,6 +533,24 @@ public class TestOpenSearchSource {
                 .text(SAMPLE_SEARCH_PHRASE);
 
         source.query(new QueryRequestImpl(new QueryImpl(filter)));
+    }
+
+    @Test
+    public void testQueryResponseWithForeignMarkup() throws UnsupportedQueryException, IOException {
+        source.setMarkUpSet(Collections.singletonList("Resource"));
+        when(response.getEntity()).thenReturn(getSampleAtomStreamWithForeignMarkup());
+        
+        Filter filter = filterBuilder.attribute(Metacard.ANY_TEXT)
+                .like()
+                .text(SAMPLE_SEARCH_PHRASE);
+
+        SourceResponse response = source.query(new QueryRequestImpl(new QueryImpl(filter)));
+        assertThat(response.getHits(), is(1L));
+        List<Result> results = response.getResults();
+        assertThat(results, hasSize(1));
+        Metacard metacard = results.get(0).getMetacard();
+        assertThat(metacard.getId(), is(SAMPLE_ID));
+        assertThat(metacard.getContentTypeName(), is(RESOURCE_TAG));
     }
 
     /**

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
@@ -537,7 +537,7 @@ public class TestOpenSearchSource {
 
     @Test
     public void testQueryResponseWithForeignMarkup() throws UnsupportedQueryException, IOException {
-        source.setMarkUpSet(Collections.singletonList("Resource"));
+        source.setMarkUpSet(Collections.singletonList(RESOURCE_TAG));
         when(response.getEntity()).thenReturn(getSampleAtomStreamWithForeignMarkup());
         
         Filter filter = filterBuilder.attribute(Metacard.ANY_TEXT)


### PR DESCRIPTION
#### What does this PR do?
This PR makes the Entry XML configurable to allow for more robust atom response parsing and transformation into a metacard.
#### Who is reviewing it? 
@adimka 
@mackncheesiest 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Build / Install.  This functionality is covered in unit tests.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3184](https://codice.atlassian.net/browse/DDF-3184)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.