### PR TITLE
DDF-3276 Text Preview

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -624,5 +624,10 @@
             <artifactId>catalog-opensearch-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>catalog-transformer-preview</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -461,6 +461,12 @@
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-overlay/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-transformer-preview" install="auto" version="${project.version}"
+             description="Transforms a metacard into the extracted tika metadata as html">
+        <feature prerequisite="true">catalog-app</feature>
+        <bundle>mvn:ddf.catalog.transformer/catalog-transformer-preview/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-app" install="auto" version="${project.version}"
              description="The Catalog provides a framework for storing, searching, processing, and transforming information.\nClients typically perform query, create, read, update, and delete (QCRUD) operations against the Catalog.\nAt the core of the Catalog functionality is the Catalog Framework, which routes all requests and responses through the system, invoking additional processing per the system configuration.::Catalog">
         <feature prerequisite="true">admin-app</feature>

--- a/catalog/transformer/catalog-transformer-preview/pom.xml
+++ b/catalog/transformer/catalog-transformer-preview/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.catalog.transformer</groupId>
+        <artifactId>transformer</artifactId>
+        <version>2.12.0-SNAPSHOT</version>
+    </parent>
+
+    <name>DDF :: Catalog :: Transformer :: Preview</name>
+    <artifactId>catalog-transformer-preview</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-actions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-endpoint</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>catalog-transformer-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            catalog-core-actions
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.77</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.73</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/transformer/catalog-transformer-preview/src/main/java/org/codice/ddf/transformer/preview/PreviewMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-preview/src/main/java/org/codice/ddf/transformer/preview/PreviewMetacardTransformer.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.preview;
+
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.data.types.experimental.Extracted;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.MetacardTransformer;
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.tika.io.IOUtils;
+
+public class PreviewMetacardTransformer implements MetacardTransformer {
+
+  @Override
+  public BinaryContent transform(Metacard metacard, Map<String, Serializable> arguments)
+      throws CatalogTransformerException {
+    if (metacard == null) {
+      throw new CatalogTransformerException("Cannot transform null metacard.");
+    }
+
+    String preview = "No preview text available.";
+    if (metacard.getAttribute(Extracted.EXTRACTED_TEXT) != null
+        && metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue() != null) {
+      preview =
+          metacard
+              .getAttribute(Extracted.EXTRACTED_TEXT)
+              .getValue()
+              .toString()
+              .replaceAll("[\n|\r]", "<br>");
+      preview = String.format("<head><meta charset=\"utf-8\"/>%s</head>", preview);
+    }
+
+    return new BinaryContentImpl(IOUtils.toInputStream(preview));
+  }
+}

--- a/catalog/transformer/catalog-transformer-preview/src/main/java/org/codice/ddf/transformer/preview/actions/PreviewActionProvider.java
+++ b/catalog/transformer/catalog-transformer-preview/src/main/java/org/codice/ddf/transformer/preview/actions/PreviewActionProvider.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.preview.actions;
+
+import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
+import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+
+import ddf.action.Action;
+import ddf.action.impl.ActionImpl;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.experimental.Extracted;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import org.apache.commons.lang.CharEncoding;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.catalog.actions.AbstractMetacardActionProvider;
+import org.codice.ddf.configuration.SystemBaseUrl;
+
+public class PreviewActionProvider extends AbstractMetacardActionProvider {
+
+  private static final String TITLE = "Text Preview";
+
+  private static final String DESCRIPTION = "Provides a text preview of the resource";
+
+  /**
+   * Constructor that accepts the values to be used when a new {@link Action} is created by this
+   * {@link ddf.action.ActionProvider}.
+   *
+   * @param actionProviderId ID that will be assigned to the {@link Action} that will be created.
+   *     Cannot be empty or blank.
+   * @param title title that will be used when this {@link ddf.action.ActionProvider} creates a new
+   *     {@link Action}
+   * @param description description that will be used when this {@link ddf.action.ActionProvider}
+   *     creates a new {@link Action}
+   */
+  protected PreviewActionProvider(String actionProviderId, String title, String description) {
+    super(actionProviderId, title, description);
+  }
+
+  public PreviewActionProvider(String actionProviderId) {
+    super(actionProviderId, TITLE, DESCRIPTION);
+  }
+
+  @Override
+  protected boolean canHandleMetacard(Metacard metacard) {
+    Attribute bodyText = metacard.getAttribute(Extracted.EXTRACTED_TEXT);
+    if (bodyText != null && StringUtils.isNotBlank((String) bodyText.getValue())) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  protected Action createMetacardAction(
+      String actionProviderId, String title, String description, URL url) {
+    return new ActionImpl(actionProviderId, title, description, url);
+  }
+
+  @Override
+  protected URL getMetacardActionUrl(String metacardSource, Metacard metacard) throws Exception {
+    String encodedMetacardId = URLEncoder.encode(metacard.getId(), CharEncoding.UTF_8);
+    String encodedMetacardSource = URLEncoder.encode(metacardSource, CharEncoding.UTF_8);
+    return getActionUrl(encodedMetacardSource, encodedMetacardId);
+  }
+
+  private URL getActionUrl(String metacardSource, String metacardId)
+      throws URISyntaxException, MalformedURLException {
+    return new URI(
+            SystemBaseUrl.constructUrl(
+                String.format(
+                    "%s%s/%s/%s?transform=preview",
+                    CONTEXT_ROOT, SOURCES_PATH, metacardSource, metacardId),
+                true))
+        .toURL();
+  }
+}

--- a/catalog/transformer/catalog-transformer-preview/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-preview/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+>
+
+    <bean id="previewMetacardTransformer"
+          class="org.codice.ddf.transformer.preview.PreviewMetacardTransformer"/>
+
+    <service ref="previewMetacardTransformer" interface="ddf.catalog.transform.MetacardTransformer">
+        <service-properties>
+            <entry key="id" value="preview"/>
+            <entry key="mime-type" value="text/html"/>
+        </service-properties>
+    </service>
+
+    <bean id="previewActionProvider"
+          class="org.codice.ddf.transformer.preview.actions.PreviewActionProvider">
+        <argument value="catalog.data.metacard.preview"/>
+    </bean>
+
+    <service ref="previewActionProvider" interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.metacard.preview"/>
+        </service-properties>
+    </service>
+</blueprint>

--- a/catalog/transformer/catalog-transformer-preview/src/test/java/org/codice/ddf/transformer/preview/PreviewMetacardTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-preview/src/test/java/org/codice/ddf/transformer/preview/PreviewMetacardTransformerTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.preview;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.experimental.Extracted;
+import ddf.catalog.transform.CatalogTransformerException;
+import org.junit.Test;
+
+public class PreviewMetacardTransformerTest {
+
+  private static final String NO_PREVIEW = "No preview text available.";
+
+  private static final String EXTRACTED_TEXT = "\nSome value";
+
+  private static final String TRANSFORMED_TEXT =
+      "<head><meta charset=\"utf-8\"/><br>Some value</head>";
+
+  private PreviewMetacardTransformer previewMetacardTransformer = new PreviewMetacardTransformer();
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testNullMetacardThrowsCatalogTransformerException() throws Exception {
+    previewMetacardTransformer.transform(null, null);
+  }
+
+  @Test
+  public void noExtractedText() throws Exception {
+    Metacard metacard = mock(Metacard.class);
+    BinaryContent content = previewMetacardTransformer.transform(metacard, null);
+
+    assertThat(content, notNullValue());
+
+    String preview = new String(content.getByteArray());
+    assertThat(preview, is(equalTo(NO_PREVIEW)));
+  }
+
+  @Test
+  public void testTransformation() throws Exception {
+    Attribute extractedText = new AttributeImpl(Extracted.EXTRACTED_TEXT, EXTRACTED_TEXT);
+    Metacard metacard = mock(Metacard.class);
+
+    doReturn(extractedText).when(metacard).getAttribute(Extracted.EXTRACTED_TEXT);
+
+    BinaryContent content = previewMetacardTransformer.transform(metacard, null);
+
+    assertThat(content, notNullValue());
+
+    String preview = new String(content.getByteArray());
+    assertThat(preview, is(equalTo(TRANSFORMED_TEXT)));
+  }
+}

--- a/catalog/transformer/catalog-transformer-preview/src/test/java/org/codice/ddf/transformer/preview/actions/PreviewActionProviderTest.java
+++ b/catalog/transformer/catalog-transformer-preview/src/test/java/org/codice/ddf/transformer/preview/actions/PreviewActionProviderTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.transformer.preview.actions;
+
+import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
+import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import ddf.action.Action;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.experimental.Extracted;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import org.apache.commons.lang.CharEncoding;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.junit.Test;
+
+public class PreviewActionProviderTest {
+  public static final String ACTION_PROVIDER_ID = "actionProviderId";
+
+  private PreviewActionProvider previewActionProvider =
+      new PreviewActionProvider(ACTION_PROVIDER_ID);
+
+  private Metacard metacard = mock(Metacard.class);
+
+  @Test
+  public void metacardNotHandled() throws Exception {
+    boolean canHandle = previewActionProvider.canHandle(metacard);
+    assertThat(canHandle, is(equalTo(false)));
+  }
+
+  @Test
+  public void metacardHandled() throws Exception {
+    Attribute extractedTextAttribute =
+        new AttributeImpl(Extracted.EXTRACTED_TEXT, "some extracted text");
+
+    doReturn(extractedTextAttribute).when(metacard).getAttribute(Extracted.EXTRACTED_TEXT);
+
+    boolean canHandle = previewActionProvider.canHandle(metacard);
+    assertThat(canHandle, is(equalTo(true)));
+  }
+
+  @Test
+  public void createMetacardAction() throws Exception {
+    String title = "title";
+    String description = "description";
+    URL url = new URL("https://localhost/url");
+
+    Action action =
+        previewActionProvider.createMetacardAction(ACTION_PROVIDER_ID, title, description, url);
+    assertThat(action.getId(), is(equalTo(ACTION_PROVIDER_ID)));
+    assertThat(action.getTitle(), is(equalTo(title)));
+    assertThat(action.getDescription(), is(equalTo(description)));
+    assertThat(url, is(equalTo(url)));
+  }
+
+  @Test
+  public void getMetacardActionUrl() throws Exception {
+    String metacardId = "metacardId";
+    String metacardSource = "metacardSource";
+    doReturn(metacardId).when(metacard).getId();
+
+    URL url = previewActionProvider.getMetacardActionUrl(metacardSource, metacard);
+
+    assertThat(url, notNullValue());
+
+    URL anotherOne = getUrl(metacardId, metacardSource);
+
+    assertThat(url, is(anotherOne));
+  }
+
+  private URL getUrl(String metacardId, String metacardSource)
+      throws MalformedURLException, UnsupportedEncodingException {
+    String encodedMetacardId = URLEncoder.encode(metacardId, CharEncoding.UTF_8);
+    String urlString =
+        String.format(
+            "%s%s/%s/%s?transform=preview",
+            CONTEXT_ROOT, SOURCES_PATH, metacardSource, encodedMetacardId);
+    return new URL(SystemBaseUrl.constructUrl(urlString, true));
+  }
+}

--- a/catalog/transformer/pom.xml
+++ b/catalog/transformer/pom.xml
@@ -104,5 +104,6 @@
         <module>catalog-transformer-overlay</module>
         <module>catalog-transformer-zip</module>
         <module>catalog-transformer-propertyjson-metacard</module>
+        <module>catalog-transformer-preview</module>
     </modules>
 </project>


### PR DESCRIPTION
Adding a metacard transformer and action provider for text preview

#### What does this PR do?
This PR adds a metacard transformer and action provider to expose the ext.extracted.text to be used as a text preview.

#### Who is reviewing it? 
@dcruver @spearskw 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith 
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
Ingest a document (pdf, doc/x, ppt/x, xls/x, mhtml)
Search for the document
Open the Inspector and select the Actions tab.
Click the 'Text Preview' action.
Verify a new browser tab is opened with a preview of the document's text.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3276](https://codice.atlassian.net/browse/DDF-3276)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
