### PR TITLE
DDF-3142 Remove catalog-core-migratable dependency in catalog-app

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -92,11 +92,6 @@
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-migratable</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
#### What does this PR do?
Removes an old dependency from the catalog-app pom that no longer exists.
This leftover dependence prevents the project from being released.
#### Who is reviewing it? 
@paouelle @brjeter 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold
@shaundmorris
#### How should this be tested? (List steps with links to updated documentation)
Successful build and maven release:prepare doesn't find any snapshot dependencies
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3142](https://codice.atlassian.net/browse/DDF-3142)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
