### PR TITLE
DDF-3121 Fixed removeall yes/no prompt on Windows

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -207,12 +207,12 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.33</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.33</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -131,11 +131,6 @@
             <version>1.9.7</version>
         </dependency>
         <dependency>
-            <groupId>ddf.catalog.transformer</groupId>
-            <artifactId>catalog-transformer-zip</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.lib</groupId>
             <artifactId>spock-shaded</artifactId>
             <version>${project.version}</version>
@@ -207,17 +202,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.25</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.18</minimum>
+                                            <minimum>0.33</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.33</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
@@ -227,20 +227,23 @@ public class RemoveAllCommand extends CatalogCommands {
                     "WARNING: This will permanently remove all %1$srecords from the %2$s. Do you want to proceed? (yes/no): ",
                     (expired ? "expired " : ""),
                     (cache ? "cache" : "Catalog"));
-            while (true) {
-                final String response;
-                try {
-                    response = session.readLine(warning, null);
-                } catch (IOException e) {
-                    console.println("Please use \"removeall -f\" or \"removeall --force\" instead");
-                    return true;
-                }
-                if (response.equalsIgnoreCase("yes")) {
-                    return false;
-                } else if (response.equalsIgnoreCase("no")) {
-                    console.println("No action taken.");
-                    return true;
-                }
+
+            final String response;
+            try {
+                response = session.readLine(warning, null);
+            } catch (IOException e) {
+                console.println("Please use \"removeall -f\" or \"removeall --force\" instead");
+                return true;
+            }
+            final String noActionTakenMessage = "No action taken.";
+            if (response.equalsIgnoreCase("yes")) {
+                return false;
+            } else if (response.equalsIgnoreCase("no")) {
+                console.println(noActionTakenMessage);
+                return true;
+            } else {
+                console.println("\"" + response + "\" is invalid. " + noActionTakenMessage);
+                return true;
             }
         }
 

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RemoveAllCommand.java
@@ -14,11 +14,9 @@
 package org.codice.ddf.commands.catalog;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,22 +52,14 @@ import ddf.catalog.source.UnsupportedQueryException;
 @Command(scope = CatalogCommands.NAMESPACE, name = "removeall", description = "Attempts to delete all records from the Catalog.")
 public class RemoveAllCommand extends CatalogCommands {
 
-    static final int PAGE_SIZE_LOWER_LIMIT = 1;
+    private static final int PAGE_SIZE_LOWER_LIMIT = 1;
 
-    static final long UNKNOWN_AMOUNT = -1;
+    private static final long UNKNOWN_AMOUNT = -1;
 
-    static final String PROGRESS_FORMAT = " Currently %1$s record(s) removed out of %2$s \r";
+    private static final String PROGRESS_FORMAT = " Currently %1$s record(s) removed out of %2$s \r";
 
     static final String BATCH_SIZE_ERROR_MESSAGE_FORMAT =
             "Improper batch size [%1$s]. For help with usage: removeall --help";
-
-    static final String WARNING_MESSAGE_FORMAT_CATALOG_REMOVAL =
-            "WARNING: This will permanently remove all %1$s"
-                    + "records from the Catalog. Do you want to proceed? (yes/no): ";
-
-    static final String WARNING_MESSAGE_FORMAT_CACHE_REMOVAL =
-            "WARNING: This will permanently remove all %1$s"
-                    + "records from the cache. Do you want to proceed? (yes/no): ";
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(RemoveAllCommand.class);
 
@@ -77,20 +67,20 @@ public class RemoveAllCommand extends CatalogCommands {
 
     @Argument(name = "Batch size", description =
             "Number of Metacards to delete at a time until completion. Change this argument based on system memory and Catalog limits. "
-                    + "Must be a positive integer.\nNOTE: Batch size may not be honored given system constraints.", index = 0, multiValued = false, required = false)
+                    + "Must be a positive integer.\nNOTE: Batch size may not be honored given system constraints.")
     int batchSize = DEFAULT_BATCH_SIZE;
 
-    @Option(name = "-e", required = false, aliases = {
-            "--expired"}, multiValued = false, description =
+    @Option(name = "-e", aliases = {
+            "--expired"}, description =
             "Remove only expired records from the Catalog. "
                     + "Expired records are based on the Metacard EXPIRATION field.")
-    boolean expired = false;
+    private boolean expired = false;
 
-    @Option(name = "-f", required = false, aliases = {
-            "--force"}, multiValued = false, description = "Force the removal without a confirmation message.")
+    @Option(name = "-f", aliases = {
+            "--force"}, description = "Force the removal without a confirmation message.")
     boolean force = false;
 
-    @Option(name = "--cache", required = false, multiValued = false, description = "Only remove cached entries.")
+    @Option(name = "--cache", description = "Only remove cached entries.")
     boolean cache = false;
 
     @Override
@@ -100,19 +90,21 @@ public class RemoveAllCommand extends CatalogCommands {
             return null;
         }
 
-        if (isAccidentalRemoval(console)) {
+        if (isAccidentalRemoval()) {
             return null;
         }
 
         if (this.cache) {
-            return executeRemoveAllFromCache();
+            executeRemoveAllFromCache();
 
         } else {
-            return executeRemoveAllFromStore();
+            executeRemoveAllFromStore();
         }
+
+        return null;
     }
 
-    private Object executeRemoveAllFromCache() throws Exception {
+    private void executeRemoveAllFromCache() throws Exception {
         long start = System.currentTimeMillis();
 
         getCacheProxy().removeAll();
@@ -127,11 +119,9 @@ public class RemoveAllCommand extends CatalogCommands {
 
         console.println();
         console.print(info);
-
-        return null;
     }
 
-    private Object executeRemoveAllFromStore() throws Exception {
+    private void executeRemoveAllFromStore() throws Exception {
         CatalogFacade catalog = getCatalog();
 
         QueryRequest firstQuery = getIntendedQuery(filterBuilder, true);
@@ -152,7 +142,7 @@ public class RemoveAllCommand extends CatalogCommands {
 
         if (response == null) {
             printErrorMessage("No response from Catalog.");
-            return null;
+            return;
         }
 
         if (needsAlternateQueryAndResponse(response)) {
@@ -209,23 +199,17 @@ public class RemoveAllCommand extends CatalogCommands {
 
         console.println();
         console.print(info);
-
-        return null;
     }
 
     private boolean needsAlternateQueryAndResponse(SourceResponse response) {
         Set<ProcessingDetails> processingDetails =
                 (Set<ProcessingDetails>) response.getProcessingDetails();
 
-        if (processingDetails == null || processingDetails.iterator() == null) {
+        if (processingDetails == null) {
             return false;
         }
 
-        Iterator<ProcessingDetails> iterator = processingDetails.iterator();
-
-        while (iterator.hasNext()) {
-
-            ProcessingDetails next = iterator.next();
+        for (ProcessingDetails next : processingDetails) {
             if (next != null && next.getException() != null && next.getException()
                     .getMessage() != null && next.getException()
                     .getMessage()
@@ -236,35 +220,27 @@ public class RemoveAllCommand extends CatalogCommands {
         return false;
     }
 
-    boolean isAccidentalRemoval(PrintStream console) throws IOException {
+    private boolean isAccidentalRemoval() {
         if (!force) {
-            StringBuffer buffer = new StringBuffer();
-
-            //use a message specific to whether they
-            //are removing from cache or the catalog
-            String warning = (this.cache ?
-                    WARNING_MESSAGE_FORMAT_CACHE_REMOVAL :
-                    WARNING_MESSAGE_FORMAT_CATALOG_REMOVAL);
-            System.err.println(String.format(warning, (expired ? "expired " : "")));
-            System.err.flush();
+            //use a message specific to cache and expired options
+            final String warning = String.format(
+                    "WARNING: This will permanently remove all %1$srecords from the %2$s. Do you want to proceed? (yes/no): ",
+                    (expired ? "expired " : ""),
+                    (cache ? "cache" : "Catalog"));
             while (true) {
-                int byteOfData = session.getKeyboard()
-                        .read();
-
-                if (byteOfData < 0) {
-                    // end of stream
+                final String response;
+                try {
+                    response = session.readLine(warning, null);
+                } catch (IOException e) {
+                    console.println("Please use \"removeall -f\" or \"removeall --force\" instead");
                     return true;
                 }
-                System.err.print((char) byteOfData);
-                if (byteOfData == '\r' || byteOfData == '\n') {
-                    break;
+                if (response.equalsIgnoreCase("yes")) {
+                    return false;
+                } else if (response.equalsIgnoreCase("no")) {
+                    console.println("No action taken.");
+                    return true;
                 }
-                buffer.append((char) byteOfData);
-            }
-            String str = buffer.toString();
-            if (!str.equals("yes")) {
-                console.println("No action taken.");
-                return true;
             }
         }
 
@@ -279,8 +255,7 @@ public class RemoveAllCommand extends CatalogCommands {
         return Long.toString(hits);
     }
 
-    private QueryRequest getIntendedQuery(FilterBuilder filterBuilder, boolean isRequestForTotal)
-            throws InterruptedException {
+    private QueryRequest getIntendedQuery(FilterBuilder filterBuilder, boolean isRequestForTotal) {
         Filter filter = addValidationAttributeToQuery(filterBuilder.attribute(Metacard.ID)
                 .is()
                 .like()
@@ -304,8 +279,7 @@ public class RemoveAllCommand extends CatalogCommands {
         return new QueryRequestImpl(query, properties);
     }
 
-    private QueryRequest getAlternateQuery(FilterBuilder filterBuilder, boolean isRequestForTotal)
-            throws InterruptedException {
+    private QueryRequest getAlternateQuery(FilterBuilder filterBuilder, boolean isRequestForTotal) {
         Filter filter = addValidationAttributeToQuery(filterBuilder.attribute(Metacard.ANY_TEXT)
                 .is()
                 .like()

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/RemoveAllCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/RemoveAllCommandTest.java
@@ -156,22 +156,11 @@ public class RemoveAllCommandTest extends ConsoleOutputCommon {
         verify(catalogFrameworkMock, times(numCatalogCalls)).delete(isA(DeleteRequest.class));
     }
 
-    /**
-     * Checks a series of responses ending with "yes" for the warning yes/no prompt
-     *
-     * @throws Exception
-     */
     @Test
     public void testExecuteWithSubjectWithoutForceOption() throws Exception {
         // given
         final Session mockSession = mock(Session.class);
-        when(mockSession.readLine(anyString(),
-                isNull(Character.class))).thenReturn("not yes nor no")
-                .thenReturn("something else")
-                .thenReturn("n\r")
-                .thenReturn("\n")
-                .thenReturn("\r")
-                .thenReturn("yes");
+        when(mockSession.readLine(anyString(), isNull(Character.class))).thenReturn("yes");
 
         batchSize = 11;
         numCatalogCalls = 1;
@@ -217,22 +206,35 @@ public class RemoveAllCommandTest extends ConsoleOutputCommon {
         verify(mbean, times(numCatalogCalls)).removeAll();
     }
 
-    /**
-     * Checks a series of responses ending with "no" for the warning yes/no prompt
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAccidentalRemoval() throws Exception {
+    public void testInvalidWarningPromptInput() throws Exception {
         // given
         final Session mockSession = mock(Session.class);
-        when(mockSession.readLine(anyString(),
-                isNull(Character.class))).thenReturn("not yes nor no")
-                .thenReturn("something else")
-                .thenReturn("n\r")
-                .thenReturn("\n")
-                .thenReturn("\r")
-                .thenReturn("no");
+        when(mockSession.readLine(anyString(), isNull(Character.class))).thenReturn("something that isn't yes nor no");
+
+        batchSize = 11;
+        numCatalogCalls = 1;
+        forceCommand = false;
+
+        setQueryAndDeleteResponseMocks(11, 0);
+
+        setCatalogQueryAndDeleteResponses();
+
+        final RemoveAllCommand command = new RemoveAllCommand();
+        command.session = mockSession;
+
+        // when
+        newRemoveAllCommand(command).executeWithSubject();
+
+        // then
+        verifyZeroInteractions(catalogFrameworkMock);
+    }
+
+    @Test
+    public void testWarningPromptInputOfNo() throws Exception {
+        // given
+        final Session mockSession = mock(Session.class);
+        when(mockSession.readLine(anyString(), isNull(Character.class))).thenReturn("no");
 
         batchSize = 11;
         numCatalogCalls = 1;

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/RemoveAllCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/RemoveAllCommandTest.java
@@ -17,18 +17,23 @@ import static java.util.stream.Collectors.toList;
 import static org.codice.ddf.commands.catalog.CommandSupport.ERROR_COLOR;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import org.apache.karaf.shell.api.console.Session;
 import org.fusesource.jansi.Ansi;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,6 +157,41 @@ public class RemoveAllCommandTest extends ConsoleOutputCommon {
     }
 
     /**
+     * Checks a series of responses ending with "yes" for the warning yes/no prompt
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testExecuteWithSubjectWithoutForceOption() throws Exception {
+        // given
+        final Session mockSession = mock(Session.class);
+        when(mockSession.readLine(anyString(),
+                isNull(Character.class))).thenReturn("not yes nor no")
+                .thenReturn("something else")
+                .thenReturn("n\r")
+                .thenReturn("\n")
+                .thenReturn("\r")
+                .thenReturn("yes");
+
+        batchSize = 11;
+        numCatalogCalls = 1;
+        forceCommand = false;
+
+        setQueryAndDeleteResponseMocks(11, 0);
+
+        setCatalogQueryAndDeleteResponses();
+
+        final RemoveAllCommand command = new RemoveAllCommand();
+        command.session = mockSession;
+
+        // when
+        newRemoveAllCommand(command).executeWithSubject();
+
+        // then
+        verify(catalogFrameworkMock, times(numCatalogCalls)).delete(isA(DeleteRequest.class));
+    }
+
+    /**
      * Checks the forced (-f) generic case with (--cache) option
      *
      * @throws Exception
@@ -175,6 +215,66 @@ public class RemoveAllCommandTest extends ConsoleOutputCommon {
         removeAllCommand.executeWithSubject();
 
         verify(mbean, times(numCatalogCalls)).removeAll();
+    }
+
+    /**
+     * Checks a series of responses ending with "no" for the warning yes/no prompt
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAccidentalRemoval() throws Exception {
+        // given
+        final Session mockSession = mock(Session.class);
+        when(mockSession.readLine(anyString(),
+                isNull(Character.class))).thenReturn("not yes nor no")
+                .thenReturn("something else")
+                .thenReturn("n\r")
+                .thenReturn("\n")
+                .thenReturn("\r")
+                .thenReturn("no");
+
+        batchSize = 11;
+        numCatalogCalls = 1;
+        forceCommand = false;
+
+        setQueryAndDeleteResponseMocks(11, 0);
+
+        setCatalogQueryAndDeleteResponses();
+
+        final RemoveAllCommand command = new RemoveAllCommand();
+        command.session = mockSession;
+
+        // when
+        newRemoveAllCommand(command).executeWithSubject();
+
+        // then
+        verifyZeroInteractions(catalogFrameworkMock);
+    }
+
+    @Test
+    public void testWarningPromptException() throws Exception {
+        // given
+        final Session mockSession = mock(Session.class);
+        when(mockSession.readLine(anyString(),
+                isNull(Character.class))).thenThrow(IOException.class);
+
+        batchSize = 11;
+        numCatalogCalls = 1;
+        forceCommand = false;
+
+        setQueryAndDeleteResponseMocks(11, 0);
+
+        setCatalogQueryAndDeleteResponses();
+
+        final RemoveAllCommand command = new RemoveAllCommand();
+        command.session = mockSession;
+
+        // when
+        newRemoveAllCommand(command).executeWithSubject();
+
+        // then
+        verifyZeroInteractions(catalogFrameworkMock);
     }
 
     private RemoveAllCommand newRemoveAllCommand(RemoveAllCommand removeAllCommand) {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue with the removeall command warning prompt on Windows.
#### Who is reviewing it?
@AzGoalie @mcalcote 
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel
#### How should this be tested? (List steps with links to updated documentation)
Execute the removeall command with different options, and confirm that the behavior is correct and that the warning prompt appears correctly.
#### Any background context you want to provide?
The issue was that the response to the warning prompt only appears on the console after hitting enter on Windows.
#### What are the relevant tickets?
[DDF-3121](https://codice.atlassian.net/browse/DDF-3121)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
