### PR TITLE
DDF-3244 CacheBulkProcessor does not account for size of bulk reques…

### DIFF
--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -523,12 +523,12 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
@@ -1,18 +1,21 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or any later version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
- * is distributed along with this program and can be found at
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
 
+import com.google.common.collect.Lists;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -22,121 +25,120 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Lists;
-
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-
-/**
- * Bulk adds metacards to the cache that are not needed immediately.
- */
+/** Bulk adds metacards to the cache that are not needed immediately. */
 public class CacheBulkProcessor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CacheBulkProcessor.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheBulkProcessor.class);
 
-    private final ScheduledExecutorService batchScheduler =
-            Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService batchScheduler =
+      Executors.newSingleThreadScheduledExecutor();
 
-    private final Map<String, Metacard> metacardsToCache = new ConcurrentHashMap<>();
+  private final Map<String, Metacard> metacardsToCache = new ConcurrentHashMap<>();
 
-    private long flushInterval = TimeUnit.SECONDS.toMillis(10);
+  private long flushInterval = TimeUnit.SECONDS.toMillis(10);
 
-    private int maximumBacklogSize = 10000;
+  private int maximumBacklogSize = 10000;
 
-    private int batchSize = 500;
+  private int batchSize = 500;
 
-    private Date lastBulkAdd = new Date();
+  private Date lastBulkAdd = new Date();
 
-    private CacheStrategy cacheStrategy;
+  private CacheStrategy cacheStrategy;
 
-    public CacheBulkProcessor(final SolrCache cache) {
-        this(cache, 1, TimeUnit.SECONDS, CacheStrategy.ALL);
-    }
+  public CacheBulkProcessor(final SolrCache cache) {
+    this(cache, 1, TimeUnit.SECONDS, CacheStrategy.ALL);
+  }
 
-    /**
-     * Create a new cache bulk processor that will check added metacards for bulk processing at
-     * the configured delay interval.
-     *
-     * @param cache target Solr cache to bulk add metacards
-     * @param delay delay between decision to bulk add
-     * @param delayUnit units of the delay
-     */
-    public CacheBulkProcessor(final SolrCache cache, final long delay, final TimeUnit delayUnit, CacheStrategy cacheStrategy) {
-        batchScheduler.scheduleWithFixedDelay(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    if (metacardsToCache.size() > 0 && (metacardsToCache.size() >= batchSize
-                            || timeToFlush())) {
-                        LOGGER.debug("{} metacards to batch add to cache", metacardsToCache.size());
+  /**
+   * Create a new cache bulk processor that will check added metacards for bulk processing at the
+   * configured delay interval.
+   *
+   * @param cache target Solr cache to bulk add metacards
+   * @param delay delay between decision to bulk add
+   * @param delayUnit units of the delay
+   */
+  public CacheBulkProcessor(
+      final SolrCache cache,
+      final long delay,
+      final TimeUnit delayUnit,
+      CacheStrategy cacheStrategy) {
+    batchScheduler.scheduleWithFixedDelay(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              if (metacardsToCache.size() > 0
+                  && (metacardsToCache.size() >= batchSize || timeToFlush())) {
+                LOGGER.debug("{} metacards to batch add to cache", metacardsToCache.size());
 
-                        List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
-                        for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
-                            LOGGER.debug("Caching a batch of {} metacards", batch.size());
-                            cache.create(batch);
+                List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
+                for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
+                  LOGGER.debug("Caching a batch of {} metacards", batch.size());
+                  cache.create(batch);
 
-                            for (Metacard metacard : batch) {
-                                metacardsToCache.remove(metacard.getId());
-                            }
-                        }
-
-                        lastBulkAdd = new Date();
-                    }
-                } catch (Throwable throwable) {
-                    LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
+                  for (Metacard metacard : batch) {
+                    metacardsToCache.remove(metacard.getId());
+                  }
                 }
+
+                lastBulkAdd = new Date();
+              }
+            } catch (Throwable throwable) {
+              LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
             }
-        }, delay, delay, delayUnit);
+          }
+        },
+        delay,
+        delay,
+        delayUnit);
 
-        this.cacheStrategy = cacheStrategy;
-    }
+    this.cacheStrategy = cacheStrategy;
+  }
 
-    private boolean timeToFlush() {
-        Date now = new Date();
-        return now.getTime() - lastBulkAdd.getTime() > flushInterval;
-    }
+  private boolean timeToFlush() {
+    Date now = new Date();
+    return now.getTime() - lastBulkAdd.getTime() > flushInterval;
+  }
 
-    /**
-     * Adds metacards to be bulk added to cache.  Metacards will be ignored if backlog grows too
-     * large.  Metacard currently in backlog will be updated if added again.
-     *
-     * @param results metacards to add to current batch
-     */
-    public void add(final List<Result> results) {
-        if (metacardsToCache.size() < maximumBacklogSize) {
-            cacheStrategy.getCacheStrategyFunction()
-                    .accept(results, m -> metacardsToCache.put(m.getId(), m));
-        }
+  /**
+   * Adds metacards to be bulk added to cache. Metacards will be ignored if backlog grows too large.
+   * Metacard currently in backlog will be updated if added again.
+   *
+   * @param results metacards to add to current batch
+   */
+  public void add(final List<Result> results) {
+    if (metacardsToCache.size() < maximumBacklogSize) {
+      cacheStrategy
+          .getCacheStrategyFunction()
+          .accept(results, m -> metacardsToCache.put(m.getId(), m));
     }
+  }
 
-    /**
-     * Shutdown scheduled tasks.
-     */
-    public void shutdown() {
-        batchScheduler.shutdown();
-    }
+  /** Shutdown scheduled tasks. */
+  public void shutdown() {
+    batchScheduler.shutdown();
+  }
 
-    int pendingMetacards() {
-        return metacardsToCache.size();
-    }
+  int pendingMetacards() {
+    return metacardsToCache.size();
+  }
 
-    public void setFlushInterval(long flushInterval) {
-        this.flushInterval = flushInterval;
-    }
+  public void setFlushInterval(long flushInterval) {
+    this.flushInterval = flushInterval;
+  }
 
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
 
-    public void setMaximumBacklogSize(int maximumBacklogSize) {
-        this.maximumBacklogSize = maximumBacklogSize;
-    }
+  public void setMaximumBacklogSize(int maximumBacklogSize) {
+    this.maximumBacklogSize = maximumBacklogSize;
+  }
 
-    public void setCacheStrategy(CacheStrategy cacheStrategy) {
-        this.cacheStrategy = cacheStrategy;
-    }
+  public void setCacheStrategy(CacheStrategy cacheStrategy) {
+    this.cacheStrategy = cacheStrategy;
+  }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
@@ -1,21 +1,18 @@
 /**
  * Copyright (c) Codice Foundation
- *
- * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
- * Lesser General Public License as published by the Free Software Foundation, either version 3 of
- * the License, or any later version.
- *
- * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
- * License is distributed along with this program and can be found at
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
 
-import com.google.common.collect.Lists;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -25,115 +22,121 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Bulk adds metacards to the cache that are not needed immediately. */
-class CacheBulkProcessor {
+import com.google.common.collect.Lists;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CacheBulkProcessor.class);
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
 
-  private final ScheduledExecutorService batchScheduler =
-      Executors.newSingleThreadScheduledExecutor(
-          StandardThreadFactoryBuilder.newThreadFactory("cacheBulkProcessorThread"));
+/**
+ * Bulk adds metacards to the cache that are not needed immediately.
+ */
+public class CacheBulkProcessor {
 
-  private final Map<String, Metacard> metacardsToCache = new ConcurrentHashMap<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheBulkProcessor.class);
 
-  private long flushInterval = TimeUnit.SECONDS.toMillis(10);
+    private final ScheduledExecutorService batchScheduler =
+            Executors.newSingleThreadScheduledExecutor();
 
-  private int maximumBacklogSize = 10000;
+    private final Map<String, Metacard> metacardsToCache = new ConcurrentHashMap<>();
 
-  private int batchSize = 500;
+    private long flushInterval = TimeUnit.SECONDS.toMillis(10);
 
-  private Date lastBulkAdd = new Date();
+    private int maximumBacklogSize = 10000;
 
-  public CacheBulkProcessor(final SolrCache cache) {
-    this(cache, 1, TimeUnit.SECONDS);
-  }
+    private int batchSize = 500;
 
-  /**
-   * Create a new cache bulk processor that will check added metacards for bulk processing at the
-   * configured delay interval.
-   *
-   * @param cache target Solr cache to bulk add metacards
-   * @param delay delay between decision to bulk add
-   * @param delayUnit units of the delay
-   */
-  public CacheBulkProcessor(final SolrCache cache, final long delay, final TimeUnit delayUnit) {
-    batchScheduler.scheduleWithFixedDelay(
-        new Runnable() {
-          @Override
-          public void run() {
-            try {
-              if (metacardsToCache.size() > 0
-                  && (metacardsToCache.size() >= batchSize || timeToFlush())) {
-                LOGGER.debug("{} metacards to batch add to cache", metacardsToCache.size());
+    private Date lastBulkAdd = new Date();
 
-                List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
-                for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
-                  LOGGER.debug("Caching a batch of {} metacards", batch.size());
-                  cache.create(batch);
+    private CacheStrategy cacheStrategy;
 
-                  for (Metacard metacard : batch) {
-                    metacardsToCache.remove(metacard.getId());
-                  }
-                }
-
-                lastBulkAdd = new Date();
-              }
-            } catch (Throwable throwable) {
-              LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
-            }
-          }
-        },
-        delay,
-        delay,
-        delayUnit);
-  }
-
-  private boolean timeToFlush() {
-    Date now = new Date();
-    return now.getTime() - lastBulkAdd.getTime() > flushInterval;
-  }
-
-  /**
-   * Adds metacards to be bulk added to cache. Metacards will be ignored if backlog grows too large.
-   * Metacard currently in backlog will be updated if added again.
-   *
-   * @param results metacards to add to current batch
-   */
-  public void add(final List<Result> results) {
-    if (metacardsToCache.size() < maximumBacklogSize) {
-      for (Result result : results) {
-        if (result != null) {
-          Metacard metacard = result.getMetacard();
-          if (metacard != null) {
-            metacardsToCache.put(metacard.getId(), metacard);
-          }
-        }
-      }
+    public CacheBulkProcessor(final SolrCache cache) {
+        this(cache, 1, TimeUnit.SECONDS, CacheStrategy.ALL);
     }
-  }
 
-  /** Shutdown scheduled tasks. */
-  public void shutdown() {
-    batchScheduler.shutdown();
-  }
+    /**
+     * Create a new cache bulk processor that will check added metacards for bulk processing at
+     * the configured delay interval.
+     *
+     * @param cache target Solr cache to bulk add metacards
+     * @param delay delay between decision to bulk add
+     * @param delayUnit units of the delay
+     */
+    public CacheBulkProcessor(final SolrCache cache, final long delay, final TimeUnit delayUnit, CacheStrategy cacheStrategy) {
+        batchScheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (metacardsToCache.size() > 0 && (metacardsToCache.size() >= batchSize
+                            || timeToFlush())) {
+                        LOGGER.debug("{} metacards to batch add to cache", metacardsToCache.size());
 
-  int pendingMetacards() {
-    return metacardsToCache.size();
-  }
+                        List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
+                        for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
+                            LOGGER.debug("Caching a batch of {} metacards", batch.size());
+                            cache.create(batch);
 
-  public void setFlushInterval(long flushInterval) {
-    this.flushInterval = flushInterval;
-  }
+                            for (Metacard metacard : batch) {
+                                metacardsToCache.remove(metacard.getId());
+                            }
+                        }
 
-  public void setBatchSize(int batchSize) {
-    this.batchSize = batchSize;
-  }
+                        lastBulkAdd = new Date();
+                    }
+                } catch (Throwable throwable) {
+                    LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
+                }
+            }
+        }, delay, delay, delayUnit);
 
-  public void setMaximumBacklogSize(int maximumBacklogSize) {
-    this.maximumBacklogSize = maximumBacklogSize;
-  }
+        this.cacheStrategy = cacheStrategy;
+    }
+
+    private boolean timeToFlush() {
+        Date now = new Date();
+        return now.getTime() - lastBulkAdd.getTime() > flushInterval;
+    }
+
+    /**
+     * Adds metacards to be bulk added to cache.  Metacards will be ignored if backlog grows too
+     * large.  Metacard currently in backlog will be updated if added again.
+     *
+     * @param results metacards to add to current batch
+     */
+    public void add(final List<Result> results) {
+        if (metacardsToCache.size() < maximumBacklogSize) {
+            cacheStrategy.getCacheStrategyFunction()
+                    .accept(results, m -> metacardsToCache.put(m.getId(), m));
+        }
+    }
+
+    /**
+     * Shutdown scheduled tasks.
+     */
+    public void shutdown() {
+        batchScheduler.shutdown();
+    }
+
+    int pendingMetacards() {
+        return metacardsToCache.size();
+    }
+
+    public void setFlushInterval(long flushInterval) {
+        this.flushInterval = flushInterval;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setMaximumBacklogSize(int maximumBacklogSize) {
+        this.maximumBacklogSize = maximumBacklogSize;
+    }
+
+    public void setCacheStrategy(CacheStrategy cacheStrategy) {
+        this.cacheStrategy = cacheStrategy;
+    }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheStrategy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.cache.solr.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+
+public final class CacheStrategy {
+    private static final Map<String, CacheStrategy> STRATEGY_MAP = new HashMap<>(3);
+
+    //Caches both local and federated search results
+    public static final CacheStrategy ALL = new CacheStrategy("ALL", m -> true);
+
+    //Caches only metacards whose source-id doesn't match the id of localSourceIdSupplier.get()
+    public static final CacheStrategy FEDERATED = new CacheStrategy("FEDERATED",
+            m -> !m.getSourceId()
+                    .equals(CacheStrategy.localSourceIdSupplier.get()));
+
+    //Disables caching
+    public static final CacheStrategy NONE = new CacheStrategy("NONE", (rs, c) -> {});
+
+    private BiConsumer<Collection<Result>, Consumer<Metacard>> cacheStrategyFunction;
+
+    private static Supplier<String> localSourceIdSupplier = () -> "ddf.distribution";
+
+    private CacheStrategy(String instanceName,
+            BiConsumer<Collection<Result>, Consumer<Metacard>> cacheStrategyFunction) {
+        this.cacheStrategyFunction = cacheStrategyFunction;
+        CacheStrategy.STRATEGY_MAP.put(instanceName, this);
+    }
+
+    private CacheStrategy(String instanceName, Predicate<Metacard> predicate) {
+        this(instanceName,
+                (rs, c) -> rs.stream()
+                        .filter(Objects::nonNull)
+                        .map(Result::getMetacard)
+                        .filter(Objects::nonNull)
+                        .filter(predicate)
+                        .forEach(c::accept)); //Caches only federated search results
+    }
+
+    public BiConsumer<Collection<Result>, Consumer<Metacard>> getCacheStrategyFunction() {
+        return this.cacheStrategyFunction;
+    }
+
+    public static void setLocalSourceIdSupplier(Supplier<String> localSourceIdSupplier) {
+        if (localSourceIdSupplier != null) {
+            CacheStrategy.localSourceIdSupplier = localSourceIdSupplier;
+        }
+    }
+
+    public static CacheStrategy valueOf(String instanceName) {
+        return CacheStrategy.STRATEGY_MAP.get(instanceName);
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -1,19 +1,41 @@
 /**
  * Copyright (c) Codice Foundation
- *
- * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
- * Lesser General Public License as published by the Free Software Foundation, either version 3 of
- * the License, or any later version.
- *
- * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
- * License is distributed along with this program and can be found at
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+import org.codice.ddf.configuration.SystemInfo;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
+
 import ddf.catalog.Constants;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -40,41 +62,21 @@ import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.Source;
 import ddf.catalog.util.impl.RelevanceResultComparator;
 import ddf.catalog.util.impl.Requests;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.Validate;
-import org.codice.ddf.configuration.SystemInfo;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link
- * ddf.catalog.data.Metacard}s. The sorting is based on the {@link ddf.catalog.operation.Query}'s
- * {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values are
- *
+ * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting
+ * {@link ddf.catalog.data.Metacard}s. The sorting is based on the {@link ddf.catalog.operation.Query}'s
+ * {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values
+ * are
  * <ul>
- *   <li>{@link ddf.catalog.data.Metacard#EFFECTIVE}
- *   <li>{@link ddf.catalog.data.Result#TEMPORAL}
- *   <li>{@link ddf.catalog.data.Result#DISTANCE}
- *   <li>{@link ddf.catalog.data.Result#RELEVANCE}
+ * <li>{@link ddf.catalog.data.Metacard#EFFECTIVE}</li>
+ * <li>{@link ddf.catalog.data.Result#TEMPORAL}</li>
+ * <li>{@link ddf.catalog.data.Result#DISTANCE}</li>
+ * <li>{@link ddf.catalog.data.Result#RELEVANCE}</li>
  * </ul>
- *
- * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and {@link
- * org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort value
- * and sort order must be provided.
+ * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and
+ * {@link org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort
+ * value and sort order must be provided.
  *
  * @see ddf.catalog.data.Metacard
  * @see ddf.catalog.operation.Query
@@ -82,508 +84,517 @@ import org.slf4j.LoggerFactory;
  */
 public class CachingFederationStrategy implements FederationStrategy, PostIngestPlugin {
 
-  /**
-   * The default comparator for sorting by {@link ddf.catalog.data.Result#RELEVANCE}, {@link
-   * org.opengis.filter.sort.SortOrder#DESCENDING}
-   */
-  protected static final Comparator<Result> DEFAULT_COMPARATOR =
-      new RelevanceResultComparator(SortOrder.DESCENDING);
+    /**
+     * The default comparator for sorting by {@link ddf.catalog.data.Result#RELEVANCE},
+     * {@link org.opengis.filter.sort.SortOrder#DESCENDING}
+     */
+    protected static final Comparator<Result> DEFAULT_COMPARATOR = new RelevanceResultComparator(
+            SortOrder.DESCENDING);
 
-  protected static final String QUERY_MODE = "mode";
+    protected static final String QUERY_MODE = "mode";
 
-  /** Query the cache */
-  protected static final String CACHE_QUERY_MODE = "cache";
+    /**
+     * Query the cache
+     */
+    protected static final String CACHE_QUERY_MODE = "cache";
 
-  /** Query without updating the cache */
-  protected static final String NATIVE_QUERY_MODE = "native";
+    /**
+     * Query without updating the cache
+     */
+    protected static final String NATIVE_QUERY_MODE = "native";
 
-  /** Query and update the cache but block until done indexing */
-  protected static final String INDEX_QUERY_MODE = "index";
+    /**
+     * Query and update the cache but block until done indexing
+     */
+    protected static final String INDEX_QUERY_MODE = "index";
 
-  /** Query and update the cache without blocking */
-  protected static final String UPDATE_QUERY_MODE = "update";
+    /**
+     * Query and update the cache without blocking
+     */
+    protected static final String UPDATE_QUERY_MODE = "update";
 
-  /** package-private to allow for unit testing */
-  static final int DEFAULT_MAX_START_INDEX = 50000;
+    /**
+     * package-private to allow for unit testing
+     */
+    static final int DEFAULT_MAX_START_INDEX = 50000;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CachingFederationStrategy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachingFederationStrategy.class);
 
-  private final SolrCache cache;
+    private final SolrCache cache;
 
-  private final SolrCacheSource cacheSource;
+    private final SolrCacheSource cacheSource;
 
-  private final ExecutorService cacheExecutorService;
+    private final ExecutorService cacheExecutorService;
 
-  /**
-   * The {@link List} of pre-federated query plugins to execute on the query request before the
-   * query is executed on the {@link Source}.
-   */
-  protected List<PreFederatedQueryPlugin> preQuery;
+    /**
+     * The {@link List} of pre-federated query plugins to execute on the query request before the
+     * query is executed on the {@link Source}.
+     */
+    protected List<PreFederatedQueryPlugin> preQuery;
 
-  /**
-   * The {@link List} of post-federated query plugins to execute on the query request after the
-   * query is executed on the {@link Source}.
-   */
-  protected List<PostFederatedQueryPlugin> postQuery;
+    /**
+     * The {@link List} of post-federated query plugins to execute on the query request after the
+     * query is executed on the {@link Source}.
+     */
+    protected List<PostFederatedQueryPlugin> postQuery;
 
-  private SortedQueryMonitorFactory sortedQueryMonitorFactory = new SortedQueryMonitorFactory(this);
+    private SortedQueryMonitorFactory sortedQueryMonitorFactory =
+            new SortedQueryMonitorFactory(this);
 
-  private ExecutorService queryExecutorService;
+    private ExecutorService queryExecutorService;
 
-  private int maxStartIndex;
+    private int maxStartIndex;
 
-  private CacheCommitPhaser cacheCommitPhaser;
+    private CacheCommitPhaser cacheCommitPhaser;
 
-  private CacheBulkProcessor cacheBulkProcessor;
+    private CacheBulkProcessor cacheBulkProcessor;
 
-  private boolean isCachingEverything = false;
+    private boolean isCachingEverything = false;
 
-  private boolean cacheRemoteIngests = false;
+    private boolean cacheRemoteIngests = false;
 
-  private ValidationQueryFactory validationQueryFactory;
+    private ValidationQueryFactory validationQueryFactory;
 
-  private CacheQueryFactory cacheQueryFactory;
+    private CacheQueryFactory cacheQueryFactory;
 
-  private boolean showErrors = false;
+    private boolean showErrors = false;
 
-  private boolean showWarnings = true;
+    private boolean showWarnings = true;
 
-  /**
-   * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
-   *
-   * @param queryExecutorService the {@link ExecutorService} for queries
-   */
-  public CachingFederationStrategy(
-      ExecutorService queryExecutorService,
-      List<PreFederatedQueryPlugin> preQuery,
-      List<PostFederatedQueryPlugin> postQuery,
-      SolrCache cache,
-      ExecutorService cacheExecutorService,
-      ValidationQueryFactory validationQueryFactory,
-      CacheQueryFactory cacheQueryFactory) {
+    /**
+     * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
+     *
+     * @param queryExecutorService the {@link ExecutorService} for queries
+     */
+    public CachingFederationStrategy(ExecutorService queryExecutorService,
+            List<PreFederatedQueryPlugin> preQuery, List<PostFederatedQueryPlugin> postQuery,
+            SolrCache cache, ExecutorService cacheExecutorService,
+            ValidationQueryFactory validationQueryFactory, CacheQueryFactory cacheQueryFactory) {
 
-    Validate.notNull(queryExecutorService, "Valid queryExecutorService required.");
-    Validate.notNull(preQuery, "Valid List<PreFederatedQueryPlugin> required.");
-    Validate.noNullElements(preQuery, "preQuery cannot contain null elements.");
-    Validate.notNull(postQuery, "Valid List<PostFederatedQueryPlugin> required.");
-    Validate.noNullElements(postQuery, "postQuery cannot contain null elements.");
-    Validate.notNull(cache, "Valid SolrCache required.");
-    Validate.notNull(cacheExecutorService, "Valid cacheExecutorService required.");
-    Validate.notNull(validationQueryFactory, "Valid ValidationQueryFactory required.");
-    Validate.notNull(cacheQueryFactory, "Valid CacheQueryFactory required.");
+        Validate.notNull(queryExecutorService, "Valid queryExecutorService required.");
+        Validate.notNull(preQuery, "Valid List<PreFederatedQueryPlugin> required.");
+        Validate.noNullElements(preQuery, "preQuery cannot contain null elements.");
+        Validate.notNull(postQuery, "Valid List<PostFederatedQueryPlugin> required.");
+        Validate.noNullElements(postQuery, "postQuery cannot contain null elements.");
+        Validate.notNull(cache, "Valid SolrCache required.");
+        Validate.notNull(cacheExecutorService, "Valid cacheExecutorService required.");
+        Validate.notNull(validationQueryFactory, "Valid ValidationQueryFactory required.");
+        Validate.notNull(cacheQueryFactory, "Valid CacheQueryFactory required.");
 
-    this.queryExecutorService = queryExecutorService;
-    this.preQuery = preQuery;
-    this.postQuery = postQuery;
-    this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-    this.cache = cache;
-    this.cacheExecutorService = cacheExecutorService;
-    cacheCommitPhaser = new CacheCommitPhaser(cache);
-    cacheBulkProcessor = new CacheBulkProcessor(cache);
-    this.validationQueryFactory = validationQueryFactory;
-    this.cacheQueryFactory = cacheQueryFactory;
-    cacheSource = new SolrCacheSource(cache);
-  }
-
-  void setSortedQueryMonitorFactory(SortedQueryMonitorFactory sortedQueryMonitorFactory) {
-    this.sortedQueryMonitorFactory = sortedQueryMonitorFactory;
-  }
-
-  void setCacheCommitPhaser(CacheCommitPhaser cacheCommitPhaser) {
-    this.cacheCommitPhaser = cacheCommitPhaser;
-  }
-
-  void setCacheBulkProcessor(CacheBulkProcessor cacheBulkProcessor) {
-    this.cacheBulkProcessor = cacheBulkProcessor;
-  }
-
-  @Override
-  public QueryResponse federate(List<Source> sources, QueryRequest queryRequest) {
-    Validate.noNullElements(sources, "Cannot federate with null sources.");
-    Validate.notNull(queryRequest, "Cannot federate with null QueryRequest.");
-    Set<String> sourceIds = new HashSet<>();
-    for (Source source : sources) {
-      sourceIds.add(source.getId());
+        this.queryExecutorService = queryExecutorService;
+        this.preQuery = preQuery;
+        this.postQuery = postQuery;
+        this.maxStartIndex = DEFAULT_MAX_START_INDEX;
+        this.cache = cache;
+        this.cacheExecutorService = cacheExecutorService;
+        cacheCommitPhaser = new CacheCommitPhaser(cache);
+        cacheBulkProcessor = new CacheBulkProcessor(cache);
+        this.validationQueryFactory = validationQueryFactory;
+        this.cacheQueryFactory = cacheQueryFactory;
+        cacheSource = new SolrCacheSource(cache);
     }
-    QueryRequest modifiedQueryRequest =
-        new QueryRequestImpl(
-            queryRequest.getQuery(),
-            queryRequest.isEnterprise(),
-            sourceIds,
-            queryRequest.getProperties());
 
-    if (CACHE_QUERY_MODE.equals(queryRequest.getProperties().get(QUERY_MODE))) {
-      return queryCache(modifiedQueryRequest);
-    } else {
-      return sourceFederate(sources, modifiedQueryRequest);
+    void setSortedQueryMonitorFactory(SortedQueryMonitorFactory sortedQueryMonitorFactory) {
+        this.sortedQueryMonitorFactory = sortedQueryMonitorFactory;
     }
-  }
 
-  QueryResponse queryCache(QueryRequest queryRequest) {
-    return sourceFederate(
-        ImmutableList.of(cacheSource),
-        cacheQueryFactory.getQueryRequestWithSourcesFilter(queryRequest));
-  }
+    void setCacheCommitPhaser(CacheCommitPhaser cacheCommitPhaser) {
+        this.cacheCommitPhaser = cacheCommitPhaser;
+    }
 
-  private QueryResponse sourceFederate(List<Source> sources, final QueryRequest queryRequest) {
-    if (LOGGER.isDebugEnabled()) {
-      for (Source source : sources) {
-        if (source != null) {
-          LOGGER.debug("source to query: {}", source.getId());
+    void setCacheBulkProcessor(CacheBulkProcessor cacheBulkProcessor) {
+        this.cacheBulkProcessor = cacheBulkProcessor;
+    }
+
+    @Override
+    public QueryResponse federate(List<Source> sources, QueryRequest queryRequest) {
+        Validate.noNullElements(sources, "Cannot federate with null sources.");
+        Validate.notNull(queryRequest, "Cannot federate with null QueryRequest.");
+        Set<String> sourceIds = new HashSet<>();
+        for (Source source : sources) {
+            sourceIds.add(source.getId());
         }
-      }
-    }
-
-    Query originalQuery = queryRequest.getQuery();
-
-    int offset = originalQuery.getStartIndex();
-    final int pageSize = originalQuery.getPageSize();
-
-    // limit offset to max value
-    if (offset > this.maxStartIndex) {
-      offset = this.maxStartIndex;
-    }
-
-    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
-
-    Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
-
-    Query modifiedQuery = getModifiedQuery(originalQuery, sources.size(), offset, pageSize);
-    QueryRequest modifiedQueryRequest =
-        new QueryRequestImpl(
-            modifiedQuery,
-            queryRequest.isEnterprise(),
-            queryRequest.getSourceIds(),
-            queryRequest.getProperties());
-
-    CompletionService<SourceResponse> queryCompletion =
-        new ExecutorCompletionService<>(queryExecutorService);
-
-    // Do NOT call source.isAvailable() when checking sources
-    for (final Source source : sources) {
-      if (source != null) {
-        LOGGER.debug("running query on source: {}", source.getId());
-
-        QueryRequest sourceQueryRequest =
-            new QueryRequestImpl(
-                modifiedQuery,
+        QueryRequest modifiedQueryRequest = new QueryRequestImpl(queryRequest.getQuery(),
                 queryRequest.isEnterprise(),
-                Collections.singleton(source.getId()),
-                new HashMap<>(queryRequest.getProperties()));
-        try {
-          for (PreFederatedQueryPlugin service : preQuery) {
-            try {
-              sourceQueryRequest = service.process(source, sourceQueryRequest);
-            } catch (PluginExecutionException e) {
-              LOGGER.info("Error executing PreFederatedQueryPlugin", e);
-            }
-          }
-        } catch (StopProcessingException e) {
-          LOGGER.info("Plugin stopped processing", e);
+                sourceIds,
+                queryRequest.getProperties());
+
+        if (CACHE_QUERY_MODE.equals(queryRequest.getProperties()
+                .get(QUERY_MODE))) {
+            return queryCache(modifiedQueryRequest);
+        } else {
+            return sourceFederate(sources, modifiedQueryRequest);
         }
-
-        if (source instanceof CatalogProvider && SystemInfo.getSiteName().equals(source.getId())) {
-          // TODO RAP 12 Jul 16: DDF-2294 - Extract into a new PreFederatedQueryPlugin
-          sourceQueryRequest =
-              validationQueryFactory.getQueryRequestWithValidationFilter(
-                  sourceQueryRequest, showErrors, showWarnings);
-        }
-
-        futures.put(
-            queryCompletion.submit(new CallableSourceResponse(source, sourceQueryRequest)),
-            sourceQueryRequest);
-      }
     }
 
-    QueryResponseImpl offsetResults = null;
-    // If there are offsets and more than one source, we have to get all the
-    // results back and then
-    // transfer them into a different Queue. That is what the
-    // OffsetResultHandler does.
-    if (offset > 1 && sources.size() > 1) {
-      offsetResults = new QueryResponseImpl(queryRequest, null);
-      queryExecutorService.submit(
-          new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
+    QueryResponse queryCache(QueryRequest queryRequest) {
+        return sourceFederate(ImmutableList.of(cacheSource),
+                cacheQueryFactory.getQueryRequestWithSourcesFilter(queryRequest));
     }
 
-    queryExecutorService.submit(
-        sortedQueryMonitorFactory.createMonitor(
-            queryCompletion, futures, queryResponseQueue, modifiedQueryRequest, postQuery));
-
-    QueryResponse queryResponse;
-    if (offset > 1 && sources.size() > 1) {
-      queryResponse = offsetResults;
-      LOGGER.debug("returning offsetResults");
-    } else {
-      queryResponse = queryResponseQueue;
-      LOGGER.debug("returning returnResults: {}", queryResponse);
-    }
-
-    LOGGER.debug("returning Query Results: {}", queryResponse);
-    return queryResponse;
-  }
-
-  private Query getModifiedQuery(
-      Query originalQuery, int numberOfSources, int offset, int pageSize) {
-
-    Query query;
-
-    // If offset is not specified, our offset is 1
-    if (offset > 1 && numberOfSources > 1) {
-
-      final int modifiedOffset = 1;
-      int modifiedPageSize = computeModifiedPageSize(offset, pageSize);
-
-      LOGGER.debug(
-          "Creating new query for federated sources to query each source from {} " + "to {}.",
-          modifiedOffset,
-          modifiedPageSize);
-      LOGGER.debug("original offset: {}", offset);
-      LOGGER.debug("original page size: {}", pageSize);
-      LOGGER.debug("modified offset: {}", modifiedOffset);
-      LOGGER.debug("modified page size: {}", modifiedPageSize);
-
-      /**
-       * Federated sources always query from offset of 1. When all query results are received from
-       * all federated sources and merged together - then the offset is applied.
-       */
-      query =
-          new QueryImpl(
-              originalQuery,
-              modifiedOffset,
-              modifiedPageSize,
-              originalQuery.getSortBy(),
-              originalQuery.requestsTotalResultsCount(),
-              originalQuery.getTimeoutMillis());
-    } else {
-      query = originalQuery;
-    }
-
-    return query;
-  }
-
-  /** Base 1 offset, hence page size is one less. */
-  private int computeModifiedPageSize(int offset, int pageSize) {
-    return offset + pageSize - 1;
-  }
-
-  @Override
-  public CreateResponse process(CreateResponse input) throws PluginExecutionException {
-    return input;
-  }
-
-  @Override
-  public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
-
-    LOGGER.debug("Post ingest processing of UpdateResponse.");
-    if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
-      return input;
-    }
-
-    if (cacheSource
-        .getId()
-        .equals(input.getRequest().getProperties().get(Constants.SERVICE_TITLE))) {
-      return input;
-    }
-
-    List<Metacard> metacards = new ArrayList<>(input.getUpdatedMetacards().size());
-
-    for (Update update : input.getUpdatedMetacards()) {
-      metacards.add(update.getNewMetacard());
-    }
-
-    LOGGER.debug("Updating metacard(s) in cache.");
-    cache.create(metacards);
-    LOGGER.debug("Updating metacard(s) in cache complete.");
-
-    return input;
-  }
-
-  @Override
-  public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
-
-    LOGGER.debug("Post ingest processing of DeleteResponse.");
-    if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
-      return input;
-    }
-
-    if (cacheSource
-        .getId()
-        .equals(input.getRequest().getProperties().get(Constants.SERVICE_TITLE))) {
-      return input;
-    }
-
-    LOGGER.debug("Deleting metacard(s) in cache.");
-    cache.delete(input.getRequest());
-    LOGGER.debug("Deletion of metacard(s) in cache complete.");
-
-    return input;
-  }
-
-  int getMaxStartIndex() {
-    return maxStartIndex;
-  }
-
-  /**
-   * To be set via Spring/Blueprint
-   *
-   * @param maxStartIndex the new default max start index value
-   */
-  public void setMaxStartIndex(int maxStartIndex) {
-    this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-
-    if (maxStartIndex > 0) {
-      this.maxStartIndex = maxStartIndex;
-    } else {
-      LOGGER.debug("Invalid max start index input. Reset to default value: {}", this.maxStartIndex);
-    }
-  }
-
-  public void setExpirationIntervalInMinutes(long expirationIntervalInMinutes) {
-    cache.setExpirationIntervalInMinutes(expirationIntervalInMinutes);
-  }
-
-  public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
-    cache.setExpirationAgeInMinutes(expirationAgeInMinutes);
-  }
-
-  public void setCachingEverything(boolean cachingEverything) {
-    this.isCachingEverything = cachingEverything;
-  }
-
-  public boolean isCacheRemoteIngests() {
-    return cacheRemoteIngests;
-  }
-
-  public void setCacheRemoteIngests(boolean cacheRemoteIngests) {
-    this.cacheRemoteIngests = cacheRemoteIngests;
-  }
-
-  public void shutdown() {
-    cacheCommitPhaser.shutdown();
-    cacheBulkProcessor.shutdown();
-  }
-
-  public boolean getShowErrors() {
-    return showErrors;
-  }
-
-  public void setShowErrors(boolean showErrors) {
-    this.showErrors = showErrors;
-  }
-
-  public boolean getShowWarnings() {
-    return showWarnings;
-  }
-
-  public void setShowWarnings(boolean showWarnings) {
-    this.showWarnings = showWarnings;
-  }
-
-  static class OffsetResultHandler implements Runnable {
-
-    private QueryResponseImpl originalResults = null;
-
-    private QueryResponseImpl offsetResultQueue = null;
-
-    private int pageSize = 0;
-
-    private int offset = 1;
-
-    OffsetResultHandler(
-        QueryResponseImpl originalResults,
-        QueryResponseImpl offsetResultQueue,
-        int pageSize,
-        int offset) {
-      this.originalResults = originalResults;
-      this.offsetResultQueue = offsetResultQueue;
-      this.pageSize = pageSize;
-      this.offset = offset;
-    }
-
-    @Override
-    public void run() {
-      int queryResultIndex = 1;
-      int resultsSent = 0;
-      Result result;
-
-      while (resultsSent < pageSize
-          && originalResults.hasMoreResults()
-          && (result = originalResults.take()) != null) {
-        if (queryResultIndex >= offset) {
-          offsetResultQueue.addResult(result, false);
-          resultsSent++;
-        }
-        queryResultIndex++;
-      }
-
-      LOGGER.debug("Closing Queue and setting the total count");
-      offsetResultQueue.setHits(originalResults.getHits());
-      offsetResultQueue.closeResultQueue();
-    }
-  }
-
-  private class CallableSourceResponse implements Callable<SourceResponse> {
-
-    private final QueryRequest request;
-
-    private final Source source;
-
-    public CallableSourceResponse(Source source, QueryRequest request) {
-      this.source = source;
-      this.request = request;
-    }
-
-    @Override
-    public SourceResponse call() throws Exception {
-      QueryRequest queryRequest;
-      if (CACHE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))
-          || INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-        queryRequest =
-            new QueryRequestImpl(
-                request.getQuery(), false, request.getSourceIds(), request.getProperties());
-      } else {
-        queryRequest = new QueryRequestImpl(request.getQuery(), request.getProperties());
-      }
-
-      final SourceResponse sourceResponse = source.query(queryRequest);
-      final SourceResponse clonedSourceResponse = cloneResponse(sourceResponse);
-
-      if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-        cacheCommitPhaser.add(clonedSourceResponse.getResults());
-      } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-        if (isCachingEverything || UPDATE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-          cacheExecutorService.submit(
-              () -> {
-                try {
-                  cacheBulkProcessor.add(clonedSourceResponse.getResults());
-                } catch (Throwable throwable) {
-                  LOGGER.warn("Unable to add results for bulk processing", throwable);
+    private QueryResponse sourceFederate(List<Source> sources, final QueryRequest queryRequest) {
+        if (LOGGER.isDebugEnabled()) {
+            for (Source source : sources) {
+                if (source != null) {
+                    LOGGER.debug("source to query: {}", source.getId());
                 }
-              });
+            }
         }
-      }
-      return sourceResponse;
+
+        Query originalQuery = queryRequest.getQuery();
+
+        int offset = originalQuery.getStartIndex();
+        final int pageSize = originalQuery.getPageSize();
+
+        // limit offset to max value
+        if (offset > this.maxStartIndex) {
+            offset = this.maxStartIndex;
+        }
+
+        final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
+
+        Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
+
+        Query modifiedQuery = getModifiedQuery(originalQuery, sources.size(), offset, pageSize);
+        QueryRequest modifiedQueryRequest = new QueryRequestImpl(modifiedQuery,
+                queryRequest.isEnterprise(),
+                queryRequest.getSourceIds(),
+                queryRequest.getProperties());
+
+        CompletionService<SourceResponse> queryCompletion = new ExecutorCompletionService<>(
+                queryExecutorService);
+
+        // Do NOT call source.isAvailable() when checking sources
+        for (final Source source : sources) {
+            if (source != null) {
+                LOGGER.debug("running query on source: {}", source.getId());
+
+                QueryRequest sourceQueryRequest = new QueryRequestImpl(modifiedQuery,
+                        queryRequest.isEnterprise(),
+                        Collections.singleton(source.getId()),
+                        new HashMap<>(queryRequest.getProperties()));
+                try {
+                    for (PreFederatedQueryPlugin service : preQuery) {
+                        try {
+                            sourceQueryRequest = service.process(source, sourceQueryRequest);
+                        } catch (PluginExecutionException e) {
+                            LOGGER.info("Error executing PreFederatedQueryPlugin", e);
+                        }
+                    }
+                } catch (StopProcessingException e) {
+                    LOGGER.info("Plugin stopped processing", e);
+                }
+
+                if (source instanceof CatalogProvider && SystemInfo.getSiteName()
+                        .equals(source.getId())) {
+                    // TODO RAP 12 Jul 16: DDF-2294 - Extract into a new PreFederatedQueryPlugin
+                    sourceQueryRequest = validationQueryFactory.getQueryRequestWithValidationFilter(
+                            sourceQueryRequest,
+                            showErrors,
+                            showWarnings);
+                }
+
+                futures.put(queryCompletion.submit(new CallableSourceResponse(source,
+                        sourceQueryRequest)), sourceQueryRequest);
+            }
+        }
+
+        QueryResponseImpl offsetResults = null;
+        // If there are offsets and more than one source, we have to get all the
+        // results back and then
+        // transfer them into a different Queue. That is what the
+        // OffsetResultHandler does.
+        if (offset > 1 && sources.size() > 1) {
+            offsetResults = new QueryResponseImpl(queryRequest, null);
+            queryExecutorService.submit(new OffsetResultHandler(queryResponseQueue,
+                    offsetResults,
+                    pageSize,
+                    offset));
+        }
+
+        queryExecutorService.submit(sortedQueryMonitorFactory.createMonitor(queryCompletion,
+                futures,
+                queryResponseQueue,
+                modifiedQueryRequest,
+                postQuery));
+
+        QueryResponse queryResponse;
+        if (offset > 1 && sources.size() > 1) {
+            queryResponse = offsetResults;
+            LOGGER.debug("returning offsetResults");
+        } else {
+            queryResponse = queryResponseQueue;
+            LOGGER.debug("returning returnResults: {}", queryResponse);
+        }
+
+        LOGGER.debug("returning Query Results: {}", queryResponse);
+        return queryResponse;
     }
 
-    private SourceResponse cloneResponse(SourceResponse sourceResponse) {
-      List<Result> clonedResults =
-          sourceResponse
-              .getResults()
-              .stream()
-              .map(Result::getMetacard)
-              .map(m -> new MetacardImpl(m, m.getMetacardType()))
-              .map(ResultImpl::new)
-              .collect(Collectors.toList());
+    private Query getModifiedQuery(Query originalQuery, int numberOfSources, int offset,
+            int pageSize) {
 
-      return new QueryResponseImpl(
-          sourceResponse.getRequest(),
-          clonedResults,
-          true,
-          sourceResponse.getHits(),
-          sourceResponse.getProperties());
+        Query query;
+
+        // If offset is not specified, our offset is 1
+        if (offset > 1 && numberOfSources > 1) {
+
+            final int modifiedOffset = 1;
+            int modifiedPageSize = computeModifiedPageSize(offset, pageSize);
+
+            LOGGER.debug("Creating new query for federated sources to query each source from {} "
+                    + "to {}.", modifiedOffset, modifiedPageSize);
+            LOGGER.debug("original offset: {}", offset);
+            LOGGER.debug("original page size: {}", pageSize);
+            LOGGER.debug("modified offset: {}", modifiedOffset);
+            LOGGER.debug("modified page size: {}", modifiedPageSize);
+
+            /**
+             * Federated sources always query from offset of 1. When all query results are received
+             * from all federated sources and merged together - then the offset is applied.
+             *
+             */
+            query = new QueryImpl(originalQuery,
+                    modifiedOffset,
+                    modifiedPageSize,
+                    originalQuery.getSortBy(),
+                    originalQuery.requestsTotalResultsCount(),
+                    originalQuery.getTimeoutMillis());
+        } else {
+            query = originalQuery;
+        }
+
+        return query;
     }
-  }
 
-  /** Phaser that forces all added metacards to commit to the cache on phase advance */
+    /**
+     * Base 1 offset, hence page size is one less.
+     */
+    private int computeModifiedPageSize(int offset, int pageSize) {
+        return offset + pageSize - 1;
+    }
+
+    @Override
+    public CreateResponse process(CreateResponse input) throws PluginExecutionException {
+        return input;
+    }
+
+    @Override
+    public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
+
+        LOGGER.debug("Post ingest processing of UpdateResponse.");
+        if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
+            return input;
+        }
+
+        if (cacheSource.getId()
+                .equals(input.getRequest()
+                        .getProperties()
+                        .get(Constants.SERVICE_TITLE))) {
+            return input;
+        }
+
+        List<Metacard> metacards = new ArrayList<>(input.getUpdatedMetacards()
+                .size());
+
+        for (Update update : input.getUpdatedMetacards()) {
+            metacards.add(update.getNewMetacard());
+        }
+
+        LOGGER.debug("Updating metacard(s) in cache.");
+        cache.create(metacards);
+        LOGGER.debug("Updating metacard(s) in cache complete.");
+
+        return input;
+    }
+
+    @Override
+    public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
+
+        LOGGER.debug("Post ingest processing of DeleteResponse.");
+        if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
+            return input;
+        }
+
+        if (cacheSource.getId()
+                .equals(input.getRequest()
+                        .getProperties()
+                        .get(Constants.SERVICE_TITLE))) {
+            return input;
+        }
+
+        LOGGER.debug("Deleting metacard(s) in cache.");
+        cache.delete(input.getRequest());
+        LOGGER.debug("Deletion of metacard(s) in cache complete.");
+
+        return input;
+    }
+
+    int getMaxStartIndex() {
+        return maxStartIndex;
+    }
+
+    /**
+     * To be set via Spring/Blueprint
+     *
+     * @param maxStartIndex the new default max start index value
+     */
+    public void setMaxStartIndex(int maxStartIndex) {
+        this.maxStartIndex = DEFAULT_MAX_START_INDEX;
+
+        if (maxStartIndex > 0) {
+            this.maxStartIndex = maxStartIndex;
+        } else {
+            LOGGER.debug("Invalid max start index input. Reset to default value: {}",
+                    this.maxStartIndex);
+        }
+    }
+
+    public void setExpirationIntervalInMinutes(long expirationIntervalInMinutes) {
+        cache.setExpirationIntervalInMinutes(expirationIntervalInMinutes);
+    }
+
+    public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
+        cache.setExpirationAgeInMinutes(expirationAgeInMinutes);
+    }
+
+    public void setCachingEverything(boolean cachingEverything) {
+        this.isCachingEverything = cachingEverything;
+    }
+
+    public boolean isCacheRemoteIngests() {
+        return cacheRemoteIngests;
+    }
+
+    public void setCacheRemoteIngests(boolean cacheRemoteIngests) {
+        this.cacheRemoteIngests = cacheRemoteIngests;
+    }
+
+    public void shutdown() {
+        cacheCommitPhaser.shutdown();
+        cacheBulkProcessor.shutdown();
+    }
+
+    public boolean getShowErrors() {
+        return showErrors;
+    }
+
+    public void setShowErrors(boolean showErrors) {
+        this.showErrors = showErrors;
+    }
+
+    public boolean getShowWarnings() {
+        return showWarnings;
+    }
+
+    public void setShowWarnings(boolean showWarnings) {
+        this.showWarnings = showWarnings;
+    }
+
+    static class OffsetResultHandler implements Runnable {
+
+        private QueryResponseImpl originalResults = null;
+
+        private QueryResponseImpl offsetResultQueue = null;
+
+        private int pageSize = 0;
+
+        private int offset = 1;
+
+        OffsetResultHandler(QueryResponseImpl originalResults, QueryResponseImpl offsetResultQueue,
+                int pageSize, int offset) {
+            this.originalResults = originalResults;
+            this.offsetResultQueue = offsetResultQueue;
+            this.pageSize = pageSize;
+            this.offset = offset;
+        }
+
+        @Override
+        public void run() {
+            int queryResultIndex = 1;
+            int resultsSent = 0;
+            Result result;
+
+            while (resultsSent < pageSize && originalResults.hasMoreResults()
+                    && (result = originalResults.take()) != null) {
+                if (queryResultIndex >= offset) {
+                    offsetResultQueue.addResult(result, false);
+                    resultsSent++;
+                }
+                queryResultIndex++;
+            }
+
+            LOGGER.debug("Closing Queue and setting the total count");
+            offsetResultQueue.setHits(originalResults.getHits());
+            offsetResultQueue.closeResultQueue();
+        }
+    }
+
+    private class CallableSourceResponse implements Callable<SourceResponse> {
+
+        private final QueryRequest request;
+
+        private final Source source;
+
+        public CallableSourceResponse(Source source, QueryRequest request) {
+            this.source = source;
+            this.request = request;
+        }
+
+        @Override
+        public SourceResponse call() throws Exception {
+            QueryRequest queryRequest;
+            if (CACHE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))
+                    || INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                queryRequest = new QueryRequestImpl(request.getQuery(),
+                        false,
+                        request.getSourceIds(),
+                        request.getProperties());
+            } else {
+                queryRequest = new QueryRequestImpl(request.getQuery(), request.getProperties());
+            }
+
+            final SourceResponse sourceResponse = source.query(queryRequest);
+            final SourceResponse clonedSourceResponse = cloneResponse(sourceResponse);
+
+            if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                cacheCommitPhaser.add(clonedSourceResponse.getResults());
+            } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                if (isCachingEverything || UPDATE_QUERY_MODE.equals(request.getPropertyValue(
+                        QUERY_MODE))) {
+                    cacheExecutorService.submit(() -> {
+                        try {
+                            cacheBulkProcessor.add(clonedSourceResponse.getResults());
+                        } catch (Throwable throwable) {
+                            LOGGER.warn("Unable to add results for bulk processing", throwable);
+                        }
+                    });
+                }
+            }
+            return sourceResponse;
+        }
+
+        private SourceResponse cloneResponse(SourceResponse sourceResponse) {
+            List<Result> clonedResults = sourceResponse.getResults()
+                    .stream()
+                    .map(Result::getMetacard)
+                    .map(m -> new MetacardImpl(m, m.getMetacardType()))
+                    .map(ResultImpl::new)
+                    .collect(Collectors.toList());
+
+            return new QueryResponseImpl(sourceResponse.getRequest(),
+                    clonedResults,
+                    true,
+                    sourceResponse.getHits(),
+                    sourceResponse.getProperties());
+        }
+    }
+
+    /**
+     * Phaser that forces all added metacards to commit to the cache on phase advance
+     */
+
+    public void setCacheStrategy(String cacheStrategy) {
+        cacheBulkProcessor.setCacheStrategy(CacheStrategy.valueOf(cacheStrategy));
+    }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -1,41 +1,19 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or any later version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
- * is distributed along with this program and can be found at
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.Validate;
-import org.codice.ddf.configuration.SystemInfo;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
-
 import ddf.catalog.Constants;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -62,21 +40,41 @@ import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.Source;
 import ddf.catalog.util.impl.RelevanceResultComparator;
 import ddf.catalog.util.impl.Requests;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.Validate;
+import org.codice.ddf.configuration.SystemInfo;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting
- * {@link ddf.catalog.data.Metacard}s. The sorting is based on the {@link ddf.catalog.operation.Query}'s
- * {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values
- * are
+ * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link
+ * ddf.catalog.data.Metacard}s. The sorting is based on the {@link ddf.catalog.operation.Query}'s
+ * {@link org.opengis.filter.sort.SortBy} propertyName. The possible sorting values are
+ *
  * <ul>
- * <li>{@link ddf.catalog.data.Metacard#EFFECTIVE}</li>
- * <li>{@link ddf.catalog.data.Result#TEMPORAL}</li>
- * <li>{@link ddf.catalog.data.Result#DISTANCE}</li>
- * <li>{@link ddf.catalog.data.Result#RELEVANCE}</li>
+ *   <li>{@link ddf.catalog.data.Metacard#EFFECTIVE}
+ *   <li>{@link ddf.catalog.data.Result#TEMPORAL}
+ *   <li>{@link ddf.catalog.data.Result#DISTANCE}
+ *   <li>{@link ddf.catalog.data.Result#RELEVANCE}
  * </ul>
- * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and
- * {@link org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort
- * value and sort order must be provided.
+ *
+ * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and {@link
+ * org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort value
+ * and sort order must be provided.
  *
  * @see ddf.catalog.data.Metacard
  * @see ddf.catalog.operation.Query
@@ -84,517 +82,511 @@ import ddf.catalog.util.impl.Requests;
  */
 public class CachingFederationStrategy implements FederationStrategy, PostIngestPlugin {
 
-    /**
-     * The default comparator for sorting by {@link ddf.catalog.data.Result#RELEVANCE},
-     * {@link org.opengis.filter.sort.SortOrder#DESCENDING}
-     */
-    protected static final Comparator<Result> DEFAULT_COMPARATOR = new RelevanceResultComparator(
-            SortOrder.DESCENDING);
+  /**
+   * The default comparator for sorting by {@link ddf.catalog.data.Result#RELEVANCE}, {@link
+   * org.opengis.filter.sort.SortOrder#DESCENDING}
+   */
+  protected static final Comparator<Result> DEFAULT_COMPARATOR =
+      new RelevanceResultComparator(SortOrder.DESCENDING);
 
-    protected static final String QUERY_MODE = "mode";
+  protected static final String QUERY_MODE = "mode";
 
-    /**
-     * Query the cache
-     */
-    protected static final String CACHE_QUERY_MODE = "cache";
+  /** Query the cache */
+  protected static final String CACHE_QUERY_MODE = "cache";
 
-    /**
-     * Query without updating the cache
-     */
-    protected static final String NATIVE_QUERY_MODE = "native";
+  /** Query without updating the cache */
+  protected static final String NATIVE_QUERY_MODE = "native";
 
-    /**
-     * Query and update the cache but block until done indexing
-     */
-    protected static final String INDEX_QUERY_MODE = "index";
+  /** Query and update the cache but block until done indexing */
+  protected static final String INDEX_QUERY_MODE = "index";
 
-    /**
-     * Query and update the cache without blocking
-     */
-    protected static final String UPDATE_QUERY_MODE = "update";
+  /** Query and update the cache without blocking */
+  protected static final String UPDATE_QUERY_MODE = "update";
 
-    /**
-     * package-private to allow for unit testing
-     */
-    static final int DEFAULT_MAX_START_INDEX = 50000;
+  /** package-private to allow for unit testing */
+  static final int DEFAULT_MAX_START_INDEX = 50000;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CachingFederationStrategy.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CachingFederationStrategy.class);
 
-    private final SolrCache cache;
+  private final SolrCache cache;
 
-    private final SolrCacheSource cacheSource;
+  private final SolrCacheSource cacheSource;
 
-    private final ExecutorService cacheExecutorService;
+  private final ExecutorService cacheExecutorService;
 
-    /**
-     * The {@link List} of pre-federated query plugins to execute on the query request before the
-     * query is executed on the {@link Source}.
-     */
-    protected List<PreFederatedQueryPlugin> preQuery;
+  /**
+   * The {@link List} of pre-federated query plugins to execute on the query request before the
+   * query is executed on the {@link Source}.
+   */
+  protected List<PreFederatedQueryPlugin> preQuery;
 
-    /**
-     * The {@link List} of post-federated query plugins to execute on the query request after the
-     * query is executed on the {@link Source}.
-     */
-    protected List<PostFederatedQueryPlugin> postQuery;
+  /**
+   * The {@link List} of post-federated query plugins to execute on the query request after the
+   * query is executed on the {@link Source}.
+   */
+  protected List<PostFederatedQueryPlugin> postQuery;
 
-    private SortedQueryMonitorFactory sortedQueryMonitorFactory =
-            new SortedQueryMonitorFactory(this);
+  private SortedQueryMonitorFactory sortedQueryMonitorFactory = new SortedQueryMonitorFactory(this);
 
-    private ExecutorService queryExecutorService;
+  private ExecutorService queryExecutorService;
 
-    private int maxStartIndex;
+  private int maxStartIndex;
 
-    private CacheCommitPhaser cacheCommitPhaser;
+  private CacheCommitPhaser cacheCommitPhaser;
 
-    private CacheBulkProcessor cacheBulkProcessor;
+  private CacheBulkProcessor cacheBulkProcessor;
 
-    private boolean isCachingEverything = false;
+  private boolean isCachingEverything = false;
 
-    private boolean cacheRemoteIngests = false;
+  private boolean cacheRemoteIngests = false;
 
-    private ValidationQueryFactory validationQueryFactory;
+  private ValidationQueryFactory validationQueryFactory;
 
-    private CacheQueryFactory cacheQueryFactory;
+  private CacheQueryFactory cacheQueryFactory;
 
-    private boolean showErrors = false;
+  private boolean showErrors = false;
 
-    private boolean showWarnings = true;
+  private boolean showWarnings = true;
 
-    /**
-     * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
-     *
-     * @param queryExecutorService the {@link ExecutorService} for queries
-     */
-    public CachingFederationStrategy(ExecutorService queryExecutorService,
-            List<PreFederatedQueryPlugin> preQuery, List<PostFederatedQueryPlugin> postQuery,
-            SolrCache cache, ExecutorService cacheExecutorService,
-            ValidationQueryFactory validationQueryFactory, CacheQueryFactory cacheQueryFactory) {
+  /**
+   * Instantiates an {@code AbstractFederationStrategy} with the provided {@link ExecutorService}.
+   *
+   * @param queryExecutorService the {@link ExecutorService} for queries
+   */
+  public CachingFederationStrategy(
+      ExecutorService queryExecutorService,
+      List<PreFederatedQueryPlugin> preQuery,
+      List<PostFederatedQueryPlugin> postQuery,
+      SolrCache cache,
+      ExecutorService cacheExecutorService,
+      ValidationQueryFactory validationQueryFactory,
+      CacheQueryFactory cacheQueryFactory) {
 
-        Validate.notNull(queryExecutorService, "Valid queryExecutorService required.");
-        Validate.notNull(preQuery, "Valid List<PreFederatedQueryPlugin> required.");
-        Validate.noNullElements(preQuery, "preQuery cannot contain null elements.");
-        Validate.notNull(postQuery, "Valid List<PostFederatedQueryPlugin> required.");
-        Validate.noNullElements(postQuery, "postQuery cannot contain null elements.");
-        Validate.notNull(cache, "Valid SolrCache required.");
-        Validate.notNull(cacheExecutorService, "Valid cacheExecutorService required.");
-        Validate.notNull(validationQueryFactory, "Valid ValidationQueryFactory required.");
-        Validate.notNull(cacheQueryFactory, "Valid CacheQueryFactory required.");
+    Validate.notNull(queryExecutorService, "Valid queryExecutorService required.");
+    Validate.notNull(preQuery, "Valid List<PreFederatedQueryPlugin> required.");
+    Validate.noNullElements(preQuery, "preQuery cannot contain null elements.");
+    Validate.notNull(postQuery, "Valid List<PostFederatedQueryPlugin> required.");
+    Validate.noNullElements(postQuery, "postQuery cannot contain null elements.");
+    Validate.notNull(cache, "Valid SolrCache required.");
+    Validate.notNull(cacheExecutorService, "Valid cacheExecutorService required.");
+    Validate.notNull(validationQueryFactory, "Valid ValidationQueryFactory required.");
+    Validate.notNull(cacheQueryFactory, "Valid CacheQueryFactory required.");
 
-        this.queryExecutorService = queryExecutorService;
-        this.preQuery = preQuery;
-        this.postQuery = postQuery;
-        this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-        this.cache = cache;
-        this.cacheExecutorService = cacheExecutorService;
-        cacheCommitPhaser = new CacheCommitPhaser(cache);
-        cacheBulkProcessor = new CacheBulkProcessor(cache);
-        this.validationQueryFactory = validationQueryFactory;
-        this.cacheQueryFactory = cacheQueryFactory;
-        cacheSource = new SolrCacheSource(cache);
+    this.queryExecutorService = queryExecutorService;
+    this.preQuery = preQuery;
+    this.postQuery = postQuery;
+    this.maxStartIndex = DEFAULT_MAX_START_INDEX;
+    this.cache = cache;
+    this.cacheExecutorService = cacheExecutorService;
+    cacheCommitPhaser = new CacheCommitPhaser(cache);
+    cacheBulkProcessor = new CacheBulkProcessor(cache);
+    this.validationQueryFactory = validationQueryFactory;
+    this.cacheQueryFactory = cacheQueryFactory;
+    cacheSource = new SolrCacheSource(cache);
+  }
+
+  void setSortedQueryMonitorFactory(SortedQueryMonitorFactory sortedQueryMonitorFactory) {
+    this.sortedQueryMonitorFactory = sortedQueryMonitorFactory;
+  }
+
+  void setCacheCommitPhaser(CacheCommitPhaser cacheCommitPhaser) {
+    this.cacheCommitPhaser = cacheCommitPhaser;
+  }
+
+  void setCacheBulkProcessor(CacheBulkProcessor cacheBulkProcessor) {
+    this.cacheBulkProcessor = cacheBulkProcessor;
+  }
+
+  @Override
+  public QueryResponse federate(List<Source> sources, QueryRequest queryRequest) {
+    Validate.noNullElements(sources, "Cannot federate with null sources.");
+    Validate.notNull(queryRequest, "Cannot federate with null QueryRequest.");
+    Set<String> sourceIds = new HashSet<>();
+    for (Source source : sources) {
+      sourceIds.add(source.getId());
+    }
+    QueryRequest modifiedQueryRequest =
+        new QueryRequestImpl(
+            queryRequest.getQuery(),
+            queryRequest.isEnterprise(),
+            sourceIds,
+            queryRequest.getProperties());
+
+    if (CACHE_QUERY_MODE.equals(queryRequest.getProperties().get(QUERY_MODE))) {
+      return queryCache(modifiedQueryRequest);
+    } else {
+      return sourceFederate(sources, modifiedQueryRequest);
+    }
+  }
+
+  QueryResponse queryCache(QueryRequest queryRequest) {
+    return sourceFederate(
+        ImmutableList.of(cacheSource),
+        cacheQueryFactory.getQueryRequestWithSourcesFilter(queryRequest));
+  }
+
+  private QueryResponse sourceFederate(List<Source> sources, final QueryRequest queryRequest) {
+    if (LOGGER.isDebugEnabled()) {
+      for (Source source : sources) {
+        if (source != null) {
+          LOGGER.debug("source to query: {}", source.getId());
+        }
+      }
     }
 
-    void setSortedQueryMonitorFactory(SortedQueryMonitorFactory sortedQueryMonitorFactory) {
-        this.sortedQueryMonitorFactory = sortedQueryMonitorFactory;
+    Query originalQuery = queryRequest.getQuery();
+
+    int offset = originalQuery.getStartIndex();
+    final int pageSize = originalQuery.getPageSize();
+
+    // limit offset to max value
+    if (offset > this.maxStartIndex) {
+      offset = this.maxStartIndex;
     }
 
-    void setCacheCommitPhaser(CacheCommitPhaser cacheCommitPhaser) {
-        this.cacheCommitPhaser = cacheCommitPhaser;
+    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
+
+    Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
+
+    Query modifiedQuery = getModifiedQuery(originalQuery, sources.size(), offset, pageSize);
+    QueryRequest modifiedQueryRequest =
+        new QueryRequestImpl(
+            modifiedQuery,
+            queryRequest.isEnterprise(),
+            queryRequest.getSourceIds(),
+            queryRequest.getProperties());
+
+    CompletionService<SourceResponse> queryCompletion =
+        new ExecutorCompletionService<>(queryExecutorService);
+
+    // Do NOT call source.isAvailable() when checking sources
+    for (final Source source : sources) {
+      if (source != null) {
+        LOGGER.debug("running query on source: {}", source.getId());
+
+        QueryRequest sourceQueryRequest =
+            new QueryRequestImpl(
+                modifiedQuery,
+                queryRequest.isEnterprise(),
+                Collections.singleton(source.getId()),
+                new HashMap<>(queryRequest.getProperties()));
+        try {
+          for (PreFederatedQueryPlugin service : preQuery) {
+            try {
+              sourceQueryRequest = service.process(source, sourceQueryRequest);
+            } catch (PluginExecutionException e) {
+              LOGGER.info("Error executing PreFederatedQueryPlugin", e);
+            }
+          }
+        } catch (StopProcessingException e) {
+          LOGGER.info("Plugin stopped processing", e);
+        }
+
+        if (source instanceof CatalogProvider && SystemInfo.getSiteName().equals(source.getId())) {
+          // TODO RAP 12 Jul 16: DDF-2294 - Extract into a new PreFederatedQueryPlugin
+          sourceQueryRequest =
+              validationQueryFactory.getQueryRequestWithValidationFilter(
+                  sourceQueryRequest, showErrors, showWarnings);
+        }
+
+        futures.put(
+            queryCompletion.submit(new CallableSourceResponse(source, sourceQueryRequest)),
+            sourceQueryRequest);
+      }
     }
 
-    void setCacheBulkProcessor(CacheBulkProcessor cacheBulkProcessor) {
-        this.cacheBulkProcessor = cacheBulkProcessor;
+    QueryResponseImpl offsetResults = null;
+    // If there are offsets and more than one source, we have to get all the
+    // results back and then
+    // transfer them into a different Queue. That is what the
+    // OffsetResultHandler does.
+    if (offset > 1 && sources.size() > 1) {
+      offsetResults = new QueryResponseImpl(queryRequest, null);
+      queryExecutorService.submit(
+          new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
+    }
+
+    queryExecutorService.submit(
+        sortedQueryMonitorFactory.createMonitor(
+            queryCompletion, futures, queryResponseQueue, modifiedQueryRequest, postQuery));
+
+    QueryResponse queryResponse;
+    if (offset > 1 && sources.size() > 1) {
+      queryResponse = offsetResults;
+      LOGGER.debug("returning offsetResults");
+    } else {
+      queryResponse = queryResponseQueue;
+      LOGGER.debug("returning returnResults: {}", queryResponse);
+    }
+
+    LOGGER.debug("returning Query Results: {}", queryResponse);
+    return queryResponse;
+  }
+
+  private Query getModifiedQuery(
+      Query originalQuery, int numberOfSources, int offset, int pageSize) {
+
+    Query query;
+
+    // If offset is not specified, our offset is 1
+    if (offset > 1 && numberOfSources > 1) {
+
+      final int modifiedOffset = 1;
+      int modifiedPageSize = computeModifiedPageSize(offset, pageSize);
+
+      LOGGER.debug(
+          "Creating new query for federated sources to query each source from {} " + "to {}.",
+          modifiedOffset,
+          modifiedPageSize);
+      LOGGER.debug("original offset: {}", offset);
+      LOGGER.debug("original page size: {}", pageSize);
+      LOGGER.debug("modified offset: {}", modifiedOffset);
+      LOGGER.debug("modified page size: {}", modifiedPageSize);
+
+      /**
+       * Federated sources always query from offset of 1. When all query results are received from
+       * all federated sources and merged together - then the offset is applied.
+       */
+      query =
+          new QueryImpl(
+              originalQuery,
+              modifiedOffset,
+              modifiedPageSize,
+              originalQuery.getSortBy(),
+              originalQuery.requestsTotalResultsCount(),
+              originalQuery.getTimeoutMillis());
+    } else {
+      query = originalQuery;
+    }
+
+    return query;
+  }
+
+  /** Base 1 offset, hence page size is one less. */
+  private int computeModifiedPageSize(int offset, int pageSize) {
+    return offset + pageSize - 1;
+  }
+
+  @Override
+  public CreateResponse process(CreateResponse input) throws PluginExecutionException {
+    return input;
+  }
+
+  @Override
+  public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
+
+    LOGGER.debug("Post ingest processing of UpdateResponse.");
+    if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
+      return input;
+    }
+
+    if (cacheSource
+        .getId()
+        .equals(input.getRequest().getProperties().get(Constants.SERVICE_TITLE))) {
+      return input;
+    }
+
+    List<Metacard> metacards = new ArrayList<>(input.getUpdatedMetacards().size());
+
+    for (Update update : input.getUpdatedMetacards()) {
+      metacards.add(update.getNewMetacard());
+    }
+
+    LOGGER.debug("Updating metacard(s) in cache.");
+    cache.create(metacards);
+    LOGGER.debug("Updating metacard(s) in cache complete.");
+
+    return input;
+  }
+
+  @Override
+  public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
+
+    LOGGER.debug("Post ingest processing of DeleteResponse.");
+    if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
+      return input;
+    }
+
+    if (cacheSource
+        .getId()
+        .equals(input.getRequest().getProperties().get(Constants.SERVICE_TITLE))) {
+      return input;
+    }
+
+    LOGGER.debug("Deleting metacard(s) in cache.");
+    cache.delete(input.getRequest());
+    LOGGER.debug("Deletion of metacard(s) in cache complete.");
+
+    return input;
+  }
+
+  int getMaxStartIndex() {
+    return maxStartIndex;
+  }
+
+  /**
+   * To be set via Spring/Blueprint
+   *
+   * @param maxStartIndex the new default max start index value
+   */
+  public void setMaxStartIndex(int maxStartIndex) {
+    this.maxStartIndex = DEFAULT_MAX_START_INDEX;
+
+    if (maxStartIndex > 0) {
+      this.maxStartIndex = maxStartIndex;
+    } else {
+      LOGGER.debug("Invalid max start index input. Reset to default value: {}", this.maxStartIndex);
+    }
+  }
+
+  public void setExpirationIntervalInMinutes(long expirationIntervalInMinutes) {
+    cache.setExpirationIntervalInMinutes(expirationIntervalInMinutes);
+  }
+
+  public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
+    cache.setExpirationAgeInMinutes(expirationAgeInMinutes);
+  }
+
+  public void setCachingEverything(boolean cachingEverything) {
+    this.isCachingEverything = cachingEverything;
+  }
+
+  public boolean isCacheRemoteIngests() {
+    return cacheRemoteIngests;
+  }
+
+  public void setCacheRemoteIngests(boolean cacheRemoteIngests) {
+    this.cacheRemoteIngests = cacheRemoteIngests;
+  }
+
+  public void shutdown() {
+    cacheCommitPhaser.shutdown();
+    cacheBulkProcessor.shutdown();
+  }
+
+  public boolean getShowErrors() {
+    return showErrors;
+  }
+
+  public void setShowErrors(boolean showErrors) {
+    this.showErrors = showErrors;
+  }
+
+  public boolean getShowWarnings() {
+    return showWarnings;
+  }
+
+  public void setShowWarnings(boolean showWarnings) {
+    this.showWarnings = showWarnings;
+  }
+
+  static class OffsetResultHandler implements Runnable {
+
+    private QueryResponseImpl originalResults = null;
+
+    private QueryResponseImpl offsetResultQueue = null;
+
+    private int pageSize = 0;
+
+    private int offset = 1;
+
+    OffsetResultHandler(
+        QueryResponseImpl originalResults,
+        QueryResponseImpl offsetResultQueue,
+        int pageSize,
+        int offset) {
+      this.originalResults = originalResults;
+      this.offsetResultQueue = offsetResultQueue;
+      this.pageSize = pageSize;
+      this.offset = offset;
     }
 
     @Override
-    public QueryResponse federate(List<Source> sources, QueryRequest queryRequest) {
-        Validate.noNullElements(sources, "Cannot federate with null sources.");
-        Validate.notNull(queryRequest, "Cannot federate with null QueryRequest.");
-        Set<String> sourceIds = new HashSet<>();
-        for (Source source : sources) {
-            sourceIds.add(source.getId());
-        }
-        QueryRequest modifiedQueryRequest = new QueryRequestImpl(queryRequest.getQuery(),
-                queryRequest.isEnterprise(),
-                sourceIds,
-                queryRequest.getProperties());
+    public void run() {
+      int queryResultIndex = 1;
+      int resultsSent = 0;
+      Result result;
 
-        if (CACHE_QUERY_MODE.equals(queryRequest.getProperties()
-                .get(QUERY_MODE))) {
-            return queryCache(modifiedQueryRequest);
-        } else {
-            return sourceFederate(sources, modifiedQueryRequest);
+      while (resultsSent < pageSize
+          && originalResults.hasMoreResults()
+          && (result = originalResults.take()) != null) {
+        if (queryResultIndex >= offset) {
+          offsetResultQueue.addResult(result, false);
+          resultsSent++;
         }
+        queryResultIndex++;
+      }
+
+      LOGGER.debug("Closing Queue and setting the total count");
+      offsetResultQueue.setHits(originalResults.getHits());
+      offsetResultQueue.closeResultQueue();
+    }
+  }
+
+  private class CallableSourceResponse implements Callable<SourceResponse> {
+
+    private final QueryRequest request;
+
+    private final Source source;
+
+    public CallableSourceResponse(Source source, QueryRequest request) {
+      this.source = source;
+      this.request = request;
     }
 
-    QueryResponse queryCache(QueryRequest queryRequest) {
-        return sourceFederate(ImmutableList.of(cacheSource),
-                cacheQueryFactory.getQueryRequestWithSourcesFilter(queryRequest));
-    }
+    @Override
+    public SourceResponse call() throws Exception {
+      QueryRequest queryRequest;
+      if (CACHE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))
+          || INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+        queryRequest =
+            new QueryRequestImpl(
+                request.getQuery(), false, request.getSourceIds(), request.getProperties());
+      } else {
+        queryRequest = new QueryRequestImpl(request.getQuery(), request.getProperties());
+      }
 
-    private QueryResponse sourceFederate(List<Source> sources, final QueryRequest queryRequest) {
-        if (LOGGER.isDebugEnabled()) {
-            for (Source source : sources) {
-                if (source != null) {
-                    LOGGER.debug("source to query: {}", source.getId());
-                }
-            }
-        }
+      final SourceResponse sourceResponse = source.query(queryRequest);
+      final SourceResponse clonedSourceResponse = cloneResponse(sourceResponse);
 
-        Query originalQuery = queryRequest.getQuery();
-
-        int offset = originalQuery.getStartIndex();
-        final int pageSize = originalQuery.getPageSize();
-
-        // limit offset to max value
-        if (offset > this.maxStartIndex) {
-            offset = this.maxStartIndex;
-        }
-
-        final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
-
-        Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
-
-        Query modifiedQuery = getModifiedQuery(originalQuery, sources.size(), offset, pageSize);
-        QueryRequest modifiedQueryRequest = new QueryRequestImpl(modifiedQuery,
-                queryRequest.isEnterprise(),
-                queryRequest.getSourceIds(),
-                queryRequest.getProperties());
-
-        CompletionService<SourceResponse> queryCompletion = new ExecutorCompletionService<>(
-                queryExecutorService);
-
-        // Do NOT call source.isAvailable() when checking sources
-        for (final Source source : sources) {
-            if (source != null) {
-                LOGGER.debug("running query on source: {}", source.getId());
-
-                QueryRequest sourceQueryRequest = new QueryRequestImpl(modifiedQuery,
-                        queryRequest.isEnterprise(),
-                        Collections.singleton(source.getId()),
-                        new HashMap<>(queryRequest.getProperties()));
+      if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+        cacheCommitPhaser.add(clonedSourceResponse.getResults());
+      } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+        if (isCachingEverything || UPDATE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+          cacheExecutorService.submit(
+              () -> {
                 try {
-                    for (PreFederatedQueryPlugin service : preQuery) {
-                        try {
-                            sourceQueryRequest = service.process(source, sourceQueryRequest);
-                        } catch (PluginExecutionException e) {
-                            LOGGER.info("Error executing PreFederatedQueryPlugin", e);
-                        }
-                    }
-                } catch (StopProcessingException e) {
-                    LOGGER.info("Plugin stopped processing", e);
+                  cacheBulkProcessor.add(clonedSourceResponse.getResults());
+                } catch (Throwable throwable) {
+                  LOGGER.warn("Unable to add results for bulk processing", throwable);
                 }
-
-                if (source instanceof CatalogProvider && SystemInfo.getSiteName()
-                        .equals(source.getId())) {
-                    // TODO RAP 12 Jul 16: DDF-2294 - Extract into a new PreFederatedQueryPlugin
-                    sourceQueryRequest = validationQueryFactory.getQueryRequestWithValidationFilter(
-                            sourceQueryRequest,
-                            showErrors,
-                            showWarnings);
-                }
-
-                futures.put(queryCompletion.submit(new CallableSourceResponse(source,
-                        sourceQueryRequest)), sourceQueryRequest);
-            }
+              });
         }
-
-        QueryResponseImpl offsetResults = null;
-        // If there are offsets and more than one source, we have to get all the
-        // results back and then
-        // transfer them into a different Queue. That is what the
-        // OffsetResultHandler does.
-        if (offset > 1 && sources.size() > 1) {
-            offsetResults = new QueryResponseImpl(queryRequest, null);
-            queryExecutorService.submit(new OffsetResultHandler(queryResponseQueue,
-                    offsetResults,
-                    pageSize,
-                    offset));
-        }
-
-        queryExecutorService.submit(sortedQueryMonitorFactory.createMonitor(queryCompletion,
-                futures,
-                queryResponseQueue,
-                modifiedQueryRequest,
-                postQuery));
-
-        QueryResponse queryResponse;
-        if (offset > 1 && sources.size() > 1) {
-            queryResponse = offsetResults;
-            LOGGER.debug("returning offsetResults");
-        } else {
-            queryResponse = queryResponseQueue;
-            LOGGER.debug("returning returnResults: {}", queryResponse);
-        }
-
-        LOGGER.debug("returning Query Results: {}", queryResponse);
-        return queryResponse;
+      }
+      return sourceResponse;
     }
 
-    private Query getModifiedQuery(Query originalQuery, int numberOfSources, int offset,
-            int pageSize) {
+    private SourceResponse cloneResponse(SourceResponse sourceResponse) {
+      List<Result> clonedResults =
+          sourceResponse
+              .getResults()
+              .stream()
+              .map(Result::getMetacard)
+              .map(m -> new MetacardImpl(m, m.getMetacardType()))
+              .map(ResultImpl::new)
+              .collect(Collectors.toList());
 
-        Query query;
-
-        // If offset is not specified, our offset is 1
-        if (offset > 1 && numberOfSources > 1) {
-
-            final int modifiedOffset = 1;
-            int modifiedPageSize = computeModifiedPageSize(offset, pageSize);
-
-            LOGGER.debug("Creating new query for federated sources to query each source from {} "
-                    + "to {}.", modifiedOffset, modifiedPageSize);
-            LOGGER.debug("original offset: {}", offset);
-            LOGGER.debug("original page size: {}", pageSize);
-            LOGGER.debug("modified offset: {}", modifiedOffset);
-            LOGGER.debug("modified page size: {}", modifiedPageSize);
-
-            /**
-             * Federated sources always query from offset of 1. When all query results are received
-             * from all federated sources and merged together - then the offset is applied.
-             *
-             */
-            query = new QueryImpl(originalQuery,
-                    modifiedOffset,
-                    modifiedPageSize,
-                    originalQuery.getSortBy(),
-                    originalQuery.requestsTotalResultsCount(),
-                    originalQuery.getTimeoutMillis());
-        } else {
-            query = originalQuery;
-        }
-
-        return query;
+      return new QueryResponseImpl(
+          sourceResponse.getRequest(),
+          clonedResults,
+          true,
+          sourceResponse.getHits(),
+          sourceResponse.getProperties());
     }
+  }
 
-    /**
-     * Base 1 offset, hence page size is one less.
-     */
-    private int computeModifiedPageSize(int offset, int pageSize) {
-        return offset + pageSize - 1;
-    }
-
-    @Override
-    public CreateResponse process(CreateResponse input) throws PluginExecutionException {
-        return input;
-    }
-
-    @Override
-    public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
-
-        LOGGER.debug("Post ingest processing of UpdateResponse.");
-        if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
-            return input;
-        }
-
-        if (cacheSource.getId()
-                .equals(input.getRequest()
-                        .getProperties()
-                        .get(Constants.SERVICE_TITLE))) {
-            return input;
-        }
-
-        List<Metacard> metacards = new ArrayList<>(input.getUpdatedMetacards()
-                .size());
-
-        for (Update update : input.getUpdatedMetacards()) {
-            metacards.add(update.getNewMetacard());
-        }
-
-        LOGGER.debug("Updating metacard(s) in cache.");
-        cache.create(metacards);
-        LOGGER.debug("Updating metacard(s) in cache complete.");
-
-        return input;
-    }
-
-    @Override
-    public DeleteResponse process(DeleteResponse input) throws PluginExecutionException {
-
-        LOGGER.debug("Post ingest processing of DeleteResponse.");
-        if (!isCacheRemoteIngests() && !Requests.isLocal(input.getRequest())) {
-            return input;
-        }
-
-        if (cacheSource.getId()
-                .equals(input.getRequest()
-                        .getProperties()
-                        .get(Constants.SERVICE_TITLE))) {
-            return input;
-        }
-
-        LOGGER.debug("Deleting metacard(s) in cache.");
-        cache.delete(input.getRequest());
-        LOGGER.debug("Deletion of metacard(s) in cache complete.");
-
-        return input;
-    }
-
-    int getMaxStartIndex() {
-        return maxStartIndex;
-    }
-
-    /**
-     * To be set via Spring/Blueprint
-     *
-     * @param maxStartIndex the new default max start index value
-     */
-    public void setMaxStartIndex(int maxStartIndex) {
-        this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-
-        if (maxStartIndex > 0) {
-            this.maxStartIndex = maxStartIndex;
-        } else {
-            LOGGER.debug("Invalid max start index input. Reset to default value: {}",
-                    this.maxStartIndex);
-        }
-    }
-
-    public void setExpirationIntervalInMinutes(long expirationIntervalInMinutes) {
-        cache.setExpirationIntervalInMinutes(expirationIntervalInMinutes);
-    }
-
-    public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
-        cache.setExpirationAgeInMinutes(expirationAgeInMinutes);
-    }
-
-    public void setCachingEverything(boolean cachingEverything) {
-        this.isCachingEverything = cachingEverything;
-    }
-
-    public boolean isCacheRemoteIngests() {
-        return cacheRemoteIngests;
-    }
-
-    public void setCacheRemoteIngests(boolean cacheRemoteIngests) {
-        this.cacheRemoteIngests = cacheRemoteIngests;
-    }
-
-    public void shutdown() {
-        cacheCommitPhaser.shutdown();
-        cacheBulkProcessor.shutdown();
-    }
-
-    public boolean getShowErrors() {
-        return showErrors;
-    }
-
-    public void setShowErrors(boolean showErrors) {
-        this.showErrors = showErrors;
-    }
-
-    public boolean getShowWarnings() {
-        return showWarnings;
-    }
-
-    public void setShowWarnings(boolean showWarnings) {
-        this.showWarnings = showWarnings;
-    }
-
-    static class OffsetResultHandler implements Runnable {
-
-        private QueryResponseImpl originalResults = null;
-
-        private QueryResponseImpl offsetResultQueue = null;
-
-        private int pageSize = 0;
-
-        private int offset = 1;
-
-        OffsetResultHandler(QueryResponseImpl originalResults, QueryResponseImpl offsetResultQueue,
-                int pageSize, int offset) {
-            this.originalResults = originalResults;
-            this.offsetResultQueue = offsetResultQueue;
-            this.pageSize = pageSize;
-            this.offset = offset;
-        }
-
-        @Override
-        public void run() {
-            int queryResultIndex = 1;
-            int resultsSent = 0;
-            Result result;
-
-            while (resultsSent < pageSize && originalResults.hasMoreResults()
-                    && (result = originalResults.take()) != null) {
-                if (queryResultIndex >= offset) {
-                    offsetResultQueue.addResult(result, false);
-                    resultsSent++;
-                }
-                queryResultIndex++;
-            }
-
-            LOGGER.debug("Closing Queue and setting the total count");
-            offsetResultQueue.setHits(originalResults.getHits());
-            offsetResultQueue.closeResultQueue();
-        }
-    }
-
-    private class CallableSourceResponse implements Callable<SourceResponse> {
-
-        private final QueryRequest request;
-
-        private final Source source;
-
-        public CallableSourceResponse(Source source, QueryRequest request) {
-            this.source = source;
-            this.request = request;
-        }
-
-        @Override
-        public SourceResponse call() throws Exception {
-            QueryRequest queryRequest;
-            if (CACHE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))
-                    || INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                queryRequest = new QueryRequestImpl(request.getQuery(),
-                        false,
-                        request.getSourceIds(),
-                        request.getProperties());
-            } else {
-                queryRequest = new QueryRequestImpl(request.getQuery(), request.getProperties());
-            }
-
-            final SourceResponse sourceResponse = source.query(queryRequest);
-            final SourceResponse clonedSourceResponse = cloneResponse(sourceResponse);
-
-            if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                cacheCommitPhaser.add(clonedSourceResponse.getResults());
-            } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                if (isCachingEverything || UPDATE_QUERY_MODE.equals(request.getPropertyValue(
-                        QUERY_MODE))) {
-                    cacheExecutorService.submit(() -> {
-                        try {
-                            cacheBulkProcessor.add(clonedSourceResponse.getResults());
-                        } catch (Throwable throwable) {
-                            LOGGER.warn("Unable to add results for bulk processing", throwable);
-                        }
-                    });
-                }
-            }
-            return sourceResponse;
-        }
-
-        private SourceResponse cloneResponse(SourceResponse sourceResponse) {
-            List<Result> clonedResults = sourceResponse.getResults()
-                    .stream()
-                    .map(Result::getMetacard)
-                    .map(m -> new MetacardImpl(m, m.getMetacardType()))
-                    .map(ResultImpl::new)
-                    .collect(Collectors.toList());
-
-            return new QueryResponseImpl(sourceResponse.getRequest(),
-                    clonedResults,
-                    true,
-                    sourceResponse.getHits(),
-                    sourceResponse.getProperties());
-        }
-    }
-
-    /**
-     * Phaser that forces all added metacards to commit to the cache on phase advance
-     */
-
-    public void setCacheStrategy(String cacheStrategy) {
-        cacheBulkProcessor.setCacheStrategy(CacheStrategy.valueOf(cacheStrategy));
-    }
+  /** Phaser that forces all added metacards to commit to the cache on phase advance */
+  public void setCacheStrategy(String cacheStrategy) {
+    cacheBulkProcessor.setCacheStrategy(CacheStrategy.valueOf(cacheStrategy));
+  }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/LocalCatalogIdSupplier.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/LocalCatalogIdSupplier.java
@@ -14,20 +14,19 @@
 
 package ddf.catalog.cache.solr.impl;
 
+import ddf.catalog.CatalogFramework;
 import java.util.function.Supplier;
 
-import ddf.catalog.CatalogFramework;
-
 public class LocalCatalogIdSupplier implements Supplier<String> {
-    private final CatalogFramework catalogFramework;
+  private final CatalogFramework catalogFramework;
 
-    public LocalCatalogIdSupplier(CatalogFramework catalogFramework) {
-        this.catalogFramework = catalogFramework;
-        CacheStrategy.setLocalSourceIdSupplier(this);
-    }
-    
-    @Override
-    public String get() {
-        return catalogFramework.getId();
-    }
+  public LocalCatalogIdSupplier(CatalogFramework catalogFramework) {
+    this.catalogFramework = catalogFramework;
+    CacheStrategy.setLocalSourceIdSupplier(this);
+  }
+
+  @Override
+  public String get() {
+    return catalogFramework.getId();
+  }
 }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/LocalCatalogIdSupplier.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/LocalCatalogIdSupplier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.cache.solr.impl;
+
+import java.util.function.Supplier;
+
+import ddf.catalog.CatalogFramework;
+
+public class LocalCatalogIdSupplier implements Supplier<String> {
+    private final CatalogFramework catalogFramework;
+
+    public LocalCatalogIdSupplier(CatalogFramework catalogFramework) {
+        this.catalogFramework = catalogFramework;
+        CacheStrategy.setLocalSourceIdSupplier(this);
+    }
+    
+    @Override
+    public String get() {
+        return catalogFramework.getId();
+    }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -69,6 +69,10 @@
         <property name="masker" ref="sourceListener"/>
     </bean>
 
+    <bean id="localCatalogIdSupplier" class="ddf.catalog.cache.solr.impl.LocalCatalogIdSupplier">
+        <argument ref="catalogFramework"/>
+    </bean>
+
     <bean id="sourcePoller" class="ddf.catalog.util.impl.SourcePoller">
         <cm:managed-properties persistent-id="ddf.catalog.util.impl.SourcePoller"
                                update-strategy="container-managed"/>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
@@ -18,7 +18,7 @@
     <!--
     This metatype resides in the standard catalog framework instead of in the SortedFederationStrategy bundle because standard catalog framework creates
     SortedFederationStrategy and uses the (executor) pool singleton from SortedFederationStrategy across a few of its instantiated implementations.
-    This metatype may goes away once a smarter federation strategy is implemented.
+    This metatype may go away once a smarter federation strategy is implemented.
      -->
     <OCD description="Catalog Caching Federation Strategy"
          name="Catalog Federation Strategy"
@@ -56,6 +56,16 @@
             name="Show Validation Warnings" id="showWarnings" required="true"
             type="Boolean"
             default="true"/>
+
+        <AD
+            description="Strategy for caching query results"
+            name="Query Result Cache Strategy" id="cacheStrategy" required="true"
+            type="String"
+            default="ALL">
+            <Option label="All" value="ALL"/>
+            <Option label="Federated" value="FEDERATED"/>
+            <Option label="None" value="NONE"/>
+        </AD>
     </OCD>
 
     <Designate pid="ddf.catalog.federation.impl.CachingFederationStrategy">

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
@@ -1,14 +1,14 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or any later version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
- * is distributed along with this program and can be found at
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
@@ -23,12 +23,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Lists;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,151 +40,141 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.Lists;
-
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-
 @RunWith(MockitoJUnitRunner.class)
 public class CacheBulkProcessorTest {
 
-    @Captor
-    ArgumentCaptor<Collection<Metacard>> capturedMetacards;
+  @Captor ArgumentCaptor<Collection<Metacard>> capturedMetacards;
 
-    private CacheBulkProcessor cacheBulkProcessor;
+  private CacheBulkProcessor cacheBulkProcessor;
 
-    @Mock
-    private SolrCache mockSolrCache;
+  @Mock private SolrCache mockSolrCache;
 
-    @Before
-    public void setUp() throws Exception {
-        cacheBulkProcessor = new CacheBulkProcessor(mockSolrCache, 1, TimeUnit.MILLISECONDS, CacheStrategy.ALL);
-        cacheBulkProcessor.setBatchSize(10);
+  @Before
+  public void setUp() throws Exception {
+    cacheBulkProcessor =
+        new CacheBulkProcessor(mockSolrCache, 1, TimeUnit.MILLISECONDS, CacheStrategy.ALL);
+    cacheBulkProcessor.setBatchSize(10);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    cacheBulkProcessor.shutdown();
+  }
+
+  @Test
+  public void bulkAdd() throws Exception {
+    cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+    List<Result> mockResults = getMockResults(10);
+
+    cacheBulkProcessor.add(mockResults);
+    waitForPendingMetacardsToCache();
+
+    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+  }
+
+  @Test
+  public void partialFlush() throws Exception {
+    cacheBulkProcessor.setFlushInterval(1);
+    List<Result> mockResults = getMockResults(1);
+
+    cacheBulkProcessor.add(mockResults);
+    waitForPendingMetacardsToCache();
+
+    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+  }
+
+  @Test
+  public void nullResult() throws Exception {
+    cacheBulkProcessor.add(Collections.singletonList((Result) null));
+
+    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+  }
+
+  @Test
+  public void nullMetacard() throws Exception {
+    Result mockResult = mock(Result.class);
+    when(mockResult.getMetacard()).thenReturn(null);
+
+    cacheBulkProcessor.add(Collections.singletonList(mockResult));
+
+    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+  }
+
+  @Test
+  public void exceedsBacklog() throws Exception {
+    cacheBulkProcessor.setMaximumBacklogSize(0);
+    cacheBulkProcessor.add(getMockResults(10));
+
+    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+  }
+
+  @Test
+  public void cacheThrowsExcpetion() throws Exception {
+    doThrow(new RuntimeException())
+        .doNothing()
+        .when(mockSolrCache)
+        .create(anyCollectionOf(Metacard.class));
+    List<Result> mockResults = getMockResults(10);
+
+    cacheBulkProcessor.add(mockResults);
+    waitForPendingMetacardsToCache();
+
+    verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
+    for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
+      assertThat(metacards).containsAll(getMetacards(mockResults));
+    }
+  }
+
+  @Test
+  public void updateMetacards() throws Exception {
+    cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+
+    List<List<Result>> mockResultHalfs = Lists.partition(getMockResults(10), 5);
+    List<Result> mockResults = new ArrayList<>(mockResultHalfs.get(0));
+
+    // Duplicate the first half
+    Collections.addAll(mockResults, mockResultHalfs.get(0).toArray(new Result[5]));
+    // Add the second half
+    Collections.addAll(mockResults, mockResultHalfs.get(1).toArray(new Result[5]));
+
+    cacheBulkProcessor.add(mockResults);
+    waitForPendingMetacardsToCache();
+
+    verify(mockSolrCache).create(capturedMetacards.capture());
+    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+  }
+
+  private void waitForPendingMetacardsToCache() throws InterruptedException {
+    while (cacheBulkProcessor.pendingMetacards() > 0) {
+      Thread.sleep(2);
+    }
+  }
+
+  private Collection<Metacard> getMetacards(List<Result> results) {
+    List<Metacard> metacards = new ArrayList<>(results.size());
+
+    for (Result result : results) {
+      metacards.add(result.getMetacard());
     }
 
-    @After
-    public void tearDown() throws Exception {
-        cacheBulkProcessor.shutdown();
+    return metacards;
+  }
+
+  private List<Result> getMockResults(int size) {
+    List<Result> results = new ArrayList<>(size);
+
+    for (int i = 0; i < size; i++) {
+      Metacard mockMetacard = mock(Metacard.class);
+      when(mockMetacard.getId()).thenReturn(Integer.toString(i));
+
+      Result mockResult = mock(Result.class);
+      when(mockResult.getMetacard()).thenReturn(mockMetacard);
+
+      results.add(mockResult);
     }
 
-    @Test
-    public void bulkAdd() throws Exception {
-        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
-        List<Result> mockResults = getMockResults(10);
-
-        cacheBulkProcessor.add(mockResults);
-        waitForPendingMetacardsToCache();
-
-        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
-        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-    }
-
-    @Test
-    public void partialFlush() throws Exception {
-        cacheBulkProcessor.setFlushInterval(1);
-        List<Result> mockResults = getMockResults(1);
-
-        cacheBulkProcessor.add(mockResults);
-        waitForPendingMetacardsToCache();
-
-        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
-        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-    }
-
-    @Test
-    public void nullResult() throws Exception {
-        cacheBulkProcessor.add(Collections.singletonList((Result) null));
-
-        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-    }
-
-    @Test
-    public void nullMetacard() throws Exception {
-        Result mockResult = mock(Result.class);
-        when(mockResult.getMetacard()).thenReturn(null);
-
-        cacheBulkProcessor.add(Collections.singletonList(mockResult));
-
-        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-    }
-
-    @Test
-    public void exceedsBacklog() throws Exception {
-        cacheBulkProcessor.setMaximumBacklogSize(0);
-        cacheBulkProcessor.add(getMockResults(10));
-
-        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-    }
-
-    @Test
-    public void cacheThrowsExcpetion() throws Exception {
-        doThrow(new RuntimeException()).doNothing()
-                .when(mockSolrCache)
-                .create(anyCollectionOf(Metacard.class));
-        List<Result> mockResults = getMockResults(10);
-
-        cacheBulkProcessor.add(mockResults);
-        waitForPendingMetacardsToCache();
-
-        verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
-        for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
-            assertThat(metacards).containsAll(getMetacards(mockResults));
-        }
-    }
-
-    @Test
-    public void updateMetacards() throws Exception {
-        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
-
-        List<List<Result>> mockResultHalfs = Lists.partition(getMockResults(10), 5);
-        List<Result> mockResults = new ArrayList<>(mockResultHalfs.get(0));
-
-        // Duplicate the first half
-        Collections.addAll(mockResults,
-                mockResultHalfs.get(0)
-                        .toArray(new Result[5]));
-        // Add the second half
-        Collections.addAll(mockResults,
-                mockResultHalfs.get(1)
-                        .toArray(new Result[5]));
-
-        cacheBulkProcessor.add(mockResults);
-        waitForPendingMetacardsToCache();
-
-        verify(mockSolrCache).create(capturedMetacards.capture());
-        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-    }
-
-    private void waitForPendingMetacardsToCache() throws InterruptedException {
-        while (cacheBulkProcessor.pendingMetacards() > 0) {
-            Thread.sleep(2);
-        }
-    }
-
-    private Collection<Metacard> getMetacards(List<Result> results) {
-        List<Metacard> metacards = new ArrayList<>(results.size());
-
-        for (Result result : results) {
-            metacards.add(result.getMetacard());
-        }
-
-        return metacards;
-    }
-
-    private List<Result> getMockResults(int size) {
-        List<Result> results = new ArrayList<>(size);
-
-        for (int i = 0; i < size; i++) {
-            Metacard mockMetacard = mock(Metacard.class);
-            when(mockMetacard.getId()).thenReturn(Integer.toString(i));
-
-            Result mockResult = mock(Result.class);
-            when(mockResult.getMetacard()).thenReturn(mockMetacard);
-
-            results.add(mockResult);
-        }
-
-        return results;
-    }
-
+    return results;
+  }
 }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
@@ -1,14 +1,14 @@
 /**
  * Copyright (c) Codice Foundation
- *
- * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
- * Lesser General Public License as published by the Free Software Foundation, either version 3 of
- * the License, or any later version.
- *
- * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
- * License is distributed along with this program and can be found at
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 package ddf.catalog.cache.solr.impl;
@@ -23,14 +23,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,140 +38,151 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.google.common.collect.Lists;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+
 @RunWith(MockitoJUnitRunner.class)
 public class CacheBulkProcessorTest {
 
-  @Captor ArgumentCaptor<Collection<Metacard>> capturedMetacards;
+    @Captor
+    ArgumentCaptor<Collection<Metacard>> capturedMetacards;
 
-  private CacheBulkProcessor cacheBulkProcessor;
+    private CacheBulkProcessor cacheBulkProcessor;
 
-  @Mock private SolrCache mockSolrCache;
+    @Mock
+    private SolrCache mockSolrCache;
 
-  @Before
-  public void setUp() throws Exception {
-    cacheBulkProcessor = new CacheBulkProcessor(mockSolrCache, 1, TimeUnit.MILLISECONDS);
-    cacheBulkProcessor.setBatchSize(10);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    cacheBulkProcessor.shutdown();
-  }
-
-  @Test
-  public void bulkAdd() throws Exception {
-    cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
-    List<Result> mockResults = getMockResults(10);
-
-    cacheBulkProcessor.add(mockResults);
-    waitForPendingMetacardsToCache();
-
-    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
-    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-  }
-
-  @Test
-  public void partialFlush() throws Exception {
-    cacheBulkProcessor.setFlushInterval(1);
-    List<Result> mockResults = getMockResults(1);
-
-    cacheBulkProcessor.add(mockResults);
-    waitForPendingMetacardsToCache();
-
-    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
-    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-  }
-
-  @Test
-  public void nullResult() throws Exception {
-    cacheBulkProcessor.add(Collections.singletonList((Result) null));
-
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-  }
-
-  @Test
-  public void nullMetacard() throws Exception {
-    Result mockResult = mock(Result.class);
-    when(mockResult.getMetacard()).thenReturn(null);
-
-    cacheBulkProcessor.add(Collections.singletonList(mockResult));
-
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-  }
-
-  @Test
-  public void exceedsBacklog() throws Exception {
-    cacheBulkProcessor.setMaximumBacklogSize(0);
-    cacheBulkProcessor.add(getMockResults(10));
-
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
-  }
-
-  @Test
-  public void cacheThrowsExcpetion() throws Exception {
-    doThrow(new RuntimeException())
-        .doNothing()
-        .when(mockSolrCache)
-        .create(anyCollectionOf(Metacard.class));
-    List<Result> mockResults = getMockResults(10);
-
-    cacheBulkProcessor.add(mockResults);
-    waitForPendingMetacardsToCache();
-
-    verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
-    for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
-      assertThat(metacards).containsAll(getMetacards(mockResults));
-    }
-  }
-
-  @Test
-  public void updateMetacards() throws Exception {
-    cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
-
-    List<List<Result>> mockResultHalfs = Lists.partition(getMockResults(10), 5);
-    List<Result> mockResults = new ArrayList<>(mockResultHalfs.get(0));
-
-    // Duplicate the first half
-    Collections.addAll(mockResults, mockResultHalfs.get(0).toArray(new Result[5]));
-    // Add the second half
-    Collections.addAll(mockResults, mockResultHalfs.get(1).toArray(new Result[5]));
-
-    cacheBulkProcessor.add(mockResults);
-    waitForPendingMetacardsToCache();
-
-    verify(mockSolrCache).create(capturedMetacards.capture());
-    assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
-  }
-
-  private void waitForPendingMetacardsToCache() throws InterruptedException {
-    while (cacheBulkProcessor.pendingMetacards() > 0) {
-      Thread.sleep(2);
-    }
-  }
-
-  private Collection<Metacard> getMetacards(List<Result> results) {
-    List<Metacard> metacards = new ArrayList<>(results.size());
-
-    for (Result result : results) {
-      metacards.add(result.getMetacard());
+    @Before
+    public void setUp() throws Exception {
+        cacheBulkProcessor = new CacheBulkProcessor(mockSolrCache, 1, TimeUnit.MILLISECONDS, CacheStrategy.ALL);
+        cacheBulkProcessor.setBatchSize(10);
     }
 
-    return metacards;
-  }
-
-  private List<Result> getMockResults(int size) {
-    List<Result> results = new ArrayList<>(size);
-
-    for (int i = 0; i < size; i++) {
-      Metacard mockMetacard = mock(Metacard.class);
-      when(mockMetacard.getId()).thenReturn(Integer.toString(i));
-
-      Result mockResult = mock(Result.class);
-      when(mockResult.getMetacard()).thenReturn(mockMetacard);
-
-      results.add(mockResult);
+    @After
+    public void tearDown() throws Exception {
+        cacheBulkProcessor.shutdown();
     }
 
-    return results;
-  }
+    @Test
+    public void bulkAdd() throws Exception {
+        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+        List<Result> mockResults = getMockResults(10);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    @Test
+    public void partialFlush() throws Exception {
+        cacheBulkProcessor.setFlushInterval(1);
+        List<Result> mockResults = getMockResults(1);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    @Test
+    public void nullResult() throws Exception {
+        cacheBulkProcessor.add(Collections.singletonList((Result) null));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void nullMetacard() throws Exception {
+        Result mockResult = mock(Result.class);
+        when(mockResult.getMetacard()).thenReturn(null);
+
+        cacheBulkProcessor.add(Collections.singletonList(mockResult));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void exceedsBacklog() throws Exception {
+        cacheBulkProcessor.setMaximumBacklogSize(0);
+        cacheBulkProcessor.add(getMockResults(10));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void cacheThrowsExcpetion() throws Exception {
+        doThrow(new RuntimeException()).doNothing()
+                .when(mockSolrCache)
+                .create(anyCollectionOf(Metacard.class));
+        List<Result> mockResults = getMockResults(10);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
+        for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
+            assertThat(metacards).containsAll(getMetacards(mockResults));
+        }
+    }
+
+    @Test
+    public void updateMetacards() throws Exception {
+        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+
+        List<List<Result>> mockResultHalfs = Lists.partition(getMockResults(10), 5);
+        List<Result> mockResults = new ArrayList<>(mockResultHalfs.get(0));
+
+        // Duplicate the first half
+        Collections.addAll(mockResults,
+                mockResultHalfs.get(0)
+                        .toArray(new Result[5]));
+        // Add the second half
+        Collections.addAll(mockResults,
+                mockResultHalfs.get(1)
+                        .toArray(new Result[5]));
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    private void waitForPendingMetacardsToCache() throws InterruptedException {
+        while (cacheBulkProcessor.pendingMetacards() > 0) {
+            Thread.sleep(2);
+        }
+    }
+
+    private Collection<Metacard> getMetacards(List<Result> results) {
+        List<Metacard> metacards = new ArrayList<>(results.size());
+
+        for (Result result : results) {
+            metacards.add(result.getMetacard());
+        }
+
+        return metacards;
+    }
+
+    private List<Result> getMockResults(int size) {
+        List<Result> results = new ArrayList<>(size);
+
+        for (int i = 0; i < size; i++) {
+            Metacard mockMetacard = mock(Metacard.class);
+            when(mockMetacard.getId()).thenReturn(Integer.toString(i));
+
+            Result mockResult = mock(Result.class);
+            when(mockResult.getMetacard()).thenReturn(mockMetacard);
+
+            results.add(mockResult);
+        }
+
+        return results;
+    }
+
 }


### PR DESCRIPTION
…t when flushing

#### What does this PR do?
Adds the concept of a CacheBulkProcessor CacheStrategy with three available options: 'All', 'None' and 'Federated'.The strategy is configurable through the Admin UI, so a metatype was also added.

#### Who is reviewing it? 
@gordocanchola 
@spearskw 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@beyelerb
@jlcsmith
@kcwire
@pklinef
@clockard 

#### How should this be tested? (List steps with links to updated documentation)
// Test the 'All' (default) setting

    Configure a federated source
    Perform a query
    go to http://localhost:8993/solr and verify that both local and federated query results are in SOLR's cache core

//Test the 'Federated' setting

    In the Karaf console, issue the 'catalog:removeall' command
    in the Karaf console, issue the 'catalog:removeall --cache' command
    With the previous federated source still configured, perform a query
    go to http://localhost:8993/solr and verify that only the federated query results are in SOLR's cache core

//Test the 'None' setting

    In the Karaf console, issue the 'catalog:removeall' command
    in the Karaf console, issue the 'catalog:removeall --cache' command
    With the previous federated source still configured, perform a query
    go to http://localhost:8993/solr and verify that SOLR's cache core is empty

#### Any background context you want to provide?
During the development of this story, it was determined that calculating the size of a given item is too expensive to rely on to determine which results to cache. We settled on separating cached results based on whether they're local or federated.

#### What are the relevant tickets?
DDF-3244

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
