### PR TITLE
DDF-3121 Refactored catalog commands to use Karaf readLine

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -212,7 +212,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.32</minimum>
+                                            <minimum>0.33</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/CatalogCommands.java
@@ -115,28 +115,6 @@ public abstract class CatalogCommands extends SubjectCommands {
                 .findFirst();
     }
 
-    protected StringBuilder getUserInputModifiable() throws IOException {
-        int in;
-        StringBuilder input = new StringBuilder();
-        while ((in = session.getKeyboard()
-                .read()) != '\r' && in != '\n') {
-            if (in == 127 || in == 8) {
-                if (input.length() > 0) {
-                    input.deleteCharAt(input.length() - 1);
-                    console.print((char) 8);
-                    console.print(' ');
-                    console.print((char) 8);
-                }
-            } else {
-                input.append((char) in);
-                console.print((char) in);
-            }
-            console.flush();
-        }
-        console.println();
-        return input;
-    }
-
     protected String getFormattedDuration(Instant start) {
         return getFormattedDuration(Duration.between(start, Instant.now()));
     }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DuplicateCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DuplicateCommands.java
@@ -264,27 +264,6 @@ public abstract class DuplicateCommands extends CqlCommands {
         return createdMetacards;
     }
 
-    protected String getInput(String message) throws IOException {
-        StringBuilder buffer = new StringBuilder();
-        console.print(String.format(message));
-        console.flush();
-        while (true) {
-            int byteOfData = session.getKeyboard()
-                    .read();
-
-            if (byteOfData < 0) {
-                // end of stream
-                return null;
-            }
-            console.print((char) byteOfData);
-            if (byteOfData == '\r' || byteOfData == '\n') {
-                break;
-            }
-            buffer.append((char) byteOfData);
-        }
-        return buffer.toString();
-    }
-
     protected List<Metacard> subtract(List<Metacard> queried, List<Metacard> ingested) {
         List<Metacard> result = new ArrayList<>(queried);
         result.removeAll(ingested);

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -162,9 +162,7 @@ public class ExportCommand extends CqlCommands {
         }
 
         if (delete && !force) {
-            console.println(
-                    "This action will remove all exported metacards and content from the catalog. Are you sure you wish to continue? (y/N):");
-            String input = getUserInputModifiable().toString();
+            final String input = session.readLine("This action will remove all exported metacards and content from the catalog. Are you sure you wish to continue? (y/N):", null);
             if (!input.matches("^[yY][eE]?[sS]?$")) {
                 console.println("ABORTED EXPORT.");
                 return null;

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
@@ -102,9 +102,7 @@ public class ImportCommand extends CatalogCommands {
 
         if (unsafe) {
             if (!force) {
-                console.println(
-                        "This will import data with no check to see if data is modified/corrupt. Do you wish to continue?");
-                String input = getUserInputModifiable().toString();
+                String input = session.readLine("This will import data with no check to see if data is modified/corrupt. Do you wish to continue? (y/N) ", null);
                 if (!input.matches("^[yY][eE]?[sS]?$")) {
                     console.println("ABORTED IMPORT.");
                     return null;

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/MigrateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/MigrateCommand.java
@@ -143,7 +143,7 @@ public class MigrateCommand extends DuplicateCommands {
             } else {
                 break;
             }
-            id = getInput(whichProvider + " Provider ID: ");
+            id = session.readLine(whichProvider + " Provider ID: ", null);
         }
 
         final String providerId = id;

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ReplicateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ReplicateCommand.java
@@ -67,7 +67,7 @@ public class ReplicateCommand extends DuplicateCommands {
             } else {
                 break;
             }
-            sourceId = getInput("ID:  ");
+            sourceId = session.readLine("ID:  ", null);
         }
 
         start = System.currentTimeMillis();

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
@@ -100,7 +100,7 @@ public abstract class SubjectCommands extends CommandSupport {
 
     private Object runWithUserName() throws InvocationTargetException {
         try {
-            String password = getLine("Password for " + user + ": ", false);
+            String password = session.readLine("Password for " + user + ": ", '*');
             Subject subject = security.getSubject(user, password);
 
             if (subject == null) {
@@ -121,38 +121,5 @@ public abstract class SubjectCommands extends CommandSupport {
         }
 
         return null;
-    }
-
-    private String getLine(String text, boolean showCharacters) throws IOException {
-        console.print(text);
-        console.flush();
-        StringBuilder buffer = new StringBuilder();
-
-        while (true) {
-            int byteOfData = session.getKeyboard()
-                    .read();
-
-            if (byteOfData < 0) {
-                break;
-            }
-
-            if (showCharacters) {
-                console.print((char) byteOfData);
-                console.flush();
-            } else {
-                console.print("*");
-                console.flush();
-            }
-
-            if (byteOfData == '\r' || byteOfData == '\n') {
-                break;
-            }
-
-            buffer.append((char) byteOfData);
-        }
-
-        console.println();
-        console.flush();
-        return buffer.toString();
     }
 }

--- a/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
+++ b/catalog/core/catalog-core-commands/src/test/groovy/org/codice/ddf/commands/catalog/ExportCommandSpec.groovy
@@ -34,6 +34,7 @@ import org.osgi.framework.BundleContext
 import org.osgi.framework.ServiceReference
 import spock.lang.Ignore
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import javax.activation.MimeType
 import java.nio.file.Paths
@@ -166,11 +167,11 @@ class ExportCommandSpec extends Specification {
         thrown(IllegalStateException)
     }
 
-    def "Test abort command"() {
+    @Unroll
+    def "Test abort command with \"#userInputString\" response to warning prompt"(final String userInputString) {
         setup:
-        InputStream keyboardInput = new ByteArrayInputStream("n\r".getBytes('utf-8'))
         def session = Mock(Session) {
-            getKeyboard() >> keyboardInput
+            readLine(_ as String, null) >> userInputString
         }
         exportCommand.with {
             it.delete = true
@@ -181,8 +182,10 @@ class ExportCommandSpec extends Specification {
         exportCommand.executeWithSubject()
 
         then:
-        notThrown(Exception)
         tmpHomeDir.list() == [] // dir is empty
+        
+        where:
+        userInputString << ["n", "N", "no", "NO", "something that isn't no", "n\r"]
     }
 
     def "Test single metacard no content export"() {

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/ReplicateCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/ReplicateCommandTest.java
@@ -17,13 +17,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -35,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.felix.service.command.CommandSession;
+import org.apache.karaf.shell.api.console.Session;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,16 +47,12 @@ import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.data.types.Core;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.source.IngestException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 
 public class ReplicateCommandTest extends ConsoleOutputCommon {
 
@@ -74,16 +72,14 @@ public class ReplicateCommandTest extends ConsoleOutputCommon {
     private ReplicateCommand replicateCommand;
 
     @Before
-    public void setUp()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException,
-            IngestException {
+    public void setUp() throws Exception {
         catalogFramework = mock(CatalogFramework.class);
-        replicateCommand = new ReplicateCommand() {
-            @Override
-            public String getInput(String message) throws IOException {
-                return "sourceId1";
-            }
-        };
+        replicateCommand = new ReplicateCommand();
+
+        final Session session = mock(Session.class);
+        when(session.readLine(anyString(), isNull(Character.class))).thenReturn("sourceId1");
+        replicateCommand.session = session;
+
         replicateCommand.catalogFramework = catalogFramework;
         replicateCommand.filterBuilder = new GeotoolsFilterBuilder();
 


### PR DESCRIPTION
#### What does this PR do?
This PR refactors the catalog commands to use the Karaf `session.readLine` method when reading console input.
#### Who is reviewing it? 
@AzGoalie @mcalcote 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel
#### How should this be tested?
| Command  | Test Step |
| ------------- | ------------- |
| `catalog:export --delete` (without `--force`) | Check that the warning prompt works. |
| `catalog:import --skip-signature-verification` (without `--force`) | Check that the warning prompt works. |
| `catalog:migrate` (without `--from` nor `--to`) | Check that the provider prompts work. |
| `atalog:replicate` (without `[ID]` argument) | Check that the `ID` prompt works. |
| `catalog:<any subject command> --user` | Check that the password prompt works and that the user input is masked. |
#### Any background context you want to provide?
This is a follow-on PR to https://github.com/codice/ddf/pull/2314.
#### What are the relevant tickets?
[DDF-3121](https://codice.atlassian.net/browse/DDF-3121)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
