### PR TITLE
DDF-3281 Add default geoname data and default to offline gazetteer.

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-lucene/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-lucene/pom.xml
@@ -165,7 +165,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                         <limit>
                                             <counter>INSTRUCTION</counter>

--- a/catalog/spatial/geocoding/spatial-geocoding-lucene/src/main/java/org/codice/ddf/spatial/geocoding/index/IndexInitializer.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-lucene/src/main/java/org/codice/ddf/spatial/geocoding/index/IndexInitializer.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.geocoding.index;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+
+import org.codice.ddf.spatial.geocoding.GeoEntryExtractionException;
+import org.codice.ddf.spatial.geocoding.GeoEntryExtractor;
+import org.codice.ddf.spatial.geocoding.GeoEntryIndexer;
+import org.codice.ddf.spatial.geocoding.GeoEntryIndexingException;
+import org.codice.ddf.spatial.geocoding.GeoNamesRemoteDownloadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IndexInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexInitializer.class);
+
+    private String defaultGeonamesDataPath;
+
+    private String indexLocationPath;
+
+    private GeoEntryExtractor extractor;
+
+    private GeoEntryIndexer indexer;
+
+    private ExecutorService executor;
+
+    public void init() {
+        File defaultGeonamesDataFile = Paths.get(defaultGeonamesDataPath)
+                .toFile();
+        File indexLocationDir = Paths.get(indexLocationPath)
+                .toFile();
+        if (!defaultGeonamesDataFile.exists()) {
+            LOGGER.warn(
+                    "Could not locate default geonames data file at {}. Check that your distribution is no corrupted");
+            return;
+        }
+
+        if (indexLocationDir.exists() && indexLocationDir.list().length > 0) {
+            LOGGER.info("Geoname index already exists. Not indexing default data set.");
+            return;
+        }
+        executor.submit(() -> {
+            try {
+                LOGGER.info("Indexing default geoname data at {}.", defaultGeonamesDataPath);
+
+                indexer.updateIndex(defaultGeonamesDataFile.getAbsolutePath(),
+                        extractor,
+                        true,
+                        progress -> {
+                            if (progress >= 100) {
+                                LOGGER.info("Default geoname data indexed successfully");
+                            }
+                        });
+            } catch (GeoEntryIndexingException | GeoEntryExtractionException | GeoNamesRemoteDownloadException e) {
+                LOGGER.error(
+                        "Failed to index default geonames data. Try using the geonames:update command to generate the index manually.",
+                        e);
+            }
+        });
+
+        executor.shutdown();
+    }
+
+    public void destroy() {
+        executor.shutdownNow();
+    }
+
+    public void setDefaultGeonamesDataPath(String defaultGeonamesDataPath) {
+        this.defaultGeonamesDataPath = defaultGeonamesDataPath;
+    }
+
+    public void setExtractor(GeoEntryExtractor extractor) {
+        this.extractor = extractor;
+    }
+
+    public void setIndexLocationPath(String indexLocationPath) {
+        this.indexLocationPath = indexLocationPath;
+    }
+
+    public void setIndexer(GeoEntryIndexer indexer) {
+        this.indexer = indexer;
+    }
+
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+}

--- a/catalog/spatial/geocoding/spatial-geocoding-lucene/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-lucene/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,6 +28,21 @@
         <property name="indexLocation" value="data/geonames-index"/>
     </bean>
 
+    <reference id="geoExtractor" interface="org.codice.ddf.spatial.geocoding.GeoEntryExtractor"/>
+
+    <bean id="executorService" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadExecutor">
+    </bean>
+
+    <bean id="indexInitializer" class="org.codice.ddf.spatial.geocoding.index.IndexInitializer"
+          init-method="init" destroy-method="destroy">
+        <property name="indexLocationPath" value="data/geonames-index"/>
+        <property name="defaultGeonamesDataPath" value="data/default_geonames_data.zip"/>
+        <property name="indexer" ref="geonamesIndexer"/>
+        <property name="extractor" ref="geoExtractor"/>
+        <property name="executor" ref="executorService"/>
+    </bean>
+
     <service ref="geonamesQueryable" interface="org.codice.ddf.spatial.geocoding.GeoEntryQueryable" ranking="50"/>
     <service ref="geonamesIndexer" interface="org.codice.ddf.spatial.geocoding.GeoEntryIndexer"/>
 

--- a/catalog/spatial/geocoding/spatial-geocoding-lucene/src/test/java/org/codice/ddf/spatial/geocoding/index/IndexInitializerTest.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-lucene/src/test/java/org/codice/ddf/spatial/geocoding/index/IndexInitializerTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.spatial.geocoding.index;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+
+import org.codice.ddf.spatial.geocoding.GeoEntryExtractor;
+import org.codice.ddf.spatial.geocoding.GeoEntryIndexer;
+import org.codice.ddf.spatial.geocoding.ProgressCallback;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.stubbing.Answer;
+
+public class IndexInitializerTest {
+
+    private GeoEntryExtractor extractor;
+
+    private GeoEntryIndexer indexer;
+
+    private ExecutorService executor;
+
+    private IndexInitializer indexInitializer;
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private File dataDir;
+
+    private File geonamesZip;
+
+    private File geoIndexDir;
+
+    @Before
+    public void setup() throws Exception {
+        extractor = mock(GeoEntryExtractor.class);
+        indexer = mock(GeoEntryIndexer.class);
+        executor = mock(ExecutorService.class);
+        indexInitializer = new IndexInitializer();
+        indexInitializer.setExecutor(executor);
+        indexInitializer.setExtractor(extractor);
+        indexInitializer.setIndexer(indexer);
+        dataDir = tempDir.newFolder("data");
+        geonamesZip = new File(dataDir, "default_geonames_data.zip");
+        geoIndexDir = new File(dataDir, "geonames-index");
+        indexInitializer.setDefaultGeonamesDataPath(geonamesZip.getAbsolutePath());
+        indexInitializer.setIndexLocationPath(geoIndexDir.getAbsolutePath());
+    }
+
+    @Test
+    public void testIndexInitializerNoDataFile() throws Exception {
+        indexInitializer.init();
+        verify(executor, never()).submit(any(Runnable.class));
+    }
+
+    @Test
+    public void testIndexInitializerExistingIndex() throws Exception {
+        geoIndexDir.mkdirs();
+        new File(geoIndexDir, "somefile.txt").createNewFile();
+        geonamesZip.createNewFile();
+        indexInitializer.init();
+        verify(executor, never()).submit(any(Runnable.class));
+    }
+
+    @Test
+    public void testIndexInitializerEmptyIndex() throws Exception {
+        geoIndexDir.mkdirs();
+        geonamesZip.createNewFile();
+        indexInitializer.init();
+        verify(executor).submit(any(Runnable.class));
+    }
+
+    @Test
+    public void testIndexInitializerRun() throws Exception {
+        when(executor.submit(any(Runnable.class))).then((Answer) invocationOnMock -> {
+            invocationOnMock.getArgumentAt(0, Runnable.class)
+                    .run();
+            return null;
+        });
+        geoIndexDir.mkdirs();
+        geonamesZip.createNewFile();
+        indexInitializer.init();
+        verify(indexer).updateIndex(anyString(),
+                any(GeoEntryExtractor.class),
+                anyBoolean(),
+                any(ProgressCallback.class));
+    }
+}

--- a/catalog/spatial/spatial-app/src/main/resources/features.xml
+++ b/catalog/spatial/spatial-app/src/main/resources/features.xml
@@ -82,7 +82,7 @@
         <bundle>mvn:org.codice.ddf.spatial/spatial-wfs-v2_0_0-connectedsource/${project.version}</bundle>
     </feature>
 
-    <feature name="webservice-gazetteer" install="auto" version="${project.version}"
+    <feature name="webservice-gazetteer" install="manual" version="${project.version}"
              description="Gazetteer service utilizing the Geonames.org web service.">
         <feature prerequisite="true">spatial-app</feature>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-geocoder/${project.version}</bundle>
@@ -90,7 +90,7 @@
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-plugin/${project.version}</bundle>
     </feature>
 
-    <feature name="offline-gazetteer" install="manual" version="${project.version}"
+    <feature name="offline-gazetteer" install="auto" version="${project.version}"
              description="Offline gazetteer service utilizing a local GeoNames index.">
         <feature prerequisite="true">spatial-app</feature>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-create/${project.version}</bundle>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -87,7 +87,7 @@
 
         <AD id="onlineGazetteer"
             name="Use Online Gazetteer"
-            description="Should the online gazetteer be used? If unchecked a local one will be used."
+            description="Should the online gazetteer be used? If unchecked a local gazetteer service will be used. This only applies to the search gazetteer in Intrigue."
             type="Boolean"
             default="true"
             required="false"/>

--- a/distribution/docs/src/main/resources/content/_application-references/managing-spatial-contents.adoc
+++ b/distribution/docs/src/main/resources/content/_application-references/managing-spatial-contents.adoc
@@ -8,10 +8,10 @@ The ${ddf-spatial} Application provides KML transformer and a KML network link e
 
 ==== Offline Gazetteer Service
 
-In the ${ddf-spatial} Application, you have the option to install a feature called `offline-gazetteer`.
+In the ${ddf-spatial} Application, the `offline-gazetteer` is installed by default.
 This feature enables you to use an offline index of GeoNames data (as an alternative to the GeoNames Web service enabled by the `webservice-gazetteer` feature) to perform searches via the gazetteer search box in the Search UI.
 
-To use the offline gazetteer, you will need to create an index using the `geonames:update` command.
+By default a small index set is included with the offline gazetteer. This index can be expanded or updated by using the `geonames:update` command.
 
 ===== ${ddf-spatial} GeoNames Console Commands
 

--- a/distribution/docs/src/main/resources/content/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/org.codice.ddf.catalog.ui.config-table-contents.adoc
@@ -101,7 +101,7 @@ TMS example (3d map support only): `[{"type" : "TMS", "url" : "https://cesiumjs.
 |Use Online Gazetteer
 |onlineGazetteer
 |Boolean
-|Should the online gazetteer be used? If unchecked a local one will be used.
+|Should the online gazetteer be used? If unchecked a local gazetteer service will be used. This only applies to the search gazetteer in Intrigue.
 |true
 |false
 


### PR DESCRIPTION
#### What does this PR do?
Switches the default gazetteer from the online version to the offline. Adds a default dataset for the offline gazetteer.
#### Who is reviewing it? 
@emmberk @mcalcote 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and turn off the option Standard Search UI -> Catalog UI Search-> Use Online Gazetteer.
Go to the Intrigue ui and
Search for a location like "Arizona" in the search map search bar in the upper right and verify that the location is found.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3281](https://codice.atlassian.net/browse/DDF-3281)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
