### PR TITLE
DDF-3318 Update URLResourceReader usages to include basic auth info

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -738,7 +738,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     if (serializableId != null) {
       String metacardId = serializableId.toString();
       WebClient restClient = newRestClient(null, metacardId, true, null);
-      if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+      if (StringUtils.isNotBlank(username)) {
         requestProperties.put(USERNAME_PROPERTY, username);
         requestProperties.put(PASSWORD_PROPERTY, password);
       }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -117,6 +117,10 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   private static final String LOCAL_SEARCH_PARAMETER = "local";
 
+  private static final String USERNAME_PROPERTY = "username";
+
+  private static final String PASSWORD_PROPERTY = "password";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchSource.class);
 
   private final EncryptionService encryptionService;
@@ -733,6 +737,10 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     if (serializableId != null) {
       String metacardId = serializableId.toString();
       WebClient restClient = newRestClient(null, metacardId, true, null);
+      if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+        requestProperties.put(USERNAME_PROPERTY, username);
+        requestProperties.put(PASSWORD_PROPERTY, password);
+      }
       return resourceReader.retrieveResource(restClient.getCurrentURI(), requestProperties);
     }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -119,6 +119,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   private static final String USERNAME_PROPERTY = "username";
 
+  @SuppressWarnings("squid:S2068" /*Key for the requestProperties map, not a hardcoded password*/)
   private static final String PASSWORD_PROPERTY = "password";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchSource.class);

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/TestOpenSearchSource.java
@@ -14,10 +14,13 @@
 package ddf.catalog.source.opensearch.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doReturn;
@@ -577,6 +580,42 @@ public class TestOpenSearchSource {
     requestProperties.put(Metacard.ID, SAMPLE_ID);
 
     // when
+    ResourceResponse response = source.retrieveResource(null, requestProperties);
+    assertThat(response.getResource().getByteArray().length, is(3));
+  }
+
+  /**
+   * Retrieve Product case using Basic Authentication. Test that the properties map passed to the
+   * resource reader includes a username and password.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testRetrieveResourceBasicAuth() throws Exception {
+
+    ResourceReader mockReader = mock(ResourceReader.class);
+    when(response.getEntity()).thenReturn(getBinaryData());
+    when(mockReader.retrieveResource(
+            any(URI.class),
+            argThat(
+                allOf(
+                    hasEntry("username", (Serializable) "user"),
+                    hasEntry("password", (Serializable) "secret")))))
+        .thenReturn(new ResourceResponseImpl(new ResourceImpl(getBinaryData(), "")));
+    when(encryptionService.decryptValue("secret")).thenReturn("secret");
+    MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+    headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("application/octet-stream"));
+    when(response.getHeaders()).thenReturn(headers);
+
+    source.setLocalQueryOnly(true);
+    source.setInputTransformer(getMockInputTransformer());
+    source.setResourceReader(mockReader);
+    source.setUsername("user");
+    source.setPassword("secret");
+
+    Map<String, Serializable> requestProperties = new HashMap<>();
+    requestProperties.put(Metacard.ID, SAMPLE_ID);
+
     ResourceResponse response = source.retrieveResource(null, requestProperties);
     assertThat(response.getResource().getByteArray().length, is(3));
   }

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -918,6 +918,14 @@ public abstract class AbstractCswSource extends MaskableImpl
       URI resourceUri, Map<String, Serializable> requestProperties)
       throws IOException, ResourceNotFoundException, ResourceNotSupportedException {
 
+    String username = cswSourceConfiguration.getUsername();
+    String password = cswSourceConfiguration.getPassword();
+
+    if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+      requestProperties.put(USERNAME_PROPERTY, username);
+      requestProperties.put(PASSWORD_PROPERTY, password);
+    }
+
     if (canRetrieveResourceById()) {
       // If no resource reader was found, retrieve the product through a GetRecordById request
       Serializable serializableId = null;

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -918,75 +918,82 @@ public abstract class AbstractCswSource extends MaskableImpl
       URI resourceUri, Map<String, Serializable> requestProperties)
       throws IOException, ResourceNotFoundException, ResourceNotSupportedException {
 
+    Serializable serializableId = null;
     String username = cswSourceConfiguration.getUsername();
     String password = cswSourceConfiguration.getPassword();
 
-    if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
-      requestProperties.put(USERNAME_PROPERTY, username);
-      requestProperties.put(PASSWORD_PROPERTY, password);
+    if (requestProperties != null) {
+      serializableId = requestProperties.get(Core.ID);
+      if (StringUtils.isNotBlank(username)) {
+        requestProperties.put(USERNAME_PROPERTY, username);
+        requestProperties.put(PASSWORD_PROPERTY, password);
+      }
     }
 
     if (canRetrieveResourceById()) {
       // If no resource reader was found, retrieve the product through a GetRecordById request
-      Serializable serializableId = null;
-      if (requestProperties != null) {
-        serializableId = requestProperties.get(Core.ID);
-      }
-
       if (serializableId == null) {
         throw new ResourceNotFoundException(
             "Unable to retrieve resource because no metacard ID was found.");
       }
       String metacardId = serializableId.toString();
-
       LOGGER.debug("Retrieving resource for ID : {}", metacardId);
-      Csw csw =
-          factory.getClientForSubject(
-              (Subject) requestProperties.get(SecurityConstants.SECURITY_SUBJECT));
-      GetRecordByIdRequest getRecordByIdRequest = new GetRecordByIdRequest();
-      getRecordByIdRequest.setService(CswConstants.CSW);
-      getRecordByIdRequest.setOutputSchema(OCTET_STREAM_OUTPUT_SCHEMA);
-      getRecordByIdRequest.setOutputFormat(MediaType.APPLICATION_OCTET_STREAM);
-      getRecordByIdRequest.setId(metacardId);
-
-      String rangeValue = "";
-      long requestedBytesToSkip = 0;
-      if (requestProperties.containsKey(CswConstants.BYTES_TO_SKIP)) {
-        requestedBytesToSkip = (Long) requestProperties.get(CswConstants.BYTES_TO_SKIP);
-        rangeValue =
-            String.format(
-                "%s%s-",
-                CswConstants.BYTES_EQUAL,
-                requestProperties.get(CswConstants.BYTES_TO_SKIP).toString());
-        LOGGER.debug("Range: {}", rangeValue);
-      }
-      CswRecordCollection recordCollection;
-      try {
-        recordCollection = csw.getRecordById(getRecordByIdRequest, rangeValue);
-
-        Resource resource = recordCollection.getResource();
-        if (resource != null) {
-
-          long responseBytesSkipped = 0L;
-          if (recordCollection.getResourceProperties().get(BYTES_SKIPPED) != null) {
-            responseBytesSkipped =
-                (Long) recordCollection.getResourceProperties().get(BYTES_SKIPPED);
-          }
-          alignStream(resource.getInputStream(), requestedBytesToSkip, responseBytesSkipped);
-
-          return new ResourceResponseImpl(
-              new ResourceImpl(
-                  new BufferedInputStream(resource.getInputStream()),
-                  resource.getMimeTypeValue(),
-                  FilenameUtils.getName(resource.getName())));
-        }
-      } catch (CswException | IOException e) {
-        throw new ResourceNotFoundException(
-            String.format(ERROR_ID_PRODUCT_RETRIEVAL, metacardId), e);
+      ResourceResponse response = retrieveResourceById(requestProperties, metacardId);
+      if (response != null) {
+        return response;
       }
     }
     LOGGER.debug("Retrieving resource at : {}", resourceUri);
     return resourceReader.retrieveResource(resourceUri, requestProperties);
+  }
+
+  private ResourceResponse retrieveResourceById(
+      Map<String, Serializable> requestProperties, String metacardId)
+      throws ResourceNotFoundException {
+    Csw csw =
+        factory.getClientForSubject(
+            (Subject) requestProperties.get(SecurityConstants.SECURITY_SUBJECT));
+    GetRecordByIdRequest getRecordByIdRequest = new GetRecordByIdRequest();
+    getRecordByIdRequest.setService(CswConstants.CSW);
+    getRecordByIdRequest.setOutputSchema(OCTET_STREAM_OUTPUT_SCHEMA);
+    getRecordByIdRequest.setOutputFormat(MediaType.APPLICATION_OCTET_STREAM);
+    getRecordByIdRequest.setId(metacardId);
+
+    String rangeValue = "";
+    long requestedBytesToSkip = 0;
+    if (requestProperties.containsKey(CswConstants.BYTES_TO_SKIP)) {
+      requestedBytesToSkip = (Long) requestProperties.get(CswConstants.BYTES_TO_SKIP);
+      rangeValue =
+          String.format(
+              "%s%s-",
+              CswConstants.BYTES_EQUAL,
+              requestProperties.get(CswConstants.BYTES_TO_SKIP).toString());
+      LOGGER.debug("Range: {}", rangeValue);
+    }
+    CswRecordCollection recordCollection;
+    try {
+      recordCollection = csw.getRecordById(getRecordByIdRequest, rangeValue);
+
+      Resource resource = recordCollection.getResource();
+      if (resource != null) {
+
+        long responseBytesSkipped = 0L;
+        if (recordCollection.getResourceProperties().get(BYTES_SKIPPED) != null) {
+          responseBytesSkipped = (Long) recordCollection.getResourceProperties().get(BYTES_SKIPPED);
+        }
+        alignStream(resource.getInputStream(), requestedBytesToSkip, responseBytesSkipped);
+
+        return new ResourceResponseImpl(
+            new ResourceImpl(
+                new BufferedInputStream(resource.getInputStream()),
+                resource.getMimeTypeValue(),
+                FilenameUtils.getName(resource.getName())));
+      } else {
+        return null;
+      }
+    } catch (CswException | IOException e) {
+      throw new ResourceNotFoundException(String.format(ERROR_ID_PRODUCT_RETRIEVAL, metacardId), e);
+    }
   }
 
   private void alignStream(InputStream in, long requestedBytesToSkip, long responseBytesSkipped)

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/TestCswSource.java
@@ -15,7 +15,9 @@ package org.codice.ddf.spatial.ogc.csw.catalog.common.source;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -24,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -1285,6 +1288,32 @@ public class TestCswSource extends TestCswSourceBase {
     cswSource.retrieveResource(new URI("http://example.com/resource"), props);
     // Verify
     verify(reader, times(1)).retrieveResource(any(URI.class), anyMap());
+  }
+
+  @Test
+  public void testRetrieveResourceUsingReaderBasicAuth()
+      throws URISyntaxException, ResourceNotFoundException, IOException,
+          ResourceNotSupportedException, CswException {
+    configureMockCsw();
+    AbstractCswSource cswSource = getCswSource(mockCsw, mockContext, null, null, null, null);
+    ResourceReader reader = mock(ResourceReader.class);
+    when(reader.retrieveResource(any(URI.class), any(Map.class)))
+        .thenReturn(mock(ResourceResponse.class));
+    cswSource.setResourceReader(reader);
+
+    cswSource.setUsername("user");
+    cswSource.setPassword("secret");
+
+    Map<String, Serializable> props = new HashMap<>();
+    props.put(Core.ID, "ID");
+    cswSource.retrieveResource(new URI("http://example.com/resource"), props);
+    verify(reader, times(1))
+        .retrieveResource(
+            any(URI.class),
+            argThat(
+                allOf(
+                    hasEntry("username", (Serializable) "user"),
+                    hasEntry("password", (Serializable) "secret"))));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Update CSW and OpenSearch sources to include basic auth info in the retrieveResource properties map.
#### Who is reviewing it? 
@vinamartin @mcalcote 
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and setup federation to query over OpenSearch and CSW endpoints. The DDF being queried should be setup to only allow basic authentication for the OpenSearch and CSW endpoints. Verify that a resource can be downloaded over both of these endpoints only when a valid user/pass is provided in the source setup. 
#### What are the relevant tickets?
[DDF-3318](https://codice.atlassian.net/browse/DDF-3318)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
