### PR TITLE
DDF-3273 Disable SSH by default

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -28,6 +28,7 @@
                 <exclude>etc/jetty.xml</exclude>
                 <exclude>etc/profile.cfg</exclude>
                 <exclude>etc/org.apache.karaf.features.cfg</exclude>
+                <exclude>etc/org.apache.karaf.shell.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.logging.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
                 <exclude>etc/org.apache.karaf.log.cfg</exclude>

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
@@ -1,0 +1,13 @@
+#
+# Configuration for SSH shell.
+# This configuration is turned off by default; in order to turn it on, uncomment
+# the sshPort property.
+# When the port is available and active, SSH access will be restricted to connections
+# originating from the same host machine. To allow direct remote access to the shell,
+# change the value of the sshHost property to 0.0.0.0
+#
+
+#sshPort=8101
+sshHost=127.0.0.1
+sshRealm=karaf
+hostKey=${karaf.etc}/host.key

--- a/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_configuring/environment-hardening-contents.adoc
@@ -45,14 +45,21 @@ On system: ensure that not everyone can change ACLs on your object.
 
 |SSH
 |tampering, information disclosure, and denial of service
-a|Create accounts for authentication (modify the default user's password) or remove ssh feature. By definition the connection will be secure when authenticated. Optionally, disable the ssh port (`default: 8101`) and set the `karaf.startRemoteShell` system property to false.
+a|By default, SSH access is disabled in ${branding}. To turn it on, edit the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg`
+file, uncommenting the `sshPort` property. SSH can also be authenticated and authorized through an external Realm,
+such as LDAP. This can be accomplished by editing the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg` file and setting the
+value for `sshRealm`, e.g. to `ldap`. No restart of ${branding} is necessary after this change.
+
+By definition, all connections over SSH will be authenticated and authorized and secure from eavesdropping.
 
 [WARNING]
 ====
-Disabling ssh will be more secure, but will disable any direct command line access to the ${branding}.
+Enabling SSH will expose your file system such that any user with access to your ${branding} shell will
+have read/write access to all directories and files accessible to your installation user. It is not
+recommended in a secure environment.
 ====
 
-Set `karaf.shutdown.port=-1` in `etc/custom.properties` or `etc/config.properties`.
+Set `karaf.shutdown.port=-1` in `<${branding}_HOME>/etc/custom.properties` or `<${branding}_HOME>/etc/config.properties`.
 
 |SSL/TLS
 |man-in-the-middle, information disclosure

--- a/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_securing/environment-hardening-contents.adoc
@@ -40,14 +40,21 @@ On system: ensure that not everyone can change ACLs on your object.
 
 |SSH
 |tampering, information disclosure, and denial of service
-a|Create accounts for authentication (modify the default user's password) or remove ssh feature. By definition the connection will be secure when authenticated. Optionally, disable the ssh port (`default: 8101`) and set the `karaf.startRemoteShell` system property to false.
+a|By default, SSH access is disabled in ${branding}. To turn it on, edit the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg`
+file, uncommenting the `sshPort` property. SSH can also be authenticated and authorized through an external Realm,
+such as LDAP. This can be accomplished by editing the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg` file and setting the
+value for `sshRealm`, e.g. to `ldap`. No restart of ${branding} is necessary after this change.
+
+By definition, all connections over SSH will be authenticated and authorized and secure from eavesdropping.
 
 [WARNING]
 ====
-Disabling ssh will be more secure, but will disable any direct command line access to the ${branding}.
+Enabling SSH will expose your file system such that any user with access to your ${branding} shell will
+have read/write access to all directories and files accessible to your installation user. It is not
+recommended in a secure environment.
 ====
 
-Set `karaf.shutdown.port=-1` in `etc/custom.properties` or `etc/config.properties`.
+Set `karaf.shutdown.port=-1` in `<${branding}_HOME>/etc/custom.properties` or `<${branding}_HOME>/etc/config.properties`.
 
 |SSL/TLS
 |man-in-the-middle, information disclosure


### PR DESCRIPTION
#### What does this PR do?
- Disables SSH by default
- Updates documentation to explain how to re-enable it and why it is disabled

#### Who is reviewing it? 
@garrettfreibott @rzwiefel @ricklarsen 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
- Install and confirm that the SSH server is not available.
- Following the documentation, enable SSH and ensure that it works.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3273](https://codice.atlassian.net/browse/DDF-3273)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
