### PR TITLE
DDF-2824 Updated owasp suppressions from doc plugin update

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -164,4 +164,22 @@
         </notes>
         <cve>CVE-2016-8739</cve>
     </suppress>
+
+    <suppress>
+        <notes>
+            These CVEs are all related to asciidoc and jruby vulnerabilities which are only used
+            when the documentation is building.
+        </notes>
+        <cve>CVE-1999-0428</cve>
+        <cve>CVE-2009-3245</cve>
+        <cve>CVE-2010-0742</cve>
+        <cve>CVE-2010-4252</cve>
+        <cve>CVE-2011-4838</cve>
+        <cve>CVE-2012-2110</cve>
+        <cve>CVE-2014-3567</cve>
+        <cve>CVE-2014-8176</cve>
+        <cve>CVE-2015-0292</cve>
+        <cve>CVE-2016-2108</cve>
+        <cve>CVE-2016-2109</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
#### What does this PR do?
Updates the owasp suppressions from doc plugin update. This includes suppressions for jruby and asciidocs used during the build process, but not runtime.

#### Who is reviewing it? 
@ricklarsen @garrettfreibott @vinamartin 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard @ricklarsen @rzwiefel 

#### How should this be tested? (List steps with links to updated documentation)
Run OWASP against the changeset

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)