### PR TITLE
DDF-3306 Display an alert in the Admin Console if the users.properties file exists

### DIFF
--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/UsersPropertiesFileValidator.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/UsersPropertiesFileValidator.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.admin.insecure.defaults.service;
 
+import ddf.security.common.audit.SecurityLogger;
 import java.util.List;
 import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
@@ -33,6 +34,9 @@ public class UsersPropertiesFileValidator extends PropertiesFileValidator {
 
   static final String CANNOT_PARSE_PASSWORD_MSG =
       "Unable to determine if [%s] is using insecure defaults. Cannot parse password from [%s].";
+
+  static final String USERS_PROPERTIES_FILE_EXISTS_MSG =
+      "The users.properties file is present at [%s].";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UsersPropertiesFileValidator.class);
 
@@ -66,6 +70,10 @@ public class UsersPropertiesFileValidator extends PropertiesFileValidator {
     Properties properties = readFile(false);
 
     if (properties != null && properties.size() > 0) {
+      // the existence of the properties file is an insecure default
+      SecurityLogger.audit("System is running with the users.properties file.");
+      alerts.add(
+          new Alert(Level.WARN, String.format(USERS_PROPERTIES_FILE_EXISTS_MSG, path.toString())));
       validateAdminUser(properties);
       validateCertificateUser(properties);
     }

--- a/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/UsersPropertiesFileValidatorTest.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/UsersPropertiesFileValidatorTest.java
@@ -94,7 +94,7 @@ public class UsersPropertiesFileValidatorTest {
               path,
               DEFAULT_ADMIN_USER_PASSWORD)
         };
-    assertThat(alerts.size(), is(3));
+    assertThat(alerts.size(), is(4));
     assertThat(actualAlertMessages, hasItems(expectedAlertMessages));
   }
 
@@ -113,7 +113,7 @@ public class UsersPropertiesFileValidatorTest {
     List<Alert> alerts = propertiesFileValidator.validate();
 
     // Verify
-    assertThat(alerts.size(), is(0));
+    assertThat(alerts.size(), is(1));
   }
 
   @Test
@@ -134,7 +134,7 @@ public class UsersPropertiesFileValidatorTest {
     List<Alert> alerts = propertiesFileValidator.validate();
 
     // Verify
-    assertThat(alerts.size(), is(0));
+    assertThat(alerts.size(), is(1));
   }
 
   private List<String> getActualAlertMessages(List<Alert> alerts) {


### PR DESCRIPTION
#### What does this PR do?
Adds another insecure default detail to the insecure defaults alert and logs a security audit message.
#### Who is reviewing it? 
@emmberk @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
@rzwiefel
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and wait for the insecure defaults alert to appear in the admin ui (could take up to 5 min).
Verify that the insecure defaults alert details contains an line for the existence of the users.properties file (see screenshot below). 
Verify that the security.log in data/logs contains an entry `System is running with the users.properties file.`

#### What are the relevant tickets?
[DDF-3306](https://codice.atlassian.net/browse/DDF-3306)
#### Screenshots (if appropriate)
![screen shot 2017-09-20 at 4 53 20 pm](https://user-images.githubusercontent.com/5248090/30829374-78ea87da-a1f5-11e7-86fe-17910d3f12b4.png)
#### Checklist:
- [X] Update / Add Unit Tests
