### PR TITLE
DDF-3316 Implement security audit logging in profile install command

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
@@ -228,11 +228,7 @@ public class ProfileInstallCommand extends AbstractProfileCommand {
       for (String bundle : stopBundleNames) {
         if (uniqueValues.add(bundle)) {
           printItemStatusPending("Stopping: ", bundle);
-          try {
-            stopBundle(bundleService, bundle);
-          } catch (BundleException e) {
-            throw e;
-          }
+          stopBundle(bundleService, bundle);
           printItemStatusSuccess("Stopped: ", bundle);
         }
       }
@@ -268,6 +264,7 @@ public class ProfileInstallCommand extends AbstractProfileCommand {
       profileMap =
           (Map<String, List<String>>)
               fromJson(FileUtils.readFileToString(profileFile, StandardCharsets.UTF_8));
+      SecurityLogger.audit("Read profile {} from {}", profileName, profileFile.getAbsolutePath());
     } catch (FileNotFoundException e) {
       LOGGER.debug(
           "The file associated with profile: {} was not found under {}", profileName, profilePath);

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
@@ -38,7 +38,6 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.codice.ddf.admin.application.service.ApplicationService;
 import org.codice.ddf.admin.application.service.ApplicationServiceException;
-import org.codice.ddf.security.common.Security;
 import org.osgi.framework.BundleException;
 import org.osgi.service.resolver.ResolutionException;
 import org.slf4j.Logger;
@@ -56,24 +55,17 @@ public class ProfileInstallCommand extends AbstractProfileCommand {
   )
   String profileName;
 
-  private Security security = Security.getInstance();
-
   private static final String ADVANCED_PROFILE_INSTALL_FEATURES = "install-features";
   private static final String ADVANCED_PROFILE_UNINSTALL_FEATURES = "uninstall-features";
   private static final String ADVANCED_PROFILE_START_APPS = "start-apps";
   private static final String ADVANCED_PROFILE_STOP_BUNDLES = "stop-bundles";
+  private static final String FEATURE_FAILURE_MESSAGE = "Feature: %s does not exist";
   private static final EnumSet NO_AUTO_REFRESH =
       EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles);
   private static final String PROFILE_PREFIX = "profile-";
   private static final String RESTART_WARNING =
       "An unexpected error occurred during the installation process. The system is in unknown state. It is strongly recommended to restart the installation from the beginning.";
-  private static final String SECURITY_ERROR = "Could not get system user to install profile ";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProfileInstallCommand.class);
-
-  // Added as a convenience for unit testing
-  void setSecurity(Security security) {
-    this.security = security;
-  }
 
   @Override
   protected void doExecute(
@@ -189,14 +181,13 @@ public class ProfileInstallCommand extends AbstractProfileCommand {
           try {
             featureObject = featuresService.getFeature(feature);
           } catch (Exception e) {
-            printError(String.format("Feature: %s does not exist", feature));
+            printError(String.format(FEATURE_FAILURE_MESSAGE, feature));
             throw e;
           }
           if (featureObject == null) {
             printItemStatusFailure("Uninstall Failed: ", feature);
-            printError(String.format("Feature: %s does not exist", feature));
-            throw new IllegalArgumentException(
-                String.format("Feature: %s does not exist", feature));
+            printError(String.format(FEATURE_FAILURE_MESSAGE, feature));
+            throw new IllegalArgumentException(String.format(FEATURE_FAILURE_MESSAGE, feature));
           }
           uninstallFeature(featuresService, featureObject);
           printItemStatusSuccess("Uninstalled: ", feature);

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
@@ -194,13 +194,6 @@ public class ProfileInstallCommandTest {
     verify(applicationService, times(3)).startApplication(anyString());
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testSystemSubjectNull() throws Exception {
-    when(security.getSystemSubject()).thenReturn(null);
-    profileInstallCommand.profileName = "devProfile";
-    profileInstallCommand.doExecute(applicationService, featuresService, bundleService);
-  }
-
   @Test(expected = IllegalArgumentException.class)
   public void testBundleNotExist() throws Exception {
     doThrow(IllegalArgumentException.class).when(bundleService).getBundle(any());

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
@@ -221,7 +221,8 @@ public class ProfileInstallCommandTest {
     when(featuresService.isInstalled(installerFeature)).thenReturn(true);
     profileInstallCommand.profileName = "invalidStopBundles";
     profileInstallCommand.doExecute(applicationService, featuresService, bundleService);
-    verify(featuresService).uninstallFeature(eq("admin-modules-installer"), eq(NO_AUTO_REFRESH));
+    verify(featuresService)
+        .uninstallFeature(eq("admin-modules-installer"), eq("0.0.0"), eq(NO_AUTO_REFRESH));
   }
 
   @Test
@@ -236,7 +237,8 @@ public class ProfileInstallCommandTest {
     profileInstallCommand.profileName = "invalidStopBundles";
     profileInstallCommand.doExecute(applicationService, featuresService, bundleService);
     verify(featuresService).installFeature(eq("admin-post-install-modules"), eq(NO_AUTO_REFRESH));
-    verify(featuresService).uninstallFeature(eq("admin-modules-installer"), eq(NO_AUTO_REFRESH));
+    verify(featuresService)
+        .uninstallFeature(eq("admin-modules-installer"), eq("0.0.0"), eq(NO_AUTO_REFRESH));
   }
 
   @Test(expected = Exception.class)
@@ -247,7 +249,7 @@ public class ProfileInstallCommandTest {
     when(featuresService.isInstalled(installerFeature)).thenReturn(true);
     doThrow(Exception.class)
         .when(featuresService)
-        .uninstallFeature("admin-modules-installer", NO_AUTO_REFRESH);
+        .uninstallFeature("admin-modules-installer", "0.0.0", NO_AUTO_REFRESH);
     profileInstallCommand.profileName = "invalidStopBundles";
     profileInstallCommand.doExecute(applicationService, featuresService, bundleService);
   }

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommandTest.java
@@ -337,14 +337,13 @@ public class ProfileInstallCommandTest {
               return callable.call();
             });
     security = mock(Security.class);
-    when(security.getSystemSubject()).thenReturn(subject);
     return security;
   }
 
   private ProfileInstallCommand getProfileInstallCommand(Path profilePath) {
     ProfileInstallCommand command = new ProfileInstallCommand();
     command.setProfilePath(profilePath);
-    command.setSecurity(createSecurityMock());
+    //    command.setSecurity(createSecurityMock());
     return command;
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Updates profile:install command to include security auditing
Removes usage of systemSubject

#### Who is reviewing it? 

@peterhuffer @emmberk @paouelle @stustison 

#### Choose 2 committers to review/merge the PR. 

@clockard 
@figliold 

#### How should this be tested? (List steps with links to updated documentation)

Run `profile:install <profile>` as an administrative user and verify that the security logs contain an audit for the actions performed by the command

#### What are the relevant tickets?

[DDF-3316](https://codice.atlassian.net/browse/DDF-3316)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
