### PR TITLE
DDF-3243 KML InputTransformer

### DIFF
--- a/catalog/spatial/kml/spatial-kml-transformer/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-transformer/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>spatial-kml-pom</artifactId>
@@ -71,6 +73,11 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.thirdparty</groupId>
+            <artifactId>geotools-suite</artifactId>
+            <version>${org.geotools.bundle.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -105,17 +112,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
 
                                     </limits>
@@ -124,6 +131,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <!-- This configures the plugin for mvn checkstyle:checkstyle -->
+                    <excludes>
+                        src/test/resources/
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlDocumentToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlDocumentToJtsGeometryConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.Document;
+
+public class KmlDocumentToJtsGeometryConverter {
+    private KmlDocumentToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(Document kmlDocument) {
+        if (kmlDocument == null) {
+            return null;
+        }
+
+        List<Geometry> jtsGeometries = kmlDocument.getFeature()
+                .stream()
+                .map(KmlFeatureToJtsGeometryConverter::from)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        if (CollectionUtils.isNotEmpty(jtsGeometries)) {
+            return geometryFactory.createGeometryCollection(jtsGeometries.toArray(new Geometry[0]));
+        }
+
+        return null;
+    }
+
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlFeatureToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlFeatureToJtsGeometryConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Document;
+import de.micromata.opengis.kml.v_2_2_0.Feature;
+import de.micromata.opengis.kml.v_2_2_0.Folder;
+import de.micromata.opengis.kml.v_2_2_0.GroundOverlay;
+import de.micromata.opengis.kml.v_2_2_0.PhotoOverlay;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class KmlFeatureToJtsGeometryConverter {
+    private KmlFeatureToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(Feature kmlFeature) {
+        if (kmlFeature == null) {
+            return null;
+        }
+
+        if (kmlFeature instanceof Document) {
+            return KmlDocumentToJtsGeometryConverter.from((Document) kmlFeature);
+        }
+
+        if (kmlFeature instanceof Folder) {
+            return KmlFolderToJtsGeometryConverter.from((Folder) kmlFeature);
+        }
+
+        if (kmlFeature instanceof Placemark) {
+            return KmlPlacemarkToJtsGeometryConverter.from((Placemark) kmlFeature);
+        }
+
+        if (kmlFeature instanceof PhotoOverlay) {
+            return KmlPhotoOverlayToJtsPointConverter.from((PhotoOverlay) kmlFeature);
+        }
+
+        if (kmlFeature instanceof GroundOverlay) {
+            return KmlGroundOverlayToJtsGeometryConverter.from((GroundOverlay) kmlFeature);
+        }
+
+        return null;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlFolderToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlFolderToJtsGeometryConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.Folder;
+
+public class KmlFolderToJtsGeometryConverter {
+    private KmlFolderToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(Folder kmlFolder) {
+        if (kmlFolder == null) {
+            return null;
+        }
+
+        List<Geometry> jtsGeometries = kmlFolder.getFeature()
+                .stream()
+                .map(KmlFeatureToJtsGeometryConverter::from)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        if (CollectionUtils.isNotEmpty(jtsGeometries)) {
+            return geometryFactory.createGeometryCollection(jtsGeometries.toArray(new Geometry[0]));
+        }
+
+        return null;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlGroundOverlayToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlGroundOverlayToJtsGeometryConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.GroundOverlay;
+
+public class KmlGroundOverlayToJtsGeometryConverter {
+    private KmlGroundOverlayToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(GroundOverlay kmlGroundOverlay) {
+        if (!isValidKmlPhotoOverlay(kmlGroundOverlay)) {
+            return null;
+        }
+
+        return KmlLatLonBoxToJtsGeometryConverter.from(kmlGroundOverlay.getLatLonBox());
+    }
+
+    public static boolean isValidKmlPhotoOverlay(GroundOverlay kmlGroundOverlay) {
+        if (kmlGroundOverlay == null) {
+            return false;
+        }
+
+        return KmlLatLonBoxToJtsGeometryConverter.isValidKmlLatLonBox(kmlGroundOverlay.getLatLonBox());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlLatLonBoxToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlLatLonBoxToJtsGeometryConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LinearRing;
+
+import de.micromata.opengis.kml.v_2_2_0.LatLonBox;
+
+public class KmlLatLonBoxToJtsGeometryConverter {
+    private KmlLatLonBoxToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(LatLonBox kmlLatLonBox) {
+        if (!isValidKmlLatLonBox(kmlLatLonBox)) {
+            return null;
+        }
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        return geometryFactory.createPolygon(createLinearRing(geometryFactory, kmlLatLonBox), null);
+    }
+
+    private static LinearRing createLinearRing(GeometryFactory geometryFactory,
+            LatLonBox latLonBox) {
+        double minX = latLonBox.getWest();
+        double maxX = latLonBox.getEast();
+        if (minX > maxX) {
+            minX = maxX;
+            maxX = latLonBox.getWest();
+        }
+
+        double minY = latLonBox.getSouth();
+        double maxY = latLonBox.getNorth();
+        if (minY > maxY) {
+            minY = maxY;
+            maxY = latLonBox.getSouth();
+        }
+
+        // WKT wants the bounding box to start upper right and go clockwise
+        return geometryFactory.createLinearRing(new Coordinate[] {new Coordinate(maxX, maxY),
+                new Coordinate(maxX, minY), new Coordinate(minX, minY), new Coordinate(minX, maxY),
+                new Coordinate(maxX, maxY)});
+    }
+
+    public static boolean isValidKmlLatLonBox(LatLonBox latLonBox) {
+        if (latLonBox == null) {
+            return false;
+        }
+
+        // check for empty lat lon box
+        return (latLonBox.getNorth() != 0.0f) || (latLonBox.getSouth() != 0.0f) || (latLonBox.getEast()
+                != 0.0f) || (latLonBox.getWest() != 0.0f);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlModelToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlModelToJtsPointConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+
+import de.micromata.opengis.kml.v_2_2_0.Location;
+import de.micromata.opengis.kml.v_2_2_0.Model;
+
+public class KmlModelToJtsPointConverter {
+    private KmlModelToJtsPointConverter() {
+    }
+
+    public static Point from(Model kmlModel) {
+        if (kmlModel == null || kmlModel.getLocation() == null) {
+            return null;
+        }
+
+        Location kmlLocation = kmlModel.getLocation();
+
+        Coordinate jtsCoordinate = new Coordinate(kmlLocation.getLongitude(),
+                kmlLocation.getLatitude(),
+                kmlLocation.getAltitude());
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        return geometryFactory.createPoint(jtsCoordinate);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlPhotoOverlayToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlPhotoOverlayToJtsPointConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import com.vividsolutions.jts.geom.Point;
+
+import de.micromata.opengis.kml.v_2_2_0.PhotoOverlay;
+
+public class KmlPhotoOverlayToJtsPointConverter {
+    private KmlPhotoOverlayToJtsPointConverter() {
+    }
+
+    public static Point from(PhotoOverlay kmlPhotoOverlay) {
+        if (!isValidKmlPhotoOverlay(kmlPhotoOverlay)) {
+            return null;
+        }
+
+        return KmlToJtsPointConverter.from(kmlPhotoOverlay.getPoint());
+    }
+
+    public static boolean isValidKmlPhotoOverlay(PhotoOverlay kmlPhotoOverlay) {
+        if (kmlPhotoOverlay == null) {
+            return false;
+        }
+
+        return KmlToJtsPointConverter.isValidKmlPoint(kmlPhotoOverlay.getPoint());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlPlacemarkToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlPlacemarkToJtsGeometryConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class KmlPlacemarkToJtsGeometryConverter {
+    private KmlPlacemarkToJtsGeometryConverter() {
+    }
+
+    public static Geometry from(Placemark kmlPlacemark) {
+        if (kmlPlacemark == null) {
+            return null;
+        }
+
+        return KmlToJtsGeometryConverter.from(kmlPlacemark.getGeometry());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+
+public class KmlToJtsConverter {
+    private KmlToJtsConverter() {
+    }
+
+    public static Geometry from(Kml kml) {
+        if (kml == null) {
+            return null;
+        }
+
+        return KmlFeatureToJtsGeometryConverter.from(kml.getFeature());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsCoordinateConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsCoordinateConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import de.micromata.opengis.kml.v_2_2_0.Coordinate;
+
+public class KmlToJtsCoordinateConverter {
+
+    private KmlToJtsCoordinateConverter() {
+
+    }
+
+    public static com.vividsolutions.jts.geom.Coordinate from(Coordinate kmlCoordinate) {
+        if (kmlCoordinate == null) {
+            return null;
+        }
+
+        return new com.vividsolutions.jts.geom.Coordinate(kmlCoordinate.getLongitude(),
+                kmlCoordinate.getLatitude(),
+                kmlCoordinate.getAltitude());
+    }
+
+    public static com.vividsolutions.jts.geom.Coordinate[] from(List<Coordinate> kmlCoordinates) {
+        if (CollectionUtils.isEmpty(kmlCoordinates)) {
+            return new com.vividsolutions.jts.geom.Coordinate[0];
+        }
+
+        List<com.vividsolutions.jts.geom.Coordinate> jtsCoordinates = kmlCoordinates.stream()
+                .filter(Objects::nonNull)
+                .map(KmlToJtsCoordinateConverter::from)
+                .collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(jtsCoordinates)) {
+            return new com.vividsolutions.jts.geom.Coordinate[0];
+        }
+
+        return jtsCoordinates.toArray(new com.vividsolutions.jts.geom.Coordinate[0]);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsGeometryConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import de.micromata.opengis.kml.v_2_2_0.Geometry;
+import de.micromata.opengis.kml.v_2_2_0.LineString;
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.Model;
+import de.micromata.opengis.kml.v_2_2_0.MultiGeometry;
+import de.micromata.opengis.kml.v_2_2_0.Point;
+import de.micromata.opengis.kml.v_2_2_0.Polygon;
+
+public class KmlToJtsGeometryConverter {
+
+    private KmlToJtsGeometryConverter() {
+    }
+
+    public static com.vividsolutions.jts.geom.Geometry from(Geometry kmlGeometry) {
+        if (kmlGeometry == null) {
+            return null;
+        }
+
+        if (kmlGeometry instanceof Point) {
+            return KmlToJtsPointConverter.from((Point) kmlGeometry);
+        }
+
+        if (kmlGeometry instanceof LineString) {
+            return KmlToJtsLineStringConverter.from((LineString) kmlGeometry);
+        }
+
+        if (kmlGeometry instanceof LinearRing) {
+            return KmlToJtsLinearRingConverter.from((LinearRing) kmlGeometry);
+        }
+
+        if (kmlGeometry instanceof Polygon) {
+            return KmlToJtsPolygonConverter.from((Polygon) kmlGeometry);
+        }
+
+        if (kmlGeometry instanceof MultiGeometry) {
+            return KmlToJtsMultiGeometryConverter.from((MultiGeometry) kmlGeometry);
+        }
+
+        if (kmlGeometry instanceof Model) {
+            return KmlModelToJtsPointConverter.from((Model) kmlGeometry);
+        }
+
+        // Shouldn't get here
+        return null;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsLineStringConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsLineStringConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.springframework.util.CollectionUtils;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.LineString;
+
+public class KmlToJtsLineStringConverter {
+    private static final GeometryFactory GEOMETRY_FACTORY = JTSFactoryFinder.getGeometryFactory();
+
+    private KmlToJtsLineStringConverter() {
+    }
+
+    public static com.vividsolutions.jts.geom.LineString from(LineString kmlLineString) {
+        if (!isValidKmlLineString(kmlLineString)) {
+            return null;
+        }
+        Coordinate[] jtsCoordinates =
+                KmlToJtsCoordinateConverter.from(kmlLineString.getCoordinates());
+
+        return GEOMETRY_FACTORY.createLineString(jtsCoordinates);
+    }
+
+    public static boolean isValidKmlLineString(LineString kmlLineString) {
+        return kmlLineString != null && !CollectionUtils.isEmpty(kmlLineString.getCoordinates());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsLinearRingConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsLinearRingConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.springframework.util.CollectionUtils;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+
+public class KmlToJtsLinearRingConverter {
+    private KmlToJtsLinearRingConverter() {
+    }
+
+    public static com.vividsolutions.jts.geom.LinearRing from(LinearRing kmlLinearRing) {
+        if (!isValidKmlLinearRing(kmlLinearRing)) {
+            return null;
+        }
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        Coordinate[] jtsCoordinates =
+                KmlToJtsCoordinateConverter.from(kmlLinearRing.getCoordinates());
+
+        return geometryFactory.createLinearRing(jtsCoordinates);
+    }
+
+    public static boolean isValidKmlLinearRing(LinearRing kmlLinearRing) {
+        return kmlLinearRing != null && !CollectionUtils.isEmpty(kmlLinearRing.getCoordinates());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsMultiGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsMultiGeometryConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryCollection;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.MultiGeometry;
+
+public class KmlToJtsMultiGeometryConverter {
+    private KmlToJtsMultiGeometryConverter() {
+    }
+
+    public static GeometryCollection from(MultiGeometry kmlMultiGeometry) {
+        if (kmlMultiGeometry == null) {
+            return null;
+        }
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        List<Geometry> jtsGeometries = kmlMultiGeometry.getGeometry()
+                .stream()
+                .map(KmlToJtsGeometryConverter::from)
+                .collect(Collectors.toList());
+
+        if (CollectionUtils.isNotEmpty(jtsGeometries)) {
+            return geometryFactory.createGeometryCollection(jtsGeometries.toArray(new Geometry[0]));
+        }
+
+        return null;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsPointConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import de.micromata.opengis.kml.v_2_2_0.Point;
+
+public class KmlToJtsPointConverter {
+    private static final GeometryFactory GEOMETRY_FACTORY = JTSFactoryFinder.getGeometryFactory();
+
+    private KmlToJtsPointConverter() {
+    }
+
+    public static com.vividsolutions.jts.geom.Point from(Point kmlPoint) {
+        if (!isValidKmlPoint(kmlPoint)) {
+            return null;
+        }
+
+        // get(0) is valid because the KML documentation states that a point contains a single tuple
+        // even though the Point object contains a list of coordinates.
+        Coordinate jtsCoordinate = KmlToJtsCoordinateConverter.from(kmlPoint.getCoordinates()
+                .get(0));
+
+        return GEOMETRY_FACTORY.createPoint(jtsCoordinate);
+    }
+
+    public static boolean isValidKmlPoint(Point kmlPoint) {
+        return kmlPoint != null && !CollectionUtils.isEmpty(kmlPoint.getCoordinates());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsPolygonConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToJtsPolygonConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LinearRing;
+
+import de.micromata.opengis.kml.v_2_2_0.Boundary;
+import de.micromata.opengis.kml.v_2_2_0.Polygon;
+
+public class KmlToJtsPolygonConverter {
+    private KmlToJtsPolygonConverter() {
+    }
+
+    public static com.vividsolutions.jts.geom.Polygon from(Polygon kmlPolygon) {
+        if (!isValidPolygon(kmlPolygon)) {
+            return null;
+        }
+
+        LinearRing jtsShell = getJtsShell(kmlPolygon.getOuterBoundaryIs());
+
+        List<LinearRing> jtsHoles = getJtsHoles(kmlPolygon.getInnerBoundaryIs());
+
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        return geometryFactory.createPolygon(jtsShell,
+                jtsHoles.toArray(new LinearRing[0]));
+    }
+
+    private static LinearRing getJtsShell(Boundary kmlOuterBoundary) {
+        if (kmlOuterBoundary == null) {
+            return null;
+        }
+
+        return KmlToJtsLinearRingConverter.from(kmlOuterBoundary.getLinearRing());
+    }
+
+    private static List<LinearRing> getJtsHoles(List<Boundary> kmlInnerBoundaries) {
+        if (CollectionUtils.isEmpty(kmlInnerBoundaries)) {
+            return new ArrayList<>();
+        }
+
+        return kmlInnerBoundaries.stream()
+                .map(Boundary::getLinearRing)
+                .filter(Objects::nonNull)
+                .map(KmlToJtsLinearRingConverter::from)
+                .collect(Collectors.toList());
+    }
+
+    public static boolean isValidPolygon(Polygon kmlPolygon) {
+        return kmlPolygon != null && isValidKmlBoundary(kmlPolygon.getOuterBoundaryIs());
+    }
+
+    private static boolean isValidKmlBoundary(Boundary kmlBoundary) {
+        if (kmlBoundary == null) {
+            return false;
+        }
+
+        return KmlToJtsLinearRingConverter.isValidKmlLinearRing(kmlBoundary.getLinearRing());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToMetacard.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/converter/KmlToMetacard.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.kml.converter;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Contact;
+import ddf.catalog.data.types.DateTime;
+import de.micromata.opengis.kml.v_2_2_0.Feature;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.TimePrimitive;
+import de.micromata.opengis.kml.v_2_2_0.TimeSpan;
+import de.micromata.opengis.kml.v_2_2_0.TimeStamp;
+
+public class KmlToMetacard {
+    public static final Logger LOGGER = LoggerFactory.getLogger(KmlToMetacard.class);
+
+    public static final String Y = "yyyy";
+
+    public static final String YM = "yyyy-MM";
+
+    public static final String YMD = "yyyy-MM-dd";
+
+    public static final String YMDHM = "yyyy-MM-dd'T'hh:mm";
+
+    public static final String YMDHMS = "yyyy-MM-dd'T'hh:mm:ss";
+
+    public static final String YMDHMSFS = "yyyy-MM-dd'T'hh:mm:ss.s";
+
+    public static final String YMDHMZ = "yyyy-MM-dd'T'hh:mmZ";
+
+    public static final String YMDHMSZ = "yyyy-MM-dd'T'hh:mm:ssZ";
+
+    public static final String YMDHMSFSZ = "yyyy-MM-dd'T'hh:mm:ss.sZ";
+
+    private static final String[] DATE_FORMATS =
+            {Y, YM, YMD, YMDHM, YMDHMS, YMDHMSFS, YMDHMZ, YMDHMSZ, YMDHMSFSZ};
+
+    private static final ThreadLocal<WKTWriter> WKT_WRITER_THREAD_LOCAL = ThreadLocal.withInitial(
+            WKTWriter::new);
+
+    private KmlToMetacard() {
+    }
+
+    public static Metacard from(Metacard metacard, Kml kml) {
+        if (kml == null) {
+            LOGGER.debug("Null kml received. Nothing to convert.");
+            return null;
+        }
+
+        setLocation(metacard, kml);
+        setDates(metacard, kml);
+        setDescription(metacard, kml);
+        setContactInfo(metacard, kml);
+
+        return metacard;
+    }
+
+    private static void setLocation(Metacard metacard, Kml kml) {
+        String location = getBboxFromKml(kml);
+
+        if (StringUtils.isNotBlank(location)) {
+            ((MetacardImpl)metacard).setLocation(location);
+        }
+    }
+
+    private static void setDates(Metacard metacard, Kml kml) {
+        setDatesFromFeature(metacard, kml.getFeature());
+    }
+
+    private static void setDescription(Metacard metacard, Kml kml) {
+        setDescriptionFromFeature(metacard, kml.getFeature());
+    }
+
+    private static void setContactInfo(Metacard metacard, Kml kml) {
+        setContactInfoFromFeature(metacard, kml.getFeature());
+    }
+
+    private static void setContactInfoFromFeature(Metacard metacard, Feature feature) {
+        if (feature == null) {
+            return;
+        }
+
+        String phoneNumber = feature.getPhoneNumber();
+        if (StringUtils.isNotBlank(phoneNumber)) {
+            metacard.setAttribute(new AttributeImpl(Contact.POINT_OF_CONTACT_PHONE, phoneNumber));
+        }
+
+        String address = feature.getAddress();
+        if (StringUtils.isNotBlank(address)) {
+            metacard.setAttribute(new AttributeImpl(Contact.POINT_OF_CONTACT_ADDRESS, address));
+        }
+    }
+
+    private static void setDescriptionFromFeature(Metacard metacard, Feature feature) {
+        if (feature == null) {
+            return;
+        }
+
+        String description = feature.getDescription();
+        if (StringUtils.isNotBlank(description)) {
+            ((MetacardImpl)metacard).setDescription(description);
+        }
+    }
+
+    private static void setDatesFromFeature(Metacard metacard, Feature feature) {
+        if (feature == null) {
+            return;
+        }
+
+        setDatesFromTimePrimitive(metacard, feature.getTimePrimitive());
+    }
+
+    private static void setDatesFromTimePrimitive(Metacard metacard,
+            TimePrimitive timePrimitive) {
+        if (timePrimitive == null) {
+            return;
+        }
+
+        if (timePrimitive instanceof TimeSpan) {
+            setDatesFromTimeSpan(metacard, (TimeSpan) timePrimitive);
+        }
+
+        if (timePrimitive instanceof TimeStamp) {
+            setDatesFromTimeStamp(metacard, (TimeStamp) timePrimitive);
+        }
+    }
+
+    private static void setDatesFromTimeSpan(Metacard metacard, TimeSpan timeSpan) {
+        if (timeSpan == null) {
+            return;
+        }
+
+        String begin = timeSpan.getBegin();
+        if (StringUtils.isNotBlank(begin)) {
+            ((MetacardImpl)metacard).setCreatedDate(getDateFromString(begin));
+        }
+
+        String end = timeSpan.getEnd();
+        if (StringUtils.isNotBlank(end) &&  StringUtils.isNotBlank(begin)) {
+            metacard.setAttribute(new AttributeImpl(DateTime.END, getDateFromString(end)));
+            metacard.setAttribute(new AttributeImpl(DateTime.START, getDateFromString(begin)));
+        }
+    }
+
+    private static void setDatesFromTimeStamp(Metacard metacard, TimeStamp timeStamp) {
+        if (timeStamp == null) {
+            return;
+        }
+
+        String created = timeStamp.getWhen();
+        if (StringUtils.isNotBlank(created)) {
+            ((MetacardImpl)metacard).setCreatedDate(getDateFromString(created));
+        }
+    }
+
+    private static String getBboxFromKml(Kml kml) {
+        Geometry geometry = KmlToJtsConverter.from(kml);
+        String bBox = "";
+        if (geometry != null) {
+            bBox = WKT_WRITER_THREAD_LOCAL.get()
+                    .write(geometry.getEnvelope());
+        }
+
+        return bBox;
+    }
+
+    private static Date getDateFromString(String dateTime) {
+        if (StringUtils.isBlank(dateTime)) {
+            return null;
+        }
+
+        Date date = null;
+        try {
+            date = DateUtils.parseDate(dateTime, DATE_FORMATS);
+        } catch (ParseException e) {
+            LOGGER.debug("Error parsing date from the string '{}'. \nException: {}", dateTime, e);
+        }
+
+        return date;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KmlInputTransformer.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KmlInputTransformer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.kml.transformer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
+import org.codice.ddf.spatial.kml.converter.KmlToMetacard;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+
+public class KmlInputTransformer implements InputTransformer {
+    private MetacardType metacardType;
+
+    public KmlInputTransformer(MetacardType metacardType) {
+        this.metacardType = metacardType;
+    }
+
+    @Override
+    public Metacard transform(InputStream inputStream)
+            throws IOException, CatalogTransformerException {
+        return transform(inputStream, null);
+    }
+
+    @Override
+    public Metacard transform(InputStream inputStream, String id)
+            throws IOException, CatalogTransformerException {
+
+        MetacardImpl metacard;
+
+        try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
+
+            try {
+                IOUtils.copy(inputStream, fileBackedOutputStream);
+
+            } catch (IOException e) {
+                throw new CatalogTransformerException(
+                        "Unable to transform KML to Metacard. Error reading input stream.",
+                        e);
+            } finally {
+                IOUtils.closeQuietly(inputStream);
+            }
+
+            try (InputStream inputStreamCopy = fileBackedOutputStream.asByteSource()
+                    .openStream()) {
+                metacard = (MetacardImpl) unmarshal(inputStreamCopy);
+            }
+
+            if (metacard == null) {
+                throw new CatalogTransformerException("Unable to transform Kml to Metacard.");
+            } else if (StringUtils.isNotEmpty(id)) {
+                metacard.setAttribute(Metacard.ID, id);
+            }
+
+
+            try (Reader reader = fileBackedOutputStream.asByteSource()
+                    .asCharSource(Charsets.UTF_8)
+                    .openStream()) {
+                String kmlString = CharStreams.toString(reader);
+                metacard.setAttribute(Metacard.METADATA, kmlString);
+            }
+
+
+        } catch (IOException e) {
+            throw new CatalogTransformerException(
+                    "Unable to transform KML to Metacard. Error using file-backed stream.",
+                    e);
+        }
+
+        return metacard;
+    }
+
+    private Metacard unmarshal(InputStream inputStream) {
+        Kml kml = Kml.unmarshal(inputStream);
+
+        return KmlToMetacard.from(new MetacardImpl(metacardType), kml);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -72,4 +72,41 @@
         </cm:managed-component>
     </cm:managed-service-factory>
 
+    <bean id="kmlMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
+        <argument value="kml"/>
+        <argument>
+            <list>
+                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
+                <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
+            </list>
+        </argument>
+    </bean>
+
+    <bean id="kmlTransformer"
+          class="org.codice.ddf.spatial.kml.transformer.KmlInputTransformer">
+        <argument ref="kmlMetacardType"/>
+    </bean>
+
+    <service ref="kmlMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="kml"/>
+        </service-properties>
+    </service>
+
+    <service ref="kmlTransformer" interface="ddf.catalog.transform.InputTransformer">
+        <service-properties>
+            <entry key="id" value="kml"/>
+            <entry key="mime-type" >
+                <list>
+                    <value>text/xml</value>
+                    <value>application/xml</value>
+                    <value>application/vnd.google-earth.kml+xml</value>
+                </list>
+            </entry>
+        </service-properties>
+    </service>
+
 </blueprint>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlDocumentToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlDocumentToJtsGeometryConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Document;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlDocumentToJtsGeometryConverter {
+    private static Document testKmlDocument;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlDocumentToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlDocument.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlDocument = ((Document) kml.getFeature());
+    }
+
+    @Test
+    public void testConvertKmlDocument() {
+        Geometry jtsGeometry = KmlDocumentToJtsGeometryConverter.from(
+                testKmlDocument);
+
+        assertThat(jtsGeometry, notNullValue());
+        assertKmlDocument(testKmlDocument, jtsGeometry);
+    }
+
+    @Test
+    public void testConvertNullKmlDocumentReturnsNullJtsGeometry() {
+        Geometry jtsGeometry = KmlDocumentToJtsGeometryConverter.from(
+                null);
+
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    static void assertKmlDocument(Document kmlDocument,
+            Geometry jtsGeometry) {
+        assertThat(kmlDocument.getFeature()
+                .size(), is(equalTo(jtsGeometry.getNumGeometries())));
+
+        for (int i = 0; i < kmlDocument.getFeature()
+                .size(); i++) {
+            TestKmlPlacemarkToJtsGeometryConverter.assertPlacemark((Placemark) kmlDocument.getFeature()
+                    .get(i), jtsGeometry.getGeometryN(i));
+        }
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlFeatureToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlFeatureToJtsGeometryConverter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+
+import de.micromata.opengis.kml.v_2_2_0.Document;
+import de.micromata.opengis.kml.v_2_2_0.Feature;
+import de.micromata.opengis.kml.v_2_2_0.Folder;
+import de.micromata.opengis.kml.v_2_2_0.GroundOverlay;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.PhotoOverlay;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlFeatureToJtsGeometryConverter {
+
+    @Test
+    public void testConverNullKmlFeatureReturnsNullJtsGeometry() {
+        Geometry jtsGeometry = KmlFeatureToJtsGeometryConverter.from(
+                null);
+
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    @Test
+    public void testConvertKmlDocumentFeature() {
+        InputStream stream = TestKmlFeatureToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlDocument.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Document kmlDocument = ((Document) kml.getFeature());
+        assertThat(kmlDocument, notNullValue());
+
+        Geometry jtsGeometry = KmlFeatureToJtsGeometryConverter.from(
+                kmlDocument);
+
+        assertThat(jtsGeometry, notNullValue());
+        assertFeature(kmlDocument, jtsGeometry);
+
+    }
+
+    @Test
+    public void testConvertKmlFolderFeature() {
+        InputStream stream = TestKmlFeatureToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlFolder.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Folder kmlFolder = ((Folder) kml.getFeature());
+        assertThat(kmlFolder, notNullValue());
+
+        Geometry jtsGeometry = KmlFeatureToJtsGeometryConverter.from(
+                kmlFolder);
+
+        assertThat(jtsGeometry, notNullValue());
+        assertFeature(kmlFolder, jtsGeometry);
+    }
+
+    @Test
+    public void testConvertKmlPlaceMarkFeature() {
+        InputStream stream = TestKmlFeatureToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlPoint.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Placemark kmlPlacemark = (Placemark) kml.getFeature();
+        assertThat(kmlPlacemark, notNullValue());
+
+        Geometry geometry = KmlFeatureToJtsGeometryConverter.from(
+                kmlPlacemark);
+
+        assertThat(geometry, notNullValue());
+
+        assertFeature(kmlPlacemark, geometry);
+    }
+
+    @Test
+    public void testConvertKmlPhotoOverlayFeature() {
+        InputStream stream = TestKmlFeatureToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlPhotoOverlay.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        PhotoOverlay kmlPhotoOverlay = (PhotoOverlay) kml.getFeature();
+        assertThat(kmlPhotoOverlay, notNullValue());
+
+        Geometry geometry = KmlFeatureToJtsGeometryConverter.from(
+                kmlPhotoOverlay);
+
+        assertThat(geometry, notNullValue());
+
+        assertFeature(kmlPhotoOverlay, geometry);
+    }
+
+    @Test
+    public void testConvertKmlGroundOverlayFeature() {
+        InputStream stream = TestKmlFeatureToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlGroundOverlay.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        GroundOverlay kmlGroundOverlay = (GroundOverlay) kml.getFeature();
+        assertThat(kmlGroundOverlay, notNullValue());
+
+        Geometry geometry = KmlFeatureToJtsGeometryConverter.from(
+                kmlGroundOverlay);
+
+        assertThat(geometry, notNullValue());
+
+        assertFeature(kmlGroundOverlay, geometry);
+    }
+
+    static void assertFeature(Feature kmlFeature,
+            Geometry jtsGeometry) {
+        if (kmlFeature instanceof Document) {
+            TestKmlDocumentToJtsGeometryConverter.assertKmlDocument((Document) kmlFeature,
+                    jtsGeometry);
+        }
+        if (kmlFeature instanceof Folder) {
+            TestKmlFolderToJtsGeometryConverter.assertKmlFolder((Folder) kmlFeature, jtsGeometry);
+        }
+        if (kmlFeature instanceof Placemark) {
+            TestKmlPlacemarkToJtsGeometryConverter.assertPlacemark((Placemark) kmlFeature,
+                    jtsGeometry);
+        }
+        if (kmlFeature instanceof PhotoOverlay) {
+            TestKmlPhotoOverlayToJtsPointConverter.assertKmlPhotoOverlayToJtsPoint((PhotoOverlay) kmlFeature,
+                    (Point) jtsGeometry);
+        }
+        if (kmlFeature instanceof GroundOverlay) {
+            TestKmlGroundOverlayToJtsGeometryConverter.assertKmlGroundOverlayToJtsGeometry((GroundOverlay) kmlFeature,
+                    jtsGeometry);
+        }
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlFolderToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlFolderToJtsGeometryConverter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Folder;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlFolderToJtsGeometryConverter {
+
+    private static Folder testKmlFolder;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlFolderToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlFolder.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlFolder = ((Folder) kml.getFeature());
+
+    }
+
+    @Test
+    public void testConvertKmlFolder() {
+        Geometry jtsGeometry = KmlFolderToJtsGeometryConverter.from(
+                testKmlFolder);
+
+        assertThat(jtsGeometry, notNullValue());
+        assertKmlFolder(testKmlFolder, jtsGeometry);
+    }
+
+    @Test
+    public void testConvertNullKmlFolderReturnsNullJtsGeometry() {
+        Geometry jtsGeometry =
+                KmlFolderToJtsGeometryConverter.from(null);
+
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    static void assertKmlFolder(Folder kmlFolder,
+            Geometry jtsGeometry) {
+        assertThat(kmlFolder.getFeature()
+                .size(), is(equalTo(jtsGeometry.getNumGeometries())));
+
+        for (int i = 0; i < kmlFolder.getFeature()
+                .size(); i++) {
+            TestKmlPlacemarkToJtsGeometryConverter.assertPlacemark((Placemark) kmlFolder.getFeature()
+                    .get(i), jtsGeometry.getGeometryN(i));
+        }
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlGroundOverlayToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlGroundOverlayToJtsGeometryConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.GroundOverlay;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+
+public class TestKmlGroundOverlayToJtsGeometryConverter {
+    private static GroundOverlay testKmlGroundOverlay;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlGroundOverlayToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlGroundOverlay.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlGroundOverlay = ((GroundOverlay) kml.getFeature());
+    }
+
+    @Test
+    public void testConvertKmlGroundOverlayToJtsPoint() {
+        Geometry jtsGeometry =
+                KmlGroundOverlayToJtsGeometryConverter.from(testKmlGroundOverlay);
+
+        assertKmlGroundOverlayToJtsGeometry(testKmlGroundOverlay, jtsGeometry);
+    }
+
+    @Test
+    public void testConvertNullKmlGroundOverlayReturnsNullPoint() {
+        Geometry jtsGeometry =
+                KmlGroundOverlayToJtsGeometryConverter.from(null);
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    @Test
+    public void testConvertEmptyKmlGroundOverlayReturnsNullPoint() {
+        Geometry jtsGeometry =
+                KmlGroundOverlayToJtsGeometryConverter.from(new GroundOverlay());
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    static void assertKmlGroundOverlayToJtsGeometry(GroundOverlay groundOverlay,
+            Geometry jtsGeometry) {
+        assertThat(jtsGeometry, notNullValue());
+
+        TestKmlLatLonBoxToJtsGeometryConverter.assertKmlLatLonBoxToJtsGeometry(groundOverlay.getLatLonBox(),
+                jtsGeometry);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlLatLonBoxToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlLatLonBoxToJtsGeometryConverter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Coordinate;
+import de.micromata.opengis.kml.v_2_2_0.GroundOverlay;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LatLonBox;
+
+public class TestKmlLatLonBoxToJtsGeometryConverter {
+    private static LatLonBox testKmlLatLonBox;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlLatLonBoxToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlGroundOverlay.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        GroundOverlay groundOverlay = ((GroundOverlay) kml.getFeature());
+
+        testKmlLatLonBox = groundOverlay.getLatLonBox();
+    }
+
+    @Test
+    public void testConvertKmlLatLonBoxToJtsPoint() {
+        Geometry jtsGeometry = KmlLatLonBoxToJtsGeometryConverter.from(
+                testKmlLatLonBox);
+
+        assertKmlLatLonBoxToJtsGeometry(testKmlLatLonBox, jtsGeometry);
+    }
+
+    @Test
+    public void testConvertNullKmlLatLonBoxReturnsNullPoint() {
+        Geometry jtsGeometry = KmlLatLonBoxToJtsGeometryConverter.from(
+                null);
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    @Test
+    public void testConvertEmptyKmlLatLonBoxReturnsNullPoint() {
+        Geometry jtsGeometry = KmlLatLonBoxToJtsGeometryConverter.from(
+                new LatLonBox());
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    static void assertKmlLatLonBoxToJtsGeometry(LatLonBox latLonBox,
+            Geometry jtsGeometry) {
+        assertThat(jtsGeometry, notNullValue());
+
+        assertCoordinates(latLonBox, jtsGeometry);
+    }
+
+    private static void assertCoordinates(LatLonBox latLonBox,
+            Geometry jtsGeometry) {
+        double minX = latLonBox.getWest();
+        double maxX = latLonBox.getEast();
+        if (minX > maxX) {
+            minX = maxX;
+            maxX = latLonBox.getWest();
+        }
+
+        double minY = latLonBox.getSouth();
+        double maxY = latLonBox.getNorth();
+        if (minY > maxY) {
+            minY = maxY;
+            maxY = latLonBox.getSouth();
+        }
+
+        List<Coordinate> boundingBoxCoordinates = createKmlBoundingBoxCoordinates(minX,
+                maxX,
+                minY,
+                maxY);
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(
+                boundingBoxCoordinates,
+                jtsGeometry.getCoordinates());
+    }
+
+    private static List<Coordinate> createKmlBoundingBoxCoordinates(double minX, double maxX,
+            double minY, double maxY) {
+        List<Coordinate> coordinates = new ArrayList<>();
+
+        // This is the order that WKT wants the polygon
+        // Starting Upper Right, moving clockwise
+        coordinates.add(new Coordinate(maxX, maxY));
+        coordinates.add(new Coordinate(maxX, minY));
+        coordinates.add(new Coordinate(minX, minY));
+        coordinates.add(new Coordinate(minX, maxY));
+        coordinates.add(new Coordinate(maxX, maxY));
+
+        return coordinates;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlModelToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlModelToJtsPointConverter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+import java.util.Collections;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Point;
+
+import de.micromata.opengis.kml.v_2_2_0.Coordinate;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.Location;
+import de.micromata.opengis.kml.v_2_2_0.Model;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlModelToJtsPointConverter {
+    private static Model testKmlModel;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlModelToJtsPointConverter.class.getResourceAsStream(
+                "/kmlModel.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlModel = ((Model) ((Placemark) kml.getFeature()).getGeometry());
+    }
+
+    @Test
+    public void testConvertKmlModelToJtsPoint() {
+        Point jtsPoint = KmlModelToJtsPointConverter.from(testKmlModel);
+
+        assertKmlModelToJtsPoint(testKmlModel, jtsPoint);
+    }
+
+    @Test
+    public void testConvertNullKmlModelReturnsNullPoint() {
+        Point jtsPoint = KmlModelToJtsPointConverter.from(null);
+        assertThat(jtsPoint, nullValue());
+    }
+
+    @Test
+    public void testConvertEmptyKmlModelReturnsNullPoint() {
+        Point jtsPoint = KmlModelToJtsPointConverter.from(new Model());
+        assertThat(jtsPoint, nullValue());
+    }
+
+    static void assertKmlModelToJtsPoint(Model kmlModel,
+            Point jtsPoint) {
+        assertThat(jtsPoint, notNullValue());
+
+        Location location = kmlModel.getLocation();
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(Collections.singletonList(
+                new Coordinate(location.getLongitude(),
+                        location.getLatitude(),
+                        location.getAltitude())), jtsPoint.getCoordinates());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlPhotoOverlayToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlPhotoOverlayToJtsPointConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Point;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.PhotoOverlay;
+
+public class TestKmlPhotoOverlayToJtsPointConverter {
+    private static PhotoOverlay testKmlPhotoOverlay;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlPhotoOverlayToJtsPointConverter.class.getResourceAsStream(
+                "/kmlPhotoOverlay.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlPhotoOverlay = ((PhotoOverlay) kml.getFeature());
+    }
+
+    @Test
+    public void testConvertKmlPhotoOverlayToJtsPoint() {
+        Point jtsPoint = KmlPhotoOverlayToJtsPointConverter.from(
+                testKmlPhotoOverlay);
+
+        assertKmlPhotoOverlayToJtsPoint(testKmlPhotoOverlay, jtsPoint);
+    }
+
+    @Test
+    public void testConvertNullKmlPhotoOverlayReturnsNullPoint() {
+        Point jtsPoint = KmlPhotoOverlayToJtsPointConverter.from(null);
+        assertThat(jtsPoint, nullValue());
+    }
+
+    @Test
+    public void testConvertEmptyKmlPhotoOverlayReturnsNullPoint() {
+        Point jtsPoint =
+                KmlPhotoOverlayToJtsPointConverter.from(new PhotoOverlay());
+        assertThat(jtsPoint, nullValue());
+    }
+
+    static void assertKmlPhotoOverlayToJtsPoint(PhotoOverlay kmlPhotoOverlay,
+            Point jtsPoint) {
+        assertThat(jtsPoint, notNullValue());
+
+        TestKmlToJtsPointConverter.assertJtsPoint(kmlPhotoOverlay.getPoint(), jtsPoint);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlPlacemarkToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlPlacemarkToJtsGeometryConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlPlacemarkToJtsGeometryConverter {
+    private static Placemark testKmlPlacemark;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlPlacemarkToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlPoint.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlPlacemark = (Placemark) kml.getFeature();
+    }
+
+    @Test
+    public void testConvertPlacemark() {
+        Geometry geometry = KmlPlacemarkToJtsGeometryConverter.from(testKmlPlacemark);
+
+        assertThat(geometry, notNullValue());
+
+        assertPlacemark(testKmlPlacemark, geometry);
+    }
+
+    @Test
+    public void testConvertNullPlacemarkReturnsNull() {
+        Geometry geometry = KmlPlacemarkToJtsGeometryConverter.from(null);
+
+        assertThat(geometry, nullValue());
+    }
+
+    static void assertPlacemark(Placemark kmlPlacemark, Geometry jtsGeometry) {
+        TestKmlToJtsGeometryConverter.assertSpecificGeometry(kmlPlacemark.getGeometry(),
+                jtsGeometry);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+
+public class TestKmlToJtsConverter {
+
+    @Test
+    public void testConvertGiantKml() {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/sampleKml.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        assertThat(kml, notNullValue());
+
+        Geometry jtsGeometry = KmlToJtsConverter.from(kml);
+        assertThat(jtsGeometry, notNullValue());
+        assertThat(jtsGeometry.toString(), not(containsString("EMPTY")));
+    }
+
+    @Test
+    public void testConvertKml() {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/kmlPoint.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        assertThat(kml, notNullValue());
+
+        Geometry jtsGeometry = KmlToJtsConverter.from(kml);
+        TestKmlFeatureToJtsGeometryConverter.assertFeature(kml.getFeature(), jtsGeometry);
+    }
+
+    @Test
+    public void testConvertNullKmlReturnsNullGeometry() {
+        Geometry jtsGeometry = KmlToJtsConverter.from(null);
+        assertThat(jtsGeometry, nullValue());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsCoordinateConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsCoordinateConverter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import de.micromata.opengis.kml.v_2_2_0.Coordinate;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlToJtsCoordinateConverter {
+
+    private static List<Coordinate> testKmlCoordinates;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsCoordinateConverter.class.getResourceAsStream(
+                "/kmlLinearRing.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        LinearRing kmlLinearRing = ((LinearRing) ((Placemark) kml.getFeature()).getGeometry());
+
+        testKmlCoordinates = kmlLinearRing.getCoordinates();
+    }
+
+    @Test
+    public void testCoordinateConversion() {
+        com.vividsolutions.jts.geom.Coordinate jtsCoordinate;
+
+        for (Coordinate kmlCoordinate : testKmlCoordinates) {
+            jtsCoordinate = KmlToJtsCoordinateConverter.from(kmlCoordinate);
+            assertJtsCoordinateFromKmlCoordinate(kmlCoordinate, jtsCoordinate);
+        }
+    }
+
+    @Test
+    public void testCoordinatesConversion() {
+        com.vividsolutions.jts.geom.Coordinate[] jtsCoordinates = KmlToJtsCoordinateConverter.from(
+                testKmlCoordinates);
+
+        assertJtsCoordinatesFromKmlCoordinates(testKmlCoordinates, jtsCoordinates);
+    }
+
+    @Test
+    public void testNullKmlCoordinateReturnsNullJtsCoordinate() {
+        com.vividsolutions.jts.geom.Coordinate jtsCoordinate =
+                KmlToJtsCoordinateConverter.from((Coordinate) null);
+        assertThat(jtsCoordinate, nullValue());
+    }
+
+    @Test
+    public void testNullKmlCoordinateListReturnsNullJtsCoordinateArray() {
+        com.vividsolutions.jts.geom.Coordinate[] jtsCoordinates =
+                KmlToJtsCoordinateConverter.from((List<Coordinate>) null);
+        assertThat(jtsCoordinates, arrayWithSize(0));
+    }
+
+    @Test
+    public void testKmlCoordinateListWithNullObjectReturnsNullJtsCoordinateArrays() {
+        com.vividsolutions.jts.geom.Coordinate[] jtsCoordinates = KmlToJtsCoordinateConverter.from(
+                Collections.singletonList(null));
+        assertThat(jtsCoordinates, arrayWithSize(0));
+    }
+
+    @Test
+    public void testKmlCoordinateListWithGoodCoordinatesAndANullObjectIgnoresTheNullObject() {
+        List<Coordinate> kmlCoordinatesWithNull = getTestKmlCoordinatesWithNull();
+
+        com.vividsolutions.jts.geom.Coordinate[] jtsCoordinates = KmlToJtsCoordinateConverter.from(
+                kmlCoordinatesWithNull);
+
+        // testing against the global testKmlCoordinates because that set doesn't include the null
+        assertJtsCoordinatesFromKmlCoordinates(testKmlCoordinates, jtsCoordinates);
+    }
+
+    private List<Coordinate> getTestKmlCoordinatesWithNull() {
+        List<Coordinate> copy = new ArrayList<>(testKmlCoordinates);
+        copy.add(null);
+        return copy;
+    }
+
+    private void assertJtsCoordinateFromKmlCoordinate(Coordinate kmlCoordinate,
+            com.vividsolutions.jts.geom.Coordinate jtsCoordinate) {
+        assertThat(jtsCoordinate.x, is(equalTo(kmlCoordinate.getLongitude())));
+        assertThat(jtsCoordinate.y, is(equalTo(kmlCoordinate.getLatitude())));
+        assertThat(jtsCoordinate.z, is(equalTo(kmlCoordinate.getAltitude())));
+    }
+
+    static void assertJtsCoordinatesFromKmlCoordinates(List<Coordinate> kmlCoordinates,
+            com.vividsolutions.jts.geom.Coordinate[] jtsCoordinates) {
+        assertThat(jtsCoordinates.length, is(equalTo(kmlCoordinates.size())));
+
+        for (Coordinate kmlCoordinate : kmlCoordinates) {
+            com.vividsolutions.jts.geom.Coordinate jtsCoordinate =
+                    new com.vividsolutions.jts.geom.Coordinate(kmlCoordinate.getLongitude(),
+                            kmlCoordinate.getLatitude(),
+                            kmlCoordinate.getAltitude());
+            assertThat(jtsCoordinates, hasItemInArray((jtsCoordinate)));
+        }
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsGeometryConverter.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.GeometryCollection;
+
+import de.micromata.opengis.kml.v_2_2_0.Geometry;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LineString;
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.Model;
+import de.micromata.opengis.kml.v_2_2_0.MultiGeometry;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+import de.micromata.opengis.kml.v_2_2_0.Point;
+import de.micromata.opengis.kml.v_2_2_0.Polygon;
+
+public class TestKmlToJtsGeometryConverter {
+
+    @Test
+    public void testConvertNullGeometry() {
+        com.vividsolutions.jts.geom.Geometry jtsGeometry = KmlToJtsGeometryConverter.from(null);
+
+        assertThat(jtsGeometry, nullValue());
+    }
+
+    @Test
+    public void testConvertPointGeometry() {
+        InputStream stream =
+                TestKmlToJtsGeometryConverter.class.getResourceAsStream("/kmlPoint.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        assertThat(kml, notNullValue());
+
+        Point kmlPoint = ((Point) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(kmlPoint, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryPoint = KmlToJtsGeometryConverter.from(
+                kmlPoint);
+        assertThat(jtsGeometryPoint, instanceOf(com.vividsolutions.jts.geom.Point.class));
+
+        assertSpecificGeometry(kmlPoint, jtsGeometryPoint);
+    }
+
+    @Test
+    public void testConvertLineStringGeometry() {
+        InputStream stream = TestKmlToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlLineString.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        LineString kmlLineString = ((LineString) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(kmlLineString, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryLineString = KmlToJtsGeometryConverter.from(
+                kmlLineString);
+        assertThat(jtsGeometryLineString, instanceOf(com.vividsolutions.jts.geom.LineString.class));
+
+        assertSpecificGeometry(kmlLineString, jtsGeometryLineString);
+    }
+
+    @Test
+    public void testConvertLinearRingGeometry() {
+        InputStream stream = TestKmlToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlLinearRing.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        LinearRing kmlLinearRing = ((LinearRing) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(kmlLinearRing, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryLinearRing = KmlToJtsGeometryConverter.from(
+                kmlLinearRing);
+        assertThat(jtsGeometryLinearRing, instanceOf(com.vividsolutions.jts.geom.LinearRing.class));
+
+        assertSpecificGeometry(kmlLinearRing, jtsGeometryLinearRing);
+    }
+
+    @Test
+    public void testConvertPolygonGeometry() {
+        InputStream stream = TestKmlToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlPolygon.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Polygon kmlPolygon = ((Polygon) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(kmlPolygon, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryPolygon = KmlToJtsGeometryConverter.from(
+                kmlPolygon);
+        assertThat(jtsGeometryPolygon, instanceOf(com.vividsolutions.jts.geom.Polygon.class));
+
+        assertSpecificGeometry(kmlPolygon, jtsGeometryPolygon);
+    }
+
+    @Test
+    public void testConvertMultiGeometry() {
+        InputStream stream = TestKmlToJtsGeometryConverter.class.getResourceAsStream(
+                "/kmlMultiGeometry.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        MultiGeometry multiGeometry =
+                ((MultiGeometry) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(multiGeometry, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryCollectionGeometry =
+                KmlToJtsGeometryConverter.from(multiGeometry);
+        assertThat(jtsGeometryCollectionGeometry,
+                instanceOf(GeometryCollection.class));
+
+        assertSpecificGeometry(multiGeometry, jtsGeometryCollectionGeometry);
+    }
+
+    @Test
+    public void testConvertModelGeometry() {
+        InputStream stream =
+                TestKmlToJtsGeometryConverter.class.getResourceAsStream("/kmlModel.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Model model = ((Model) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(model, notNullValue());
+
+        com.vividsolutions.jts.geom.Geometry jtsGeometryPointFromModel =
+                KmlToJtsGeometryConverter.from(model);
+        assertThat(jtsGeometryPointFromModel, instanceOf(com.vividsolutions.jts.geom.Point.class));
+
+        assertSpecificGeometry(model, jtsGeometryPointFromModel);
+    }
+
+    static void assertSpecificGeometry(Geometry kmlGeometry,
+            com.vividsolutions.jts.geom.Geometry jtsGeometry) {
+        if (kmlGeometry instanceof Point) {
+            TestKmlToJtsPointConverter.assertJtsPoint((Point) kmlGeometry,
+                    (com.vividsolutions.jts.geom.Point) jtsGeometry);
+        }
+
+        if (kmlGeometry instanceof LineString) {
+            TestKmlToJtsLineStringConverter.assertTestKmlLineString((LineString) kmlGeometry,
+                    (com.vividsolutions.jts.geom.LineString) jtsGeometry);
+        }
+
+        if (kmlGeometry instanceof LinearRing) {
+            TestKmlToJtsLinearRingConverter.assertJtsLinearRing((LinearRing) kmlGeometry,
+                    (com.vividsolutions.jts.geom.LinearRing) jtsGeometry);
+        }
+
+        if (kmlGeometry instanceof Polygon) {
+            TestKmlToJtsPolygonConverter.assertJtsPolygon((Polygon) kmlGeometry,
+                    (com.vividsolutions.jts.geom.Polygon) jtsGeometry);
+        }
+
+        if (kmlGeometry instanceof MultiGeometry) {
+            TestKmlToJtsMultiGeometryConverter.assertJtsGeometryCollection((MultiGeometry) kmlGeometry,
+                    (GeometryCollection) jtsGeometry);
+        }
+
+        if (kmlGeometry instanceof Model) {
+            TestKmlModelToJtsPointConverter.assertKmlModelToJtsPoint((Model) kmlGeometry,
+                    (com.vividsolutions.jts.geom.Point) jtsGeometry);
+        }
+    }
+
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsLineStringConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsLineStringConverter.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LineString;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlToJtsLineStringConverter {
+    private static LineString testKmlLineString;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsLineStringConverter.class.getResourceAsStream(
+                "/kmlLineString.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlLineString = ((LineString) ((Placemark) kml.getFeature()).getGeometry());
+    }
+
+    @Test
+    public void testConversion() {
+        com.vividsolutions.jts.geom.LineString jtsLineString = KmlToJtsLineStringConverter.from(
+                testKmlLineString);
+
+        assertTestKmlLineString(jtsLineString);
+    }
+
+    @Test
+    public void testNullKmlLineStringReturnsNullJtsLineString() {
+        com.vividsolutions.jts.geom.LineString jtsLineString =
+                KmlToJtsLineStringConverter.from(null);
+
+        assertThat(jtsLineString, nullValue());
+    }
+
+    @Test
+    public void testKmlLineStringWithNoCoordinatesReturnsNull() {
+        com.vividsolutions.jts.geom.LineString jtsLineString =
+                KmlToJtsLineStringConverter.from(new LineString());
+
+        assertThat(jtsLineString, nullValue());
+    }
+
+    private void assertTestKmlLineString(com.vividsolutions.jts.geom.LineString lineString) {
+        assertTestKmlLineString(testKmlLineString, lineString);
+    }
+
+    static void assertTestKmlLineString(LineString kmlLineString,
+            com.vividsolutions.jts.geom.LineString jtsLineString) {
+        assertThat(jtsLineString, notNullValue());
+
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(kmlLineString.getCoordinates(),
+                jtsLineString.getCoordinates());
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsLinearRingConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsLinearRingConverter.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlToJtsLinearRingConverter {
+
+    private static LinearRing testKmlLinearRing;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsLinearRingConverter.class.getResourceAsStream(
+                "/kmlLinearRing.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlLinearRing = ((LinearRing) ((Placemark) kml.getFeature()).getGeometry());
+    }
+
+    @Test
+    public void testConversion() {
+        com.vividsolutions.jts.geom.LinearRing jtsLinearRing = KmlToJtsLinearRingConverter.from(
+                testKmlLinearRing);
+        assertJtsLinearRing(jtsLinearRing);
+    }
+
+    @Test
+    public void testNullKmlLinearRingReturnsNullJtsLinearRing() {
+        com.vividsolutions.jts.geom.LinearRing jtsLinearRing =
+                KmlToJtsLinearRingConverter.from(null);
+
+        assertThat(jtsLinearRing, nullValue());
+    }
+
+    @Test
+    public void testKmlLinearRingWithNoCoordinatesReturnsNull() {
+        com.vividsolutions.jts.geom.LinearRing jtsLinearRing =
+                KmlToJtsLinearRingConverter.from(new LinearRing());
+
+        assertThat(jtsLinearRing, nullValue());
+    }
+
+    static void assertJtsLinearRing(LinearRing kmlLinearRing,
+            com.vividsolutions.jts.geom.LinearRing jtsLinearRing) {
+        assertThat(jtsLinearRing, notNullValue());
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(kmlLinearRing.getCoordinates(),
+                jtsLinearRing.getCoordinates());
+    }
+
+    private void assertJtsLinearRing(com.vividsolutions.jts.geom.LinearRing jtsLinearRing) {
+        assertJtsLinearRing(testKmlLinearRing, jtsLinearRing);
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsMultiGeometryConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsMultiGeometryConverter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.GeometryCollection;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.MultiGeometry;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlToJtsMultiGeometryConverter {
+    private static MultiGeometry testKmlMultiGeometry;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsMultiGeometryConverter.class.getResourceAsStream(
+                "/kmlMultiGeometry.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlMultiGeometry = ((MultiGeometry) ((Placemark) kml.getFeature()).getGeometry());
+    }
+
+    @Test
+    public void testNullKmlMultiGeometryReturnsNullJtsGeometryCollection() {
+        GeometryCollection geometryCollection =
+                KmlToJtsMultiGeometryConverter.from(null);
+
+        assertThat(geometryCollection, nullValue());
+    }
+
+    @Test
+    public void testConvertMultiGeometry() {
+        GeometryCollection geometryCollection =
+                KmlToJtsMultiGeometryConverter.from(testKmlMultiGeometry);
+
+        assertJtsGeometryCollection(geometryCollection);
+    }
+
+    private void assertJtsGeometryCollection(
+            GeometryCollection jtsGeometryCollection) {
+        assertJtsGeometryCollection(testKmlMultiGeometry, jtsGeometryCollection);
+    }
+
+    static void assertJtsGeometryCollection(MultiGeometry kmlMultiGeometry,
+            GeometryCollection jtsGeometryCollection) {
+        assertThat(jtsGeometryCollection, notNullValue());
+
+        assertThat(jtsGeometryCollection.getNumGeometries(),
+                is(equalTo(kmlMultiGeometry.getGeometry()
+                        .size())));
+
+        for (int i = 0; i < jtsGeometryCollection.getNumGeometries(); i++) {
+            TestKmlToJtsGeometryConverter.assertSpecificGeometry(kmlMultiGeometry.getGeometry()
+                    .get(i), jtsGeometryCollection.getGeometryN(i));
+        }
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsPointConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsPointConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+import de.micromata.opengis.kml.v_2_2_0.Point;
+
+public class TestKmlToJtsPointConverter {
+    private static Point testKmlPoint;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsPointConverter.class.getResourceAsStream("/kmlPoint.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlPoint = ((Point) ((Placemark) kml.getFeature()).getGeometry());
+
+    }
+
+    @Test
+    public void testPointConversion() {
+        com.vividsolutions.jts.geom.Point jtsPoint = KmlToJtsPointConverter.from(testKmlPoint);
+
+        assertJtsPoint(testKmlPoint, jtsPoint);
+    }
+
+    @Test
+    public void testNullKmlPointReturnsNullJtsPoint() {
+        com.vividsolutions.jts.geom.Point jtsPoint = KmlToJtsPointConverter.from(null);
+
+        assertThat(jtsPoint, nullValue());
+    }
+
+    @Test
+    public void testKmlPointWithNoCoordinatesReturnsNullJtsPoint() {
+        com.vividsolutions.jts.geom.Point jtsPoint = KmlToJtsPointConverter.from(new Point());
+
+        assertThat(jtsPoint, nullValue());
+    }
+
+    static void assertJtsPoint(Point kmlPoint, com.vividsolutions.jts.geom.Point jtsPoint) {
+        assertThat(jtsPoint, notNullValue());
+
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(kmlPoint.getCoordinates(),
+                jtsPoint.getCoordinates());
+    }
+
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsPolygonConverter.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToJtsPolygonConverter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.LineString;
+
+import de.micromata.opengis.kml.v_2_2_0.Boundary;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+import de.micromata.opengis.kml.v_2_2_0.Polygon;
+
+public class TestKmlToJtsPolygonConverter {
+
+    private static Polygon testKmlPolygon;
+
+    @BeforeClass
+    public static void setupClass() {
+        InputStream stream = TestKmlToJtsPolygonConverter.class.getResourceAsStream(
+                "/kmlPolygon.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        testKmlPolygon =
+                ((Polygon) ((Placemark) kml.getFeature()).getGeometry());
+    }
+
+    @Test
+    public void testConvertPolygon() {
+        com.vividsolutions.jts.geom.Polygon jtsPolygon = KmlToJtsPolygonConverter.from(
+                testKmlPolygon);
+
+        assertJtsPolygon(testKmlPolygon, jtsPolygon);
+    }
+
+    @Test
+    public void testConvertPolygonWithHoles() {
+        Polygon kmlPolygonWithHoles = getTestKmlPolygonWithHoles();
+        com.vividsolutions.jts.geom.Polygon jtsPolygon = KmlToJtsPolygonConverter.from(
+                kmlPolygonWithHoles);
+
+        assertJtsPolygon(kmlPolygonWithHoles, jtsPolygon);
+    }
+
+    @Test
+    public void testNullKmlPolygonReturnsNullJtsPolygon() {
+        com.vividsolutions.jts.geom.Polygon jtsPolygon = KmlToJtsPolygonConverter.from(null);
+
+        assertThat(jtsPolygon, nullValue());
+    }
+
+    @Test
+    public void testEmptyKmlPolygonReturnsNull() {
+        com.vividsolutions.jts.geom.Polygon jtsPolygon =
+                KmlToJtsPolygonConverter.from(new Polygon());
+
+        assertThat(jtsPolygon, nullValue());
+    }
+
+    static void assertJtsPolygon(Polygon kmlPolygon,
+            com.vividsolutions.jts.geom.Polygon jtsPolygon) {
+        assertThat(jtsPolygon, notNullValue());
+
+        assertThat(jtsPolygon.getNumInteriorRing(),
+                is(equalTo(kmlPolygon.getInnerBoundaryIs()
+                        .size())));
+        assertKmlLinearRingMatchesJtsLineString(kmlPolygon.getOuterBoundaryIs()
+                .getLinearRing(), jtsPolygon.getExteriorRing());
+
+        for (int i = 0; i < kmlPolygon.getInnerBoundaryIs()
+                .size(); i++) {
+            assertKmlLinearRingMatchesJtsLineString(kmlPolygon.getInnerBoundaryIs()
+                    .get(i)
+                    .getLinearRing(), jtsPolygon.getInteriorRingN(i));
+        }
+
+    }
+
+    private static void assertKmlLinearRingMatchesJtsLineString(LinearRing kmlLinearRing,
+            LineString jtsLineString) {
+        TestKmlToJtsCoordinateConverter.assertJtsCoordinatesFromKmlCoordinates(kmlLinearRing.getCoordinates(),
+                jtsLineString.getCoordinates());
+    }
+
+    private Polygon getTestKmlPolygonWithHoles() {
+        InputStream stream = TestKmlToJtsPolygonConverter.class.getResourceAsStream(
+                "/kmlPolygonWithHoles.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+        assertThat(kml, notNullValue());
+
+        Polygon polygon =
+                ((Polygon) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(polygon, notNullValue());
+
+        LinearRing linearRing = polygon.getOuterBoundaryIs()
+                .getLinearRing();
+        assertThat(linearRing, notNullValue());
+
+        List<LinearRing> holes = polygon.getInnerBoundaryIs()
+                .stream()
+                .map(Boundary::getLinearRing)
+                .collect(Collectors.toList());
+        assertThat(holes, not(empty()));
+
+        return polygon;
+    }
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToMetacard.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/converter/TestKmlToMetacard.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import de.micromata.opengis.kml.v_2_2_0.Kml;
+import de.micromata.opengis.kml.v_2_2_0.MultiGeometry;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class TestKmlToMetacard {
+
+    @Test
+    public void testConvertKmlMultiGeometryToMetacardWithBbox() {
+        InputStream stream =
+                TestKmlToJtsConverter.class.getResourceAsStream("/kmlMultiGeometry.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        assertThat(kml, notNullValue());
+
+        Metacard metacard = KmlToMetacard.from(new MetacardImpl(), kml);
+        assertThat(metacard, notNullValue());
+
+        MultiGeometry kmlMultiGeometry =
+                ((MultiGeometry) ((Placemark) kml.getFeature()).getGeometry());
+        assertThat(kmlMultiGeometry, notNullValue());
+
+        Geometry jtsGeometryCollectionGeometry =
+                KmlToJtsGeometryConverter.from(kmlMultiGeometry);
+        assertThat(jtsGeometryCollectionGeometry, notNullValue());
+
+        String wktBbox = jtsGeometryCollectionGeometry.getEnvelope()
+                .toText();
+        assertThat(metacard.getAttribute(Metacard.GEOGRAPHY)
+                .getValue()
+                .toString(), is(equalToIgnoringWhiteSpace(wktBbox)));
+    }
+
+    @Test
+    public void testConvertBadKmlReturnsNullMetacard() {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/notKml.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        Metacard metacard = KmlToMetacard.from(new MetacardImpl(), kml);
+        assertThat(metacard, nullValue());
+    }
+
+    @Test
+    public void testKmlWithNoGeometry() {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream(
+                "/kmlWithNoGeometry.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        Metacard metacard = KmlToMetacard.from(new MetacardImpl(), kml);
+        assertThat(metacard, notNullValue());
+    }
+
+    @Test
+    public void testKmlWithTimeSpan() {
+        InputStream stream =
+                TestKmlToJtsConverter.class.getResourceAsStream("/kmlWithTimeSpan.kml");
+
+        Kml kml = Kml.unmarshal(stream);
+
+        Metacard metacard = KmlToMetacard.from(new MetacardImpl(), kml);
+        assertThat(metacard, notNullValue());
+    }
+
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestKmlInputTransformer.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/TestKmlInputTransformer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.kml.transformer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codice.ddf.spatial.kml.converter.TestKmlToJtsConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+import ddf.catalog.transform.CatalogTransformerException;
+
+public class TestKmlInputTransformer {
+
+    private KmlInputTransformer kmlInputTransformer;
+
+    private static List<MetacardType> metacardTypes;
+
+    static {
+        metacardTypes = new ArrayList<>();
+        metacardTypes.add(new AssociationsAttributes());
+        metacardTypes.add(new ContactAttributes());
+        metacardTypes.add(new DateTimeAttributes());
+        metacardTypes.add(new LocationAttributes());
+        metacardTypes.add(new ValidationAttributes());
+    }
+
+    @Before
+    public void setUp() {
+        kmlInputTransformer = new KmlInputTransformer(new MetacardTypeImpl("kmlMetacardType",
+                metacardTypes));
+    }
+
+    @Test(expected = CatalogTransformerException.class)
+    public void testTransformBadKmlThrowsException() throws Exception {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/notKml.kml");
+
+        kmlInputTransformer.transform(stream);
+    }
+
+    @Test
+    public void testTransformPointKml() throws Exception {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/kmlPoint.kml");
+
+        Metacard metacard = kmlInputTransformer.transform(stream);
+        assertThat(metacard, notNullValue());
+    }
+
+    @Test
+    public void testMetacardKeepsTheIdThatTheTransformIsCalledWith() throws Exception {
+        InputStream stream = TestKmlToJtsConverter.class.getResourceAsStream("/kmlPoint.kml");
+
+        String id = "someId";
+        Metacard metacard = kmlInputTransformer.transform(stream, id);
+        assertThat(metacard, notNullValue());
+        assertThat(metacard.getId(), is(equalTo(id)));
+    }
+
+    @Test(expected = CatalogTransformerException.class)
+    public void transformerThrowsCatalogTransformerExceptionOnIOException() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+        doThrow(IOException.class).when(inputStream)
+                .read(any(byte[].class));
+
+        kmlInputTransformer.transform(inputStream);
+    }
+
+}

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlDocument.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlDocument.kml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Document>
+        <name>Document.kml</name>
+        <open>1</open>
+        <Style id="exampleStyleDocument">
+            <LabelStyle>
+                <color>ff0000cc</color>
+            </LabelStyle>
+        </Style>
+        <Placemark>
+            <name>Document Feature 1</name>
+            <styleUrl>#exampleStyleDocument</styleUrl>
+            <Point>
+                <coordinates>-122.371,37.816,0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <name>Document Feature 2</name>
+            <styleUrl>#exampleStyleDocument</styleUrl>
+            <Point>
+                <coordinates>-122.370,37.817,0</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlFolder.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlFolder.kml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Folder>
+        <name>Folder.kml</name>
+        <open>1</open>
+        <description>
+            A folder is a container that can hold multiple other objects
+        </description>
+        <Placemark>
+            <name>Folder object 1 (Placemark)</name>
+            <Point>
+                <coordinates>-122.377588,37.830266,0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <name>Folder object 2 (Polygon)</name>
+            <Polygon>
+                <outerBoundaryIs>
+                    <LinearRing>
+                        <coordinates>
+                            -122.377830,37.830445,0
+                            -122.377576,37.830631,0
+                            -122.377840,37.830642,0
+                            -122.377830,37.830445,0
+                        </coordinates>
+                    </LinearRing>
+                </outerBoundaryIs>
+            </Polygon>
+        </Placemark>
+        <Placemark>
+            <name>Folder object 3 (Path)</name>
+            <LineString>
+                <tessellate>1</tessellate>
+                <coordinates>
+                    -122.378009,37.830128,0 -122.377885,37.830379,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+    </Folder>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlGroundOverlay.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlGroundOverlay.kml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <GroundOverlay>
+        <name>Large-scale overlay on terrain</name>
+        <visibility>0</visibility>
+        <description>Overlay shows Mount Etna erupting on July 13th, 2001.</description>
+        <LookAt>
+            <longitude>15.02468937557116</longitude>
+            <latitude>37.67395167941667</latitude>
+            <altitude>0</altitude>
+            <heading>-16.5581842842829</heading>
+            <tilt>58.31228652890705</tilt>
+            <range>30350.36838438907</range>
+        </LookAt>
+        <Icon>
+            <href>http://developers.google.com/kml/documentation/images/etna.jpg</href>
+        </Icon>
+        <LatLonBox>
+            <north>37.91904192681665</north>
+            <south>37.46543388598137</south>
+            <east>15.35832653742206</east>
+            <west>14.60128369746704</west>
+            <rotation>-0.1556640799496235</rotation>
+        </LatLonBox>
+    </GroundOverlay>
+
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlLineString.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlLineString.kml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>Absolute</name>
+        <visibility>0</visibility>
+        <description>Transparent purple line</description>
+        <LookAt>
+            <longitude>-112.2719329043177</longitude>
+            <latitude>36.08890633450894</latitude>
+            <altitude>0</altitude>
+            <heading>-106.8161545998597</heading>
+            <tilt>44.60763714063257</tilt>
+            <range>2569.386744398339</range>
+        </LookAt>
+        <styleUrl>#transPurpleLineGreenPoly</styleUrl>
+        <LineString>
+            <tessellate>1</tessellate>
+            <altitudeMode>absolute</altitudeMode>
+            <coordinates> -112.265654928602,36.09447672602546,2357
+                -112.2660384528238,36.09342608838671,2357
+                -112.2668139013453,36.09251058776881,2357
+                -112.2677826834445,36.09189827357996,2357
+                -112.2688557510952,36.0913137941187,2357
+                -112.2694810717219,36.0903677207521,2357
+                -112.2695268555611,36.08932171487285,2357
+                -112.2690144567276,36.08850916060472,2357
+                -112.2681528815339,36.08753813597956,2357
+                -112.2670588176031,36.08682685262568,2357
+                -112.2657374587321,36.08646312301303,2357 </coordinates>
+        </LineString>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlLinearRing.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlLinearRing.kml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <LinearRing>
+            <coordinates>-112.3348783983763,36.1514008468736,100
+                -112.3372535345629,36.14888517553886,100
+                -112.3356068927954,36.14781612679284,100
+                -112.3350034807972,36.14846469024177,100
+                -112.3358353861232,36.1489624162954,100
+                -112.3345888301373,36.15026229372507,100
+                -112.3337937856278,36.14978096026463,100
+                -112.3331798208424,36.1504472788618,100
+                -112.3348783983763,36.1514008468736,100
+            </coordinates>
+        </LinearRing>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlModel.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlModel.kml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>Sample Model</name>
+        <LookAt>
+            <longitude>-105.2727379358738</longitude>
+            <latitude>40.01000594412381</latitude>
+            <altitude>0</altitude>
+            <range>127.2393107680517</range>
+            <tilt>65.74454495876547</tilt>
+            <heading>-27.70337734057933</heading>
+        </LookAt>
+        <Model id="model_4">
+            <altitudeMode>relativeToGround</altitudeMode>
+            <Location>
+                <longitude>-105.272774533734</longitude>
+                <latitude>40.009993372683</latitude>
+                <altitude>0</altitude>
+            </Location>
+            <Orientation>
+                <heading>0</heading>
+                <tilt>0</tilt>
+                <roll>0</roll>
+            </Orientation>
+            <Scale>
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+            </Scale>
+        </Model>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlMultiGeometry.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlMultiGeometry.kml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>Multiple geometries example</name>
+        <MultiGeometry>
+            <Point>
+                <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+            </Point>
+            <LineString>
+                <tessellate>1</tessellate>
+                <altitudeMode>absolute</altitudeMode>
+                <coordinates>-112.265654928602,36.09447672602546,2357
+                    -112.2660384528238,36.09342608838671,2357
+                    -112.2668139013453,36.09251058776881,2357
+                    -112.2677826834445,36.09189827357996,2357
+                    -112.2688557510952,36.0913137941187,2357
+                    -112.2694810717219,36.0903677207521,2357
+                    -112.2695268555611,36.08932171487285,2357
+                    -112.2690144567276,36.08850916060472,2357
+                    -112.2681528815339,36.08753813597956,2357
+                    -112.2670588176031,36.08682685262568,2357
+                    -112.2657374587321,36.08646312301303,2357
+                </coordinates>
+            </LineString>
+            <LinearRing>
+                <coordinates>-112.3348783983763,36.1514008468736,100
+                    -112.3372535345629,36.14888517553886,100
+                    -112.3356068927954,36.14781612679284,100
+                    -112.3350034807972,36.14846469024177,100
+                    -112.3358353861232,36.1489624162954,100
+                    -112.3345888301373,36.15026229372507,100
+                    -112.3337937856278,36.14978096026463,100
+                    -112.3331798208424,36.1504472788618,100
+                    -112.3348783983763,36.1514008468736,100
+                </coordinates>
+            </LinearRing>
+            <Polygon>
+                <extrude>1</extrude>
+                <altitudeMode>relativeToGround</altitudeMode>
+                <outerBoundaryIs>
+                    <LinearRing>
+                        <coordinates>-77.05788457660967,38.87253259892824,100
+                            -77.05465973756702,38.87291016281703,100
+                            -77.05315536854791,38.87053267794386,100
+                            -77.05552622493516,38.868757801256,100
+                            -77.05844056290393,38.86996206506943,100
+                            -77.05788457660967,38.87253259892824,100
+                        </coordinates>
+                    </LinearRing>
+                </outerBoundaryIs>
+                <innerBoundaryIs>
+                    <LinearRing>
+                        <coordinates>-77.05668055019126,38.87154239798456,100
+                            -77.05542625960818,38.87167890344077,100
+                            -77.05485125901024,38.87076535397792,100
+                            -77.05577677433152,38.87008686581446,100
+                            -77.05691162017543,38.87054446963351,100
+                            -77.05668055019126,38.87154239798456,100
+                        </coordinates>
+                    </LinearRing>
+                </innerBoundaryIs>
+            </Polygon>
+            <Model id="model_4">
+                <altitudeMode>relativeToGround</altitudeMode>
+                <Location>
+                    <longitude>-105.272774533734</longitude>
+                    <latitude>40.009993372683</latitude>
+                    <altitude>0</altitude>
+                </Location>
+                <Orientation>
+                    <heading>0</heading>
+                    <tilt>0</tilt>
+                    <roll>0</roll>
+                </Orientation>
+                <Scale>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                </Scale>
+            </Model>
+            <MultiGeometry>
+                <Point>
+                    <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+                </Point>
+                <LineString>
+                    <tessellate>1</tessellate>
+                    <altitudeMode>absolute</altitudeMode>
+                    <coordinates>-112.265654928602,36.09447672602546,2357
+                        -112.2660384528238,36.09342608838671,2357
+                        -112.2668139013453,36.09251058776881,2357
+                        -112.2677826834445,36.09189827357996,2357
+                        -112.2688557510952,36.0913137941187,2357
+                        -112.2694810717219,36.0903677207521,2357
+                        -112.2695268555611,36.08932171487285,2357
+                        -112.2690144567276,36.08850916060472,2357
+                        -112.2681528815339,36.08753813597956,2357
+                        -112.2670588176031,36.08682685262568,2357
+                        -112.2657374587321,36.08646312301303,2357
+                    </coordinates>
+                </LineString>
+                <LinearRing>
+                    <coordinates>-112.3348783983763,36.1514008468736,100
+                        -112.3372535345629,36.14888517553886,100
+                        -112.3356068927954,36.14781612679284,100
+                        -112.3350034807972,36.14846469024177,100
+                        -112.3358353861232,36.1489624162954,100
+                        -112.3345888301373,36.15026229372507,100
+                        -112.3337937856278,36.14978096026463,100
+                        -112.3331798208424,36.1504472788618,100
+                        -112.3348783983763,36.1514008468736,100
+                    </coordinates>
+                </LinearRing>
+                <Polygon>
+                    <extrude>1</extrude>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <outerBoundaryIs>
+                        <LinearRing>
+                            <coordinates>-77.05788457660967,38.87253259892824,100
+                                -77.05465973756702,38.87291016281703,100
+                                -77.05315536854791,38.87053267794386,100
+                                -77.05552622493516,38.868757801256,100
+                                -77.05844056290393,38.86996206506943,100
+                                -77.05788457660967,38.87253259892824,100
+                            </coordinates>
+                        </LinearRing>
+                    </outerBoundaryIs>
+                    <innerBoundaryIs>
+                        <LinearRing>
+                            <coordinates>-77.05668055019126,38.87154239798456,100
+                                -77.05542625960818,38.87167890344077,100
+                                -77.05485125901024,38.87076535397792,100
+                                -77.05577677433152,38.87008686581446,100
+                                -77.05691162017543,38.87054446963351,100
+                                -77.05668055019126,38.87154239798456,100
+                            </coordinates>
+                        </LinearRing>
+                    </innerBoundaryIs>
+                </Polygon>
+                <Model>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <Location>
+                        <longitude>-105.272774533734</longitude>
+                        <latitude>40.009993372683</latitude>
+                        <altitude>0</altitude>
+                    </Location>
+                    <Orientation>
+                        <heading>0</heading>
+                        <tilt>0</tilt>
+                        <roll>0</roll>
+                    </Orientation>
+                    <Scale>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                    </Scale>
+                </Model>
+            </MultiGeometry>
+        </MultiGeometry>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPhotoOverlay.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPhotoOverlay.kml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <PhotoOverlay>
+        <!-- Feature elements -->
+        <name>A simple non-pyramidal photo</name>
+        <description>High above the ocean</description>
+        <!-- Overlay elements -->
+        <Icon>
+            <!-- A simple normal jpeg image -->
+            <href>small-photo.jpg</href>
+        </Icon>
+        <!-- PhotoOverlay elements -->
+        <!-- default: <rotation> default is 0 -->
+        <ViewVolume>
+            <near>1000</near>
+            <leftFov>-60</leftFov>
+            <rightFov>60</rightFov>
+            <bottomFov>-45</bottomFov>
+            <topFov>45</topFov>
+        </ViewVolume>
+        <!-- if no ImagePyramid only level 0 is shown,
+             fine for a non-pyramidal image -->
+        <Point>
+            <coordinates>1,1</coordinates>
+        </Point>
+        <!-- default: <shape> -->
+    </PhotoOverlay>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPoint.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPoint.kml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>Simple placemark</name>
+        <description>Attached to the ground. Intelligently places itself at the
+            height of the underlying terrain.
+        </description>
+        <Point>
+            <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+        </Point>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPolygon.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPolygon.kml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>Building 40</name>
+        <visibility>0</visibility>
+        <styleUrl>#transRedPoly</styleUrl>
+        <Polygon>
+            <extrude>1</extrude>
+            <altitudeMode>relativeToGround</altitudeMode>
+            <outerBoundaryIs>
+                <LinearRing>
+                    <coordinates>-122.0848938459612,37.42257124044786,17
+                        -122.0849580979198,37.42211922626856,17
+                        -122.0847469573047,37.42207183952619,17
+                        -122.0845725380962,37.42209006729676,17
+                        -122.0845954886723,37.42215932700895,17
+                        -122.0838521118269,37.42227278564371,17
+                        -122.083792243335,37.42203539112084,17
+                        -122.0835076656616,37.42209006957106,17
+                        -122.0834709464152,37.42200987395161,17
+                        -122.0831221085748,37.4221046494946,17
+                        -122.0829247374572,37.42226503990386,17
+                        -122.0829339169385,37.42231242843094,17
+                        -122.0833837359737,37.42225046087618,17
+                        -122.0833607854248,37.42234159228745,17
+                        -122.0834204551642,37.42237075460644,17
+                        -122.083659133885,37.42251292011001,17
+                        -122.0839758438952,37.42265873093781,17
+                        -122.0842374743331,37.42265143972521,17
+                        -122.0845036949503,37.4226514386435,17
+                        -122.0848020460801,37.42261133916315,17
+                        -122.0847882750515,37.42256395055121,17
+                        -122.0848938459612,37.42257124044786,17
+                    </coordinates>
+                </LinearRing>
+            </outerBoundaryIs>
+        </Polygon>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPolygonWithHoles.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlPolygonWithHoles.kml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark>
+        <name>The Pentagon</name>
+        <LookAt>
+            <longitude>-77.05580139178142</longitude>
+            <latitude>38.870832443487</latitude>
+            <heading>59.88865561738225</heading>
+            <tilt>48.09646074797388</tilt>
+            <range>742.0552506670548</range>
+        </LookAt>
+        <Polygon>
+            <extrude>1</extrude>
+            <altitudeMode>relativeToGround</altitudeMode>
+            <outerBoundaryIs>
+                <LinearRing>
+                    <coordinates>-77.05788457660967,38.87253259892824,100
+                        -77.05465973756702,38.87291016281703,100
+                        -77.05315536854791,38.87053267794386,100
+                        -77.05552622493516,38.868757801256,100
+                        -77.05844056290393,38.86996206506943,100
+                        -77.05788457660967,38.87253259892824,100
+                    </coordinates>
+                </LinearRing>
+            </outerBoundaryIs>
+            <innerBoundaryIs>
+                <LinearRing>
+                    <coordinates>-77.05668055019126,38.87154239798456,100
+                        -77.05542625960818,38.87167890344077,100
+                        -77.05485125901024,38.87076535397792,100
+                        -77.05577677433152,38.87008686581446,100
+                        -77.05691162017543,38.87054446963351,100
+                        -77.05668055019126,38.87154239798456,100
+                    </coordinates>
+                </LinearRing>
+            </innerBoundaryIs>
+        </Polygon>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlWithNoGeometry.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlWithNoGeometry.kml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+    * Copyright (c) Codice Foundation
+    * <p>
+    * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+    * General Public License as published by the Free Software Foundation, either version 3 of the
+    * License, or any later version.
+    * <p>
+    * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+    * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+    * is distributed along with this program and can be found at
+    * <http://www.gnu.org/licenses/lgpl.html>.
+    **/
+-->
+<kml xmlns="http://earth.google.com/kml/2.0">
+    <Folder>
+        <name>some name</name>
+        <description>some other works</description>
+        <Placemark>
+            <description>some more words</description>
+            <visibility>1</visibility>
+        </Placemark>
+    </Folder>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlWithTimeSpan.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/kmlWithTimeSpan.kml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+/**
+    * Copyright (c) Codice Foundation
+    * <p>
+    * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+    * General Public License as published by the Free Software Foundation, either version 3 of the
+    * License, or any later version.
+    * <p>
+    * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+    * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+    * is distributed along with this program and can be found at
+    * <http://www.gnu.org/licenses/lgpl.html>.
+    **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Placemark id="anId">
+        <name>someName</name>
+        <description>description</description>
+        <TimeSpan>
+            <begin>2017-05-18T16:21:55</begin>
+        </TimeSpan>
+
+        <Point>
+            <coordinates>-114.87194444,39.49027778</coordinates>
+        </Point>
+    </Placemark>
+</kml>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/notKml.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/notKml.kml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<rim:Service xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+             objectType="urn:federation:service">
+
+    <!-- each service binding should have at least one slot for bindingType -->
+    <rim:ServiceBinding id="registry.federation.method.csw"
+                        service="urn:uuid:2014ca7f59ac46f495e32b4a67a51276">
+
+</rim:Service>

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/sampleKml.kml
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/resources/sampleKml.kml
@@ -1,0 +1,935 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions of this page are reproduced from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
+ *
+ **/
+-->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Document>
+        <name>KML Samples</name>
+        <open>1</open>
+        <description>Unleash your creativity with the help of these examples!</description>
+        <Style id="downArrowIcon">
+            <IconStyle>
+                <Icon>
+                    <href>http://maps.google.com/mapfiles/kml/pal4/icon28.png</href>
+                </Icon>
+            </IconStyle>
+        </Style>
+        <Style id="globeIcon">
+            <IconStyle>
+                <Icon>
+                    <href>http://maps.google.com/mapfiles/kml/pal3/icon19.png</href>
+                </Icon>
+            </IconStyle>
+            <LineStyle>
+                <width>2</width>
+            </LineStyle>
+        </Style>
+        <Style id="transPurpleLineGreenPoly">
+            <LineStyle>
+                <color>7fff00ff</color>
+                <width>4</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7f00ff00</color>
+            </PolyStyle>
+        </Style>
+        <Style id="yellowLineGreenPoly">
+            <LineStyle>
+                <color>7f00ffff</color>
+                <width>4</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7f00ff00</color>
+            </PolyStyle>
+        </Style>
+        <Style id="thickBlackLine">
+            <LineStyle>
+                <color>87000000</color>
+                <width>10</width>
+            </LineStyle>
+        </Style>
+        <Style id="redLineBluePoly">
+            <LineStyle>
+                <color>ff0000ff</color>
+            </LineStyle>
+            <PolyStyle>
+                <color>ffff0000</color>
+            </PolyStyle>
+        </Style>
+        <Style id="blueLineRedPoly">
+            <LineStyle>
+                <color>ffff0000</color>
+            </LineStyle>
+            <PolyStyle>
+                <color>ff0000ff</color>
+            </PolyStyle>
+        </Style>
+        <Style id="transRedPoly">
+            <LineStyle>
+                <width>1.5</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7d0000ff</color>
+            </PolyStyle>
+        </Style>
+        <Style id="transBluePoly">
+            <LineStyle>
+                <width>1.5</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7dff0000</color>
+            </PolyStyle>
+        </Style>
+        <Style id="transGreenPoly">
+            <LineStyle>
+                <width>1.5</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7d00ff00</color>
+            </PolyStyle>
+        </Style>
+        <Style id="transYellowPoly">
+            <LineStyle>
+                <width>1.5</width>
+            </LineStyle>
+            <PolyStyle>
+                <color>7d00ffff</color>
+            </PolyStyle>
+        </Style>
+        <Style id="noDrivingDirections">
+            <BalloonStyle>
+                <text><![CDATA[
+          <b>$[name]</b>
+          <br /><br />
+          $[description]
+        ]]></text>
+            </BalloonStyle>
+        </Style>
+        <Folder>
+            <name>Placemarks</name>
+            <description>These are just some of the different kinds of placemarks with
+                which you can mark your favorite places</description>
+            <LookAt>
+                <longitude>-122.0839597145766</longitude>
+                <latitude>37.42222904525232</latitude>
+                <altitude>0</altitude>
+                <heading>-148.4122922628044</heading>
+                <tilt>40.5575073395506</tilt>
+                <range>500.6566641072245</range>
+            </LookAt>
+            <Placemark>
+                <name>Simple placemark</name>
+                <description>Attached to the ground. Intelligently places itself at the
+                    height of the underlying terrain.</description>
+                <Point>
+                    <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+                </Point>
+            </Placemark>
+            <Placemark>
+                <name>Floating placemark</name>
+                <visibility>0</visibility>
+                <description>Floats a defined distance above the ground.</description>
+                <LookAt>
+                    <longitude>-122.0839597145766</longitude>
+                    <latitude>37.42222904525232</latitude>
+                    <altitude>0</altitude>
+                    <heading>-148.4122922628044</heading>
+                    <tilt>40.5575073395506</tilt>
+                    <range>500.6566641072245</range>
+                </LookAt>
+                <styleUrl>#downArrowIcon</styleUrl>
+                <Point>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <coordinates>-122.084075,37.4220033612141,50</coordinates>
+                </Point>
+            </Placemark>
+            <Placemark>
+                <name>Extruded placemark</name>
+                <visibility>0</visibility>
+                <description>Tethered to the ground by a customizable
+                    &quot;tail&quot;</description>
+                <LookAt>
+                    <longitude>-122.0845787421525</longitude>
+                    <latitude>37.42215078737763</latitude>
+                    <altitude>0</altitude>
+                    <heading>-148.4126684946234</heading>
+                    <tilt>40.55750733918048</tilt>
+                    <range>365.2646606980322</range>
+                </LookAt>
+                <styleUrl>#globeIcon</styleUrl>
+                <Point>
+                    <extrude>1</extrude>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <coordinates>-122.0857667006183,37.42156927867553,50</coordinates>
+                </Point>
+            </Placemark>
+        </Folder>
+        <Folder>
+            <name>Styles and Markup</name>
+            <visibility>0</visibility>
+            <description>With KML it is easy to create rich, descriptive markup to
+                annotate and enrich your placemarks</description>
+            <LookAt>
+                <longitude>-122.0845787422371</longitude>
+                <latitude>37.42215078726837</latitude>
+                <altitude>0</altitude>
+                <heading>-148.4126777488172</heading>
+                <tilt>40.55750733930874</tilt>
+                <range>365.2646826292919</range>
+            </LookAt>
+            <styleUrl>#noDrivingDirections</styleUrl>
+            <Document>
+                <name>Highlighted Icon</name>
+                <visibility>0</visibility>
+                <description>Place your mouse over the icon to see it display the new
+                    icon</description>
+                <LookAt>
+                    <longitude>-122.0856552124024</longitude>
+                    <latitude>37.4224281311035</latitude>
+                    <altitude>0</altitude>
+                    <heading>0</heading>
+                    <tilt>0</tilt>
+                    <range>265.8520424250024</range>
+                </LookAt>
+                <Style id="highlightPlacemark">
+                    <IconStyle>
+                        <Icon>
+                            <href>http://maps.google.com/mapfiles/kml/paddle/red-stars.png</href>
+                        </Icon>
+                    </IconStyle>
+                </Style>
+                <Style id="normalPlacemark">
+                    <IconStyle>
+                        <Icon>
+                            <href>http://maps.google.com/mapfiles/kml/paddle/wht-blank.png</href>
+                        </Icon>
+                    </IconStyle>
+                </Style>
+                <StyleMap id="exampleStyleMap">
+                    <Pair>
+                        <key>normal</key>
+                        <styleUrl>#normalPlacemark</styleUrl>
+                    </Pair>
+                    <Pair>
+                        <key>highlight</key>
+                        <styleUrl>#highlightPlacemark</styleUrl>
+                    </Pair>
+                </StyleMap>
+                <Placemark>
+                    <name>Roll over this icon</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#exampleStyleMap</styleUrl>
+                    <Point>
+                        <coordinates>-122.0856545755255,37.42243077405461,0</coordinates>
+                    </Point>
+                </Placemark>
+            </Document>
+            <Placemark>
+                <name>Descriptive HTML</name>
+                <visibility>0</visibility>
+                <description><![CDATA[Click on the blue link!<br><br>
+Placemark descriptions can be enriched by using many standard HTML tags.<br>
+For example:
+<hr>
+Styles:<br>
+<i>Italics</i>,
+<b>Bold</b>,
+<u>Underlined</u>,
+<s>Strike Out</s>,
+subscript<sub>subscript</sub>,
+superscript<sup>superscript</sup>,
+<big>Big</big>,
+<small>Small</small>,
+<tt>Typewriter</tt>,
+<em>Emphasized</em>,
+<strong>Strong</strong>,
+<code>Code</code>
+<hr>
+Fonts:<br>
+<font color="red">red by name</font>,
+<font color="#408010">leaf green by hexadecimal RGB</font>
+<br>
+<font size=1>size 1</font>,
+<font size=2>size 2</font>,
+<font size=3>size 3</font>,
+<font size=4>size 4</font>,
+<font size=5>size 5</font>,
+<font size=6>size 6</font>,
+<font size=7>size 7</font>
+<br>
+<font face=times>Times</font>,
+<font face=verdana>Verdana</font>,
+<font face=arial>Arial</font><br>
+<hr>
+Links:
+<br>
+<a href="http://earth.google.com/">Google Earth!</a>
+<br>
+ or:  Check out our website at www.google.com
+<hr>
+Alignment:<br>
+<p align=left>left</p>
+<p align=center>center</p>
+<p align=right>right</p>
+<hr>
+Ordered Lists:<br>
+<ol><li>First</li><li>Second</li><li>Third</li></ol>
+<ol type="a"><li>First</li><li>Second</li><li>Third</li></ol>
+<ol type="A"><li>First</li><li>Second</li><li>Third</li></ol>
+<hr>
+Unordered Lists:<br>
+<ul><li>A</li><li>B</li><li>C</li></ul>
+<ul type="circle"><li>A</li><li>B</li><li>C</li></ul>
+<ul type="square"><li>A</li><li>B</li><li>C</li></ul>
+<hr>
+Definitions:<br>
+<dl>
+<dt>Google:</dt><dd>The best thing since sliced bread</dd>
+</dl>
+<hr>
+Centered:<br><center>
+Time present and time past<br>
+Are both perhaps present in time future,<br>
+And time future contained in time past.<br>
+If all time is eternally present<br>
+All time is unredeemable.<br>
+</center>
+<hr>
+Block Quote:
+<br>
+<blockquote>
+We shall not cease from exploration<br>
+And the end of all our exploring<br>
+Will be to arrive where we started<br>
+And know the place for the first time.<br>
+<i>-- T.S. Eliot</i>
+</blockquote>
+<br>
+<hr>
+Headings:<br>
+<h1>Header 1</h1>
+<h2>Header 2</h2>
+<h3>Header 3</h3>
+<h3>Header 4</h4>
+<h3>Header 5</h5>
+<hr>
+Images:<br>
+<i>Remote image</i><br>
+<img src="//developers.google.com/kml/documentation/images/googleSample.png"><br>
+<i>Scaled image</i><br>
+<img src="//developers.google.com/kml/documentation/images/googleSample.png" width=100><br>
+<hr>
+Simple Tables:<br>
+<table border="1" padding="1">
+<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>
+<tr><td>a</td><td>b</td><td>c</td><td>d</td><td>e</td></tr>
+</table>
+<br>
+[Did you notice that double-clicking on the placemark doesn't cause the viewer to take you anywhere? This is because it is possible to directly author a "placeless placemark". If you look at the code for this example, you will see that it has neither a point coordinate nor a LookAt element.]]]></description>
+            </Placemark>
+        </Folder>
+        <Folder>
+            <name>Ground Overlays</name>
+            <visibility>0</visibility>
+            <description>Examples of ground overlays</description>
+            <GroundOverlay>
+                <name>Large-scale overlay on terrain</name>
+                <visibility>0</visibility>
+                <description>Overlay shows Mount Etna erupting on July 13th, 2001.</description>
+                <LookAt>
+                    <longitude>15.02468937557116</longitude>
+                    <latitude>37.67395167941667</latitude>
+                    <altitude>0</altitude>
+                    <heading>-16.5581842842829</heading>
+                    <tilt>58.31228652890705</tilt>
+                    <range>30350.36838438907</range>
+                </LookAt>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/etna.jpg</href>
+                </Icon>
+                <LatLonBox>
+                    <north>37.91904192681665</north>
+                    <south>37.46543388598137</south>
+                    <east>15.35832653742206</east>
+                    <west>14.60128369746704</west>
+                    <rotation>-0.1556640799496235</rotation>
+                </LatLonBox>
+            </GroundOverlay>
+        </Folder>
+        <Folder>
+            <name>Screen Overlays</name>
+            <visibility>0</visibility>
+            <description>Screen overlays have to be authored directly in KML. These
+                examples illustrate absolute and dynamic positioning in screen space.</description>
+            <ScreenOverlay>
+                <name>Simple crosshairs</name>
+                <visibility>0</visibility>
+                <description>This screen overlay uses fractional positioning to put the
+                    image in the exact center of the screen</description>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/crosshairs.png</href>
+                </Icon>
+                <overlayXY x="0.5" y="0.5" xunits="fraction" yunits="fraction"/>
+                <screenXY x="0.5" y="0.5" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0.5" y="0.5" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="0" xunits="pixels" yunits="pixels"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Absolute Positioning: Top left</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/top_left.jpg</href>
+                </Icon>
+                <overlayXY x="0" y="1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="0" y="1" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="0" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Absolute Positioning: Top right</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/top_right.jpg</href>
+                </Icon>
+                <overlayXY x="1" y="1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="1" y="1" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="0" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Absolute Positioning: Bottom left</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/bottom_left.jpg</href>
+                </Icon>
+                <overlayXY x="0" y="-1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="0" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Absolute Positioning: Bottom right</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/bottom_right.jpg</href>
+                </Icon>
+                <overlayXY x="1" y="-1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="1" y="0" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="0" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Dynamic Positioning: Top of screen</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/dynamic_screenoverlay.jpg</href>
+                </Icon>
+                <overlayXY x="0" y="1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="0" y="1" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="1" y="0.2" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+            <ScreenOverlay>
+                <name>Dynamic Positioning: Right of screen</name>
+                <visibility>0</visibility>
+                <Icon>
+                    <href>http://developers.google.com/kml/documentation/images/dynamic_right.jpg</href>
+                </Icon>
+                <overlayXY x="1" y="1" xunits="fraction" yunits="fraction"/>
+                <screenXY x="1" y="1" xunits="fraction" yunits="fraction"/>
+                <rotationXY x="0" y="0" xunits="fraction" yunits="fraction"/>
+                <size x="0" y="1" xunits="fraction" yunits="fraction"/>
+            </ScreenOverlay>
+        </Folder>
+        <Folder>
+            <name>Paths</name>
+            <visibility>0</visibility>
+            <description>Examples of paths. Note that the tessellate tag is by default
+                set to 0. If you want to create tessellated lines, they must be authored
+                (or edited) directly in KML.</description>
+            <Placemark>
+                <name>Tessellated</name>
+                <visibility>0</visibility>
+                <description><![CDATA[If the <tessellate> tag has a value of 1, the line will contour to the underlying terrain]]></description>
+                <LookAt>
+                    <longitude>-112.0822680013139</longitude>
+                    <latitude>36.09825589333556</latitude>
+                    <altitude>0</altitude>
+                    <heading>103.8120432044965</heading>
+                    <tilt>62.04855796276328</tilt>
+                    <range>2889.145007690472</range>
+                </LookAt>
+                <LineString>
+                    <tessellate>1</tessellate>
+                    <coordinates> -112.0814237830345,36.10677870477137,0
+                        -112.0870267752693,36.0905099328766,0 </coordinates>
+                </LineString>
+            </Placemark>
+            <Placemark>
+                <name>Untessellated</name>
+                <visibility>0</visibility>
+                <description><![CDATA[If the <tessellate> tag has a value of 0, the line follow a simple straight-line path from point to point]]></description>
+                <LookAt>
+                    <longitude>-112.0822680013139</longitude>
+                    <latitude>36.09825589333556</latitude>
+                    <altitude>0</altitude>
+                    <heading>103.8120432044965</heading>
+                    <tilt>62.04855796276328</tilt>
+                    <range>2889.145007690472</range>
+                </LookAt>
+                <LineString>
+                    <tessellate>0</tessellate>
+                    <coordinates> -112.080622229595,36.10673460007995,0
+                        -112.085242575315,36.09049598612422,0 </coordinates>
+                </LineString>
+            </Placemark>
+            <Placemark>
+                <name>Absolute</name>
+                <visibility>0</visibility>
+                <description>Transparent purple line</description>
+                <LookAt>
+                    <longitude>-112.2719329043177</longitude>
+                    <latitude>36.08890633450894</latitude>
+                    <altitude>0</altitude>
+                    <heading>-106.8161545998597</heading>
+                    <tilt>44.60763714063257</tilt>
+                    <range>2569.386744398339</range>
+                </LookAt>
+                <styleUrl>#transPurpleLineGreenPoly</styleUrl>
+                <LineString>
+                    <tessellate>1</tessellate>
+                    <altitudeMode>absolute</altitudeMode>
+                    <coordinates> -112.265654928602,36.09447672602546,2357
+                        -112.2660384528238,36.09342608838671,2357
+                        -112.2668139013453,36.09251058776881,2357
+                        -112.2677826834445,36.09189827357996,2357
+                        -112.2688557510952,36.0913137941187,2357
+                        -112.2694810717219,36.0903677207521,2357
+                        -112.2695268555611,36.08932171487285,2357
+                        -112.2690144567276,36.08850916060472,2357
+                        -112.2681528815339,36.08753813597956,2357
+                        -112.2670588176031,36.08682685262568,2357
+                        -112.2657374587321,36.08646312301303,2357 </coordinates>
+                </LineString>
+            </Placemark>
+            <Placemark>
+                <name>Absolute Extruded</name>
+                <visibility>0</visibility>
+                <description>Transparent green wall with yellow outlines</description>
+                <LookAt>
+                    <longitude>-112.2643334742529</longitude>
+                    <latitude>36.08563154742419</latitude>
+                    <altitude>0</altitude>
+                    <heading>-125.7518698668815</heading>
+                    <tilt>44.61038665812578</tilt>
+                    <range>4451.842204068102</range>
+                </LookAt>
+                <styleUrl>#yellowLineGreenPoly</styleUrl>
+                <LineString>
+                    <extrude>1</extrude>
+                    <tessellate>1</tessellate>
+                    <altitudeMode>absolute</altitudeMode>
+                    <coordinates> -112.2550785337791,36.07954952145647,2357
+                        -112.2549277039738,36.08117083492122,2357
+                        -112.2552505069063,36.08260761307279,2357
+                        -112.2564540158376,36.08395660588506,2357
+                        -112.2580238976449,36.08511401044813,2357
+                        -112.2595218489022,36.08584355239394,2357
+                        -112.2608216347552,36.08612634548589,2357
+                        -112.262073428656,36.08626019085147,2357
+                        -112.2633204928495,36.08621519860091,2357
+                        -112.2644963846444,36.08627897945274,2357
+                        -112.2656969554589,36.08649599090644,2357 </coordinates>
+                </LineString>
+            </Placemark>
+            <Placemark>
+                <name>Relative</name>
+                <visibility>0</visibility>
+                <description>Black line (10 pixels wide), height tracks terrain</description>
+                <LookAt>
+                    <longitude>-112.2580438551384</longitude>
+                    <latitude>36.1072674824385</latitude>
+                    <altitude>0</altitude>
+                    <heading>4.947421249553717</heading>
+                    <tilt>44.61324882043339</tilt>
+                    <range>2927.61105910266</range>
+                </LookAt>
+                <styleUrl>#thickBlackLine</styleUrl>
+                <LineString>
+                    <tessellate>1</tessellate>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <coordinates> -112.2532845153347,36.09886943729116,645
+                        -112.2540466121145,36.09919570465255,645
+                        -112.254734666947,36.09984998366178,645
+                        -112.255493345654,36.10051310621746,645
+                        -112.2563157098468,36.10108441943419,645
+                        -112.2568033076439,36.10159722088088,645
+                        -112.257494011321,36.10204323542867,645
+                        -112.2584106072308,36.10229131995655,645
+                        -112.2596588987972,36.10240001286358,645
+                        -112.2610581199487,36.10213176873407,645
+                        -112.2626285262793,36.10157011437219,645 </coordinates>
+                </LineString>
+            </Placemark>
+            <Placemark>
+                <name>Relative Extruded</name>
+                <visibility>0</visibility>
+                <description>Opaque blue walls with red outline, height tracks terrain</description>
+                <LookAt>
+                    <longitude>-112.2683594333433</longitude>
+                    <latitude>36.09884362144909</latitude>
+                    <altitude>0</altitude>
+                    <heading>-72.24271551768405</heading>
+                    <tilt>44.60855445139561</tilt>
+                    <range>2184.193522571467</range>
+                </LookAt>
+                <styleUrl>#redLineBluePoly</styleUrl>
+                <LineString>
+                    <extrude>1</extrude>
+                    <tessellate>1</tessellate>
+                    <altitudeMode>relativeToGround</altitudeMode>
+                    <coordinates> -112.2656634181359,36.09445214722695,630
+                        -112.2652238941097,36.09520916122063,630
+                        -112.2645079986395,36.09580763864907,630
+                        -112.2638827428817,36.09628572284063,630
+                        -112.2635746835406,36.09679275951239,630
+                        -112.2635711822407,36.09740038871899,630
+                        -112.2640296531825,36.09804913435539,630
+                        -112.264327720538,36.09880337400301,630
+                        -112.2642436562271,36.09963644790288,630
+                        -112.2639148687042,36.10055381117246,630
+                        -112.2626894973474,36.10149062823369,630 </coordinates>
+                </LineString>
+            </Placemark>
+        </Folder>
+        <Folder>
+            <name>Polygons</name>
+            <visibility>0</visibility>
+            <description>Examples of polygon shapes</description>
+            <Folder>
+                <name>Google Campus</name>
+                <visibility>0</visibility>
+                <description>A collection showing how easy it is to create 3-dimensional
+                    buildings</description>
+                <LookAt>
+                    <longitude>-122.084120030116</longitude>
+                    <latitude>37.42174011925477</latitude>
+                    <altitude>0</altitude>
+                    <heading>-34.82469740081282</heading>
+                    <tilt>53.454348562403</tilt>
+                    <range>276.7870053764046</range>
+                </LookAt>
+                <Placemark>
+                    <name>Building 40</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transRedPoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -122.0848938459612,37.42257124044786,17
+                                    -122.0849580979198,37.42211922626856,17
+                                    -122.0847469573047,37.42207183952619,17
+                                    -122.0845725380962,37.42209006729676,17
+                                    -122.0845954886723,37.42215932700895,17
+                                    -122.0838521118269,37.42227278564371,17
+                                    -122.083792243335,37.42203539112084,17
+                                    -122.0835076656616,37.42209006957106,17
+                                    -122.0834709464152,37.42200987395161,17
+                                    -122.0831221085748,37.4221046494946,17
+                                    -122.0829247374572,37.42226503990386,17
+                                    -122.0829339169385,37.42231242843094,17
+                                    -122.0833837359737,37.42225046087618,17
+                                    -122.0833607854248,37.42234159228745,17
+                                    -122.0834204551642,37.42237075460644,17
+                                    -122.083659133885,37.42251292011001,17
+                                    -122.0839758438952,37.42265873093781,17
+                                    -122.0842374743331,37.42265143972521,17
+                                    -122.0845036949503,37.4226514386435,17
+                                    -122.0848020460801,37.42261133916315,17
+                                    -122.0847882750515,37.42256395055121,17
+                                    -122.0848938459612,37.42257124044786,17 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Building 41</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transBluePoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -122.0857412771483,37.42227033155257,17
+                                    -122.0858169768481,37.42231408832346,17
+                                    -122.085852582875,37.42230337469744,17
+                                    -122.0858799945639,37.42225686138789,17
+                                    -122.0858860101409,37.4222311076138,17
+                                    -122.0858069157288,37.42220250173855,17
+                                    -122.0858379542653,37.42214027058678,17
+                                    -122.0856732640519,37.42208690214408,17
+                                    -122.0856022926407,37.42214885429042,17
+                                    -122.0855902778436,37.422128290487,17
+                                    -122.0855841672237,37.42208171967246,17
+                                    -122.0854852065741,37.42210455874995,17
+                                    -122.0855067264352,37.42214267949824,17
+                                    -122.0854430712915,37.42212783846172,17
+                                    -122.0850990714904,37.42251282407603,17
+                                    -122.0856769818632,37.42281815323651,17
+                                    -122.0860162273783,37.42244918858722,17
+                                    -122.0857260327004,37.42229239604253,17
+                                    -122.0857412771483,37.42227033155257,17 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Building 42</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transGreenPoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -122.0857862287242,37.42136208886969,25
+                                    -122.0857312990603,37.42136935989481,25
+                                    -122.0857312992918,37.42140934910903,25
+                                    -122.0856077073679,37.42138390166565,25
+                                    -122.0855802426516,37.42137299550869,25
+                                    -122.0852186221971,37.42137299504316,25
+                                    -122.0852277765639,37.42161656508265,25
+                                    -122.0852598189347,37.42160565894403,25
+                                    -122.0852598185499,37.42168200156,25
+                                    -122.0852369311478,37.42170017860346,25
+                                    -122.0852643957828,37.42176197982575,25
+                                    -122.0853239032746,37.42176198013907,25
+                                    -122.0853559454324,37.421852864452,25
+                                    -122.0854108752463,37.42188921823734,25
+                                    -122.0854795379357,37.42189285337048,25
+                                    -122.0855436229819,37.42188921797546,25
+                                    -122.0856260178042,37.42186013499926,25
+                                    -122.085937287963,37.42186013453605,25
+                                    -122.0859428718666,37.42160898590042,25
+                                    -122.0859655469861,37.42157992759144,25
+                                    -122.0858640462341,37.42147115002957,25
+                                    -122.0858548911215,37.42140571326184,25
+                                    -122.0858091162768,37.4214057134039,25
+                                    -122.0857862287242,37.42136208886969,25 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Building 43</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transYellowPoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -122.0844371128284,37.42177253003091,19
+                                    -122.0845118855746,37.42191111542896,19
+                                    -122.0850470999805,37.42178755121535,19
+                                    -122.0850719913391,37.42143663023161,19
+                                    -122.084916406232,37.42137237822116,19
+                                    -122.0842193868167,37.42137237801626,19
+                                    -122.08421938659,37.42147617161496,19
+                                    -122.0838086419991,37.4214613409357,19
+                                    -122.0837899728564,37.42131306410796,19
+                                    -122.0832796534698,37.42129328840593,19
+                                    -122.0832609819207,37.42139213944298,19
+                                    -122.0829373621737,37.42137236399876,19
+                                    -122.0829062425667,37.42151569778871,19
+                                    -122.0828502269665,37.42176282576465,19
+                                    -122.0829435788635,37.42176776969635,19
+                                    -122.083217411188,37.42179248552686,19
+                                    -122.0835970430103,37.4217480074456,19
+                                    -122.0839455556771,37.42169364237603,19
+                                    -122.0840077894637,37.42176283815853,19
+                                    -122.084113587521,37.42174801104392,19
+                                    -122.0840762473784,37.42171341292375,19
+                                    -122.0841447047739,37.42167881534569,19
+                                    -122.084144704223,37.42181720660197,19
+                                    -122.0842503333074,37.4218170700446,19
+                                    -122.0844371128284,37.42177253003091,19 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+            </Folder>
+            <Folder>
+                <name>Extruded Polygon</name>
+                <description>A simple way to model a building</description>
+                <Placemark>
+                    <name>The Pentagon</name>
+                    <LookAt>
+                        <longitude>-77.05580139178142</longitude>
+                        <latitude>38.870832443487</latitude>
+                        <heading>59.88865561738225</heading>
+                        <tilt>48.09646074797388</tilt>
+                        <range>742.0552506670548</range>
+                    </LookAt>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -77.05788457660967,38.87253259892824,100
+                                    -77.05465973756702,38.87291016281703,100
+                                    -77.05315536854791,38.87053267794386,100
+                                    -77.05552622493516,38.868757801256,100
+                                    -77.05844056290393,38.86996206506943,100
+                                    -77.05788457660967,38.87253259892824,100 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                        <innerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -77.05668055019126,38.87154239798456,100
+                                    -77.05542625960818,38.87167890344077,100
+                                    -77.05485125901024,38.87076535397792,100
+                                    -77.05577677433152,38.87008686581446,100
+                                    -77.05691162017543,38.87054446963351,100
+                                    -77.05668055019126,38.87154239798456,100 </coordinates>
+                            </LinearRing>
+                        </innerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+            </Folder>
+            <Folder>
+                <name>Absolute and Relative</name>
+                <visibility>0</visibility>
+                <description>Four structures whose roofs meet exactly. Turn on/off
+                    terrain to see the difference between relative and absolute
+                    positioning.</description>
+                <LookAt>
+                    <longitude>-112.3348969157552</longitude>
+                    <latitude>36.14845533214919</latitude>
+                    <altitude>0</altitude>
+                    <heading>-86.91235037566909</heading>
+                    <tilt>49.30695423894192</tilt>
+                    <range>990.6761201087104</range>
+                </LookAt>
+                <Placemark>
+                    <name>Absolute</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transBluePoly</styleUrl>
+                    <Polygon>
+                        <tessellate>1</tessellate>
+                        <altitudeMode>absolute</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -112.3372510731295,36.14888505105317,1784
+                                    -112.3356128688403,36.14781540589019,1784
+                                    -112.3368169371048,36.14658677734382,1784
+                                    -112.3384408457543,36.14762778914076,1784
+                                    -112.3372510731295,36.14888505105317,1784 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Absolute Extruded</name>
+                    <visibility>0</visibility>
+                    <styleUrl>#transRedPoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <tessellate>1</tessellate>
+                        <altitudeMode>absolute</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -112.3396586818843,36.14637618647505,1784
+                                    -112.3380597654315,36.14531751871353,1784
+                                    -112.3368254237788,36.14659596244607,1784
+                                    -112.3384555043203,36.14762621763982,1784
+                                    -112.3396586818843,36.14637618647505,1784 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Relative</name>
+                    <visibility>0</visibility>
+                    <LookAt>
+                        <longitude>-112.3350152490417</longitude>
+                        <latitude>36.14943123077423</latitude>
+                        <altitude>0</altitude>
+                        <heading>-118.9214100848499</heading>
+                        <tilt>37.92486261093203</tilt>
+                        <range>345.5169113679813</range>
+                    </LookAt>
+                    <styleUrl>#transGreenPoly</styleUrl>
+                    <Polygon>
+                        <tessellate>1</tessellate>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -112.3349463145932,36.14988705767721,100
+                                    -112.3354019540677,36.14941108398372,100
+                                    -112.3344428289146,36.14878490381308,100
+                                    -112.3331289492913,36.14780840132443,100
+                                    -112.3317019516947,36.14680755678357,100
+                                    -112.331131440106,36.1474173426228,100
+                                    -112.332616324338,36.14845453364654,100
+                                    -112.3339876620524,36.14926570522069,100
+                                    -112.3349463145932,36.14988705767721,100 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+                <Placemark>
+                    <name>Relative Extruded</name>
+                    <visibility>0</visibility>
+                    <LookAt>
+                        <longitude>-112.3351587892382</longitude>
+                        <latitude>36.14979247129029</latitude>
+                        <altitude>0</altitude>
+                        <heading>-55.42811560891606</heading>
+                        <tilt>56.10280503739589</tilt>
+                        <range>401.0997279712519</range>
+                    </LookAt>
+                    <styleUrl>#transYellowPoly</styleUrl>
+                    <Polygon>
+                        <extrude>1</extrude>
+                        <tessellate>1</tessellate>
+                        <altitudeMode>relativeToGround</altitudeMode>
+                        <outerBoundaryIs>
+                            <LinearRing>
+                                <coordinates> -112.3348783983763,36.1514008468736,100
+                                    -112.3372535345629,36.14888517553886,100
+                                    -112.3356068927954,36.14781612679284,100
+                                    -112.3350034807972,36.14846469024177,100
+                                    -112.3358353861232,36.1489624162954,100
+                                    -112.3345888301373,36.15026229372507,100
+                                    -112.3337937856278,36.14978096026463,100
+                                    -112.3331798208424,36.1504472788618,100
+                                    -112.3348783983763,36.1514008468736,100 </coordinates>
+                            </LinearRing>
+                        </outerBoundaryIs>
+                    </Polygon>
+                </Placemark>
+            </Folder>
+        </Folder>
+    </Document>
+</kml>


### PR DESCRIPTION
Adding the Kml Input Transformer
Adding the Kml Converters to convert from Kml to Jts Geometry
Adding the Kml to Metacard converter used to populate the metacard from the KML

#### What does this PR do?
This PR adds an input transformer for KML files

#### Who is reviewing it? 
@dcruver @spearskw 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard 
@jlcsmith
@kcwire 
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
Ingest KML file
Verify a metacard was created with the kml metacard-type
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3243](https://codice.atlassian.net/browse/DDF-3243)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
