### PR TITLE
DDF-3248 Limited HTML rendering capabilities in the Admin-UI Usage Modal to formatting only.

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/SystemUsageModal.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/SystemUsageModal.view.js
@@ -29,6 +29,15 @@ define([
             initialize: function () {
                 // there is no automatic chaining of initialize.
                 Modal.prototype.initialize.apply(this, arguments);
+            },
+            onRender: function () {
+                var usage = properties.admin.systemUsageMessage;
+                var $iframe = this.$el.find('iframe');
+                $iframe.ready(function(){
+                    $iframe.contents()[0].open();
+                    $iframe.contents()[0].write('<html>' +  usage + '</html>');
+                    $iframe.contents()[0].close();
+                });
             }
         });
         return SystemUsageModal;

--- a/platform/admin/ui/src/main/webapp/templates/systemUsage.layout.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/systemUsage.layout.handlebars
@@ -17,7 +17,8 @@
             <h5 class="modal-title">{{admin.systemUsageTitle}}</h5>
         </div>
         <div class="modal-body">
-            {{{admin.systemUsageMessage}}}
+            <iframe sandbox='allow-same-origin'>
+            </iframe>
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true">OK</button>


### PR DESCRIPTION
#### What does this PR do?

Limits HTML rendering capabilities in the Admin-UI Usage Modal to formatting only.

#### Who is reviewing it? 

@garrettfreibott 
@blen-desta 

#### Choose 2 committers to review/merge the PR.

@andrewkfiedler 
@stustison

#### How should this be tested?

- Build distribution
- Enable and set system usage modal to contain a script tag `<script>alert(1)</script>`
- Refresh admin ui and ensure that js didn't execute but that any other content shows up correctly formatted

#### What are the relevant tickets?

[DDF-3248 ](https://codice.atlassian.net/browse/DDF-3248)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
