### PR TITLE
DDF-3247 Adds granular permissions checking to Configurator operations.

### DIFF
--- a/platform/admin/configurator/admin-configurator-impl/pom.xml
+++ b/platform/admin/configurator/admin-configurator-impl/pom.xml
@@ -107,7 +107,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.48</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -117,7 +117,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
#### What does this PR do?
Adds granular checks before allowing a user to make feature/bundle changes.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie @Lambeaux 

#### Select relevant component teams: 
@codice/security

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1. Full build and test. 
2. Install of the downstream Admin Console Beta kar and run through its operations. 
3. Attempt to use the Configurator to perform feature/bundle operations with an unauthorized user.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3247](https://codice.atlassian.net/browse/DDF-3247)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
