### PR TITLE
DDF-3353 Made delete button in Map Layers red

### DIFF
--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -81,7 +81,7 @@ const Title = muiThemeable()(({ children, muiTheme }) => (
 ))
 
 const DeleteIconThemed = muiThemeable()(({ muiTheme }) => (
-    <DeleteIcon style={{ color: muiTheme.palette.errorColor}}/>
+  <DeleteIcon style={{ color: muiTheme.palette.errorColor }} />
 ))
 
 const implementationSupport = (implementors) => {

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -80,6 +80,10 @@ const Title = muiThemeable()(({ children, muiTheme }) => (
   <h1 style={{ color: muiTheme.palette.textColor, textAlign: 'center' }}>{children}</h1>
 ))
 
+const DeleteIconThemed = muiThemeable()(({ muiTheme }) => (
+    <DeleteIcon style={{ color: muiTheme.palette.errorColor}}/>
+))
+
 const implementationSupport = (implementors) => {
   if (!implementors.includes('ol')) {
     return '3D Only'
@@ -418,7 +422,7 @@ const MapLayers = (props) => {
               <IconButton
                 tooltip='Delete Layer'
                 onClick={() => onUpdate(null, [i])}>
-                <DeleteIcon />
+                <DeleteIconThemed />
               </IconButton>
             </div>
             <ProviderEditor


### PR DESCRIPTION
#### What does this PR do?
The trash can icon in Map Layers is now the "error" color in the chosen theme. This is to make the icon stand out and be consistent with the admin-console-beta trash icon.

#### Who is reviewing it? 
@djblue  @garrettfreibott 

#### Choose 2 committers to review/merge the PR. 
@clockard 
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Build DDF and make sure that the map layers trash icon is red and is aligned correctly. Observe that its correct in Chrome, Firefox and IE

#### What are the relevant tickets?
[DDF-3353](https://codice.atlassian.net/browse/)
#### Screenshots
![image](https://user-images.githubusercontent.com/11358088/31256775-709a10b8-a9e9-11e7-904c-4f28cf0d05be.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
