### PR TITLE
DDF-3317 Add better handling of Tika extraction errors

### DIFF
--- a/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.sl.usermodel.SlideShow;
 import org.apache.poi.sl.usermodel.SlideShowFactory;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
@@ -111,7 +112,11 @@ public class PptxInputTransformer implements InputTransformer {
       Metacard metacard =
           extractInitialMetadata(fileBackedOutputStream.asByteSource().openStream());
 
-      extractThumbnail(metacard, fileBackedOutputStream.asByteSource().openStream());
+      try {
+        extractThumbnail(metacard, fileBackedOutputStream.asByteSource().openStream());
+      } catch (EncryptedDocumentException e) {
+        LOGGER.debug("Unable to generate thumbnail", e);
+      }
       return metacard;
     }
   }
@@ -140,6 +145,7 @@ public class PptxInputTransformer implements InputTransformer {
    * @param metacard
    * @param input
    * @throws IOException
+   * @throws EncryptedDocumentException
    */
   private void extractThumbnail(Metacard metacard, InputStream input) throws IOException {
 

--- a/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.transformer.input.pptx;
 
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.transformer.input.tika.TikaInputTransformer;
@@ -33,6 +35,8 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.apache.poi.openxml4j.util.Nullable;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class PptxInputTransformerTest {
@@ -64,11 +68,15 @@ public class PptxInputTransformerTest {
     t.transform(null);
   }
 
-  @Test(expected = CatalogTransformerException.class)
+  @Test
   public void testPasswordProtected() throws IOException, CatalogTransformerException {
     PptxInputTransformer t = new PptxInputTransformer(inputTransformer);
     try (InputStream is = getResource("/password-powerpoint.pptx")) {
-      t.transform(is);
+      Metacard metacard = t.transform(is);
+      assertThat(metacard, notNullValue());
+      assertThat(metacard.getThumbnail(), nullValue());
+      MatcherAssert.assertThat(
+          metacard.getAttribute(Core.DATATYPE).getValue(), Matchers.is("Dataset"));
     }
   }
 

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -596,6 +596,16 @@ public class TikaInputTransformerTest {
   }
 
   @Test
+  public void testBadPpt() throws Exception {
+    InputStream stream =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream("testBadPPT.ppt");
+    Metacard metacard = transform(stream);
+    assertNotNull(metacard);
+    assertNull(metacard.getMetadata());
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is("Dataset"));
+  }
+
+  @Test
   public void testXls() throws Exception {
     InputStream stream =
         Thread.currentThread().getContextClassLoader().getResourceAsStream("testEXCEL.xls");


### PR DESCRIPTION
Adding a catch throwable around the Tika metadata extraction that logs the error
Changing the flow so that the transform will continue given a Tika extraction failure

#### What does this PR do?
This PR provides better Tika exception handling. 
A catch throwable is used to wrap the Tika extraction because it's hard to capture all of the possible Tika exceptions.
The flow was changed so that an exception in the Tika extraction will not prevent the transform.

#### Who is reviewing it? 
@dcruver @beyelerb @kcwire 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3317](https://codice.atlassian.net/browse/DDF-3317)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
