### PR TITLE
DDF-3121 Fixed catalog commands progress bar

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -267,16 +267,17 @@ public class IngestCommand extends CatalogCommands {
                 calculateRecordsPerSecond(ingestCount.get(), start, end));
 
         if (fileCount.get() != ingestCount.get()) {
-            console.println();
             if ((fileCount.get() - ingestCount.get() - ignoreCount.get()) >= 1) {
                 String failedAmount = Integer.toString(
                         fileCount.get() - ingestCount.get() - ignoreCount.get());
+                console.println();
                 printErrorMessage(failedAmount
                         + " file(s) failed to be ingested.  See the ingest log for more details.");
                 INGEST_LOGGER.warn("{} files(s) failed to be ingested.", failedAmount);
             }
             if (ignoreList != null) {
                 String ignoredAmount = Integer.toString(ignoreCount.get());
+                console.println();
                 printColor(Ansi.Color.YELLOW,
                         ignoredAmount + " file(s) ignored.  See the ingest log for more details.");
                 INGEST_LOGGER.warn("{} files(s) were ignored.", ignoredAmount);


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the progress bar for a few catalog commands.
#### Who is reviewing it? 
@ahoffer @johnsliao @vinamartin @mcalcote 
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel 
#### How should this be tested?
The modified progress bar is used in a few situations:
- `catalog:ingest`
  - `--batchsize`
  - `--multithreaded`
- `catalog:seed`
- `catalog:migrate`
  - `--batchsize`
  - `--multithreaded`
- `catalog:replicate`
  - `--batchsize`
  - `--multithreaded`

Check that the progress bar looks correct for processing different edge cases with the commands:
- small/large batch sizes
- small/large number of records to process
- no records to process
- multithreaded/not multithreaded
#### Any background context you want to provide?
This PR doesn't change anything about the behavior before the regression except:

- There is no longer an arrow when the progress bar is at 100%.
- The progress bar width matches that of the Karaf start-up progress bar.

#### What are the relevant tickets?
[DDF-3121](https://codice.atlassian.net/browse/DDF-3121)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
