### PR TITLE
DDF-3261 (Backport) Updated nsp Static Analysis stage to only scan projects using browserify or webpack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,9 +149,12 @@ pipeline {
                                 def packageFiles = findFiles(glob: '**/package.json')
                                 for (int i = 0; i < packageFiles.size(); i++) {
                                     dir(packageFiles[i].path.split('package.json')[0]) {
-                                        echo "Scanning ${packageFiles[i].name}"
-                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                            sh 'nsp check'
+                                        def packageFile = readJSON file: 'package.json'
+                                        if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
+                                            nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
+                                                echo "Scanning ${packageFiles[i].path}"
+                                                sh 'nsp check'
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
#### What does this PR do?

Backports #2408 to 2.11.x

#### Who is reviewing it? 
@clockard @mcalcote 

#### Select relevant component teams: 
@codice/build 

#### What are the relevant tickets?
[DDF-3261](https://codice.atlassian.net/browse/DDF-3261)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
