### PR TITLE
DDF-3297 Adds security manager to container

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -33,7 +33,7 @@
 DIRNAME=`dirname "$0"`
 
 # Set environment variable for DDF home directory (used by DDF Java code)
-DDF_HOME=`cd $DIRNAME/..; pwd`
+DDF_HOME=`cd $DIRNAME/..; pwd -P`
 
 # NOTE: export on separate line to support caveat of Solaris OS
 export DDF_HOME
@@ -64,5 +64,22 @@ export EXTRA_JAVA_OPTS
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder
 
-export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME"
+#
+# Admins can uncomment the following line and comment out the other definition of
+# the KARAF_SYSTEM_OPTS variable in order to determine any missing security permissions
+# should they install third-party bundles requiring additional access.
+#
+# Please note that turning on the PolicyFileGeneratorJSM has the side-effect of turning off
+# security on your system. It should be used with caution, only to ascertain missing
+# permissions to be added to the default.policy file.
+#
+# N.B. The use of the double equals on the 'java.security.policy' property is intentional.
+# See http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#DefaultLocs
+# for more information.
+#
+# export KARAF_SYSTEM_OPTS="-Dprograde.generated.policy=$DDF_HOME/generated.policy -Dprograde.use.own.policy=true -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM -Djava.security.policy==$DDF_HOME/security/default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"
+
+export KARAF_SYSTEM_OPTS="-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==$DDF_HOME/security/default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"
+
+export KARAF_OPTS="-Dfile.encoding=UTF8 -Dddf.home=$DDF_HOME -Dddf.home.policy=$DDF_HOME/"
 export JAVA_OPTS="-Xms2g -Xmx4g -XX:+UnlockDiagnosticVMOptions -XX:+DisableAttachMechanism"

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -56,10 +56,28 @@ rem SET KARAF_DATA
 rem Karaf base folder
 rem SET KARAF_BASE
 rem Additional available Karaf options
-rem SET KARAF_OPTS=-Dderby.system.home="..\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -XX:+DisableAttachMechanism
+rem SET KARAF_OPTS=
 
 rem comment out the line below to enable cxf logging interceptors
 rem set EXTRA_JAVA_OPTS="-Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
 
-set JAVA_OPTS=-Xms2g -Xmx4g -Dderby.system.home="%DDF_HOME%\data\derby"  -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -XX:+DisableAttachMechanism
-:: set JAVA_OPTS=-Xms2g -Xmx4g -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore=../etc/keystores/serverKeystore.jks -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=../etc/keystores/serverTruststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Dddf.home=%DDF_HOME%
+set DDF_HOME_POLICY=/%DDF_HOME:/bin/..=/%
+
+rem
+rem Admins can uncomment the following line and comment out the other definition of
+rem the KARAF_SYSTEM_OPTS variable in order to determine any missing security permissions
+rem should they install third-party bundles requiring additional access.
+rem
+rem Please note that turning on the PolicyFileGeneratorJSM has the side-effect of turning off
+rem security on your system. It should be used with caution, only to ascertain missing
+rem permissions to be added to the default.policy file.
+rem
+rem N.B. The use of the double equals on the 'java.security.policy' property is intentional.
+rem See http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#DefaultLocs
+rem for more information.
+rem
+rem set KARAF_SYSTEM_OPTS=-Dprograde.generated.policy="%DDF_HOME%/generated.policy" -Dprograde.use.own.policy=true -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM -Djava.security.policy==%DDF_HOME%\security\default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
+
+set KARAF_SYSTEM_OPTS=-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==%DDF_HOME%\security\default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
+
+set JAVA_OPTS=-Xms2g -Xmx4g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.policy=%DDF_HOME_POLICY% -XX:+DisableAttachMechanism

--- a/distribution/ddf-common/src/main/resources/etc/startup.properties
+++ b/distribution/ddf-common/src/main/resources/etc/startup.properties
@@ -7,7 +7,8 @@ mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.1 = 8
 mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1 = 8
 # Using a boot feature won't be good enough. We need to actually replace Felix with our own impl.
 # The following ddf.platform.osgi line (for the currently used karaf version) used to be:
-# mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
-mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
+# mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
+
+mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.0 = 11
 mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.1.2 = 15

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -288,6 +288,13 @@ user.language="en"
 user.country="US"
 
 #
+# This is the default home location which will work in development and test
+# and, by virtue of being beneath the ${user.home} directory, will not cause
+# an access exception for being inaccessible.
+#
+org.ops4j.pax.url.mvn.settings=file:${user.home}/.m2/settings.xml
+
+#
 # Disable Hazelcast version check
 #
 hazelcast.version.check.enabled=false

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -1,0 +1,169 @@
+priority "grant";
+
+deny {
+    // Read, write, or execute any file
+    permission java.io.FilePermission "<<ALL FILES>>", "read, write, execute";
+
+    // Deny deletion of the security policy file through any Java code
+    permission java.io.FilePermission "${ddf.home}${/}security${/}default.policy", "read, write, execute, delete";
+
+    permission java.util.PropertyPermission "javax.net.ssl.*", "read, write";
+    permission java.util.PropertyPermission "java.io.tmpdir", "write";
+    permission java.util.PropertyPermission "user.home", "write";
+
+    // Change current security manager
+    permission java.lang.RuntimePermission "setSecurityManager";
+
+    // Modify application permissions at will.
+    permission java.security.SecurityPermission "setPolicy, insertProvider, removeProvider.*, clearProviderProperties.*, putProviderProperty.*, removeProviderProperty.*";
+
+    // Load classes into any protection domain
+    permission java.lang.RuntimePermission "createClassLoader";
+};
+
+//
+// DDF Libraries have broad file permissions within the install directory
+//
+grant
+  codeBase "file:${ddf.home.policy}system/ddf/-" {
+    permission java.io.FilePermission "${ddf.home}", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}-", "read, write";
+
+    permission java.util.PropertyPermission "javax.net.ssl.*", "read, write";
+};
+grant
+  codeBase "file:${ddf.home.policy}system/org/codice/-" {
+    permission java.io.FilePermission "${ddf.home}", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}-", "read, write";
+
+    permission java.util.PropertyPermission "javax.net.ssl.*", "read, write";
+};
+
+//
+// DDF Migration Framework and Config Admin Migratable
+//
+grant
+  codeBase "file:${ddf.home.policy}system/ddf/platform/platform-migratable/-" {
+    // some permissions might be repeated here to ensure that they are granted to the migration
+    // framework if we ever tighten the permissions above
+
+    permission java.io.FilePermission "<<ALL FILES>>", "read, readlink";
+    permission java.io.FilePermission "${ddf.home}", "read, write";
+
+    permission java.util.PropertyPermission "*", "read";
+    permission java.util.PropertyPermission "ddf.home", "read";
+    permission java.util.PropertyPermission "karaf.restart.jvm", "write";
+};
+
+//
+// DDF Platform Migratable
+//
+grant
+  codeBase "file:${ddf.home.policy}system/ddf/platform/platform-migratable/-" {
+    // some permissions might be repeated here to ensure that they are granted to the migration
+    // framework if we ever tighten the permissions above
+
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}ws-security", "read";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}ws-security${/}-", "read, delete";
+
+    permission java.util.PropertyPermission "javax.net.ssl.keyStore", "read";
+    permission java.util.PropertyPermission "javax.net.ssl.trustStore", "read";
+};
+
+//
+// DDF Security Migratable
+//
+grant
+  codeBase "file:${ddf.home.policy}system/ddf/security/migration/security-migratable/-" {
+    // some permissions might be repeated here to ensure that they are granted to the migration
+    // framework if we ever tighten the permissions above
+
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}pdp", "read";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}pdp${/}-", "read, delete";
+};
+
+//
+// The lib directory contains root, trusted jars for DDF, OSGi, and security
+//
+grant
+  codeBase "file:${ddf.home.policy}lib/-" {
+    permission java.io.FilePermission "${ddf.home}", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}*", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}-", "read";
+
+    permission java.lang.RuntimePermission "createClassLoader";
+    permission java.util.PropertyPermission "javax.net.ssl.*", "read, write";
+};
+grant
+  codeBase "file:${ddf.home.policy}lib/boot/-" {
+    permission java.io.FilePermission "${ddf.home}${/}*", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}config.properties", "write";
+    permission java.util.PropertyPermission "karaf.restart.jvm", "write";
+};
+grant
+  codeBase "file:${ddf.home.policy}lib/boot/org.osgi.core-6.0.0.jar" {
+    permission java.io.FilePermission "${ddf.home}${/}*", "read, execute";
+    permission java.io.FilePermission "${ddf.home}${/}deploy${/}-", "read, execute";
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}-", "read, execute";
+};
+
+//
+// Core OSGi libraries
+//
+grant
+  codeBase "file:${ddf.home.policy}system/org/eclipse/platform/org.eclipse.osgi/-" {
+    permission java.io.FilePermission "${ddf.home}", "read, write, execute";
+    permission java.io.FilePermission "${ddf.home}${/}*", "read, write, execute";
+
+    permission java.io.FilePermission "${ddf.home}${/}deploy${/}-", "read, execute";
+
+    permission java.io.FilePermission "${ddf.home}${/}etc${/}-", "read, write, execute";
+
+    permission java.io.FilePermission "${ddf.home}${/}examples", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}examples${/}-", "read, write";
+
+    permission java.lang.RuntimePermission "createClassLoader";
+    permission java.util.PropertyPermission "javax.net.ssl.*", "read";
+
+    permission java.io.FilePermission "${ddf.home}${/}bin_third_party${/}-", "read, execute";
+};
+
+grant {
+    // User's home directory
+    permission java.io.FilePermission "${user.home}${/}-", "read, write";
+
+    // Temporary file storage
+    permission java.io.FilePermission "${java.io.tmpdir}", "read, write, execute, delete";
+    permission java.io.FilePermission "${java.io.tmpdir}${/}-", "read, write, execute, delete";
+
+    // Java libraries
+    permission java.io.FilePermission "${java.home}${/}release", "read";
+    permission java.io.FilePermission "${java.home}${/}lib${/}-", "read";
+
+    // System libraries
+    permission java.io.FilePermission "/dev/urandom", "read";
+    permission java.io.FilePermission "/lib", "read";
+    permission java.io.FilePermission "/proc/self/exe", "read";
+    permission java.io.FilePermission "/usr/lib", "read";
+
+
+    // Distribution File Permissions
+    permission java.io.FilePermission "${ddf.home}", "read";
+    permission java.io.FilePermission "${ddf.home}${/}*", "read";
+    permission java.io.FilePermission "${ddf.home}${/}lib${/}-", "read";
+    permission java.io.FilePermission "${ddf.home}${/}documentation${/}-", "read";
+
+    permission java.io.FilePermission "${ddf.home}${/}karaf.pid", "read, write";
+
+    permission java.io.FilePermission "${ddf.home}${/}data", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}instances", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}solr", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}system", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}workspace", "read, write";
+
+    permission java.io.FilePermission "${ddf.home}${/}data${/}-", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}instances${/}-", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}solr${/}-", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}system${/}-", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}workspace${/}-", "read, write";
+};

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -38,6 +38,7 @@
         <win.setup.folder>target/temp/win</win.setup.folder>
         <!-- The name of the distribution zip file to generate in the /target directory -->
         <distribution.file.name>ddf-${project.artifactId}-${project.version}</distribution.file.name>
+        <pro-grade.version>1.1.3</pro-grade.version>
     </properties>
     <dependencies>
         <!--
@@ -72,6 +73,12 @@
             <groupId>org.codice.ddf</groupId>
             <artifactId>ddf-common</artifactId>
             <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.pro-grade</groupId>
+            <artifactId>pro-grade</artifactId>
+            <version>${pro-grade.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -153,6 +160,13 @@
                                     <version>${bouncy.version}</version>
                                     <outputDirectory>${setup.folder}/ext</outputDirectory>
                                     <destFileName>bcpkix-${bouncy.version}.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.pro-grade</groupId>
+                                    <artifactId>pro-grade</artifactId>
+                                    <version>${pro-grade.version}</version>
+                                    <outputDirectory>${setup.folder}/ext</outputDirectory>
+                                    <destFileName>pro-grade-${pro-grade.version}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>ddf.platform.osgi</groupId>

--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -54,3 +54,9 @@ If you want to change the logging level, use the flags `-DitestLogLevel=<level>`
 
 ## Run unstable tests
 By default, all tests that include a call to `unstableTest` will not be run. To include them as part of a build, add the `-DincludeUnstableTests=true` property to the Maven command.
+
+## Generate missing security permissions
+When adding new functionality that requires security permissions that have
+not been added to `security/default.policy`, running with the `DgeneratePolicyFile=true`
+flag and the `-DkeepRuntimeFolder=true` flag will generate the missing
+policies in the `generated.policy` file in the exam folder.

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -46,11 +46,17 @@ import java.lang.reflect.Proxy;
 import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -73,6 +79,7 @@ import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.options.extra.VMOption;
 import org.osgi.framework.BundleException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -116,6 +123,8 @@ public abstract class AbstractIntegrationTest {
   public static final String REMOVE_ALL = "catalog:removeall -f -p";
 
   private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
+
+  private static final File UNPACK_DIRECTORY = new File("target/exam");
 
   protected static ServerSocket placeHolderSocket;
 
@@ -422,7 +431,7 @@ public abstract class AbstractIntegrationTest {
                     .getURL(),
                 "ddf",
                 KARAF_VERSION)
-            .unpackDirectory(new File("target/exam"))
+            .unpackDirectory(UNPACK_DIRECTORY)
             .useDeployFolder(false));
   }
 
@@ -442,7 +451,8 @@ public abstract class AbstractIntegrationTest {
         editConfigurationFilePut("etc/system.properties", "host", "localhost"),
         editConfigurationFilePut("etc/system.properties", "jetty.port", HTTPS_PORT.getPort()),
         editConfigurationFilePut("etc/system.properties", "hostContext", "/solr"),
-        editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
+        editConfigurationFilePut("etc/system.properties", "maven.home", "${user.home}"),
+        editConfigurationFilePut("etc/system.properties", "M2_HOME", "${user.home}"),
         editConfigurationFilePut(
             "etc/users.properties",
             SYSTEM_ADMIN_USER,
@@ -587,7 +597,27 @@ public abstract class AbstractIntegrationTest {
         vmOption("-Xmx2048M"),
         // avoid integration tests stealing focus on OS X
         vmOption("-Djava.awt.headless=true"),
-        vmOption("-Dfile.encoding=UTF8"));
+        vmOption("-Dfile.encoding=UTF8"),
+        vmOption("-Djava.security.policy==security/default.policy"),
+        vmOption(
+            "-DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"),
+        vmOption("-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy"),
+        HomeAwareVmOption.homeAwareVmOption("-Dddf.home={karaf.home}"),
+        HomeAwareVmOption.homeAwareVmOption("-Dddf.home.policy={karaf.home}/"),
+        when(Boolean.getBoolean("generatePolicyFile")).useOptions(generatorSecurityManager()),
+        when(!Boolean.getBoolean("generatePolicyFile")).useOptions(standardSecurityManager()));
+  }
+
+  private Option[] generatorSecurityManager() {
+    return options(
+        HomeAwareVmOption.homeAwareVmOption(
+            "-Dprograde.generated.policy={karaf.home}/generated.policy"),
+        vmOption("-Dprograde.use.own.policy=true"),
+        vmOption("-Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM"));
+  }
+
+  private Option[] standardSecurityManager() {
+    return options(vmOption("-Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM"));
   }
 
   protected Option[] configureStartScript() {
@@ -803,6 +833,46 @@ public abstract class AbstractIntegrationTest {
       return true;
     } catch (AssertionError e) {
       return false;
+    }
+  }
+
+  /**
+   * Helper Option class to allow interpolation of {@code karaf.home} directory based on the
+   * provided {@link #UNPACK_DIRECTORY}.
+   */
+  static class HomeAwareVmOption extends VMOption {
+    static HomeAwareVmOption homeAwareVmOption(String option) {
+      return new HomeAwareVmOption(option);
+    }
+
+    private HomeAwareVmOption(String option) {
+      super(option);
+    }
+
+    @Override
+    @SuppressWarnings({
+      "squid:S00112" /* A generic RuntimeException is perfectly reasonable in this case. */
+    })
+    public String getOption() {
+      final Function<Path, FileTime> createTimeComp =
+          path -> {
+            try {
+              return Files.readAttributes(path, BasicFileAttributes.class).creationTime();
+            } catch (IOException e) {
+              throw new RuntimeException("Unable to determine current exam directory", e);
+            }
+          };
+
+      try (final Stream<Path> dirContents = Files.list(UNPACK_DIRECTORY.toPath())) {
+        return dirContents
+            .max(Comparator.comparing(createTimeComp))
+            .map(Path::toAbsolutePath)
+            .map(Path::toString)
+            .map(s -> StringUtils.replace(super.getOption(), "{karaf.home}", s))
+            .orElseGet(super::getOption);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to determine current exam directory", e);
+      }
     }
   }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -703,54 +703,6 @@ public class TestFederation extends AbstractIntegrationTest {
         .body(containsString("Unable to transform Metacard."));
   }
 
-  /**
-   * Tests Source CANNOT retrieve existing product. The product is NOT located in one of the
-   * URLResourceReader's root resource directories, so it CANNOT be downloaded.
-   *
-   * <p>For example: The resource uri in the metacard is:
-   * file:/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/exam/e59b02bf-5774-489f-8aa9-53cf99c25d25/../../testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt
-   * which really means:
-   * file:/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt
-   *
-   * <p>The URLResourceReader's root resource directories are: <ddf.home>/data/products and
-   * /Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/exam/e59b02bf-5774-489f-8aa9-53cf99c25d25
-   *
-   * <p>So the product
-   * (/Users/andrewreynolds/projects/ddf-projects/ddf/distribution/test/itests/test-itests-ddf/target/testFederatedRetrieveProductInvalidResourceUrlWithBackReferences.txt)
-   * is not located under either of the URLResourceReader's root resource directories.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testFederatedRetrieveProductInvalidResourceUrlWithBackReferences() throws Exception {
-    // Setup
-    String fileName = testName.getMethodName() + HTTPS_PORT.getPort() + ".txt";
-    String fileNameWithBackReferences = ".." + File.separator + ".." + File.separator + fileName;
-    resourcesToDelete.add(fileNameWithBackReferences);
-    // Add back references to file name
-    String metacardId = ingestXmlWithProduct(fileNameWithBackReferences);
-    String productDirectory = new File(fileName).getAbsoluteFile().getParent();
-    urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
-        DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS, productDirectory);
-
-    String restUrl =
-        REST_PATH.getUrl()
-            + "sources/"
-            + OPENSEARCH_SOURCE_ID
-            + "/"
-            + metacardId
-            + "?transform=resource";
-
-    // Perform Test and Verify
-    when()
-        .get(restUrl)
-        .then()
-        .assertThat()
-        .contentType("text/html")
-        .statusCode(equalTo(500))
-        .body(containsString("Unable to transform Metacard."));
-  }
-
   @Test
   public void testFederatedRetrieveExistingProductCsw() throws Exception {
     String productDirectory =
@@ -788,22 +740,6 @@ public class TestFederation extends AbstractIntegrationTest {
             + "?transform=resource";
 
     // Perform Test and Verify
-    when().get(restUrl).then().assertThat().statusCode(equalTo(500));
-  }
-
-  @Test
-  public void testFederatedRetrieveNoProductCsw() throws Exception {
-    File[] rootDirectories = File.listRoots();
-    String rootDir = rootDirectories[0].getCanonicalPath();
-    urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(rootDir);
-    String restUrl =
-        REST_PATH.getUrl()
-            + "sources/"
-            + CSW_SOURCE_ID
-            + "/"
-            + metacardIds[GEOJSON_RECORD_INDEX]
-            + "?transform=resource";
-
     when().get(restUrl).then().assertThat().statusCode(equalTo(500));
   }
 

--- a/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/ConfigurationInstaller.java
+++ b/platform/admin/admin-configuration-configinstaller/src/main/java/org/codice/ddf/admin/configuration/ConfigurationInstaller.java
@@ -18,6 +18,8 @@ import static org.osgi.service.cm.ConfigurationEvent.CM_UPDATED;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -94,18 +96,24 @@ public class ConfigurationInstaller implements SynchronousConfigurationListener 
   @Override
   public void configurationEvent(ConfigurationEvent event) {
     String pid = event.getPid();
-    switch (event.getType()) {
-      case CM_UPDATED:
-        LOGGER.debug("Handling update for pid {}", pid);
-        handleUpdate(event);
-        break;
-      case CM_DELETED:
-        LOGGER.debug("Handling delete for pid {}", pid);
-        handleDelete(event);
-        break;
-      default:
-        LOGGER.debug("Unknown configuration event type, taking no action for pid {}", pid);
-    }
+    AccessController.doPrivileged(
+        (PrivilegedAction<Void>)
+            () -> {
+              switch (event.getType()) {
+                case CM_UPDATED:
+                  LOGGER.debug("Handling update for pid {}", pid);
+                  handleUpdate(event);
+                  break;
+                case CM_DELETED:
+                  LOGGER.debug("Handling delete for pid {}", pid);
+                  handleDelete(event);
+                  break;
+                default:
+                  LOGGER.debug(
+                      "Unknown configuration event type, taking no action for pid {}", pid);
+              }
+              return null;
+            });
   }
 
   /**

--- a/platform/osgi/platform-osgi-configadmin/pom.xml
+++ b/platform/osgi/platform-osgi-configadmin/pom.xml
@@ -144,6 +144,10 @@
                             won't even start if we allow this import to be included (since it's not
                             installed in the container anymore). -->
                             !org.apache.felix.cm.*,
+                            !org.apache.log4j;resolution:=optional,
+                            !org.slf4j;resolution:=optional,
+                            !javax.crypto;resolution:=optional,
+                            !javax.crypto.spec;resolution:=optional,
                             org.osgi.service.cm;version="[1.5,1.6)",
                             org.osgi.framework;version="[1.4,2)",
                             org.osgi.service.log;resolution:=optional;version="1.3",

--- a/platform/osgi/platform-osgi-configadmin/src/main/resources/OSGI-INF/permissions.perm
+++ b/platform/osgi/platform-osgi-configadmin/src/main/resources/OSGI-INF/permissions.perm
@@ -1,0 +1,2 @@
+(java.util.PropertyPermission "*" "read")
+(java.lang.RuntimePermission "createClassLoader")

--- a/platform/security/core/security-core-impl/pom.xml
+++ b/platform/security/core/security-core-impl/pom.xml
@@ -278,7 +278,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.21</minimum>
+                                            <minimum>0.18</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/config/impl/ConfigurationSecurityLogger.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/config/impl/ConfigurationSecurityLogger.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Dictionary;
 import javax.security.auth.Subject;
 import org.apache.felix.cm.file.ConfigurationHandler;
@@ -37,29 +38,37 @@ public class ConfigurationSecurityLogger implements SynchronousConfigurationList
 
   @Override
   public void configurationEvent(ConfigurationEvent event) {
-    try {
-      String type = getType(event);
-      Configuration[] configuration =
-          configurationAdmin.listConfigurations("(service.pid=" + event.getPid() + ')');
+    AccessController.doPrivileged(
+        (PrivilegedAction<Void>)
+            () -> {
+              try {
+                String type = getType(event);
+                Configuration[] configuration =
+                    configurationAdmin.listConfigurations("(service.pid=" + event.getPid() + ')');
 
-      String updatedConfiguration = "{}";
-      // the service.pid is unique so we just need to check if we got anything.
-      if (configuration != null && configuration.length > 0) {
-        updatedConfiguration = dictionaryToString(configuration[0].getProperties());
-      }
+                String updatedConfiguration = "{}";
+                // the service.pid is unique so we just need to check if we got anything.
+                if (configuration != null && configuration.length > 0) {
+                  updatedConfiguration = dictionaryToString(configuration[0].getProperties());
+                }
 
-      // check if there is a subject associated with the configuration change
-      if (ThreadContext.getSubject() != null
-          || Subject.getSubject(AccessController.getContext()) != null) {
-        SecurityLogger.audit("Configuration {}: {}", type, updatedConfiguration);
-      } else {
-        // there was no subject change was caused by an update to the config file on the filesystem
-        SecurityLogger.auditWarn("Configuration {} via filesystem: {}", type, updatedConfiguration);
-      }
-    } catch (Throwable e) {
-      LOGGER.error("Error auditing config update for {}", event.getPid(), e);
-      SecurityLogger.audit("Error auditing config update for {}", event.getPid());
-    }
+                // check if there is a subject associated with the configuration change
+                if (ThreadContext.getSubject() != null
+                    || Subject.getSubject(AccessController.getContext()) != null) {
+                  SecurityLogger.audit("Configuration {}: {}", type, updatedConfiguration);
+                } else {
+                  // there was no subject change was caused by an update to the config file on the
+                  // filesystem
+                  SecurityLogger.auditWarn(
+                      "Configuration {} via filesystem: {}", type, updatedConfiguration);
+                }
+              } catch (Throwable e) {
+                LOGGER.error("Error auditing config update for {}", event.getPid(), e);
+                SecurityLogger.audit("Error auditing config update for {}", event.getPid());
+              }
+
+              return null;
+            });
   }
 
   private String dictionaryToString(Dictionary<String, Object> properties) {

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Set;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
@@ -172,13 +174,16 @@ public class PollingPolicyFinderModule extends FileBasedPolicyFinderModule
    * @return true if the directory is empty and false otherwise.
    */
   private boolean isXacmlPoliciesDirectoryEmpty(File xacmlPoliciesDirectory) {
-    boolean empty = false;
-    if (null != xacmlPoliciesDirectory && xacmlPoliciesDirectory.isDirectory()) {
-      File[] files = xacmlPoliciesDirectory.listFiles();
-      empty = files == null || files.length == 0;
-    }
-
-    return empty;
+    return AccessController.doPrivileged(
+        (PrivilegedAction<Boolean>)
+            () -> {
+              if (null != xacmlPoliciesDirectory && xacmlPoliciesDirectory.isDirectory()) {
+                File[] files = xacmlPoliciesDirectory.listFiles();
+                return files == null || files.length == 0;
+              } else {
+                return false;
+              }
+            });
   }
 
   /**


### PR DESCRIPTION
#### What does this PR do?
Adds ProGrade security manager and policy file to container.

#### Who is reviewing it? 
@paouelle @Lambeaux @SmithJosh @garrettfreibott @ryeats 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full regression test of DDF. This will potentially impact downstream projects; they will need to add/update policy files and `setenv` scripts accordingly.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
