### PR TITLE
DDF-3262 Increase Solr string indexing size and exclude attributes

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -238,7 +238,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SchemaFields.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SchemaFields.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.source.solr;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -65,36 +66,40 @@ public class SchemaFields {
 
     public static final String SORT_KEY_SUFFIX = "_sk";
 
-    private static final Map<String, AttributeFormat> SUFFIX_TO_FORMAT_MAP = new HashMap<>();
+    protected static final Map<String, AttributeFormat> SUFFIX_TO_FORMAT_MAP;
 
-    private static final Map<AttributeFormat, String> FORMAT_TO_SUFFIX_MAP = new HashMap<>();
+    protected static final Map<AttributeFormat, String> FORMAT_TO_SUFFIX_MAP;
 
     static {
-        SUFFIX_TO_FORMAT_MAP.put(GEO_SUFFIX, AttributeFormat.GEOMETRY);
-        SUFFIX_TO_FORMAT_MAP.put(DATE_SUFFIX, AttributeFormat.DATE);
-        SUFFIX_TO_FORMAT_MAP.put(BINARY_SUFFIX, AttributeFormat.BINARY);
-        SUFFIX_TO_FORMAT_MAP.put(XML_SUFFIX, AttributeFormat.XML);
-        SUFFIX_TO_FORMAT_MAP.put(TEXT_SUFFIX, AttributeFormat.STRING);
-        SUFFIX_TO_FORMAT_MAP.put(BOOLEAN_SUFFIX, AttributeFormat.BOOLEAN);
-        SUFFIX_TO_FORMAT_MAP.put(DOUBLE_SUFFIX, AttributeFormat.DOUBLE);
-        SUFFIX_TO_FORMAT_MAP.put(FLOAT_SUFFIX, AttributeFormat.FLOAT);
-        SUFFIX_TO_FORMAT_MAP.put(INTEGER_SUFFIX, AttributeFormat.INTEGER);
-        SUFFIX_TO_FORMAT_MAP.put(LONG_SUFFIX, AttributeFormat.LONG);
-        SUFFIX_TO_FORMAT_MAP.put(SHORT_SUFFIX, AttributeFormat.SHORT);
-        SUFFIX_TO_FORMAT_MAP.put(OBJECT_SUFFIX, AttributeFormat.OBJECT);
+        HashMap<String, AttributeFormat> suffixToFormatMap = new HashMap<>();
+        suffixToFormatMap.put(GEO_SUFFIX, AttributeFormat.GEOMETRY);
+        suffixToFormatMap.put(DATE_SUFFIX, AttributeFormat.DATE);
+        suffixToFormatMap.put(BINARY_SUFFIX, AttributeFormat.BINARY);
+        suffixToFormatMap.put(XML_SUFFIX, AttributeFormat.XML);
+        suffixToFormatMap.put(TEXT_SUFFIX, AttributeFormat.STRING);
+        suffixToFormatMap.put(BOOLEAN_SUFFIX, AttributeFormat.BOOLEAN);
+        suffixToFormatMap.put(DOUBLE_SUFFIX, AttributeFormat.DOUBLE);
+        suffixToFormatMap.put(FLOAT_SUFFIX, AttributeFormat.FLOAT);
+        suffixToFormatMap.put(INTEGER_SUFFIX, AttributeFormat.INTEGER);
+        suffixToFormatMap.put(LONG_SUFFIX, AttributeFormat.LONG);
+        suffixToFormatMap.put(SHORT_SUFFIX, AttributeFormat.SHORT);
+        suffixToFormatMap.put(OBJECT_SUFFIX, AttributeFormat.OBJECT);
+        SUFFIX_TO_FORMAT_MAP = Collections.unmodifiableMap(suffixToFormatMap);
 
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.GEOMETRY, GEO_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.DATE, DATE_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.BINARY, BINARY_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.XML, XML_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.STRING, TEXT_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.BOOLEAN, BOOLEAN_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.DOUBLE, DOUBLE_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.FLOAT, FLOAT_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.INTEGER, INTEGER_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.LONG, LONG_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.SHORT, SHORT_SUFFIX);
-        FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.OBJECT, OBJECT_SUFFIX);
+        HashMap<AttributeFormat, String> formatToSuffixMap = new HashMap<>();
+        formatToSuffixMap.put(AttributeFormat.GEOMETRY, GEO_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.DATE, DATE_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.BINARY, BINARY_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.XML, XML_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.STRING, TEXT_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.BOOLEAN, BOOLEAN_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.DOUBLE, DOUBLE_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.FLOAT, FLOAT_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.INTEGER, INTEGER_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.LONG, LONG_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.SHORT, SHORT_SUFFIX);
+        formatToSuffixMap.put(AttributeFormat.OBJECT, OBJECT_SUFFIX);
+        FORMAT_TO_SUFFIX_MAP = Collections.unmodifiableMap(formatToSuffixMap);
 
     }
 

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,6 +49,8 @@ import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
 
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeType;
@@ -90,6 +93,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     public static final String SORT_FIELD_KEY = "sfield";
 
     public static final String POINT_KEY = "pt";
+
+    public static final String EXCLUDE_ATTRIBUTES = "excludeAttributes";
 
     private final SolrClient client;
 
@@ -377,7 +382,55 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
         setSortProperty(request, query, filterDelegate);
 
+        filterAttributes(request, query);
+
         return query;
+    }
+
+    private void filterAttributes(QueryRequest request, SolrQuery query) {
+        if (!request.hasProperties() || !request.containsPropertyName(EXCLUDE_ATTRIBUTES)
+                || !(request.getPropertyValue(EXCLUDE_ATTRIBUTES) instanceof Set) ||
+                "true".equals(System.getProperty("solr.client.filterAttributes.disable"))) {
+            return;
+        }
+
+        Set<String> excludedAttributes = (Set<String>) request.getPropertyValue(EXCLUDE_ATTRIBUTES);
+
+        Set<String> excludedFields = resolver.fieldsCache.stream()
+                .filter(Objects::nonNull)
+                .filter(field -> excludedAttributes.stream().anyMatch(field::startsWith))
+                .collect(Collectors.toSet());
+
+        Set<String> wildcardFields = SchemaFields.FORMAT_TO_SUFFIX_MAP.values()
+                .stream()
+                .filter(suffix -> excludedFields.stream()
+                        .noneMatch(field -> field.endsWith(suffix)))
+                .map(suffix -> "*" + suffix)
+                .collect(Collectors.toSet());
+
+        Set<String> includedFields = SchemaFields.FORMAT_TO_SUFFIX_MAP.values()
+                .stream()
+                .filter(suffix -> excludedFields.stream()
+                        .anyMatch(field -> field.endsWith(suffix)))
+                .flatMap(suffix -> resolver.fieldsCache.stream()
+                        .filter(Objects::nonNull)
+                        .filter(field -> field.endsWith(suffix))
+                        .filter(field -> excludedAttributes.stream()
+                                .noneMatch(field::startsWith)))
+                .collect(Collectors.toSet());
+
+        Set<String> fields = Sets.union(includedFields, wildcardFields);
+
+        if (query.getFields() != null && query.getFields().length() > 2) {
+            fields = Sets.union(fields,
+                    Sets.newHashSet(query.getFields()
+                            .substring(2)
+                            .split(",")));
+        }
+
+        if (fields.size() > 0) {
+            query.setFields(fields.toArray(new String[fields.size()]));
+        }
     }
 
     private boolean queryingForAllRecords(QueryRequest request) {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -2859,6 +2859,43 @@ public class SolrProviderTest extends SolrProviderTestCase {
                         .text(soughtWord));
     }
 
+    @Test
+    public void testExcludingAttributes() throws Exception {
+
+        deleteAllIn(provider);
+
+        List<Metacard> list = new ArrayList<Metacard>();
+
+        MockMetacard metacard1 = new MockMetacard(Library.getFlagstaffRecord());
+        String soughtWord = "nitf";
+        metacard1.setTitle(soughtWord);
+        list.add(metacard1);
+
+        MockMetacard metacard2 = new MockMetacard(Library.getTampaRecord());
+        list.add(metacard2);
+
+        MockMetacard metacard3 = new MockMetacard(Library.getShowLowRecord());
+        list.add(metacard3);
+
+        create(list);
+
+        QueryImpl query = new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT)
+                .is()
+                .like()
+                .text(soughtWord));
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SolrMetacardClientImpl.EXCLUDE_ATTRIBUTES,
+                com.google.common.collect.Sets.newHashSet(Metacard.TITLE));
+        SourceResponse sourceResponse = provider.query(new QueryRequestImpl(query, properties));
+        assertEquals(1,
+                sourceResponse.getResults()
+                        .size());
+        assertThat(sourceResponse.getResults()
+                .get(0)
+                .getMetacard()
+                .getTitle(), is(nullValue()));
+    }
+
     /**
      * Testing Tokenization of the search phrase.
      *

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -26,6 +26,8 @@ import org.opengis.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Sets;
+
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.filter.FilterBuilder;
@@ -61,6 +63,8 @@ public class CqlRequest {
     private String sort;
 
     private boolean normalize = false;
+
+    private boolean excludeXmlAndBinary = true;
 
     public String getSrc() {
         return src;
@@ -139,6 +143,11 @@ public class CqlRequest {
                     .put("mode", "update");
         }
 
+        if (excludeXmlAndBinary) {
+            queryRequest.getProperties().put("excludeAttributes", Sets.newHashSet(
+                    Metacard.METADATA, "lux"));
+        }
+
         return queryRequest;
     }
 
@@ -209,5 +218,13 @@ public class CqlRequest {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public boolean isExcludeXmlAndBinary() {
+        return excludeXmlAndBinary;
+    }
+
+    public void setExcludeXmlAndBinary(boolean excludeXmlAndBinary) {
+        this.excludeXmlAndBinary = excludeXmlAndBinary;
     }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -85,6 +85,7 @@ define([
                     scheduleUnits: 'minutes',
                     timeType: 'modified',
                     radiusUnits: 'meters',
+                    excludeXmlAndBinary: true,
                     radius: 0,
                     count: properties.resultCount,
                     start: 1,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -65,7 +65,9 @@ define([
               return this.get('queries').length < 10;
             },
             addQuery: function () {
-                var query = new Query.Model();
+                var query = new Query.Model({
+                    excludeXmlAndBinary: false
+                });
                 this.get('queries').add(query);
                 return query.get('id');
             },
@@ -194,6 +196,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Local',
                     federation: 'local',
+                    excludeXmlAndBinary: false,
                     cql: "anyText ILIKE '*'"
                 });
                 this.create({
@@ -207,6 +210,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Federated',
                     federation: 'enterprise',
+                    excludeXmlAndBinary: false,
                     cql: "anyText ILIKE '*'"
                 });
                 this.create({
@@ -219,6 +223,7 @@ define([
             createGeoWorkspace: function(){
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Location',
+                    excludeXmlAndBinary: false,
                     cql: "anyText ILIKE '*' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))"
                 });
                 this.create({
@@ -231,6 +236,7 @@ define([
             createLatestWorkspace: function(){
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Temporal',
+                    excludeXmlAndBinary: false,
                     cql: 'anyText ILIKE \'*\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')'
                 });
                 this.create({

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolver.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolver.java
@@ -91,7 +91,9 @@ public class FilteringDynamicSchemaResolver extends DynamicSchemaResolver {
 
     @Override
     public String getCaseSensitiveField(String mappedPropertyName) {
-        String field = super.getCaseSensitiveField(mappedPropertyName);
+        String field = mappedPropertyName.split(SchemaFields.TEXT_SUFFIX, 0)[0] + getFieldSuffix(
+                AttributeType.AttributeFormat.STRING)
+                + getSpecialIndexSuffix(AttributeType.AttributeFormat.STRING);
         usedFields.add(field);
         return field;
     }
@@ -105,7 +107,9 @@ public class FilteringDynamicSchemaResolver extends DynamicSchemaResolver {
 
     @Override
     public String getWhitespaceTokenizedField(String mappedPropertyName) {
-        String field = super.getWhitespaceTokenizedField(mappedPropertyName);
+        String field = mappedPropertyName.split(SchemaFields.TEXT_SUFFIX, 0)[0] + getFieldSuffix(
+                AttributeType.AttributeFormat.STRING)
+                + getSpecialIndexSuffix(AttributeType.AttributeFormat.STRING);
         usedFields.add(field);
         return field;
     }

--- a/catalog/ui/search-ui/search-endpoint/src/test/groovy/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolverTest.groovy
+++ b/catalog/ui/search-ui/search-endpoint/src/test/groovy/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolverTest.groovy
@@ -44,6 +44,8 @@ class FilteringDynamicSchemaResolverTest extends Specification {
 
     public static final String METADATA_TXT_FIELD = "$Metacard.METADATA$SchemaFields.TEXT_SUFFIX"
 
+    public static final String METADATA_TXT_TOKENIZED_FIELD = "$METADATA_TXT_FIELD$SchemaFields.TOKENIZED"
+
     public static final String METADATA_TXT_WS_FIELD = "$METADATA_TXT_FIELD$SchemaFields.WHITESPACE_TEXT_SUFFIX"
 
     public static final String METADATA_TXT_WS_HAS_CASE_FIELD = "$METADATA_TXT_WS_FIELD$SchemaFields.HAS_CASE"
@@ -143,8 +145,7 @@ class FilteringDynamicSchemaResolverTest extends Specification {
         resolver.addFields(metacard, solrDoc)
 
         then:
-        solrDoc.getFieldNames().size() == 5
-        solrDoc.getFieldNames().contains(METADATA_TXT_WS_HAS_CASE_FIELD)
+        solrDoc.getFieldNames().contains(METADATA_TXT_TOKENIZED_FIELD)
     }
 
     def "Do not filter used whitespace tokenized fields"() {
@@ -153,8 +154,7 @@ class FilteringDynamicSchemaResolverTest extends Specification {
         resolver.addFields(metacard, solrDoc)
 
         then:
-        solrDoc.getFieldNames().size() == 4
-        solrDoc.getFieldNames().contains(METADATA_TXT_WS_FIELD)
+        solrDoc.getFieldNames().contains(METADATA_TXT_TOKENIZED_FIELD)
     }
 
     def "Do not filter used fields"() {

--- a/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
@@ -234,10 +234,9 @@
     <!-- copyField commands copy one field to another at the time a document
           is added to the index.  It's used either to index the same field differently,
           or to add multiple fields to the same field for easier/faster searching.  -->
-    <copyField source="*_txt" dest="*_txt_tokenized"/>
-    <copyField source="*_txt" dest="*_txt_tokenized_has_case"/>
-    <copyField source="*_txt" dest="*_txt_ws"/>
-    <copyField source="*_txt" dest="*_txt_ws_has_case"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_tokenized_has_case"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_ws"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_ws_has_case"/>
 
     <!-- Necessary for Spatial4j to work -->
     <copyField source="*_geo" dest="*_geo_index"/>


### PR DESCRIPTION
#### What does this PR do?
Allow Solr tokenized txt field to index more data than txt string field.
Support excluding attributes from Solr response.

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Configure Tika and PDF transformers to a higher character limit (e.g. 1000000). Ingest large text files and verify that all text up to the character limit is indexed but only the first 32k of text is returned. Verify that metadata and lux fields are not returned.

#### What are the relevant tickets?
[DDF-3262](https://codice.atlassian.net/browse/DDF-3262)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
