### PR TITLE
DDF-3336 Temporarily separate the `Configuring for an LDAP Server` documentation into two .adoc files

### DIFF
--- a/distribution/docs/src/main/resources/content/_configuring/for-an-ldap-server-content.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/for-an-ldap-server-content.adoc
@@ -2,9 +2,7 @@
 :type: configuringAdminConsole
 :status: published
 :summary: Configurations to enable using an LDAP server.
-:order: 03
-
-==== Configuring for an LDAP Server
+:order: 032
 
 [WARNING]
 ====

--- a/distribution/docs/src/main/resources/content/_configuring/for-an-ldap-server-title.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/for-an-ldap-server-title.adoc
@@ -1,0 +1,7 @@
+:title: Configuring for an LDAP Server
+:type: configuringAdminConsole
+:status: published
+:summary: Configurations to enable using an LDAP server.
+:order: 03
+
+==== Configuring for an LDAP Server


### PR DESCRIPTION
#### What does this PR do?
Temporarily separated the {{"Configuring for an LDAP Server"}} documentation into two .adoc files one for the title and one for the content. This is to add a note between them from a different project. This change is required until the Admin Console Wizards are merged into DDF.

#### Who is reviewing it? 
@peterhuffer @djblue 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@ricklarsen - Documentation

#### What are the relevant tickets?
[DDF-3336](https://codice.atlassian.net/browse/DDF-3336)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests