### PR TITLE
DDF-3251 Allow descriptive tooltips when selecting an attribute in advanced search

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -147,6 +147,13 @@ public class ConfigurationApplication implements SparkApplication {
         return hiddenAttributes;
     }
 
+    public List<String> getAttributeDescriptions() {
+        return attributeDescriptions.entrySet()
+                .stream()
+                .map(pair -> String.format("%s=%s", pair.getKey(), pair.getValue()))
+                .collect(Collectors.toList());
+    }
+
     public void setScheduleFrequencyList(List<Long> scheduleFrequencyList) {
         this.scheduleFrequencyList = scheduleFrequencyList;
     }
@@ -173,6 +180,12 @@ public class ConfigurationApplication implements SparkApplication {
         this.hiddenAttributes = hiddenAttributes;
     }
 
+    public void setAttributeDescriptions(List<String> attributeDescriptions) {
+        this.attributeDescriptions = attributeDescriptions.stream()
+                .map(str -> str.split("="))
+                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
+    }
+
     private List<String> readOnly = ImmutableList.of("checksum",
             "checksum-algorithm",
             "id",
@@ -189,6 +202,8 @@ public class ConfigurationApplication implements SparkApplication {
     private Map<String, String> attributeAliases = Collections.emptyMap();
 
     private List<String> hiddenAttributes = Collections.emptyList();
+
+    private Map<String, String> attributeDescriptions = Collections.emptyMap();
 
     private int sourcePollInterval = 60000;
 
@@ -252,6 +267,7 @@ public class ConfigurationApplication implements SparkApplication {
         config.put("summaryShow", summaryShow);
         config.put("resultShow", resultShow);
         config.put("hiddenAttributes", hiddenAttributes);
+        config.put("attributeDescriptions", attributeDescriptions);
         config.put("attributeAliases", attributeAliases);
         config.put("sourcePollInterval", sourcePollInterval);
         config.put("scheduleFrequencyList", scheduleFrequencyList);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -171,18 +171,7 @@ public class ConfigurationApplication implements SparkApplication {
     }
 
     public void setAttributeAliases(List<String> attributeAliases) {
-        this.attributeAliases = attributeAliases.stream()
-                .map(str -> str.split("=", 2))
-                .filter((list) -> {
-                    if (list.length <= 1) {
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Filtered out invalid attribute/alias: {}", list[0]);
-                        }
-                        return false;
-                    }
-                    return true;
-                })
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
+        this.attributeAliases = parseAttributeAndValuePairs(attributeAliases);
     }
 
     public void setHiddenAttributes(List<String> hiddenAttributes) {
@@ -190,18 +179,7 @@ public class ConfigurationApplication implements SparkApplication {
     }
 
     public void setAttributeDescriptions(List<String> attributeDescriptions) {
-        this.attributeDescriptions = attributeDescriptions.stream()
-                .map(str -> str.split("=", 2))
-                .filter((list) -> {
-                    if (list.length <= 1) {
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Filtered out invalid attribute/description: {}", list[0]);
-                        }
-                        return false;
-                    }
-                    return true;
-                })
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
+        this.attributeDescriptions = parseAttributeAndValuePairs(attributeDescriptions);
     }
 
     private List<String> readOnly = ImmutableList.of("checksum",
@@ -519,6 +497,19 @@ public class ConfigurationApplication implements SparkApplication {
         }
 
         return config;
+    }
+
+    private Map<String, String> parseAttributeAndValuePairs(List<String> pairs) {
+        return pairs.stream()
+            .map(str -> str.split("=", 2))
+            .filter((list) -> {
+                if (list.length <= 1) {
+                    LOGGER.debug("Filtered out invalid attribute/value pair: {}", list[0]);
+                    return false;
+                }
+                return true;
+            })
+            .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
     }
 
     public HttpProxyService getHttpProxy() {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -173,7 +173,16 @@ public class ConfigurationApplication implements SparkApplication {
     public void setAttributeAliases(List<String> attributeAliases) {
         this.attributeAliases = attributeAliases.stream()
                 .map(str -> str.split("=", 2))
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list.length > 1 ? list[1].trim() : ""));
+                .filter((list) -> {
+                    if (list.length <= 1) {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("Filtered out invalid attribute/alias: {}", list[0]);
+                        }
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
     }
 
     public void setHiddenAttributes(List<String> hiddenAttributes) {
@@ -183,7 +192,16 @@ public class ConfigurationApplication implements SparkApplication {
     public void setAttributeDescriptions(List<String> attributeDescriptions) {
         this.attributeDescriptions = attributeDescriptions.stream()
                 .map(str -> str.split("=", 2))
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list.length > 1 ? list[1].trim() : ""));
+                .filter((list) -> {
+                    if (list.length <= 1) {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("Filtered out invalid attribute/description: {}", list[0]);
+                        }
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
     }
 
     private List<String> readOnly = ImmutableList.of("checksum",

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -172,8 +172,8 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setAttributeAliases(List<String> attributeAliases) {
         this.attributeAliases = attributeAliases.stream()
-                .map(str -> str.split("="))
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
+                .map(str -> str.split("=", 2))
+                .collect(Collectors.toMap(list -> list[0].trim(), list -> list.length > 1 ? list[1].trim() : ""));
     }
 
     public void setHiddenAttributes(List<String> hiddenAttributes) {
@@ -182,8 +182,8 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setAttributeDescriptions(List<String> attributeDescriptions) {
         this.attributeDescriptions = attributeDescriptions.stream()
-                .map(str -> str.split("="))
-                .collect(Collectors.toMap(list -> list[0].trim(), list -> list[1].trim()));
+                .map(str -> str.split("=", 2))
+                .collect(Collectors.toMap(list -> list[0].trim(), list -> list.length > 1 ? list[1].trim() : ""));
     }
 
     private List<String> readOnly = ImmutableList.of("checksum",

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -138,7 +138,7 @@
 
         <AD id="attributeAliases"
             name="Attribute Aliases"
-            description="List of attribute aliases. Example 'title=Title'"
+            description="List of attribute aliases. Separate the attribute name and alias with an equals (=) sign. Example: 'title=Title'"
             type="String"
             cardinality="10000"
             required="false"/>
@@ -153,7 +153,7 @@
 
         <AD id="attributeDescriptions"
             name="Attribute Descriptions"
-            description="List of friendly attribute descriptions. Example 'checksum-algorithm=Method for generating a small-sized datum from a block of digital data for the purpose of detecting errors'"
+            description="List of friendly attribute descriptions. Separate the attribute name and description with an equals (=) sign. Example: 'checksum-algorithm=Method for generating a small-sized datum from a block of digital data for the purpose of detecting errors'"
             type="String"
             cardinality="10000"
             required="false"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -151,6 +151,13 @@
             default="^sortOrder$,^sortField$,^cql$,^polling$,^cached$"
             required="false"/>
 
+        <AD id="attributeDescriptions"
+            name="Attribute Descriptions"
+            description="List of friendly attribute descriptions. Example 'checksum-algorithm=Method for generating a small-sized datum from a block of digital data for the purpose of detecting errors'"
+            type="String"
+            cardinality="10000"
+            required="false"/>
+
         <AD id="scheduleFrequencyList"
             name="Query Schedule Frequencies"
             description="Custom list of schedule frequencies in seconds.  This will override the frequency list in the query schedule tab.  Leave this empty to use the frequency list on the Catalog UI."

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -42,7 +42,7 @@ define([
         '<': '<',
         '=': '=',
         '<=': '<=',
-        '>=': '>=' 
+        '>=': '>='
     };
 
     var CQLtoComparator = {};
@@ -78,6 +78,7 @@ define([
                 }).map(function(metacardType){
                     return {
                         label: metacardType.alias || metacardType.id,
+                        description: (properties.attributeDescriptions || {})[metacardType.id],
                         value: metacardType.id
                     };
                 }),
@@ -113,7 +114,7 @@ define([
                         this.model.set('comparator', 'BEFORE');
                     }
                     break;
-                case 'BOOLEAN': 
+                case 'BOOLEAN':
                     if (['='].indexOf(currentComparator) === -1){
                         this.model.set('comparator', '=');
                     }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.hbs
@@ -11,7 +11,7 @@
  *
  **/
  --}}
-<div class="choice-text" title="{{label}}">
+<div class="choice-text" title="{{label}}{{description}}">
     {{#if isThumbnail}}
         {{#unless hasNoValue}}
             <img src="{{img}}">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.view.js
@@ -41,6 +41,11 @@ define([
                 'data-help': this.model.get('help')
             };
         },
+        onRender: function(){
+            if (this.model.get('description')) {
+                this.$el.attr('data-help', this.model.get('description'));
+            }
+        },
         serializeData: function(){
             var modelJSON = this.model.toJSON();
             if (modelJSON.label.constructor === Array){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/select/select.view.js
@@ -46,6 +46,11 @@ define([
             if (modelJSON.label.constructor === Array){
                 modelJSON.label = modelJSON.label.join(' | ');
             }
+            if (modelJSON.description) {
+                // add line breaks to separate the description from the label
+                // within the tooltip
+                modelJSON.description = '\n\n' + modelJSON.description;
+            }
             if (modelJSON.isThumbnail && !modelJSON.hasNoValue){
                 modelJSON.img = Common.getImageSrc(modelJSON.value[0]);
             }


### PR DESCRIPTION
#### What does this PR do?
Lets descriptions for metacard attributes be edited and stored in system configuration, to be shown as tooltips in the attribute selector dropdown (in advanced search).

#### Who is reviewing it? 
@bdeining 
@andrewkfiedler 
@millerw8 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining 
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
In admin console, navigate to Standard Search UI -> Configuration -> Catalog UI Search and add an entry to the new `Attribute Descriptions` section.
For example, `title=Descriptive title for metacard`
In Intrigue, navigate to the advanced search editor. Choose the attribute you created a description for and verify that a tooltip appears over it with the description text.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3251

#### Screenshots (if appropriate)
![screenshot from 2017-08-29 15-00-07](https://user-images.githubusercontent.com/1081932/29884356-1b25da2e-8d68-11e7-922b-577fbb7308e3.png)
![screenshot from 2017-08-29 15-09-34](https://user-images.githubusercontent.com/1081932/29884357-1b38bac2-8d68-11e7-8297-40af7cd076a1.png)

