### PR TITLE
DDF-3236 Added window file path support

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -58,6 +58,7 @@ import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.support.completers.FileCompleter;
 import org.codice.ddf.commands.catalog.facade.CatalogFacade;
+import org.codice.ddf.commands.util.CrossPlatformFilePathEvaluator;
 import org.codice.ddf.platform.util.Exceptions;
 import org.fusesource.jansi.Ansi;
 import org.joda.time.Period;
@@ -288,7 +289,7 @@ public class IngestCommand extends CatalogCommands {
     }
 
     private File getInputFile() {
-        final File inputFile = new File(filePath);
+        final File inputFile = CrossPlatformFilePathEvaluator.handlePath(filePath);
 
         SecurityLogger.audit("Called catalog:ingest command with path : {}", filePath);
 
@@ -597,7 +598,7 @@ public class IngestCommand extends CatalogCommands {
     }
 
     private void processIncludeContent(ArrayBlockingQueue<Metacard> metacardQueue) {
-        File inputFile = new File(filePath);
+        File inputFile = CrossPlatformFilePathEvaluator.handlePath(filePath);
         Map<String, Serializable> arguments = new HashMap<>();
         arguments.put(DumpCommand.FILE_PATH, inputFile.getParent() + File.separator);
         arguments.put(FILE_NAME, inputFile.getName());

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
@@ -35,6 +35,7 @@ import org.apache.shiro.util.ThreadContext;
 import org.codice.ddf.commands.catalog.validation.ValidateExecutor;
 import org.codice.ddf.commands.catalog.validation.ValidatePrinter;
 import org.codice.ddf.commands.catalog.validation.ValidateReport;
+import org.codice.ddf.commands.util.CrossPlatformFilePathEvaluator;
 import org.codice.ddf.security.common.Security;
 
 import ddf.catalog.data.Metacard;
@@ -143,7 +144,7 @@ public class ValidateCommand extends CqlCommands {
     }
 
     private Collection<File> getFiles() throws FileNotFoundException {
-        File file = new File(path);
+        File file = CrossPlatformFilePathEvaluator.handlePath(path);
 
         if (!file.exists()) {
             printer.printError("File not found.");

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/util/CrossPlatformFilePathEvaluator.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/util/CrossPlatformFilePathEvaluator.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.commands.util;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import ddf.security.common.audit.SecurityLogger;
+
+/*
+ * Handles converting given Windows file paths (whose backslashes get escaped) into something the
+ * commands can handle.
+ */
+public class CrossPlatformFilePathEvaluator {
+
+    public static File handlePath(String path) {
+        //return java can find the file using the path
+        File file = new File(path);
+        if (file.exists()) {
+            return file;
+        }
+
+        //look for drive letter
+        if (path.contains(":")) {
+            String[] splitPath = path.split(":");
+            Optional<File> result = handleWindowsPath(splitPath[1], new File(splitPath[0] + ":\\"));
+            if (result.isPresent()) {
+                file = result.get();
+            }
+        } else { //relative path
+            Optional<File> result = handleWindowsPath(path, new File(System.getProperty("ddf.home")));
+            if (result.isPresent()) {
+                file = result.get();
+            }
+        }
+        return file;
+    }
+
+    private static Optional<File> handleWindowsPath(String path, File pwd) {
+        if (!pwd.exists()) {
+            return Optional.empty();
+        }
+
+        List<File> fileList = Arrays.asList(pwd.listFiles());
+
+        for (File file : fileList) {
+            if (path.equals(file.getName())) {
+                //found the exact match
+                SecurityLogger.audit("Found file with path : {}",
+                        file.getAbsolutePath());
+                return Optional.of(file);
+            } else if (path.startsWith(file.getName())) {
+                Optional<File> result = handleWindowsPath(path.replace(file.getName(), ""), file);
+                if (result.isPresent()) {
+                    return result;
+                }
+            } else {
+                continue;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/CrossPlatformFilePathEvaluatorTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/CrossPlatformFilePathEvaluatorTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.commands.catalog;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.codice.ddf.commands.util.CrossPlatformFilePathEvaluator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CrossPlatformFilePathEvaluatorTest {
+    String docsDirPath;
+
+    String downloadsDirPath;
+
+    String downDirPath;
+
+    String ideasDirPath;
+
+    final String sampleA = "sampleA.txt";
+
+    final String sampleB = "sampleB.png";
+
+    final String sampleC = "sampleC.jpg";
+
+    final String sampleD = "sampleD.txt";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        docsDirPath = setupDirWithSampleFiles("Documents");
+        downloadsDirPath = setupDirWithSampleFiles("downloads");
+        downDirPath = setupDirWithSampleFiles("down");
+        ideasDirPath = setupDirWithSampleFiles("brilliantIdeas");
+    }
+
+    private String setupDirWithSampleFiles(String dirName) throws IOException {
+        File dir = temporaryFolder.newFolder(dirName);
+        new File(dir.getAbsolutePath() + sampleA).createNewFile();
+        new File(dir.getAbsolutePath() + sampleB).createNewFile();
+        new File(dir.getAbsolutePath() + sampleC).createNewFile();
+        new File(dir.getAbsolutePath() + sampleD).createNewFile();
+        return dir.getAbsolutePath();
+    }
+
+    @Test
+    public void testAbsolutePath() throws Exception {
+        String path = docsDirPath.replaceAll("\\\\", "") + sampleA;
+        File file = CrossPlatformFilePathEvaluator.handlePath(path);
+        assertThat(file.exists(), is(true));
+    }
+
+    @Test
+    public void testAbsolutePathSimilarFolderName() throws Exception {
+        String path = downloadsDirPath.replaceAll("\\\\", "") + sampleB;
+        File file = CrossPlatformFilePathEvaluator.handlePath(path);
+        assertThat(file.getAbsolutePath(), equals(downDirPath + "\\" + sampleB));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Walks the file system in order to parse escaped Windows file paths so they can be used in console commands.

#### Who is reviewing it? 
@ahoffer 
@vinamartin 
@paouelle 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@clockard

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
