### PR TITLE
DDF-3261 Updated nsp Static Analysis stage to only scan projects using browserify or webpack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,12 +152,8 @@ pipeline {
                                         def packageFile = readJSON file: 'package.json'
                                         if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
                                             nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                                try {
-                                                    echo "Scanning ${packageFiles[i].path}"
-                                                    sh 'nsp check'
-                                                } catch (err) {
-                                                    echo "Failed for ${packageFiles[i].path}"
-                                                }
+                                                echo "Scanning ${packageFiles[i].path}"
+                                                sh 'nsp check'
                                             }
                                         }
                                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,9 +149,16 @@ pipeline {
                                 def packageFiles = findFiles(glob: '**/package.json')
                                 for (int i = 0; i < packageFiles.size(); i++) {
                                     dir(packageFiles[i].path.split('package.json')[0]) {
-                                        echo "Scanning ${packageFiles[i].name}"
-                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                            sh 'nsp check'
+                                        def packageFile = readJSON file: 'package.json'
+                                        if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
+                                            nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
+                                                try {
+                                                    echo "Scanning ${packageFiles[i].path}"
+                                                    sh 'nsp check'
+                                                } catch (err) {
+                                                    echo "Failed for ${packageFiles[i].path}"
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
#### What does this PR do?

Changes the node security scan to only scan projects that are actually packaging dependencies

#### Who is reviewing it? 

@mcalcote  @djblue 

#### Select relevant component teams: 

@codice/build 

#### Choose 2 committers to review/merge the PR. 

@clockard @shaundmorris 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
