### PR TITLE
DDF-3327 Fix description overflow in Admin UI Application boxes

### DIFF
--- a/platform/admin/ui/src/main/webapp/less/application/app-card.less
+++ b/platform/admin/ui/src/main/webapp/less/application/app-card.less
@@ -25,6 +25,8 @@
   .panel-body {
     padding: 0px @app-card-overlay-width 0px 0px; // reset bootstrap
     height: 100%;
+    display: -ms-flexbox;
+    -ms-flex-direction: column;
     display: flex;
     flex-direction: column;
   }
@@ -35,6 +37,7 @@
   }
 
   .description {
+    -ms-flex: 1;
     height: 150px;
     .divider {
       margin: 1px 0px;

--- a/platform/admin/ui/src/main/webapp/less/application/app-card.less
+++ b/platform/admin/ui/src/main/webapp/less/application/app-card.less
@@ -25,6 +25,8 @@
   .panel-body {
     padding: 0px @app-card-overlay-width 0px 0px; // reset bootstrap
     height: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   .name {

--- a/platform/admin/ui/src/main/webapp/less/utils.less
+++ b/platform/admin/ui/src/main/webapp/less/utils.less
@@ -54,7 +54,7 @@
     -moz-box-sizing: content-box;
     float: right;
     position: relative;
-    top: -25px;
+    top: -15%;
     left: 100%;
     width: 3em; margin-left: -3em;
     padding-right: 5px; // magic number #1


### PR DESCRIPTION
#### What does this PR do?
Fixes a problem where the description of an application would overflow the box it was held in depending on the size of the user's window.
#### Who is reviewing it? 
@mcalcote @vinamartin 
#### Choose 2 committers to review/merge the PR. 
@clockard 
@rzwiefel 
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and navigate to the admin console. Verify that resizing your browser does not cause the description text for applications to overflow the application boxes. This should be tested on IE10, chrome and firefox.
#### What are the relevant tickets?
[DDF-3327](https://codice.atlassian.net/browse/DDF-3327)
#### Screenshots (if appropriate)
![screen shot 2017-09-28 at 10 23 17 am](https://user-images.githubusercontent.com/6457885/31026030-cfa18752-a512-11e7-9a7c-620c8a618114.png)
![screen shot 2017-09-29 at 12 33 33 pm](https://user-images.githubusercontent.com/6457885/31026047-de803980-a512-11e7-8e9d-4a4e12fe27a6.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
