### PR TITLE
DDF-3259 Moved SortBy normalization logic after the query filter transforms

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/MetacardCswRecordMap.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/mappings/MetacardCswRecordMap.java
@@ -29,5 +29,15 @@ public class MetacardCswRecordMap implements CswRecordMap {
     public String getProperty(String propertyName) {
         return DefaultCswRecordMap.getDefaultMetacardFieldFor(propertyName);
     }
+
+    @Override
+    public boolean hasProperty(String propertyName, NamespaceSupport context) {
+        return DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(propertyName, context);
+    }
+
+    @Override
+    public boolean hasProperty(String propertyName) {
+        return DefaultCswRecordMap.hasDefaultMetacardFieldForPrefixedString(propertyName);
+    }
 }
 

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMap.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMap.java
@@ -27,7 +27,7 @@ public interface CswRecordMap {
      * will be used to resolve namespaces. If {@link NamespaceSupport} is
      * null, then {@link CswRecordMap#getProperty(String)} should be used.
      *
-     * @param propertyName CSW query property name, can be prefixed.
+     * @param propertyName CSW query property name. Can be prefixed.
      * @param context      Namespace context from the CSW query
      * @return Catalog taxonomy attribute name.
      */
@@ -42,4 +42,26 @@ public interface CswRecordMap {
      * @return Catalog taxonomy attribute name
      */
     String getProperty(String propertyName);
+
+    /**
+     * Returns true if the property name has a corresponding catalog taxonomy
+     * attribute. {@link NamespaceSupport} will be used to resolve namespaces.
+     * If {@link NamespaceSupport} is null, then {@link CswRecordMap#hasProperty(String)}
+     * should be used.
+     *
+     * @param propertyName CSW query property name. Can be prefixed.
+     * @param context      Namespace context from the CSW query
+     * @return True if the property name has a corresponding catalog taxonomy attribute.
+     */
+    boolean hasProperty(String propertyName, NamespaceSupport context);
+
+    /**
+     * Returns true if the property name has a corresponding catalog taxonomy
+     * attribute. If the property name is prefixed, then the prefix will be
+     * removed before performing the check.
+     *
+     * @param propertyName CSW query property name. Can be prefixed.
+     * @return True if the property name has a corresponding catalog taxonomy attribute.
+     */
+    boolean hasProperty(String propertyName);
 }

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -183,6 +183,7 @@
 
     <bean id="cswFilterFactory"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswQueryFactory">
+        <argument ref="metacardCswRecordMap"/>
         <argument ref="filterBuilder"/>
         <argument ref="filterAdapter"/>
         <property name="attributeRegistry" ref="attributeRegistry"/>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -243,7 +243,7 @@ public class CswQueryFactoryTest {
         FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
         CswRecordMap cswRecordMap = new MetacardCswRecordMap();
 
-        queryFactory = new CswQueryFactory(cswRecordMap,filterBuilder, filterAdapter);
+        queryFactory = new CswQueryFactory(cswRecordMap, filterBuilder, filterAdapter);
 
         AttributeRegistry mockAttributeRegistry = mock(AttributeRegistry.class);
         when(mockAttributeRegistry.lookup(TITLE_TEST_ATTRIBUTE)).thenReturn(Optional.of(mock(

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -1043,9 +1043,10 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        assertThat(((QueryImpl) frameworkQuery.getFilter()).getFilter(), instanceOf(clz));
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        N spatial = (N) queryFilter;
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -364,8 +364,9 @@ public class CswQueryFactoryTest {
 
         QueryRequest queryRequest = queryFactory.getQuery(grr);
         QueryImpl frameworkQuery = (QueryImpl) queryRequest.getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(PropertyIsLike.class));
-        PropertyIsLike like = (PropertyIsLike) frameworkQuery.getFilter();
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(PropertyIsLike.class));
+        PropertyIsLike like = (PropertyIsLike) queryFilter;
         assertThat(like.getLiteral(), is(CQL_CONTEXTUAL_PATTERN));
         assertThat(((AttributeExpressionImpl) like.getExpression()).getPropertyName(),
                 is(CQL_FRAMEWORK_TEST_ATTRIBUTE));
@@ -428,8 +429,9 @@ public class CswQueryFactoryTest {
 
         QueryRequest queryRequest = queryFactory.getQuery(grr);
         QueryImpl frameworkQuery = (QueryImpl) queryRequest.getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(PropertyIsEqualTo.class));
-        PropertyIsEqualTo equalTo = (PropertyIsEqualTo) frameworkQuery.getFilter();
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(PropertyIsEqualTo.class));
+        PropertyIsEqualTo equalTo = (PropertyIsEqualTo) queryFilter;
         assertThat(equalTo.getExpression1(), instanceOf(Function.class));
         Function function = (Function) equalTo.getExpression1();
         assertThat(equalTo.getExpression2(), instanceOf(Literal.class));
@@ -784,9 +786,10 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(clz));
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) frameworkQuery.getFilter();
+        N spatial = (N) queryFilter;
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
@@ -825,9 +828,10 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(clz));
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) frameworkQuery.getFilter();
+        N spatial = (N) queryFilter;
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
@@ -951,9 +955,10 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr.get202RecordsType())
                 .getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(clz));
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) frameworkQuery.getFilter();
+        N spatial = (N) queryFilter;
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
@@ -994,9 +999,10 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(clz));
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
+        assertThat(queryFilter, instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) frameworkQuery.getFilter();
+        N spatial = (N) queryFilter;
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
@@ -1037,9 +1043,9 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        assertThat(frameworkQuery.getFilter(), instanceOf(clz));
+        assertThat(((QueryImpl) frameworkQuery.getFilter()).getFilter(), instanceOf(clz));
         @SuppressWarnings("unchecked")
-        N spatial = (N) frameworkQuery.getFilter();
+        N spatial = (N) ((QueryImpl) frameworkQuery.getFilter()).getFilter();
         assertThat(((LiteralExpressionImpl) spatial.getExpression2()).getValue(), is(polygon));
 
         assertThat(((AttributeExpressionImpl) spatial.getExpression1()).getPropertyName(),
@@ -1126,7 +1132,7 @@ public class CswQueryFactoryTest {
 
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
-        return frameworkQuery.getFilter();
+        return ((QueryImpl) frameworkQuery.getFilter()).getFilter();
     }
 
     @SuppressWarnings("unchecked")
@@ -1153,16 +1159,17 @@ public class CswQueryFactoryTest {
         QueryImpl frameworkQuery = (QueryImpl) queryFactory.getQuery(grr)
                 .getQuery();
         N temporal = null;
+        Filter queryFilter = ((QueryImpl) frameworkQuery.getFilter()).getFilter();
         if (classes.length > 1) {
-            assertThat(frameworkQuery.getFilter(), instanceOf(Or.class));
+            assertThat(queryFilter, instanceOf(Or.class));
             int i = 0;
-            for (Filter filter : ((Or) frameworkQuery.getFilter()).getChildren()) {
+            for (Filter filter : ((Or) queryFilter).getChildren()) {
                 assertThat(filter, instanceOf(classes[i++]));
                 temporal = (N) filter;
             }
         } else {
-            assertThat(frameworkQuery.getFilter(), instanceOf(classes[0]));
-            temporal = (N) frameworkQuery.getFilter();
+            assertThat(queryFilter, instanceOf(classes[0]));
+            temporal = (N) queryFilter;
         }
         assertThat(((AttributeExpressionImpl) temporal.getExpression1()).getPropertyName(),
                 is(expectedAttr));

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -43,6 +43,7 @@ import org.codice.ddf.spatial.ogc.csw.catalog.common.CswException;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.GetRecordsRequest;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.mappings.MetacardCswRecordMap;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswQueryFilterTransformer;
+import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswRecordMap;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.LiteralExpressionImpl;
 import org.geotools.styling.UomOgcMapping;
@@ -240,8 +241,9 @@ public class CswQueryFactoryTest {
             FederationException, ParseException, IngestException {
         FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
         FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
+        CswRecordMap cswRecordMap = new MetacardCswRecordMap();
 
-        queryFactory = new CswQueryFactory(filterBuilder, filterAdapter);
+        queryFactory = new CswQueryFactory(cswRecordMap,filterBuilder, filterAdapter);
 
         AttributeRegistry mockAttributeRegistry = mock(AttributeRegistry.class);
         when(mockAttributeRegistry.lookup(TITLE_TEST_ATTRIBUTE)).thenReturn(Optional.of(mock(


### PR DESCRIPTION
#### What does this PR do?
Moves the SortBy normalization logic after the QueryFilterTransformers have run. This makes it possible to update invalid SortBy parameters in the QueryFilterTransformer.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka @brianfelix @mackncheesiest @brendan-hofmann 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build with unit and itests.

#### Any background context you want to provide?
Previously, the SortBy parameters were normalized before the QueryRequest object was created and passed to the QueryFilterTransformers. If a SortBy parameter was an invalid CSW attribute, then it was stripped out completely. This change allows the QueryFilterTransformers to update the SortBy before it is normalized like usual.

#### What are the relevant tickets?
[DDF-3259](https://codice.atlassian.net/browse/DDF-3259)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [* ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
