### PR TITLE
DDF-3180 Fix sanitizeGeometry to use regex

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -23,11 +23,32 @@ define([
         sanitizeForCql: function (text) {
             return text.split('[').join('(').split(']').join(')').split("'").join('').split('"').join('');
         },
-        //we should probably regex this or find a better way, but for now this works
+
         sanitizeGeometryCql: function (cqlString) {
-            return cqlString.split("'POLYGON((").join("POLYGON((").split("))'").join("))")
-                .split("'POINT(").join("POINT(").replace(/(POINT\([-0-9. ]*\))/g, '$1' + specialDelimiter).split(")"+specialDelimiter+"'").join(")")
-                .split(")'").join(")").split("'LINESTRING(").join("LINESTRING(").split("))'").join("))");
+            //sanitize polygons
+            let polygons = cqlString.match(/'POLYGON\(\(.*\)\)'/g);
+            if (polygons) {
+                polygons.forEach((polygon) => {
+                    cqlString = cqlString.replace(polygon, polygon.replace(/'/g, ''));
+                });
+            }
+
+            //sanitize points
+            let points = cqlString.match(/'POINT\(.*\)'/g);
+            if (points) {
+                points.forEach((point) => {
+                    cqlString = cqlString.replace(point, point.replace(/'/g, ''));
+                });
+            }
+
+            //sanitize linestrings
+            let linestrings = cqlString.match(/'LINESTRING\(.*\)'/g);
+            if (linestrings) {
+                linestrings.forEach((linestring) => {
+                    cqlString = cqlString.replace(linestring, linestring.replace(/'/g, ''));
+                });
+            }
+            return cqlString;
         },
         getProperty: function (filter) {
             if (typeof(filter.property) !== 'string') {


### PR DESCRIPTION
#### What does this PR do?
Change the sanitizeGeometry function in CQLUtils.js to use regex instead of replacing matches that break other queries, such as the relative temporal query.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@ryeats 
@albany551 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler 
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Manually verify that geometry queries all sanitize as expected and no other queries will be pulled in.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
