### PR TITLE
DDF-3273 Secure DDF shell and ssh access.

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -30,7 +30,10 @@
                 <exclude>etc/org.apache.karaf.features.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.logging.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
+                <exclude>etc/org.apache.karaf.command.acl.shell.cfg</exclude>
+                <exclude>etc/org.apache.karaf.command.acl.ssh.cfg</exclude>
                 <exclude>etc/org.apache.karaf.log.cfg</exclude>
+                <exclude>etc/org.apache.karaf.shell.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.web.cfg</exclude>
                 <exclude>etc/users.properties</exclude>
                 <exclude>etc/system.properties</exclude>

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.shell.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.shell.cfg
@@ -1,0 +1,17 @@
+#
+# This configuration file defines the ACLs for commands in the shell subshell
+#
+
+* = NO_ACCESS
+complete = admin
+echo = admin
+format = admin
+grep = admin
+if = admin
+keymap = admin
+less = admin
+set = admin
+setopt = admin
+tac = admin
+wc = admin
+while = admin

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.ssh.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.ssh.cfg
@@ -1,0 +1,5 @@
+#
+# This configuration file defines the ACLs for commands in the ssh subshell
+#
+
+* = NO_ACCESS

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
@@ -1,0 +1,4 @@
+sshPort=8101
+sshHost=127.0.0.1
+sshRealm=karaf
+hostKey=${karaf.etc}/host.key

--- a/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
@@ -45,7 +45,10 @@ On system: ensure that not everyone can change ACLs on your object.
 
 |SSH
 |tampering, information disclosure, and denial of service
-a|Create accounts for authentication (modify the default user's password) or remove ssh feature. By definition the connection will be secure when authenticated. Optionally, disable the ssh port (`default: 8101`) and set the `karaf.startRemoteShell` system property to false.
+a|Create accounts for authentication (modify the default user's password) or remove ssh feature. Additionally,
+ssh can be authenticated and authorized through an external Realm, such as LDAP. This can be accomplished by
+editing the `/etc/org.apache.karaf.shell.cfg` file and setting the value for `sshRealm`, e.g. to `ldap`.
+By definition the connection will be secure when authenticated. Optionally, disable the ssh port (`default: 8101`) and set the `karaf.startRemoteShell` system property to false.
 
 [WARNING]
 ====

--- a/distribution/docs/src/main/jdocs/content/_configuring/hardening-user-access-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/hardening-user-access-contents.adoc
@@ -11,6 +11,9 @@
 Once ${branding} is configured to use an external user (such as LDAP), remove the `users.properties` file from the `<INSTALL_HOME>/etc` directory.
 Use of a `users.properties` file should be limited to emergency recovery operations and replaced as soon as effectively possible.
 
+If SSH access to the Karaf shell is to be supported, edit the file `org.apache.karaf.shell.cfg` in the `<INSTALL_HOME>/etc` directory, changing the value
+of the `sshRealm` property from `karaf` to `ldap`.
+
 .Emergency Use of `users.properties` file
 [NOTE]
 ====

--- a/distribution/docs/src/main/resources/_contents/_securing/hardening-user-access-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/hardening-user-access-contents.adoc
@@ -6,6 +6,9 @@
 Once ${branding} is configured to use an external user (such as LDAP), remove the `users.properties` file from the `<INSTALL_HOME>/etc` directory.
 Use of a `users.properties` file should be limited to emergency recovery operations and replaced as soon as effectively possible.
 
+If SSH access to the Karaf shell is to be supported, edit the file `org.apache.karaf.shell.cfg` in the `<INSTALL_HOME>/etc` directory, changing the value
+of the `sshRealm` property from `karaf` to `ldap`.
+
 .Emergency Use of `users.properties` file
 [NOTE]
 ====


### PR DESCRIPTION
#### What does this PR do?
- Lock down the ssh server within DDF so it only allows logins from the localhost.
- Restrict all outbound ssh connections from DDF
- Restrict the shell commands available in the Karaf console to a limited subset

#### Who is reviewing it? 
@garrettfreibott @rzwiefel @ricklarsen 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/security

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Install DDF.
1. From the karaf shell, ensure you cannot open an outbound ssh connection
2. From the karaf shell, ensure that only the following subset of `shell:` commands work:
    - complete
    - echo
    - format
    - grep
    - if
    - keymap
    - less
    - set
    - setopt
    - tac
    - wc
    - while
3. From the same host, ensure you can ssh into DDF
4. From another host, ensure that direct ssh access to DDF is restricted

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3273](https://codice.atlassian.net/browse/DDF-3273)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
