### PR TITLE
DDF-3210 Updated catalog taxonomy to support new DCMI-defined types

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/constants/core/DataType.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/data/types/constants/core/DataType.java
@@ -15,22 +15,28 @@ package ddf.catalog.data.types.constants.core;
 
 /**
  * These are the allowed values for the attribute Core#DATATYPE.
+ * <p>
+ * These generic type(s) of the resource include the Dublin Core Metadata Initiative DCMI Type
+ * Vocabulary (http://dublincore.org/documents/dcmi-type-vocabulary/).
+ * DCMI Type term labels are included here, as opposed to term names.
  *
- * Based on Dublin Core (http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-type) and extended to include other DDF supported types.
+ * The DDF extension types of "Document" and "Video" have been removed as of DDF-2.11.0
  */
 public enum DataType {
 
+    // DCMI type vocabulary labels
     COLLECTION("Collection"), //
     DATASET("Dataset"), //
     EVENT("Event"), //
     IMAGE("Image"), //
     INTERACTIVE_RESOURCE("Interactive Resource"), //
+    MOVING_IMAGE("Moving Image"), //
+    PHYSICAL_OBJECT("Physical Object"), //
     SERVICE("Service"), //
     SOFTWARE("Software"), //
     SOUND("Sound"), //
-    TEXT("Text"), //
-    VIDEO("Video"), //
-    DOCUMENT("Document");
+    STILL_IMAGE("Still Image"), //
+    TEXT("Text");
 
     private final String value;
 
@@ -41,6 +47,15 @@ public enum DataType {
     @Override
     public String toString() {
         return value;
+    }
+
+    public static DataType fromValue(String value) {
+        for (DataType type: DataType.values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException(value);
     }
 
 }

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -239,7 +239,7 @@ public class PdfInputTransformer implements InputTransformer {
         metacard.setId(id);
         metacard.setContentTypeName(MediaType.PDF.toString());
         metacard.setAttribute(Media.TYPE, MediaType.PDF.toString());
-        metacard.setAttribute(Core.DATATYPE, DataType.DOCUMENT.toString());
+        metacard.setAttribute(Core.DATATYPE, DataType.TEXT.toString());
 
         return metacard;
     }

--- a/catalog/transformer/catalog-transformer-video-input/src/main/java/ddf/catalog/transformer/input/video/VideoInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-video-input/src/main/java/ddf/catalog/transformer/input/video/VideoInputTransformer.java
@@ -109,7 +109,7 @@ public class VideoInputTransformer implements InputTransformer {
                 metadataText,
                 metacardType);
 
-        metacard.setAttribute(new AttributeImpl(Core.DATATYPE, DataType.VIDEO.toString()));
+        metacard.setAttribute(new AttributeImpl(Core.DATATYPE, DataType.MOVING_IMAGE.toString()));
 
         return metacard;
     }

--- a/catalog/transformer/catalog-transformer-video-input/src/test/java/ddf/catalog/transformer/input/video/VideoInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-video-input/src/test/java/ddf/catalog/transformer/input/video/VideoInputTransformerTest.java
@@ -58,7 +58,7 @@ public class VideoInputTransformerTest {
         Metacard metacard = transform(stream);
 
         assertThat(metacard.getAttribute(Core.DATATYPE),
-                is(new AttributeImpl(Core.DATATYPE, DataType.VIDEO.toString())));
+                is(new AttributeImpl(Core.DATATYPE, DataType.MOVING_IMAGE.toString())));
     }
 
     private InputStream getVideoInputStream() {

--- a/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/core-attributes-validator.json
@@ -10,12 +10,13 @@
           "Event",
           "Image",
           "Interactive Resource",
+          "Moving Image",
+          "Physical Object",
           "Service",
           "Software",
           "Sound",
-          "Text",
-          "Video",
-          "Document"
+          "Still Image",
+          "Text"
         ]
       }
     ],

--- a/distribution/docs/src/main/resources/_contents/_data/core-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/core-attributes-table-contents.adoc
@@ -41,7 +41,7 @@
 |metadata
 |Additional XML metadata describing the resource.
 |XML
-|A valid XML string per RFC 4825 (must be well-formed but not necessarily schema-compliant).
+|A valid XML string per RFC 4825 (must be well-formed but not necessarily schema-compliant)
 |
 
 |location
@@ -84,7 +84,7 @@ __Coordinates must be in *lon-lat* coordinate order__
 |resource-size
 |Size in bytes of resource.
 |String
-|Although this type cannot be changed for legacy reasons, its value should always be a parseable whole number.
+|Although this type cannot be changed for legacy reasons, its value should always be a parsable whole number
 |
 
 |thumbnail
@@ -127,13 +127,13 @@ __Coordinates must be in *lon-lat* coordinate order__
 |language
 |The language(s) of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#language[Dublin Core language].
 |List of Strings
-|Alpha-3 language code(s) per ISO_639-2.
+|Alpha-3 language code(s) per ISO_639-2
 |
 
 |resource.derived-download-url
 |Download URL(s) for accessing the derived formats for the metacard resource.
 |List of Strings
-|Valid URL(s) per RFC 2396.
+|Valid URL(s) per RFC 2396
 |
 
 |resource.derived-uri
@@ -143,10 +143,10 @@ __Coordinates must be in *lon-lat* coordinate order__
 |
 
 |datatype
-|The generic type(s) of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-type[Dublin Core terms-type] and extended to include other DDF supported types.
+|The generic type(s) of the resource including the http://dublincore.org/documents/dcmi-type-vocabulary/[Dublin Core terms-type]. DCMI Type term labels are expected here as opposed to term names.
 |List of Strings
-|Collection, Dataset, Event, Image, Interactive Resource, Service, Software, Sound, Text, Video, Document.
-|
+|`Collection`, `Dataset`, `Event`, `Image`, `Interactive Resource`, `Moving Image`, `Physical Object`, `Service`, `Software`, `Sound`, `Still Image`, and/or `Text`
+|`Video`
 
 |===
 

--- a/distribution/test/itests/test-itests-common/src/main/resources/xml/record/testNumerical.xml
+++ b/distribution/test/itests/test-itests-common/src/main/resources/xml/record/testNumerical.xml
@@ -21,7 +21,7 @@
         <value>b0e9968e</value>
     </string>
     <string name="datatype">
-        <value>Document</value>
+        <value>Text</value>
     </string>
     <base64Binary name="thumbnail">
         <value>


### PR DESCRIPTION
#### What does this PR do?
Updates the DDF DataTypes to conform to the DCMI types.
#### Who is reviewing it? 
@emmberk @brendan-hofmann 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@figliold
#### How should this be tested? (List steps with links to updated documentation)
Install ddf and ingest a pdf and video file through Intrigue. Verify that they have the updated datatypes of Text and Moving Image.
#### What are the relevant tickets?
[DDF-3210](https://codice.atlassian.net/browse/DDF-3210)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
