### PR TITLE
DDF-3335 Fixed null service reference in platform-scheduler

### DIFF
--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/SecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/SecurityTest.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.security;
+package org.codice.ddf.security.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;

--- a/platform/security/common/src/test/java/org/codice/ddf/security/common/SecurityTest.java
+++ b/platform/security/common/src/test/java/org/codice/ddf/security/common/SecurityTest.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.security.common;
 
+import static org.codice.ddf.security.common.Security.MAX_RETRIES;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -39,12 +41,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.security.PrivilegedAction;
 import java.util.concurrent.Callable;
+import net.jodah.failsafe.RetryPolicy;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.subject.ExecutionException;
 import org.apache.shiro.subject.PrincipalCollection;
-import org.codice.ddf.security.common.Security;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -178,6 +180,121 @@ public class SecurityTest {
     configureMocksForBundleContext("bad-alias");
 
     assertThat(security.getSystemSubject(), equalTo(null));
+  }
+
+  @Test
+  public void testGetSecurityManager() {
+    final Bundle bundle = mock(Bundle.class);
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(bundle);
+    final BundleContext bundleContext = mock(BundleContext.class);
+    when(bundle.getBundleContext()).thenReturn(bundleContext);
+    final ServiceReference securityManagerServiceReference = mock(ServiceReference.class);
+    when(bundleContext.getServiceReference(SecurityManager.class))
+        .thenReturn(securityManagerServiceReference);
+    final SecurityManager securityManager = mock(SecurityManager.class);
+    when(bundleContext.getService(securityManagerServiceReference)).thenReturn(securityManager);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), is(securityManager));
+          return null;
+        });
+  }
+
+  /** Tests the default retryPolicy for the getSecurityManager method */
+  @Test
+  public void testGetSecurityManagerWhenTheSecurityManagerServiceIsNotImmediatelyAvailable() {
+    final Bundle bundle = mock(Bundle.class);
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(bundle);
+    final BundleContext bundleContext = mock(BundleContext.class);
+    when(bundle.getBundleContext()).thenReturn(bundleContext);
+    final ServiceReference securityManagerServiceReference = mock(ServiceReference.class);
+    when(bundleContext.getServiceReference(SecurityManager.class))
+        .thenReturn(securityManagerServiceReference);
+    final SecurityManager securityManager = mock(SecurityManager.class);
+    // the SecurityManager service is available by the 3rd (less than the max retries) try
+    when(bundleContext.getService(securityManagerServiceReference))
+        .thenReturn(null, null, securityManager);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), is(securityManager));
+          return null;
+        });
+  }
+
+  @Test
+  public void testGetSecurityManagerWhenUnableToGetSecurityManagerService() {
+    // inject a RetryPolicy that does not include a delay so that the unit test completes quickly
+    security.retryPolicySupplier =
+        () -> new RetryPolicy().withMaxRetries(MAX_RETRIES).retryWhen(null);
+
+    final Bundle bundle = mock(Bundle.class);
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(bundle);
+    final BundleContext bundleContext = mock(BundleContext.class);
+    when(bundle.getBundleContext()).thenReturn(bundleContext);
+    final ServiceReference securityManagerServiceReference = mock(ServiceReference.class);
+    when(bundleContext.getServiceReference(SecurityManager.class))
+        .thenReturn(securityManagerServiceReference);
+    // the SecurityManager service is never available
+    when(bundleContext.getService(securityManagerServiceReference)).thenReturn(null);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), nullValue());
+          return null;
+        });
+  }
+
+  @Test
+  public void testGetSecurityManagerWhenUnableToGetSecurityManagerServiceReference() {
+    // inject a RetryPolicy that does not include a delay so that the unit test completes quickly
+    security.retryPolicySupplier =
+        () -> new RetryPolicy().withMaxRetries(MAX_RETRIES).retryWhen(null);
+
+    final Bundle bundle = mock(Bundle.class);
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(bundle);
+    final BundleContext bundleContext = mock(BundleContext.class);
+    when(bundle.getBundleContext()).thenReturn(bundleContext);
+    when(bundleContext.getServiceReference(SecurityManager.class)).thenReturn(null);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), nullValue());
+          return null;
+        });
+  }
+
+  @Test
+  public void testGetSecurityManagerWhenUnableToGetBundleContext() {
+    // inject a RetryPolicy that does not include a delay so that the unit test completes quickly
+    security.retryPolicySupplier =
+        () -> new RetryPolicy().withMaxRetries(MAX_RETRIES).retryWhen(null);
+
+    final Bundle bundle = mock(Bundle.class);
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(bundle);
+    when(bundle.getBundleContext()).thenReturn(null);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), nullValue());
+          return null;
+        });
+  }
+
+  @Test
+  public void testGetSecurityManagerWhenUnableToGetBundle() {
+    // inject a RetryPolicy that does not include a delay so that the unit test completes quickly
+    security.retryPolicySupplier =
+        () -> new RetryPolicy().withMaxRetries(MAX_RETRIES).retryWhen(null);
+
+    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(null);
+
+    security.runAsAdmin(
+        () -> {
+          assertThat(security.getSecurityManager(), nullValue());
+          return null;
+        });
   }
 
   @Test


### PR DESCRIPTION
# DO NOT MERGE

#### What does this PR do?
This PR fixes a NPE when a `ddf.platform.scheduler.Command` configuration exists on startup.

See https://github.com/codice/ddf/pull/2357#discussion_r140836331.
#### Who is reviewing it? 
@peterhuffer @vinamartin 
#### Select relevant component teams: 
@codice/test 
@codice/security @stustison 
#### Choose 2 committers to review/merge the PR.
@clockard
@lessarderic
#### How should this be tested?
1. Install DDF.
2. Follow the documentation to add a `Platform Command Scheduler` configuration, e.g.
    - `Command`: "removeall -f expired"
    - `Interval`: "10"
    - `Interval Type`: "Second Interval"
3. Restart DDF.
4. Confirm that there are no errors in the log like
```
15:39:21,467 | ERROR | heduler_Worker-1 | org.quartz.core.JobRunShell               222 | platform-scheduler   | Job CommandJob.job1505774360984 threw an unhandled Exception:
java.lang.NullPointerException: A null service reference is not allowed.
    at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:617) ~[?:?]
    at org.codice.ddf.security.common.Security.getSecurityManager(Security.java:305) ~[?:?]
    at org.codice.ddf.security.common.Security.getSystemSubject(Security.java:228) ~[?:?]
    at ddf.platform.scheduler.CommandJob.getSystemSubject(CommandJob.java:54) ~[?:?]
    at ddf.platform.scheduler.CommandJob.lambda$execute$1(CommandJob.java:60) ~[?:?]
    at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
    at javax.security.auth.Subject.doAs(Subject.java:360) [?:?]
    at org.codice.ddf.security.common.Security.runAsAdmin(Security.java:312) [261:platform-scheduler:2.11.0.2017-09-18110909]
    at ddf.platform.scheduler.CommandJob.execute(CommandJob.java:59) [261:platform-scheduler:2.11.0.2017-09-18110909]
    at org.quartz.core.JobRunShell.run(JobRunShell.java:213) [261:platform-scheduler:2.11.0.2017-09-18110909]
    at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:557) [261:platform-scheduler:2.11.0.2017-09-18110909]
15:39:21,480 | ERROR | heduler_Worker-1 | org.quartz.core.ErrorLogger              2361 | platform-scheduler   | Job (CommandJob.job1505774360984 threw an exception.
org.quartz.SchedulerException: Job threw an unhandled exception.
    at org.quartz.core.JobRunShell.run(JobRunShell.java:224) [261:platform-scheduler:2.11.0.2017-09-18110909]
    at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:557) [261:platform-scheduler:2.11.0.2017-09-18110909]
Caused by: java.lang.NullPointerException: A null service reference is not allowed.
    at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:617) ~[?:?]
    at org.codice.ddf.security.common.Security.getSecurityManager(Security.java:305) ~[?:?]
    at org.codice.ddf.security.common.Security.getSystemSubject(Security.java:228) ~[?:?]
    at ddf.platform.scheduler.CommandJob.getSystemSubject(CommandJob.java:54) ~[?:?]
    at ddf.platform.scheduler.CommandJob.lambda$execute$1(CommandJob.java:60) ~[?:?]
    at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
    at javax.security.auth.Subject.doAs(Subject.java:360) ~[?:?]
    at org.codice.ddf.security.common.Security.runAsAdmin(Security.java:312) ~[?:?]
    at ddf.platform.scheduler.CommandJob.execute(CommandJob.java:59) ~[?:?]
    at org.quartz.core.JobRunShell.run(JobRunShell.java:213) ~[?:?]
    ... 1 more
```
5. Also confirm that the command is still executed as specified. For the `removeall` command, for example, there will be an log message every time that the command is executed.
#### What are the relevant tickets?
[DDF-3335](https://codice.atlassian.net/browse/DDF-3335)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
