### PR TITLE
DDF-3304 Upgraded maven-deploy-plugin and maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>2.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>clean install</preparationGoals>


### PR DESCRIPTION
#### What does this PR do?

* Upgrades maven-deploy-plugin from 2.6 to 2.8.2
* Upgrades maven-releaes-plugin from 2.5.1 to 2.5.3

Upgrading to a newer version will allow for retrying on failed deploys

The previous version of the maven-release plugin did not work correctly on windows

#### Who is reviewing it?
 
@LinkMJB @emanns95 

#### Select relevant component teams: 

@codice/build 

#### Choose 2 committers to review/merge the PR. 

@shaundmorris 
@clockard 

#### Any background context you want to provide?

The build pipeline specifies ` -DretryFailedDeploymentCount=10` during the deploy stage, however this was being ignored due to it not being supported in the version of the deploy plugin in use.

#### What are the relevant tickets?

[DDF-3304](https://codice.atlassian.net/browse/DDF-3304)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
