### PR TITLE
DDF-2850 Make gazetteer configurable in Intrigue.

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -87,6 +87,8 @@ public class ConfigurationApplication implements SparkApplication {
 
     private Boolean isGazetteer = true;
 
+    private Boolean isOnlineGazetteer = true;
+
     private Boolean isIngest = true;
 
     private Boolean isCacheDisabled = false;
@@ -272,6 +274,7 @@ public class ConfigurationApplication implements SparkApplication {
         config.put("terrainProvider", proxiedTerrainProvider);
         config.put("imageryProviders", getConfigImageryProviders());
         config.put("gazetteer", isGazetteer);
+        config.put("onlineGazetteer", isOnlineGazetteer);
         config.put("showIngest", isIngest);
         config.put("projection", projection);
         config.put("bingKey", bingKey);
@@ -574,6 +577,14 @@ public class ConfigurationApplication implements SparkApplication {
 
     public void setGazetteer(Boolean isGazetteer) {
         this.isGazetteer = isGazetteer;
+    }
+
+    public Boolean getOnlineGazetteer() {
+        return isOnlineGazetteer;
+    }
+
+    public void setOnlineGazetteer(Boolean onlineGazetteer) {
+        isOnlineGazetteer = onlineGazetteer;
     }
 
     public Boolean getIngest() {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -85,6 +85,13 @@
             default="true"
             required="false"/>
 
+        <AD id="onlineGazetteer"
+            name="Use Online Gazetteer"
+            description="Should the online gazetteer be used? If unchecked a local one will be used."
+            type="Boolean"
+            default="true"
+            required="false"/>
+
         <AD id="ingest"
             name="Show Uploader"
             description="Show upload menu for adding new record."

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/geocoder.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/geocoder.js
@@ -17,11 +17,12 @@ var Backbone = require('backbone');
 
 var Cesium = require('cesium');
 var announcement = require('component/announcement');
+var properties = require('properties');
 
 // Note: using a non-secure resource will fail when running DDF with TLS.
 var geocoderOnlineEndpoint = 'https://nominatim.openstreetmap.org/search?format=json&q=';
 var geocoderOfflineEndpoint = '/services/REST/v1/Locations?jsonp=loadJsonp&key=0&query=';
-var onlineGazetteer = true;
+var onlineGazetteer = properties.onlineGazetteer;
 
 module.exports = Backbone.Model.extend({
     geocode(input) {

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config.config
@@ -9,6 +9,7 @@ sourcePollInterval = I"60000"
 signIn = B"true"
 task = B"false"
 gazetteer = B"true"
+onlineGazetteer = B"true"
 ingest = B"true"
 externalAuthentication = B"false"
 summaryShow = [ \

--- a/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -98,6 +98,13 @@ TMS example (3d map support only): `[{"type" : "TMS", "url" : "https://cesiumjs.
 |true
 |false
 
+|Use Online Gazetteer
+|onlineGazetteer
+|Boolean
+|Should the online gazetteer be used? If unchecked a local one will be used.
+|true
+|false
+
 |Show Uploader
 |ingest
 |Boolean


### PR DESCRIPTION
#### What does this PR do?
Makes gazetteer configurable in Intrigue.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emmberk @mcalcote @vinamartin 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@rzwiefel
#### How should this be tested? (List steps with links to updated documentation)
Install DDF, go to Intrigue and select Local for a workspace.
Once the globe loads open up the dev tools network tab and search for location name
![screen shot 2017-09-11 at 1 46 08 pm](https://user-images.githubusercontent.com/5248090/30296031-a9637b46-96f7-11e7-9e41-8fba48d7e5c8.png)
You should see a request to https://nominatim.openstreetmap.org/search
Now go to the admin ui -> Standard Search UI -> Catalog UI Search -> org.codice.ddf.catalog.ui.config and uncheck Use Online Gazetteer
Reload Intrigue and perform the same search. 
Verify that the search request is now sent to https://localhost:8993/services/REST/v1/Locations
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2850](https://codice.atlassian.net/browse/DDF-2850)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
