### PR TITLE
DDF-3300 Metacard actions do not display in IE 11

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/map-actions/map-actions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/map-actions/map-actions.view.js
@@ -47,13 +47,13 @@ define([
 
         getMapActions: function () {
             return this.getActions().filter(function(action) {
-                return action.get('id').startsWith('catalog.data.metacard.map.');
+                return action.get('id').indexOf('catalog.data.metacard.map.') === 0;
             });
         },
 
         getOverlayActions: function () {
             var modelOverlayActions = this.getActions().filter(function(action) {
-                return action.get('id').startsWith('catalog.data.metacard.map.overlay.');
+                return action.get('id').indexOf('catalog.data.metacard.map.overlay.') === 0;
             });
 
             var _this = this;


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where the metacard actions page content did not display in IE11

#### Who is reviewing it? 
@gordocanchola @dcruver @millerw8 

#### Select relevant component teams: 
@codice/ui 
#### Choose 2 committers to review/merge the PR. 
@pklinef 
@kcwire 

#### How should this be tested? (List steps with links to updated documentation)
Verify metacard actions display properly in IE11, Chrome and Firefox

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3300](https://codice.atlassian.net/browse/DDF-3300)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
