### PR TITLE
DDF-3094 Updates histogram to bin dates by ranges instead of categories, and to show the entire result set

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -44,6 +44,11 @@ define([
                 type: Backbone.Many,
                 key: 'activeSearchResults',
                 relatedModel: Metacard.MetacardResult
+            },
+            {
+                type: Backbone.Many,
+                key: 'completeActiveSearchResults',
+                relatedModel: Metacard.MetacardResult
             }
         ],
         defaults: {
@@ -53,11 +58,14 @@ define([
             selectedResults: [],
             activeSearchResults: [],
             activeSearchResultsAttributes: [],
+            completeActiveSearchResults: [],
+            completeActiveSearchResultsAttributes: [],
         },
         initialize: function(){
             this.set('currentResult', new Metacard.SearchResult());
             this.listenTo(this, 'change:currentAlert', this.clearSelectedResults);
             this.listenTo(this.get('activeSearchResults'), 'update add remove reset', this.updateActiveSearchResultsAttributes);
+            this.listenTo(this.get('completeActiveSearchResults'), 'update add remove reset', this.updateActiveSearchResultsFullAttributes);
         },
         updateActiveSearchResultsAttributes: function(){
             var availableAttributes = this.get('activeSearchResults').reduce(function(currentAvailable, result) {
@@ -66,6 +74,22 @@ define([
             }, []).sort();
             this.set('activeSearchResultsAttributes', availableAttributes);
         }, 
+        updateActiveSearchResultsFullAttributes: function() {
+            var availableAttributes = this.get('completeActiveSearchResults').reduce(function(currentAvailable, result) {
+                currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
+                return currentAvailable;
+            }, []).sort();
+            this.set('completeActiveSearchResultsAttributes', availableAttributes);
+        },
+        getCompleteActiveSearchResultsAttributes: function(){
+            return this.get('completeActiveSearchResultsAttributes');
+        },
+        getCompleteActiveSearchResults: function(){
+            return this.get('completeActiveSearchResults');
+        },
+        setCompleteActiveSearchResults: function(results){
+            this.get('completeActiveSearchResults').reset(results.models || results);
+        },
         getActiveSearchResultsAttributes: function(){
             return this.get('activeSearchResultsAttributes');
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -51,6 +51,11 @@ define([
                 key: 'activeSearchResults',
                 relatedModel: Metacard.MetacardResult
             },
+            {
+                type: Backbone.Many,
+                key: 'completeActiveSearchResults',
+                relatedModel: Metacard.MetacardResult
+            }
         ],
         defaults: {
             currentWorkspace: undefined,
@@ -64,6 +69,8 @@ define([
             editing: true,
             activeSearchResults: [],
             activeSearchResultsAttributes: [],
+            completeActiveSearchResults: [],
+            completeActiveSearchResultsAttributes: [],
             drawing: false
         },
         initialize: function(){
@@ -74,6 +81,23 @@ define([
             this.listenTo(wreqr.vent, 'search:drawstop', this.turnOffDrawing);
             this.listenTo(wreqr.vent, 'search:drawend', this.turnOffDrawing);
             this.listenTo(this.get('activeSearchResults'), 'update add remove reset', this.updateActiveSearchResultsAttributes);
+            this.listenTo(this.get('completeActiveSearchResults'), 'update add remove reset', this.updateActiveSearchResultsFullAttributes);
+        },
+        updateActiveSearchResultsFullAttributes: function() {
+            var availableAttributes = this.get('completeActiveSearchResults').reduce(function(currentAvailable, result) {
+                currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
+                return currentAvailable;
+            }, []).sort();
+            this.set('completeActiveSearchResultsAttributes', availableAttributes);
+        },
+        getCompleteActiveSearchResultsAttributes: function(){
+            return this.get('completeActiveSearchResultsAttributes');
+        },
+        getCompleteActiveSearchResults: function(){
+            return this.get('completeActiveSearchResults');
+        },
+        setCompleteActiveSearchResults: function(results){
+            this.get('completeActiveSearchResults').reset(results.models || results);
         },
         updateActiveSearchResultsAttributes: function(){
             var availableAttributes = this.get('activeSearchResults').reduce(function(currentAvailable, result) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
@@ -55,6 +55,7 @@ function getGoldenLayoutSettings(){
     return {
         settings: {
             showPopoutIcon: false,
+            responsiveMode: 'none'
         },
         dimensions: {
             borderWidth: 0.5 * parseFloat(theme.minimumSpacing) * fontSize,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
@@ -38,6 +38,11 @@ define([
                 type: Backbone.Many,
                 key: 'activeSearchResults',
                 relatedModel: Metacard.MetacardResult
+            },
+            {
+                type: Backbone.Many,
+                key: 'completeActiveSearchResults',
+                relatedModel: Metacard.MetacardResult
             }
         ],
         defaults: {
@@ -46,6 +51,8 @@ define([
             selectedResults: [],
             activeSearchResults: [],
             activeSearchResultsAttributes: [],
+            completeActiveSearchResults: [],
+            completeActiveSearchResultsAttributes: [],
         },
         initialize: function(){
             this.set('currentResult', new Metacard.SearchResult());
@@ -53,6 +60,23 @@ define([
             this.listenTo(this, 'change:currentMetacard', this.handleCurrentMetacard);
             this.listenTo(this, 'change:currentResult', this.handleResultChange);
             this.listenTo(this.get('activeSearchResults'), 'update add remove reset', this.updateActiveSearchResultsAttributes);
+            this.listenTo(this.get('completeActiveSearchResults'), 'update add remove reset', this.updateActiveSearchResultsFullAttributes);
+        },
+        updateActiveSearchResultsFullAttributes: function() {
+            var availableAttributes = this.get('completeActiveSearchResults').reduce(function(currentAvailable, result) {
+                currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
+                return currentAvailable;
+            }, []).sort();
+            this.set('completeActiveSearchResultsAttributes', availableAttributes);
+        },
+        getCompleteActiveSearchResultsAttributes: function(){
+            return this.get('completeActiveSearchResultsAttributes');
+        },
+        getCompleteActiveSearchResults: function(){
+            return this.get('completeActiveSearchResults');
+        },
+        setCompleteActiveSearchResults: function(results){
+            this.get('completeActiveSearchResults').reset(results.models || results);
         },
         handleResultChange: function(){
             this.listenTo(this.get('currentResult'), 'sync reset:results', this.handleResults);
@@ -73,6 +97,7 @@ define([
         handleUpdate: function(){
             this.clearSelectedResults();
             this.setActiveSearchResults(this.get('currentResult').get('results'));
+            this.setCompleteActiveSearchResults(this.get('currentResult').get('results'));
             this.addSelectedResult(this.get('currentMetacard'));
         },
         handleCurrentMetacard: function(){

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/paging/paging.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/paging/paging.view.js
@@ -27,7 +27,19 @@ define([
         template: template,
         initialize: function (options) {
             this.listenTo(this.model, 'reset', this.render);
+            this.listenTo(this.model.fullCollection, 'add remove update', this.updateSelectionInterfaceComplete);
             this.updateSelectionInterface = _debounce(this.updateSelectionInterface, 200, {leading: true, trailing: true});
+            this.updateSelectionInterfaceComplete = _debounce(this.updateSelectionInterfaceComplete, 200, {leading: true, trailing: true});
+            this.updateSelectionInterfaceComplete();
+        },
+        updateSelectionInterfaceComplete: function(){
+            this.options.selectionInterface.setCompleteActiveSearchResults(this.model.fullCollection.reduce(function(results, result){
+                results.push(result);
+                if (result.duplicates) {
+                    results = results.concat(result.duplicates);
+                }
+                return results;
+            }, []));
         },
         updateSelectionInterface: function(){
             this.options.selectionInterface.setActiveSearchResults(this.model.reduce(function(results, result){
@@ -36,7 +48,7 @@ define([
                     results = results.concat(result.duplicates);
                 }
                 return results;
-            }, []))
+            }, []));
         },
         events: {
             'click .first': 'firstPage',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/workspace-content/tabs-workspace-content.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/tabs/workspace-content/tabs-workspace-content.view.js
@@ -31,6 +31,7 @@ define([
             this.options.selectionInterface.setCurrentQuery(undefined);
             this.options.selectionInterface.setActiveSearchResults([]);
             this.options.selectionInterface.clearSelectedResults();
+            this.options.selectionInterface.setCompleteActiveSearchResults([]);
         },
         onDestroy: function(){
             this.closePanelTwo();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/upload/upload.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/upload/upload.js
@@ -44,6 +44,11 @@ define([
                 type: Backbone.Many,
                 key: 'activeSearchResults',
                 relatedModel: Metacard.MetacardResult
+            },
+            {
+                type: Backbone.Many,
+                key: 'completeActiveSearchResults',
+                relatedModel: Metacard.MetacardResult
             }
         ],
         defaults: {
@@ -53,11 +58,30 @@ define([
             selectedResults: [],
             activeSearchResults: [],
             activeSearchResultsAttributes: [],
+            completeActiveSearchResults: [],
+            completeActiveSearchResultsAttributes: [],
         },
         initialize: function(){
             this.set('currentResult', new Metacard.SearchResult());
             this.listenTo(this, 'change:currentUpload', this.clearSelectedResults);
             this.listenTo(this.get('activeSearchResults'), 'update add remove reset', this.updateActiveSearchResultsAttributes);
+            this.listenTo(this.get('completeActiveSearchResults'), 'update add remove reset', this.updateActiveSearchResultsFullAttributes);
+        },
+        updateActiveSearchResultsFullAttributes: function() {
+            var availableAttributes = this.get('completeActiveSearchResults').reduce(function(currentAvailable, result) {
+                currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
+                return currentAvailable;
+            }, []).sort();
+            this.set('completeActiveSearchResultsAttributes', availableAttributes);
+        },
+        getCompleteActiveSearchResultsAttributes: function(){
+            return this.get('completeActiveSearchResultsAttributes');
+        },
+        getCompleteActiveSearchResults: function(){
+            return this.get('completeActiveSearchResults');
+        },
+        setCompleteActiveSearchResults: function(results){
+            this.get('completeActiveSearchResults').reset(results.models || results);
         },
         updateActiveSearchResultsAttributes: function(){
             var availableAttributes = this.get('activeSearchResults').reduce(function(currentAvailable, result) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.hbs
@@ -17,6 +17,13 @@
 <div class="histogram-attribute">
 
 </div>
+<div class="histogram-no-matching-data">
+    <h3>
+        <span class="fa fa-exclamation-triangle">
+        </span>
+        Nothing in the current result set contains this attribute.
+    </h3>
+</div>
 <div class="histogram-container">
 
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.less
@@ -1,3 +1,16 @@
+//plotly styling only
+@{customElementNamespace}histogram{
+  .hovertext rect, .hovertext path, .axistext path {
+    fill: @dropdown-background-color !important;
+    stroke: @text-color !important;
+    fill-opacity: 1 !important;
+  }
+
+  .hovertext text, .axistext text {
+    fill: @text-color !important;
+  }
+}
+
 @{customElementNamespace}histogram {
   .customElement;
 
@@ -24,9 +37,14 @@
     transform: translateX(0%);
   }
 
-  > .histogram-empty {
+  > .histogram-empty, > .histogram-no-matching-data {
     text-align: center;
+    padding: @largeSpacing;
     display: none;
+
+    span {
+      color: @warning-color;
+    }
   }
 
 }
@@ -45,6 +63,16 @@
   }
 
 }
+
+@{customElementNamespace}histogram.no-matching-data:not(.is-empty) {
+  overflow: hidden;
+
+  > .histogram-no-matching-data {
+    display: block;
+  }
+
+}
+
 
 .is-medium-screen, .is-small-screen, .is-mobile-screen {
   @{customElementNamespace}histogram {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/store.js
@@ -130,6 +130,15 @@ define([
         removeSelectedResult: function(metacard){
             this.getSelectedResults().remove(metacard);
         },
+        getCompleteActiveSearchResultsAttributes: function(){
+            return this.get('content').getCompleteActiveSearchResultsAttributes();
+        },
+        getCompleteActiveSearchResults: function(){
+            return this.get('content').getCompleteActiveSearchResults();
+        },
+        setCompleteActiveSearchResults: function(results){
+            this.get('content').setCompleteActiveSearchResults(results);
+        },
         getActiveSearchResultsAttributes: function(){
             return this.get('content').getActiveSearchResultsAttributes();
         },


### PR DESCRIPTION
- Added new method to calculate categories for date type histograms.
 - Updated single click methods to utilize the getCategories methods instead of trying to calculate the single bin.  This is more reliable.
 - Do note that plotly uses a special convention sometimes for date bin sizes.  Instead of a number, they give a string like so: 'M3'.  Where M means months, and the number following M means the number of months.
 - Updates histogram to use full result set rather than page
 - Adds guard for attributes that have no matching data.
 - Updates new selection interface attribute to be cleared when going back to searches from results.
 - Updates metacard.js to account for new selection interface attribute
 - Updates the histogram tooltips to be more consistent with the rest of the UI, and readable.

@jlcsmith 
@kcwire 
@pklinef 