### PR TITLE
DDF-3208 Fixes Geospatial searches over OpenSearch endpoint

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -89,6 +89,11 @@
             <version>1.5.0</version>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-cql</artifactId>
+            <version>${org.geotools.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom</artifactId>
             <version>2.0.2</version>

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitor.java
@@ -197,10 +197,12 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
             if (geometryExpression instanceof SurfaceImpl) {
                 SurfaceImpl surface = (SurfaceImpl) literalWrapper.evaluate(null);
                 Polygon polygon = (Polygon) surface.getJTSGeometry();
-                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(polygon)));
+                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(
+                        polygon)));
             } else if (geometryExpression instanceof Polygon) {
                 Polygon polygon = (Polygon) literalWrapper.evaluate(null);
-                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(polygon)));
+                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(
+                        polygon)));
             } else {
                 LOGGER.debug("Only POLYGON geometry WKT for Contains filter is supported");
             }
@@ -239,10 +241,12 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
             if (geometryExpression instanceof SurfaceImpl) {
                 SurfaceImpl surface = (SurfaceImpl) literalWrapper.evaluate(null);
                 Polygon polygon = (Polygon) surface.getJTSGeometry();
-                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(polygon)));
+                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(
+                        polygon)));
             } else if (geometryExpression instanceof Polygon) {
                 Polygon polygon = (Polygon) literalWrapper.evaluate(null);
-                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(polygon)));
+                openSearchFilterVisitorObject.setSpatialSearch(new SpatialFilter(wktWriter.write(
+                        polygon)));
             } else {
                 LOGGER.debug("Only POLYGON geometry WKT for Intersects filter is supported");
             }

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
@@ -49,7 +49,7 @@ public class TestOpenSearchFilterVisitor {
 
     private static final String WKT_POINT = "POINT(1.0 2.0)";
 
-    private static final String WKT_POLYGON = "POLYGON((1.0 1.0,1.0 2.0,2.0 2.0,2.0 1.0,1.0 1.0))";
+    private static final String WKT_POLYGON = "POLYGON ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1))";
 
     private static final String CQL_DWITHIN = "(DWITHIN(anyGeo, " + WKT_POINT + ", 1, meters))";
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.geotools.filter.temporal.TOverlapsImpl;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.And;
@@ -48,6 +50,12 @@ public class TestOpenSearchFilterVisitor {
     private static final String WKT_POINT = "POINT(1.0 2.0)";
 
     private static final String WKT_POLYGON = "POLYGON((1.0 1.0,1.0 2.0,2.0 2.0,2.0 1.0,1.0 1.0))";
+
+    private static final String CQL_DWITHIN = "(DWITHIN(anyGeo, " + WKT_POINT + ", 1, meters))";
+
+    private static final String CQL_CONTAINS = "(CONTAINS(anyGeo, " + WKT_POLYGON + "))";
+
+    private static final String CQL_INTERSECTS = "(INTERSECTS(anyGeo, " + WKT_POLYGON + "))";
 
     private static final String TEST_STRING = "test";
 
@@ -95,7 +103,7 @@ public class TestOpenSearchFilterVisitor {
     }
 
     @Test
-    public void testAndilter() {
+    public void testAndFilter() {
         Filter textLikeFilter = geotoolsFilterBuilder.attribute(Core.TITLE)
                 .is()
                 .like()
@@ -159,6 +167,21 @@ public class TestOpenSearchFilterVisitor {
     }
 
     @Test
+    public void testDWithinCqlFilter() throws CQLException {
+        DWithin dWithinFilter = (DWithin) ECQL.toFilter(CQL_DWITHIN);
+
+        OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+                new OpenSearchFilterVisitorObject();
+        openSearchFilterVisitorObject.setCurrentNest(NestedTypes.AND);
+        OpenSearchFilterVisitorObject result =
+                (OpenSearchFilterVisitorObject) openSearchFilterVisitor.visit(dWithinFilter,
+                        openSearchFilterVisitorObject);
+        SpatialFilter spatialFilter = result.getSpatialSearch();
+        assertThat(spatialFilter, notNullValue());
+        assertThat(spatialFilter.getGeometryWkt(), is(WKT_POINT));
+    }
+
+    @Test
     public void testContains() {
         Contains containsFilter = (Contains) geotoolsFilterBuilder.attribute(Core.TITLE)
                 .containing()
@@ -202,6 +225,21 @@ public class TestOpenSearchFilterVisitor {
                         openSearchFilterVisitorObject);
         SpatialFilter spatialFilter = result.getSpatialSearch();
         assertThat(spatialFilter, nullValue());
+    }
+
+    @Test
+    public void testContainsCqlFilter() throws CQLException {
+        Contains containsFilter = (Contains) ECQL.toFilter(CQL_CONTAINS);
+        OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+                new OpenSearchFilterVisitorObject();
+        openSearchFilterVisitorObject.setCurrentNest(NestedTypes.AND);
+        OpenSearchFilterVisitorObject result =
+                (OpenSearchFilterVisitorObject) openSearchFilterVisitor.visit(containsFilter,
+                        openSearchFilterVisitorObject);
+        SpatialFilter spatialFilter = result.getSpatialSearch();
+        assertThat(spatialFilter, notNullValue());
+        assertThat(spatialFilter.getGeometryWkt(), is(WKT_POLYGON));
+
     }
 
     @Test
@@ -278,6 +316,20 @@ public class TestOpenSearchFilterVisitor {
                         openSearchFilterVisitorObject);
         SpatialFilter spatialFilter = result.getSpatialSearch();
         assertThat(spatialFilter, nullValue());
+    }
+
+    @Test
+    public void testIntersectsCqlFilter() throws CQLException {
+        Intersects intersectsFilter = (Intersects) ECQL.toFilter(CQL_INTERSECTS);
+        OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+                new OpenSearchFilterVisitorObject();
+        openSearchFilterVisitorObject.setCurrentNest(NestedTypes.AND);
+        OpenSearchFilterVisitorObject result =
+                (OpenSearchFilterVisitorObject) openSearchFilterVisitor.visit(intersectsFilter,
+                        openSearchFilterVisitorObject);
+        SpatialFilter spatialFilter = result.getSpatialSearch();
+        assertThat(spatialFilter, notNullValue());
+        assertThat(spatialFilter.getGeometryWkt(), is(WKT_POLYGON));
     }
 
     @Test

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchFilterVisitor.java
@@ -239,7 +239,6 @@ public class TestOpenSearchFilterVisitor {
         SpatialFilter spatialFilter = result.getSpatialSearch();
         assertThat(spatialFilter, notNullValue());
         assertThat(spatialFilter.getGeometryWkt(), is(WKT_POLYGON));
-
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for vividsolution geometries in OpenSearchFilterVisitor. ECQL.toFilter creates filters with geometries of this type which were previously unhandled. This would result in failed spatial queries over the OpenSearch endpoint.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mcalcote @vinamartin @emmberk 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
* Spin up and install with system defaults
* Federate with another DDF over the OpenSearch endpoint
* Using Intrigue, perform spatial queries using Point-Radius, Polygon and BBox and confirm that the expected results are returned
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3208](https://codice.atlassian.net/browse/DDF-3208)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
