### PR TITLE
DDF-3283 Workspace security updates.

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -252,6 +252,11 @@
             <artifactId>spatial-geocoding-geocoder</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>alerts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -331,7 +336,8 @@
                             quartz-jobs,
                             spark-core,
                             spatial4j,
-                            versioning-common
+                            versioning-common,
+                            alerts
                         </Embed-Dependency>
                         <Web-ContextPath>/search/catalog</Web-ContextPath>
                         <_wab>src/main/webapp,${project.build.directory}/webapp</_wab>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/Constants.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/Constants.java
@@ -15,6 +15,8 @@ package org.codice.ddf.catalog.ui.security;
 
 public class Constants {
 
+    public static final String IS_WORKSPACE = "security.tag.is-workspace";
+
     public static final String ROLES_CLAIM_URI =
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/README.md
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/README.md
@@ -1,23 +1,28 @@
 # Workspace Security
 
-The following are invariants/conditions that the security code enforces:
+The following are invariants/conditions that the workspace security code enforces:
 
-- All workspaces must have an owner (identified by email)
+- The system user has complete access to all workspaces
+    - the system user can be configured
+
+- All workspaces must have an owner
+    - stored as the `metacard.owner` attribute on the workspace metacard
+    - a workspace cannot lose the owner attribute, however it can be changed
+    - owner always has complete access to a workspace
+
 - On create, an owner will be resolved using the following:
-    - provided on initial create
-    - provided by subject email
-    - workspace fails creation!
-- Users cannot change the owner of an existing workspace
+    - provided on initial create in the metacard create request
+        - this is how an external system can create metacards on behalf of other users
+    - provided by current thread context subject
+        - by default the `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
+          subject attribute is the owner identifier
+        - the owner identifier can be configured to any subject attribute to help in scenarios
+          where emails are not guaranteed to be available
+    - workspace fails creation and the admin is alerted of the failure
+
 - Users can only see workspaces which:
     - they are the owner of
-    - have been shared with them
-- Sharing permissions can only be altered by the owner
-- Owners can share by:
-    - a role
-    - an email address
-- Owners can share:
-    - read access
-    - update access
-    - delete access
-
-- None of these rules apply to admin, they can do anything
+    - have been shared with them through the following attributes:
+        - `security.access-groups` allows for a role based sharing
+        - `security.access-individuals` allows for direct user sharing
+    - sharing permissions can only be altered by the system or the owner

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSecurityConfiguration.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSecurityConfiguration.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+public class WorkspaceSecurityConfiguration {
+
+    private String ownerAttribute = Constants.EMAIL_ADDRESS_CLAIM_URI;
+
+    private String systemUserAttribute = Constants.ROLES_CLAIM_URI;
+
+    private String systemUserAttributeValue = "admin";
+
+    public String getOwnerAttribute() {
+        return ownerAttribute;
+    }
+
+    public void setOwnerAttribute(String ownerAttribute) {
+        this.ownerAttribute = ownerAttribute.trim();
+    }
+
+    public String getSystemUserAttribute() {
+        return systemUserAttribute;
+    }
+
+    public void setSystemUserAttribute(String systemUserAttribute) {
+        this.systemUserAttribute = systemUserAttribute.trim();
+    }
+
+    public String getSystemUserAttributeValue() {
+        return systemUserAttributeValue;
+    }
+
+    public void setSystemUserAttributeValue(String systemUserAttributeValue) {
+        this.systemUserAttributeValue = systemUserAttributeValue.trim();
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPlugin.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPlugin.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceMetacardImpl;
-import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceTransformer;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -46,10 +45,8 @@ import ddf.catalog.plugin.impl.PolicyResponseImpl;
 
 public class WorkspaceSharingPolicyPlugin implements PolicyPlugin {
 
-    private final WorkspaceTransformer transformer;
-
-    public WorkspaceSharingPolicyPlugin(WorkspaceTransformer transformer) {
-        this.transformer = transformer;
+    private static Map<String, Set<String>> getWorkspaceSecurityTag() {
+        return ImmutableMap.of(Constants.IS_WORKSPACE, ImmutableSet.of(Constants.IS_WORKSPACE));
     }
 
     private static Map<String, Set<String>> getOwnerPermission(String owner) {
@@ -87,12 +84,14 @@ public class WorkspaceSharingPolicyPlugin implements PolicyPlugin {
     }
 
     private Map<String, Set<String>> getPolicy(WorkspaceMetacardImpl workspace) {
-        return Stream.of(getOwnerPermission(workspace),
+        return Stream.of(getWorkspaceSecurityTag(),
+                getOwnerPermission(workspace),
                 getGroupPermission(workspace),
                 getIndividualPermission(workspace))
                 .map(Map::entrySet)
                 .flatMap(Collection::stream)
-                .filter(entry -> !entry.getValue().isEmpty())
+                .filter(entry -> !entry.getValue()
+                        .isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Sets::union));
     }
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -62,8 +62,14 @@
         <bean class="org.codice.ddf.catalog.ui.metacard.workspace.QueryMetacardTypeImpl"/>
     </service>
 
+    <bean id="workspacePreIngestPlugin"
+          class="org.codice.ddf.catalog.ui.security.WorkspacePreIngestPlugin">
+        <argument ref="workspaceSecurityConfiguration" />
+        <argument ref="eventAdmin"/>
+    </bean>
+
     <service interface="ddf.catalog.plugin.PreIngestPlugin">
-        <bean class="org.codice.ddf.catalog.ui.security.WorkspacePreIngestPlugin"/>
+        <ref component-id="workspacePreIngestPlugin" />
     </service>
 
     <bean id="workspaceAccessPlugin"
@@ -75,17 +81,21 @@
     </service>
 
     <service interface="ddf.catalog.plugin.PolicyPlugin">
-        <bean class="org.codice.ddf.catalog.ui.security.WorkspaceSharingPolicyPlugin">
-            <argument ref="workspaceTransformer"/>
-        </bean>
+        <bean class="org.codice.ddf.catalog.ui.security.WorkspaceSharingPolicyPlugin" />
     </service>
 
-    <bean id="workspacePolicyExtension"
-          class="org.codice.ddf.catalog.ui.security.WorkspacePolicyExtension">
-
+    <bean id="workspaceSecurityConfiguration"
+          class="org.codice.ddf.catalog.ui.security.WorkspaceSecurityConfiguration">
         <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.ui.security"
                 update-strategy="container-managed"/>
+    </bean>
+
+    <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
+
+    <bean id="workspacePolicyExtension"
+          class="org.codice.ddf.catalog.ui.security.WorkspacePolicyExtension">
+        <argument ref="workspaceSecurityConfiguration" />
     </bean>
 
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
@@ -17,6 +17,12 @@
 
     <OCD name="Workspace Security"
          id="org.codice.ddf.catalog.ui.security">
+        <AD id="ownerAttribute"
+            name="Owner Attribute"
+            description="The name of the attribute to determine an owner."
+            required="true"
+            type="String"
+            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
 
         <AD id="systemUserAttribute"
             name="System User Attribute"

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspacePreIngestPluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspacePreIngestPluginTest.java
@@ -14,47 +14,175 @@
 package org.codice.ddf.catalog.ui.security;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.io.Serializable;
+import java.util.Map;
+import java.util.SortedSet;
+
 import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceMetacardImpl;
+import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.operation.OperationTransaction;
+import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.OperationTransactionImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.plugin.StopProcessingException;
 
 public class WorkspacePreIngestPluginTest {
 
-    private static WorkspacePreIngestPlugin makePlugin(String email, String name) {
-        return new WorkspacePreIngestPlugin() {
-            protected String getSubjectEmail() {
-                return email;
+    private WorkspaceSecurityConfiguration config;
+
+    private boolean alerted;
+
+    @Before
+    public void setUp() {
+        alerted = false;
+        config = new WorkspaceSecurityConfiguration();
+    }
+
+    private WorkspacePreIngestPlugin makePlugin(Map<String, SortedSet<String>> attrs) {
+        return new WorkspacePreIngestPlugin(config, null) {
+            protected Map<String, SortedSet<String>> getSubjectAttributes() {
+                return attrs;
             }
 
             protected String getSubjectName() {
-                return name;
+                return "test";
             }
 
-            protected void warn(String message) {
+            protected void alertMissingClaim(String ownerAttribute) {
+                alerted = true;
             }
         };
     }
 
-    private static WorkspacePreIngestPlugin makePlugin() {
-        return makePlugin("admin@localhost", "admin");
+    @Test
+    public void testCreateShouldIgnoreNonWorkspaceMetacards() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
+        Metacard metacard = new MetacardImpl();
+
+        wpip.process(new CreateRequestImpl(metacard));
+        assertThat(metacard.getAttribute(Core.METACARD_OWNER), nullValue());
     }
 
     @Test
-    public void testSuccessfulIngest() throws Exception {
-        WorkspacePreIngestPlugin wpip = makePlugin();
+    public void testCreateWorkspaceSuccess() throws Exception {
+        Map<String, SortedSet<String>> attrs = ImmutableMap.of(config.getOwnerAttribute(),
+                ImmutableSortedSet.of("owner"));
+
+        WorkspacePreIngestPlugin wpip = makePlugin(attrs);
         WorkspaceMetacardImpl workspace = new WorkspaceMetacardImpl();
 
         wpip.process(new CreateRequestImpl(workspace));
-        assertThat(workspace.getOwner(), is("admin@localhost"));
+        assertThat(workspace.getOwner(), is("owner"));
+    }
+
+    @Test
+    public void testCreateWorkspaceSuccessWithOverride() throws Exception {
+        final String override = "override";
+
+        Map<String, SortedSet<String>> attrs = ImmutableMap.of(override,
+                ImmutableSortedSet.of("owner"));
+        config.setOwnerAttribute(override);
+
+        WorkspacePreIngestPlugin wpip = makePlugin(attrs);
+        WorkspaceMetacardImpl workspace = new WorkspaceMetacardImpl();
+
+        wpip.process(new CreateRequestImpl(workspace));
+        assertThat(workspace.getOwner(), is("owner"));
     }
 
     @Test(expected = StopProcessingException.class)
-    public void testUnsuccessfulIngest() throws Exception {
-        WorkspacePreIngestPlugin wpip = makePlugin(null, null);
+    public void testCreateWorkspaceFailure() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
         wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
+    }
+
+    @Test(expected = StopProcessingException.class)
+    public void testCreateWorkspaceFailureWithOverride() throws Exception {
+        final String override = "override";
+
+        Map<String, SortedSet<String>> attrs = ImmutableMap.of(config.getOwnerAttribute(),
+                ImmutableSortedSet.of("owner"));
+        config.setOwnerAttribute(override);
+
+        WorkspacePreIngestPlugin wpip = makePlugin(attrs);
+        wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
+    }
+
+    @Test(expected = StopProcessingException.class)
+    public void testCreateAlertOnFailure() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
+        wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
+        assertThat(alerted, is(true));
+    }
+
+    private UpdateRequest updateRequest(Metacard prev, Metacard next) {
+        UpdateRequestImpl request = new UpdateRequestImpl(next.getId(), next);
+
+        OperationTransactionImpl tx =
+                new OperationTransactionImpl(OperationTransaction.OperationType.UPDATE,
+                        ImmutableList.of(prev));
+
+        Map<String, Serializable> properties = ImmutableMap.of(Constants.OPERATION_TRANSACTION_KEY,
+                tx);
+
+        request.setProperties(properties);
+
+        return request;
+    }
+
+    @Test
+    public void testUpdateIgnoreNonWorkspaceMetacards() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
+
+        MetacardImpl prev = new MetacardImpl();
+        prev.setId("id");
+        prev.setAttribute(Core.METACARD_OWNER, "prev");
+        MetacardImpl next = new MetacardImpl();
+        next.setId("id");
+
+        wpip.process(updateRequest(prev, next));
+        assertThat(next.getAttribute(Core.METACARD_OWNER), nullValue());
+    }
+
+    @Test
+    public void testUpdatePreserveOwner() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
+
+        WorkspaceMetacardImpl prev = new WorkspaceMetacardImpl("id");
+        WorkspaceMetacardImpl next = WorkspaceMetacardImpl.clone(prev);
+
+        prev.setOwner("prev");
+
+        assertThat(next.getOwner(), nullValue());
+        wpip.process(updateRequest(prev, next));
+        assertThat(next.getOwner(), is(prev.getOwner()));
+    }
+
+    @Test
+    public void testUpdateAllowOwnerChange() throws Exception {
+        WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
+
+        WorkspaceMetacardImpl prev = new WorkspaceMetacardImpl("id");
+        WorkspaceMetacardImpl next = WorkspaceMetacardImpl.clone(prev);
+
+        prev.setOwner("prev");
+        next.setOwner("next");
+
+        wpip.process(updateRequest(prev, next));
+        assertThat(next.getOwner(), is("next"));
     }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPluginTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceMetacardImpl;
-import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceTransformer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,13 +37,10 @@ public class WorkspaceSharingPolicyPluginTest {
 
     private PolicyPlugin plugin;
 
-    private WorkspaceTransformer transformer;
-
     @Before
     public void setUp() {
         properties = mock(Map.class);
-        transformer = mock(WorkspaceTransformer.class);
-        plugin = new WorkspaceSharingPolicyPlugin(transformer);
+        plugin = new WorkspaceSharingPolicyPlugin();
     }
 
     @Test
@@ -63,6 +59,9 @@ public class WorkspaceSharingPolicyPluginTest {
         workspace.setOwner(email);
         PolicyResponse response = plugin.processPreUpdate(workspace, properties);
         assertThat(response.itemPolicy(),
-                is(ImmutableMap.of(Core.METACARD_OWNER, ImmutableSet.of(email))));
+                is(ImmutableMap.of(Core.METACARD_OWNER,
+                        ImmutableSet.of(email),
+                        Constants.IS_WORKSPACE,
+                        ImmutableSet.of(Constants.IS_WORKSPACE))));
     }
 }


### PR DESCRIPTION
#### What does this PR do?

- Updates workspace security to allow owner attribute to be configurable.
- Adds admin alerting on failure to create workspace.
- Simplifies policy extension.
- Increases unit test code coverage.
- General code cleanup.

#### Who is reviewing it?

@tbatie 
@peterhuffer 

#### Select relevant component teams: 

@codice/security 

#### Choose 2 committers to review/merge the PR.

@rzwiefel
@stustison

#### How should this be tested? (List steps with links to updated documentation)

- Full build with itests.
- Edit `user.properties` and `user.attributes` to add a new user with no email but with a nameidentifier.
- Ensure that the new user cannot use workspaces but that the admin is notified.
- Update the workspace security configuration to use nameidentifier for the owner attribute.
- Ensure the new user can use workspaces in intrigue.

#### What are the relevant tickets?

[DDF-3283](https://codice.atlassian.net/browse/DDF-3283)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
