### PR TITLE
DDF-3314 - Adding directory filtering when processing a zip file during migration import

### DIFF
--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
@@ -101,6 +101,7 @@ public class ImportMigrationManagerImpl implements Closeable {
       // add a system contexts
       contexts.put(null, new ImportMigrationContextImpl(report, zip));
       zip.stream()
+          .filter(ze -> !ze.isDirectory())
           .map(ze -> new ImportMigrationEntryImpl(this::getContextFor, ze))
           .forEach(me -> me.getContext().addEntry(me));
       metadata = retrieveMetadata();


### PR DESCRIPTION
#### What does this PR do?
Adds directory filtering when processing a zip file during migration import.
#### Who is reviewing it? 
@brjeter 
@Lambeaux 
@tbatie 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@figliold
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
Run the migration:export command. Then unzip it the content. Re-zip the content from the command line:
- first cd to the exported-XXXX directory created
- zip -r -X ../exported-XXXX *
Finally, run the migration:import command using the newly created zip file.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3314](https://codice.atlassian.net/browse/DDF-3314)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
