### PR TITLE
DDF-3324 Catch VirtualMachineError before Throwable

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
@@ -86,6 +86,8 @@ public class CacheBulkProcessor {
 
                 lastBulkAdd = new Date();
               }
+            } catch (VirtualMachineError vme) {
+              throw vme;
             } catch (Throwable throwable) {
               LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
             }

--- a/distribution/sdk/sample-cometd/java-cli-example/src/main/java/org/codice/ddf/cli/CommandExecutor.java
+++ b/distribution/sdk/sample-cometd/java-cli-example/src/main/java/org/codice/ddf/cli/CommandExecutor.java
@@ -24,6 +24,8 @@ public class CommandExecutor {
     try {
       int exitCode = cmd.run();
       System.exit(exitCode);
+    } catch (VirtualMachineError vme) {
+      throw vme;
     } catch (Throwable e) {
       Notify.error("Command threw error: ", e.getMessage());
     }
@@ -36,6 +38,8 @@ public class CommandExecutor {
       execute(cmd);
     } catch (ParseException e) {
       Notify.error("Parser error: ", e.getMessage());
+    } catch (VirtualMachineError vme) {
+      throw vme;
     } catch (Throwable e) {
       Notify.error("Unexpected error: ", e.getMessage());
     }
@@ -47,6 +51,8 @@ public class CommandExecutor {
       execute(cmd);
     } catch (ParseException e) {
       Notify.error("Parser error: ", e.getMessage());
+    } catch (VirtualMachineError vme) {
+      throw vme;
     } catch (Throwable e) {
       Notify.error("Unexpected error: ", e.getMessage());
     }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/config/impl/ConfigurationSecurityLogger.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/config/impl/ConfigurationSecurityLogger.java
@@ -62,8 +62,10 @@ public class ConfigurationSecurityLogger implements SynchronousConfigurationList
                   SecurityLogger.auditWarn(
                       "Configuration {} via filesystem: {}", type, updatedConfiguration);
                 }
+              } catch (VirtualMachineError vme) {
+                throw vme;
               } catch (Throwable e) {
-                LOGGER.error("Error auditing config update for {}", event.getPid(), e);
+                LOGGER.error("Error auditing config update for " + event.getPid(), e);
                 SecurityLogger.audit("Error auditing config update for {}", event.getPid());
               }
 


### PR DESCRIPTION
#### What does this PR do?
Fix dangerous condition where Throwable is caught by catching VirtualMachineErrors beforehand and rethrowing them so that important JVM errors that require action are not hidden
#### Who is reviewing it? @paouelle @figliold @tbatie @djblue @emanns95 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@figliold 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
