### PR TITLE
DDF-3236 Added file path completion for ingest command

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -52,9 +52,11 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.support.completers.FileCompleter;
 import org.codice.ddf.commands.catalog.facade.CatalogFacade;
 import org.codice.ddf.platform.util.Exceptions;
 import org.fusesource.jansi.Ansi;
@@ -143,7 +145,8 @@ public class IngestCommand extends CatalogCommands {
     @Argument(name = "File path or Directory path", description =
             "File path to a record or a directory of files to be ingested. Paths are absolute and must be in quotes."
                     + " This command can only detect roughly 2 billion records in one folder. Individual operating system limits might also apply.", index = 0, multiValued = false, required = true)
-    String filePath = null;
+    @Completion(FileCompleter.class)
+    String filePath;
 
     // DDF-535: Remove this argument in ddf-3.0
     @Argument(name = "Batch size", description = "Number of Metacards to ingest at a time. Change this argument based on system memory and Catalog Provider limits. [DEPRECATED: use --batchsize option instead]", index = 1, multiValued = false, required = false)


### PR DESCRIPTION
#### What does this PR do?


#### Who is reviewing it? 
@spearskw 
@AzGoalie 
@mweser 
@ahoffer
@rzwiefel  

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
Build and attempt to do tab-filepath completion using the ingest command.

#### Any background context you want to provide?
This was already supported using this same feature for the validate command.

#### What are the relevant tickets?
[DDF-3236](https://codice.atlassian.net/browse/DDF-3236)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
