### PR TITLE
DDF-2931: Close inputstream if product retrieval fails in CSW

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -914,6 +914,9 @@ public abstract class AbstractCswSource extends MaskableImpl
   }
 
   @Override
+  @SuppressWarnings("squid:S3776"
+  /* The codes complexity is not unreasonable in this case. Breaking up this method would serve little value as of this writing */
+  )
   public ResourceResponse retrieveResource(
       URI resourceUri, Map<String, Serializable> requestProperties)
       throws IOException, ResourceNotFoundException, ResourceNotSupportedException {


### PR DESCRIPTION
#### What does this PR do?
Closes the products inputstream if product retrieval fails

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
anyone

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Successful full build

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
