### PR TITLE
DDF-3237 Add ID claim to PropertyFileClaimsHandler

### DIFF
--- a/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.security.sts.claims.property.PropertyFileClaimsHandler-table-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.security.sts.claims.property.PropertyFileClaimsHandler-table-contents.adoc
@@ -23,6 +23,13 @@
 |http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role
 |true
 
+|ID Claim Type
+|idClaimType
+|String
+|ID claim URI.
+|http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier
+|true
+
 |User Role File
 |propertyFileLocation
 |String

--- a/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
@@ -138,7 +138,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,6 +30,8 @@
                 update-strategy="container-managed"/>
         <property name="roleClaimType"
                   value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"/>
+        <property name="idClaimType"
+                  value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"/>
         <property name="propertyFileLocation" value="${ddf.home}/etc/users.properties"/>
     </bean>
 

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,6 +25,11 @@
             description="Role claim URI.">
         </AD>
 
+        <AD name="ID Claim Type:" id="idClaimType" required="true" type="String"
+            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+            description="ID claim URI.">
+        </AD>
+
         <AD name="User Role File:" id="propertyFileLocation" required="true" type="String"
             default="etc/users.properties"
             description="Location of the file which maps roles to users.">

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestPropertyFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/TestPropertyFileClaimsHandler.java
@@ -15,12 +15,10 @@ package org.codice.ddf.security.sts.claims.property;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.Principal;
 
 import javax.security.auth.kerberos.KerberosPrincipal;
@@ -41,15 +39,15 @@ public class TestPropertyFileClaimsHandler {
         PropertyFileClaimsHandler propertyFileClaimsHandler = new PropertyFileClaimsHandler();
         propertyFileClaimsHandler.setPropertyFileLocation("/users.properties");
         propertyFileClaimsHandler.setRoleClaimType("http://myroletype");
+        propertyFileClaimsHandler.setIdClaimType("http://myidtype");
 
         ClaimCollection claimCollection = new ClaimCollection();
-        Claim claim = new Claim();
-        try {
-            claim.setClaimType(new URI("http://myroletype"));
-        } catch (URISyntaxException e) {
-            fail("Could not create URI");
-        }
-        claimCollection.add(claim);
+        Claim claim1 = new Claim();
+        claim1.setClaimType(URI.create("http://myroletype"));
+        Claim claim2 = new Claim();
+        claim2.setClaimType(URI.create("http://myidtype"));
+        claimCollection.add(claim1);
+        claimCollection.add(claim2);
         ClaimsParameters claimsParameters = mock(ClaimsParameters.class);
         Principal principal = mock(Principal.class);
         when(principal.getName()).thenReturn("admin");
@@ -57,11 +55,13 @@ public class TestPropertyFileClaimsHandler {
         ProcessedClaimCollection processedClaimCollection =
                 propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParameters);
 
-        assertEquals(1, processedClaimCollection.size());
+        assertEquals(2, processedClaimCollection.size());
         assertEquals(4,
                 processedClaimCollection.get(0)
                         .getValues()
                         .size());
+        assertEquals("admin",
+                processedClaimCollection.get(1).getValues().get(0));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
Add ID claim to PropertyFileClaimsHandler
#### Who is reviewing it? 
@vinamartin @emmberk  @mcalcote @ricklarsen 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@shaundmorris
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and login as admin.
Go to https:/localhost:8993/whoami and verify the admin has the claim http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier= [admin, guest]
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3237](https://codice.atlassian.net/browse/DDF-3237)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
