### PR TITLE
DDF-3234 Catalog REST endpoint should return 404 when a Metacard is not found, but returns 500

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/InternalServerErrorException.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/InternalServerErrorException.java
@@ -18,23 +18,23 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-public class ServerErrorException extends WebApplicationException {
+public class InternalServerErrorException extends WebApplicationException {
     /**
      *
      */
     private static final long serialVersionUID = 1L;
 
-    public ServerErrorException(String message, Status status) {
-        super(Response.status(status)
+    public InternalServerErrorException(String message) {
+        super(Response.status(Status.INTERNAL_SERVER_ERROR)
                 .entity("<pre>" + message + "</pre>")
                 .type(MediaType.TEXT_HTML)
                 .build());
 
     }
 
-    public ServerErrorException(Throwable t, Status status) {
+    public InternalServerErrorException(Throwable t) {
         super(t,
-                Response.status(status)
+                Response.status(Status.INTERNAL_SERVER_ERROR)
                         .entity("<pre>" + t.getMessage() + "</pre>")
                         .type(MediaType.TEXT_HTML)
                         .build());

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
@@ -47,7 +47,7 @@ public interface RESTService {
      * @param transformerParam (OPTIONAL)
      * @param uriInfo
      * @return
-     * @throws ServerErrorException
+     * @throws InternalServerErrorException
      */
     @GET
     @Path("/{id}")


### PR DESCRIPTION
#### What does this PR do?
Catalog REST endpoint should return 404 when a Metacard is not found, but returns 500
* Changed the server error exception that was thrown to return a 404 instead
* Changed `ServerErrorException` (now `InternalServerException`) to only throw Internal Server Errors (500)
* Created a private method (`createBadRequestResponse`) which creates a 400 instead of having `ServerErrorException` handle it

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@Lambeaux 
@rzwiefel  

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@kcwire 

#### How should this be tested? (List steps with links to updated documentation)
1- Successful build and making sure all tests pass
2- Making sure that a 404 is returned instead of a 500 when a Metacard is not found

#### What are the relevant tickets?
[DDF-3234](https://codice.atlassian.net/browse/DDF-3234)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.