### PR TITLE
DDF-3262 Increase Solr string indexing size and exclude attributes

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SchemaFields.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SchemaFields.java
@@ -14,6 +14,7 @@
 package ddf.catalog.source.solr;
 
 import ddf.catalog.data.AttributeType.AttributeFormat;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,36 +64,40 @@ public class SchemaFields {
 
   public static final String SORT_KEY_SUFFIX = "_sk";
 
-  private static final Map<String, AttributeFormat> SUFFIX_TO_FORMAT_MAP = new HashMap<>();
+  protected static final Map<String, AttributeFormat> SUFFIX_TO_FORMAT_MAP;
 
-  private static final Map<AttributeFormat, String> FORMAT_TO_SUFFIX_MAP = new HashMap<>();
+  protected static final Map<AttributeFormat, String> FORMAT_TO_SUFFIX_MAP;
 
   static {
-    SUFFIX_TO_FORMAT_MAP.put(GEO_SUFFIX, AttributeFormat.GEOMETRY);
-    SUFFIX_TO_FORMAT_MAP.put(DATE_SUFFIX, AttributeFormat.DATE);
-    SUFFIX_TO_FORMAT_MAP.put(BINARY_SUFFIX, AttributeFormat.BINARY);
-    SUFFIX_TO_FORMAT_MAP.put(XML_SUFFIX, AttributeFormat.XML);
-    SUFFIX_TO_FORMAT_MAP.put(TEXT_SUFFIX, AttributeFormat.STRING);
-    SUFFIX_TO_FORMAT_MAP.put(BOOLEAN_SUFFIX, AttributeFormat.BOOLEAN);
-    SUFFIX_TO_FORMAT_MAP.put(DOUBLE_SUFFIX, AttributeFormat.DOUBLE);
-    SUFFIX_TO_FORMAT_MAP.put(FLOAT_SUFFIX, AttributeFormat.FLOAT);
-    SUFFIX_TO_FORMAT_MAP.put(INTEGER_SUFFIX, AttributeFormat.INTEGER);
-    SUFFIX_TO_FORMAT_MAP.put(LONG_SUFFIX, AttributeFormat.LONG);
-    SUFFIX_TO_FORMAT_MAP.put(SHORT_SUFFIX, AttributeFormat.SHORT);
-    SUFFIX_TO_FORMAT_MAP.put(OBJECT_SUFFIX, AttributeFormat.OBJECT);
+    HashMap<String, AttributeFormat> suffixToFormatMap = new HashMap<>();
+    suffixToFormatMap.put(GEO_SUFFIX, AttributeFormat.GEOMETRY);
+    suffixToFormatMap.put(DATE_SUFFIX, AttributeFormat.DATE);
+    suffixToFormatMap.put(BINARY_SUFFIX, AttributeFormat.BINARY);
+    suffixToFormatMap.put(XML_SUFFIX, AttributeFormat.XML);
+    suffixToFormatMap.put(TEXT_SUFFIX, AttributeFormat.STRING);
+    suffixToFormatMap.put(BOOLEAN_SUFFIX, AttributeFormat.BOOLEAN);
+    suffixToFormatMap.put(DOUBLE_SUFFIX, AttributeFormat.DOUBLE);
+    suffixToFormatMap.put(FLOAT_SUFFIX, AttributeFormat.FLOAT);
+    suffixToFormatMap.put(INTEGER_SUFFIX, AttributeFormat.INTEGER);
+    suffixToFormatMap.put(LONG_SUFFIX, AttributeFormat.LONG);
+    suffixToFormatMap.put(SHORT_SUFFIX, AttributeFormat.SHORT);
+    suffixToFormatMap.put(OBJECT_SUFFIX, AttributeFormat.OBJECT);
+    SUFFIX_TO_FORMAT_MAP = Collections.unmodifiableMap(suffixToFormatMap);
 
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.GEOMETRY, GEO_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.DATE, DATE_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.BINARY, BINARY_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.XML, XML_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.STRING, TEXT_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.BOOLEAN, BOOLEAN_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.DOUBLE, DOUBLE_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.FLOAT, FLOAT_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.INTEGER, INTEGER_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.LONG, LONG_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.SHORT, SHORT_SUFFIX);
-    FORMAT_TO_SUFFIX_MAP.put(AttributeFormat.OBJECT, OBJECT_SUFFIX);
+    HashMap<AttributeFormat, String> formatToSuffixMap = new HashMap<>();
+    formatToSuffixMap.put(AttributeFormat.GEOMETRY, GEO_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.DATE, DATE_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.BINARY, BINARY_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.XML, XML_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.STRING, TEXT_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.BOOLEAN, BOOLEAN_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.DOUBLE, DOUBLE_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.FLOAT, FLOAT_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.INTEGER, INTEGER_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.LONG, LONG_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.SHORT, SHORT_SUFFIX);
+    formatToSuffixMap.put(AttributeFormat.OBJECT, OBJECT_SUFFIX);
+    FORMAT_TO_SUFFIX_MAP = Collections.unmodifiableMap(formatToSuffixMap);
   }
 
   public AttributeFormat getFormat(String suffix) {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
@@ -14,6 +14,8 @@
 package ddf.catalog.source.solr;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -31,7 +33,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrInputDocument;
@@ -39,6 +44,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 public class DynamicSchemaResolverTest {
+
+  private static final int INITIAL_FIELDS_CACHE_COUNT = 8;
   /**
    * Verify that when a metacard type has attribute descriptors that inherit from
    * AttributeDescriptorImpl, the attribute descriptors are recreated as AttributeDescriptorsImpls
@@ -83,6 +90,31 @@ public class DynamicSchemaResolverTest {
       assertThat(
           attributeDescriptor.getClass().getName(), is(AttributeDescriptorImpl.class.getName()));
     }
+  }
+
+  @Test
+  public void testAdditionalFieldConstructorWithEmptyList() throws Exception {
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver(Collections.EMPTY_LIST);
+    int fieldsCacheSize = resolver.fieldsCache.size();
+
+    assertThat(fieldsCacheSize, equalTo(INITIAL_FIELDS_CACHE_COUNT));
+  }
+
+  @Test
+  public void testAdditionalFieldConstructor() throws Exception {
+    String someExtraField = "someExtraField";
+    String anotherExtraField = "anotherExtraField";
+
+    List<String> additionalFields = new ArrayList<>();
+    additionalFields.add(someExtraField);
+    additionalFields.add(anotherExtraField);
+
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver(additionalFields);
+
+    assertThat(
+        resolver.fieldsCache.size(), equalTo(INITIAL_FIELDS_CACHE_COUNT + additionalFields.size()));
+    assertThat(resolver.fieldsCache, hasItem(someExtraField));
+    assertThat(resolver.fieldsCache, hasItem(anotherExtraField));
   }
 
   private MetacardType deserializeMetacardType(byte[] serializedMetacardType)

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -2551,6 +2551,37 @@ public class SolrProviderTest extends SolrProviderTestCase {
     queryAndVerifyCount(1, filterBuilder.attribute(Metacard.ANY_TEXT).is().like().text(soughtWord));
   }
 
+  @Test
+  public void testExcludingAttributes() throws Exception {
+
+    deleteAllIn(provider);
+
+    List<Metacard> list = new ArrayList<Metacard>();
+
+    MockMetacard metacard1 = new MockMetacard(Library.getFlagstaffRecord());
+    String soughtWord = "nitf";
+    metacard1.setTitle(soughtWord);
+    list.add(metacard1);
+
+    MockMetacard metacard2 = new MockMetacard(Library.getTampaRecord());
+    list.add(metacard2);
+
+    MockMetacard metacard3 = new MockMetacard(Library.getShowLowRecord());
+    list.add(metacard3);
+
+    create(list);
+
+    QueryImpl query =
+        new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT).is().like().text(soughtWord));
+    Map<String, Serializable> properties = new HashMap<>();
+    properties.put(
+        SolrMetacardClientImpl.EXCLUDE_ATTRIBUTES,
+        com.google.common.collect.Sets.newHashSet(Metacard.TITLE));
+    SourceResponse sourceResponse = provider.query(new QueryRequestImpl(query, properties));
+    assertEquals(1, sourceResponse.getResults().size());
+    assertThat(sourceResponse.getResults().get(0).getMetacard().getTitle(), is(nullValue()));
+  }
+
   /**
    * Testing Tokenization of the search phrase.
    *

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
@@ -21,7 +21,9 @@ import ddf.catalog.source.solr.DynamicSchemaResolver;
 import ddf.catalog.source.solr.SolrFilterDelegateFactory;
 import ddf.catalog.source.solr.SolrMetacardClientImpl;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -32,11 +34,18 @@ import org.apache.solr.common.SolrInputDocument;
 /** {@link SolrCache} specific implementation of {@link SolrMetacardClientImpl}. */
 class CacheSolrMetacardClient extends SolrMetacardClientImpl {
 
+  private static final List<String> ADDITIONAL_FIELDS =
+      Arrays.asList(SolrCache.METACARD_SOURCE_NAME, SolrCache.METACARD_ID_NAME);
+
   public CacheSolrMetacardClient(
       SolrClient client,
       FilterAdapter catalogFilterAdapter,
       SolrFilterDelegateFactory solrFilterDelegateFactory) {
-    super(client, catalogFilterAdapter, solrFilterDelegateFactory, new DynamicSchemaResolver());
+    super(
+        client,
+        catalogFilterAdapter,
+        solrFilterDelegateFactory,
+        new DynamicSchemaResolver(ADDITIONAL_FIELDS));
   }
 
   @Override

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -15,6 +15,7 @@ package org.codice.ddf.catalog.ui.query.cql;
 
 import static spark.Spark.halt;
 
+import com.google.common.collect.Sets;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.filter.FilterBuilder;
@@ -59,6 +60,8 @@ public class CqlRequest {
   private String sort;
 
   private boolean normalize = false;
+
+  private boolean excludeUnnecessaryAttributes = true;
 
   public String getSrc() {
     return src;
@@ -131,6 +134,12 @@ public class CqlRequest {
       queryRequest.getProperties().put("mode", "update");
     }
 
+    if (excludeUnnecessaryAttributes) {
+      queryRequest
+          .getProperties()
+          .put("excludeAttributes", Sets.newHashSet(Metacard.METADATA, "lux"));
+    }
+
     return queryRequest;
   }
 
@@ -199,5 +208,13 @@ public class CqlRequest {
 
   public void setId(String id) {
     this.id = id;
+  }
+
+  public boolean isExcludeUnnecessaryAttributes() {
+    return excludeUnnecessaryAttributes;
+  }
+
+  public void setExcludeUnnecessaryAttributes(boolean excludeUnnecessaryAttributes) {
+    this.excludeUnnecessaryAttributes = excludeUnnecessaryAttributes;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -85,6 +85,7 @@ define([
                     scheduleUnits: 'minutes',
                     timeType: 'modified',
                     radiusUnits: 'meters',
+                    excludeUnnecessaryAttributes: true,
                     radius: 0,
                     count: properties.resultCount,
                     start: 1,

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -72,7 +72,9 @@ define([
                 }
             },
             addQuery: function () {
-                var query = new Query.Model();
+                var query = new Query.Model({
+                    excludeUnnecessaryAttributes: false
+                });
                 this.get('queries').add(query);
                 return query.get('id');
             },
@@ -229,6 +231,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Local',
                     federation: 'local',
+                    excludeUnnecessaryAttributes: false,
                     cql: "anyText ILIKE '*'"
                 });
                 this.create({
@@ -242,6 +245,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Federated',
                     federation: 'enterprise',
+                    excludeUnnecessaryAttributes: false,
                     cql: "anyText ILIKE '*'"
                 });
                 this.create({
@@ -254,6 +258,7 @@ define([
             createGeoWorkspace: function(){
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Location',
+                    excludeUnnecessaryAttributes: false,
                     cql: "anyText ILIKE '*' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))"
                 });
                 this.create({
@@ -266,6 +271,7 @@ define([
             createLatestWorkspace: function(){
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Temporal',
+                    excludeUnnecessaryAttributes: false,
                     cql: 'anyText ILIKE \'*\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')'
                 });
                 this.create({

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolver.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolver.java
@@ -89,7 +89,10 @@ public class FilteringDynamicSchemaResolver extends DynamicSchemaResolver {
 
   @Override
   public String getCaseSensitiveField(String mappedPropertyName) {
-    String field = super.getCaseSensitiveField(mappedPropertyName);
+    String field =
+        mappedPropertyName.split(SchemaFields.TEXT_SUFFIX, 0)[0]
+            + getFieldSuffix(AttributeType.AttributeFormat.STRING)
+            + getSpecialIndexSuffix(AttributeType.AttributeFormat.STRING);
     usedFields.add(field);
     return field;
   }
@@ -103,7 +106,10 @@ public class FilteringDynamicSchemaResolver extends DynamicSchemaResolver {
 
   @Override
   public String getWhitespaceTokenizedField(String mappedPropertyName) {
-    String field = super.getWhitespaceTokenizedField(mappedPropertyName);
+    String field =
+        mappedPropertyName.split(SchemaFields.TEXT_SUFFIX, 0)[0]
+            + getFieldSuffix(AttributeType.AttributeFormat.STRING)
+            + getSpecialIndexSuffix(AttributeType.AttributeFormat.STRING);
     usedFields.add(field);
     return field;
   }

--- a/catalog/ui/search-ui/search-endpoint/src/test/groovy/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolverTest.groovy
+++ b/catalog/ui/search-ui/search-endpoint/src/test/groovy/org/codice/ddf/ui/searchui/query/solr/FilteringDynamicSchemaResolverTest.groovy
@@ -44,6 +44,8 @@ class FilteringDynamicSchemaResolverTest extends Specification {
 
     public static final String METADATA_TXT_FIELD = "$Metacard.METADATA$SchemaFields.TEXT_SUFFIX"
 
+    public static final String METADATA_TXT_TOKENIZED_FIELD = "$METADATA_TXT_FIELD$SchemaFields.TOKENIZED"
+
     public static final String METADATA_TXT_WS_FIELD = "$METADATA_TXT_FIELD$SchemaFields.WHITESPACE_TEXT_SUFFIX"
 
     public static final String METADATA_TXT_WS_HAS_CASE_FIELD = "$METADATA_TXT_WS_FIELD$SchemaFields.HAS_CASE"
@@ -143,8 +145,7 @@ class FilteringDynamicSchemaResolverTest extends Specification {
         resolver.addFields(metacard, solrDoc)
 
         then:
-        solrDoc.getFieldNames().size() == 5
-        solrDoc.getFieldNames().contains(METADATA_TXT_WS_HAS_CASE_FIELD)
+        solrDoc.getFieldNames().contains(METADATA_TXT_TOKENIZED_FIELD)
     }
 
     def "Do not filter used whitespace tokenized fields"() {
@@ -153,8 +154,7 @@ class FilteringDynamicSchemaResolverTest extends Specification {
         resolver.addFields(metacard, solrDoc)
 
         then:
-        solrDoc.getFieldNames().size() == 4
-        solrDoc.getFieldNames().contains(METADATA_TXT_WS_FIELD)
+        solrDoc.getFieldNames().contains(METADATA_TXT_TOKENIZED_FIELD)
     }
 
     def "Do not filter used fields"() {

--- a/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/schema.xml
@@ -234,10 +234,9 @@
     <!-- copyField commands copy one field to another at the time a document
           is added to the index.  It's used either to index the same field differently,
           or to add multiple fields to the same field for easier/faster searching.  -->
-    <copyField source="*_txt" dest="*_txt_tokenized"/>
-    <copyField source="*_txt" dest="*_txt_tokenized_has_case"/>
-    <copyField source="*_txt" dest="*_txt_ws"/>
-    <copyField source="*_txt" dest="*_txt_ws_has_case"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_tokenized_has_case"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_ws"/>
+    <copyField source="*_txt_tokenized" dest="*_txt_ws_has_case"/>
 
     <!-- Necessary for Spatial4j to work -->
     <copyField source="*_geo" dest="*_geo_index"/>


### PR DESCRIPTION
#### What does this PR do?
Allow Solr tokenized txt field to index more data than txt string field.
Support excluding attributes from Solr response.

#### Who is reviewing it? 
@brendan-hofmann 
@bdeining 

#### Select relevant component teams: 
@codice/solr 

#### Choose 2 committers to review/merge the PR. 
@jlcsmith
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Create or modify a record with a string field (e.g. title, description) that contains over 32k of text.  At the end of the text (past 32k) include a unique word.  Verify that the record ingests, the unique word past the 32k is searchable, and the first 32k of the string is returned.

#### Any background context you want to provide?
This provides the ability to search more than 32k of text that is extracted by the Tika transformer after the DDF-3268 changes to the Tika transformer.
https://github.com/codice/ddf/pull/2302

#### What are the relevant tickets?
[DDF-3262](https://codice.atlassian.net/browse/DDF-3262)

#### Screenshots (if appropriate)

#### Checklist:
- [ n/a ] Documentation Updated
- [x] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
