### PR TITLE
DDF-3323 - Adds ability for admin to configure the map home in Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -122,6 +122,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private Integer autoMergeTime = 1000;
 
+  private String mapHome = "";
+
   public List<Long> getScheduleFrequencyList() {
     return scheduleFrequencyList;
   }
@@ -339,6 +341,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("defaultLayout", getDefaultLayoutConfig());
     config.put("isExperimental", isExperimental);
     config.put("autoMergeTime", autoMergeTime);
+    config.put("mapHome", mapHome);
 
     return config;
   }
@@ -802,5 +805,13 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setIsExperimental(Boolean isExperimental) {
     this.isExperimental = isExperimental;
+  }
+
+  public String getMapHome() {
+    return mapHome;
+  }
+
+  public void setMapHome(String mapHome) {
+    this.mapHome = mapHome;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -267,6 +267,13 @@
             default="1048576"
             required="true"/>
 
+        <AD id="mapHome"
+            name="Map Home"
+            description="Specifies the default home view for the map by bounding box.  The format is: 'West, South, East, North' where North, East, South, and West are coordinates in degrees.  An example is: '-124, 60, -100, 40'."
+            type="String"
+            default=""
+            required="false"/>
+
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.ui.config">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -55,7 +55,8 @@ function createMap(insertionElement) {
             fullscreenButton: false,
             timeline: false,
             geocoder: new gazetteer(),
-            homeButton: true,
+            homeButton: false,
+            navigationHelpButton: false,
             sceneModePicker: false,
             selectionIndicator: false,
             infoBox: false,
@@ -87,13 +88,6 @@ function createMap(insertionElement) {
         var initObj = _.omit(properties.terrainProvider, 'type');
         viewer.scene.terrainProvider = new type(initObj);
     }
-
-    $(insertionElement).find('.cesium-viewer-toolbar')
-        .append("<button class='cesium-button cesium-toolbar-button cluster-button' " +
-            "data-help='Toggles whether or not results on the map are clustered.'>" +
-            "<span class='fa fa-cubes'></span>" +
-            "</span><span class='fa fa-cube'></span>" +
-            "</button>");
 
     return viewer;
 }
@@ -326,6 +320,12 @@ module.exports = function CesiumMap(insertionElement, selectionInterface, notifi
             });
         },
         zoomToExtent: function(coords) {},
+        zoomToBoundingBox: function({north, south, east, west}) {
+            map.scene.camera.flyTo({
+                duration: 0.50,
+                destination: Cesium.Rectangle.fromDegrees(west, south, east, north)
+            });
+        },
         overlayImage: function(model) {
             var metacardId = model.get('properties').get('id');
             this.removeOverlay(metacardId);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
@@ -19,6 +19,10 @@
 }
 
 @{customElementNamespace}map {
+  .cesium-button {
+    vertical-align: top;
+  }
+
   .map-context-menu {
     position: absolute;
     left: 0px;
@@ -26,5 +30,23 @@
     width: 1px;
     height: 1px;
     overflow: hidden;
+  }
+
+  .is-clustering {
+      display: none;
+  }
+
+  .is-clustering.fa-toggle-on {
+    color: lighten(@warning-color, 20%);
+  }
+}
+
+@{customElementNamespace}map.is-clustering {
+  .is-clustering {
+    display: inline;
+  }
+
+  .is-not-clustering {
+    display: none;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -248,6 +248,9 @@ module.exports = function OpenlayersMap(insertionElement, selectionInterface, no
             map.beforeRender(pan1, zoom);
             map.getView().fit(extent, map.getSize());
         },
+        zoomToBoundingBox: function({north, east, south, west}) {
+            this.zoomToExtent([[west, south], [east, north]]);
+        },
         overlayImage: function(model) {
             var metacardId = model.get('properties').get('id');
             this.removeOverlay(metacardId);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/templates/geocoder.handlebars
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/templates/geocoder.handlebars
@@ -16,8 +16,4 @@
             <input id="searchfield" name="searchText" class="geocoder-input" type="search" placeholder="Enter an address or landmark...">
             <span id="searchbutton" class="geocoder-search-button fa fa-2x fa-search"></span>
     </div>
-    <button class="cesium-button cesium-toolbar-button cluster-button" data-help="Toggles whether or not results on the map are clustered">
-        <span class="fa fa-cubes"></span>
-        <span class="fa fa-cube"></span>
-    </button>
 </div>


### PR DESCRIPTION
 - Adds configuration for map home to Intrigue, allowing admins to customize it.
 - Adds map home button to openlayers, removes the default map home button from cesium and replaces it with our own for consistency.
 - Default map home is a rough bounding box of the USA.
 - The help for map home specifies it needs to be in a particular order, but really it works so long as a series of coordinates in lon, lat order are supplied.

@jlcsmith 
@djblue 
@kcwire 