### PR TITLE
DDF-3342 Fixed downloading qualified resources from a federated source

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/pom.xml
+++ b/catalog/core/catalog-core-urlresourcereader/pom.xml
@@ -142,19 +142,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.64</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
-                                        
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -15,6 +15,7 @@ package ddf.catalog.resource.impl;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
+import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.operation.impl.ResourceResponseImpl;
@@ -41,6 +42,7 @@ import java.util.Set;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -258,6 +260,16 @@ public class URLResourceReader implements ResourceReader {
     if (resourceURI.getScheme().equals(URL_HTTP_SCHEME)
         || resourceURI.getScheme().equals(URL_HTTPS_SCHEME)) {
       LOGGER.debug("Resource URI is HTTP or HTTPS");
+
+      final Serializable qualifierSerializable = properties.get(ContentItem.QUALIFIER);
+      if (qualifierSerializable instanceof String) {
+        final String qualifier = (String) qualifierSerializable;
+        if (StringUtils.isNotBlank(qualifier)) {
+          resourceURI =
+              UriBuilder.fromUri(resourceURI).queryParam(ContentItem.QUALIFIER, qualifier).build();
+        }
+      }
+
       String fileAddress = resourceURI.toURL().getFile();
       LOGGER.debug("resource name: {}", fileAddress);
       return retrieveHttpProduct(resourceURI, fileAddress, bytesToSkip, properties);
@@ -274,7 +286,7 @@ public class URLResourceReader implements ResourceReader {
                 + resourceURI.toString()
                 + "]. Invalid Resource URI of ["
                 + resourceURI.toString()
-                + "]. Resources  must be in one of the following directories: "
+                + "]. Resources must be in one of the following directories: "
                 + this.rootResourceDirectories.toString());
       }
     } else {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue which caused the main resource would be retrieved instead of the qualified resource from a federated source.
#### Who is reviewing it? 
@peterhuffer @AzGoalie @oconnormi 
#### Select relevant component teams:
@codice/core-apis 
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel
#### How should this be tested?
Because there are no content types in DDF that get qualified resources, the easiest way to test this is to set up two instances of Alliance and look at the qualified resources for a NITF record.
1. Setup Alliance A with a OpenSearch Federated Source connected to Alliance B.
2. Ingest a NITF in Alliance B.
3. In Intrigue on Alliance A, find the NITF result from Alliance B.
4. The `View overview` and `View original` `Actions` should return images (jpeg or jpeg200), not the original NITF file. Downloading the original NITF should still work as well.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3342](https://codice.atlassian.net/browse/DDF-3342)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
