### PR TITLE
DDF-3255 Skip search references when reading LDAP attributes

### DIFF
--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
@@ -35,6 +35,7 @@ import org.forgerock.opendj.ldap.SearchScope;
 import org.forgerock.opendj.ldap.requests.BindRequest;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
+import org.forgerock.opendj.ldap.responses.SearchResultReference;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,39 +137,45 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
 
                     SearchResultEntry entry;
                     while (entryReader.hasNext()) {
-                        entry = entryReader.readEntry();
-                        for (Claim claim : claims) {
-                            URI claimType = claim.getClaimType();
-                            String ldapAttribute = getClaimsLdapAttributeMapping().get(
-                                    claimType.toString());
-                            Attribute attr = entry.getAttribute(ldapAttribute);
-                            if (attr == null) {
-                                LOGGER.trace("Claim '{}' is null", claim.getClaimType());
-                            } else {
-                                ProcessedClaim c = new ProcessedClaim();
-                                c.setClaimType(claimType);
-                                c.setPrincipal(principal);
+                        if (entryReader.isEntry()) {
+                            entry = entryReader.readEntry();
+                            for (Claim claim : claims) {
+                                URI claimType = claim.getClaimType();
+                                String ldapAttribute = getClaimsLdapAttributeMapping().get(
+                                        claimType.toString());
+                                Attribute attr = entry.getAttribute(ldapAttribute);
+                                if (attr == null) {
+                                    LOGGER.trace("Claim '{}' is null", claim.getClaimType());
+                                } else {
+                                    ProcessedClaim c = new ProcessedClaim();
+                                    c.setClaimType(claimType);
+                                    c.setPrincipal(principal);
 
-                                for (ByteString value : attr) {
-                                    String itemValue = value.toString();
-                                    if (this.isX500FilterEnabled()) {
-                                        try {
-                                            X500Principal x500p = new X500Principal(itemValue);
-                                            itemValue = x500p.getName();
-                                            int index = itemValue.indexOf('=');
-                                            itemValue = itemValue.substring(index + 1,
-                                                    itemValue.indexOf(',', index));
-                                        } catch (Exception ex) {
-                                            // Ignore, not X500 compliant thus use the whole
-                                            // string as the value
-                                            LOGGER.debug("Not X500 compliant", ex);
+                                    for (ByteString value : attr) {
+                                        String itemValue = value.toString();
+                                        if (this.isX500FilterEnabled()) {
+                                            try {
+                                                X500Principal x500p = new X500Principal(itemValue);
+                                                itemValue = x500p.getName();
+                                                int index = itemValue.indexOf('=');
+                                                itemValue = itemValue.substring(index + 1,
+                                                        itemValue.indexOf(',', index));
+                                            } catch (Exception ex) {
+                                                // Ignore, not X500 compliant thus use the whole
+                                                // string as the value
+                                                LOGGER.debug("Not X500 compliant", ex);
+                                            }
                                         }
+                                        c.addValue(itemValue);
                                     }
-                                    c.addValue(itemValue);
-                                }
 
-                                claimsColl.add(c);
+                                    claimsColl.add(c);
+                                }
                             }
+                        } else {
+                            // Got a continuation reference
+                            final SearchResultReference ref = entryReader.readReference();
+                            LOGGER.trace("Skipping result reference: {}", ref.getURIs().toString());
                         }
 
                     }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -132,6 +132,7 @@ public class LdapClaimsHandlerTest {
         when(mockConnection.search(anyObject(), anyObject(), anyObject(), anyObject())).thenReturn(
                 mockEntryReader);
         when(mockEntryReader.hasNext()).thenReturn(true, false);
+        when(mockEntryReader.isEntry()).thenReturn(true);
         when(mockEntryReader.readEntry()).thenReturn(mockEntry);
         when(mockEntry.getAttribute(anyString())).thenReturn(attribute);
         claimsHandler.setLdapConnectionFactory(mockConnectionFactory);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -87,12 +87,14 @@ public class RoleClaimsHandlerTest {
 
         // hasNext() returns 'true' the first time, then 'false' every time after.
         when(membershipReader.hasNext()).thenReturn(true, false);
+        when(membershipReader.isEntry()).thenReturn(true);
         when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
 
         groupNameAttribute.add(groupName);
         when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
 
         when(groupNameReader.hasNext()).thenReturn(true, false);
+        when(groupNameReader.isEntry()).thenReturn(true);
         when(groupNameReader.readEntry()).thenReturn(groupNameSearchResult);
 
         when(connection.bind(anyObject())).thenReturn(bindResult);


### PR DESCRIPTION
#### What does this PR do?
Skips search references when reading LDAP attributes, which allows administrators to connect to an LDAP that has search references.

#### Who is reviewing it? 
@tbatie @gordocanchola 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security

#### Choose 2 committers to review/merge the PR. 
@beyelerb
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1) Create or use an LDAP that has search references in the attributes
2) Go to Security -> Features and turn on security-sts-ldapclaimshandler and security-sts-ldaplogin
3) Go to Security -> Congiruation -> Security STS LDAP and Roles Claim Handler and configure it to use the LDAP from 1)
4) Go to Security -> Configuration -> Web Context Policy Manager and add LDAP as a realm for something like /search
5) Ensure that you can log in

#### What are the relevant tickets?
[DDF-3255](https://codice.atlassian.net/browse/DDF-3255)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
