### PR TITLE
DDF-2824 fixed typo in docs section heading

### DIFF
--- a/distribution/docs/src/main/resources/content/_developingComponents/assuring-authenticity-of-bundles-and-applications-contents.adoc
+++ b/distribution/docs/src/main/resources/content/_developingComponents/assuring-authenticity-of-bundles-and-applications-contents.adoc
@@ -7,7 +7,7 @@
 
 ${branding} Artifacts in the JAR file format (such as bundles or ${branding} applications packaged as KAR files) can be signed and verified using the tools included as part of the Java Runtime Environment.
 
-===== Prerequisites
+==== Prerequisites
 
 To work with Java signatures, a keystore/truststore is required.
 For testing or trial purposes ${branding} can sign and validate using a self-signed certificate, generated with the keytool utility.
@@ -38,7 +38,7 @@ Enter key password for <selfsigned>
 Re-enter new password:
 ----
 
-===== Signing a JAR/KAR
+==== Signing a JAR/KAR
 
 Once a keystore is available, the JAR can be signed using the `jarsigner`
  tool.

--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -2,6 +2,7 @@ Version ${project.version}. Copyright (c) Codice Foundation
 :imagesdir: ${project.build.directory}/doc-contents/images
 :title: ${branding-expanded} Documentation
 :type: config
+:status: published
 :toc: left
 :toclevels: 6
 :example-caption:


### PR DESCRIPTION
#### What does this PR do?

Adjust section heading levels in docs to follow asciidoctor outline. 
Also added a "status" property to config.adoc

#### Who is reviewing it? 

@mcalcote @vinamartin @emmberk @Lambeaux @jrnorth 


#### Choose 2 committers to review/merge the PR. 

@clockard
@coyotesqrl
@lessarderic
@pklinef
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

builds successfully.
#### Any background context you want to provide?

This will remove instances of 'Section header out of order...' warnings in build logs.
`:status: published` gives the config.adoc file a valid header in regards to the templates and clears up noise in build logs.

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Screenshots (if appropriate)


#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
