### PR TITLE
DDF-3321: (2.11.x backport) Investigate warnings logged on startup

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -93,6 +93,11 @@ log4j2.logger.org_ops4j_pax_web.name = org.ops4j.pax.web
 log4j2.logger.org_ops4j_pax_web.level = WARN
 log4j2.logger.org_ops4j_pax_web_jsp.name = org.ops4j.pax.web.jsp
 log4j2.logger.org_ops4j_pax_web_jsp.level = WARN
+# Logging for the UnregisterWebAppVisitorWC has been set to ERROR as paxweb logs stacktraces at WARN on startup. This may be
+# related to PAXWEB-1117. When Karaf upgrades paxweb, we need to see if these stacktrace log messages go away (see DDF-3321)
+# and remove this suppression.
+log4j2.logger.org_ops4j_pax_web_extender_war_internal_UnregisterWebAppVisitorWC.name = org.ops4j.pax.web.extender.war.internal.UnregisterWebAppVisitorWC
+log4j2.logger.org_ops4j_pax_web_extender_war_internal_UnregisterWebAppVisitorWC.level = ERROR
 log4j2.logger.org_apache_aries_spifly.name = org.apache.aries.spifly
 log4j2.logger.org_apache_aries_spifly.level = WARN
 log4j2.logger.org_apache_cxf_jaxrs_impl_WebApplicationExceptionMapper.name = org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper


### PR DESCRIPTION
#### What does this PR do?
Suppresses WARN logs with exceptions printed by Pax Web's org.ops4j.pax.web.extender.war.internal.UnregisterWebAppVisitorWC.java.

Backport to 2.11.x of PR https://github.com/codice/ddf/pull/2372

#### Who is reviewing it? 
@clockard 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard 
#### How should this be tested? (List steps with links to updated documentation)
CI Build
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3321
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
