### PR TITLE
[2.11.x] DDF-3279 Updates itests to use embedded solr

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -366,6 +366,7 @@ public abstract class AbstractIntegrationTest {
     basePort = findPortNumber(20000);
     return combineOptions(
         configureCustom(),
+        configureEmbeddedSolr(),
         configureLogLevel(),
         configureIncludeUnstableTests(),
         configureDistribution(),
@@ -628,6 +629,15 @@ public abstract class AbstractIntegrationTest {
       LoggingUtils.failWithThrowableStacktrace(e, "Failed to deploy configuration files: ");
     }
     return null;
+  }
+
+  private Option[] configureEmbeddedSolr() {
+    return options(
+        editConfigurationFilePut("etc/system.properties", "solr.client", "EmbeddedSolrServer"),
+        editConfigurationFilePut("etc/system.properties", "solr.http.url", ""),
+        editConfigurationFilePut(
+            "etc/system.properties", "solr.data.dir", "${karaf.home}/data/solr"),
+        editConfigurationFilePut("etc/system.properties", "solr.cloud.zookeeper", ""));
   }
 
   /**

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -2599,6 +2599,8 @@ public class TestCatalog extends AbstractIntegrationTest {
         .post(REST_PATH.getUrl());
   }
 
+  // TODO: Turn on this test once DDF-3340 is complete
+  @Ignore
   @Test
   public void testSolrSimilarityConfiguration() throws Exception {
     getServiceManager().startFeature(true, "catalog-solr-solrclient");

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -31,6 +31,7 @@ import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.itests.common.utils.LoggingUtils;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -73,12 +74,16 @@ public class TestSolrCommands extends AbstractIntegrationTest {
     cleanUpBackups(CATALOG_CORE_NAME);
   }
 
+  // TODO: Turn on this test once DDF-3340 is complete
+  @Ignore
   @Test
   public void testSolrBackupCommand() {
     String output = console.runCommand(BACKUP_COMMAND);
     assertThat(output, containsString(BACKUP_SUCCESS_MESSAGE));
   }
 
+  // TODO: Turn on this test once DDF-3340 is complete
+  @Ignore
   @Test
   public void testSolrBackupBadCoreName() {
     String coreName = "blah";
@@ -88,6 +93,8 @@ public class TestSolrCommands extends AbstractIntegrationTest {
     assertThat(output, containsString(String.format(BACKUP_ERROR_MESSAGE_FORMAT, coreName)));
   }
 
+  // TODO: Turn on this test once DDF-3340 is complete
+  @Ignore
   @Test
   public void testSolrBackupNumToKeep() throws InterruptedException {
     int numToKeep = 2;


### PR DESCRIPTION
#### What does this PR do?
Updates itests to use embedded solr + disables tests that require http solr client. 

#### Who is reviewing it? 
@clockard @tbatie @emanns95 @Lambeaux 

#### Choose 2 committers to review/merge the PR. 
@figliold 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Full build with all itests passing 

#### What are the relevant tickets?
[DDF-3279](https://codice.atlassian.net/browse/DDF-3279)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
