### PR TITLE
DDF-3273 [2.11.x] Turns SSH back on, only accessible from localhost.

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -27,6 +27,8 @@
                 <exclude>etc/custom.properties</exclude>
                 <exclude>etc/jetty.xml</exclude>
                 <exclude>etc/profile.cfg</exclude>
+                <exclude>etc/org.apache.karaf.command.acl.shell.cfg</exclude>
+                <exclude>etc/org.apache.karaf.command.acl.ssh.cfg</exclude>
                 <exclude>etc/org.apache.karaf.features.cfg</exclude>
                 <exclude>etc/org.apache.karaf.shell.cfg</exclude>
                 <exclude>etc/org.ops4j.pax.logging.cfg</exclude>

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.shell.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.shell.cfg
@@ -1,0 +1,18 @@
+#
+# This configuration file defines the ACLs for commands in the shell subshell
+#
+
+* = NO_ACCESS
+complete = admin
+echo = admin
+format = admin
+grep = admin
+if = admin
+keymap = admin
+less = admin
+set = admin
+setopt = admin
+sleep = admin
+tac = admin
+wc = admin
+while = admin

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.ssh.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.ssh.cfg
@@ -1,0 +1,5 @@
+#
+# This configuration file defines the ACLs for commands in the ssh subshell
+#
+
+* = NO_ACCESS

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.shell.cfg
@@ -1,13 +1,12 @@
 #
 # Configuration for SSH shell.
-# This configuration is turned off by default; in order to turn it on, uncomment
-# the sshPort property.
-# When the port is available and active, SSH access will be restricted to connections
-# originating from the same host machine. To allow direct remote access to the shell,
-# change the value of the sshHost property to 0.0.0.0
+#
+# By default, SSH access will be restricted to connections originating from the same
+# host machine. To allow direct remote access to the shell, change the value of the
+# sshHost property to 0.0.0.0
 #
 
-#sshPort=8101
+sshPort=8101
 sshHost=127.0.0.1
 sshRealm=karaf
 hostKey=${karaf.etc}/host.key

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -126,11 +126,17 @@ grant
     permission java.util.PropertyPermission "javax.net.ssl.*", "read";
 
     permission java.io.FilePermission "${ddf.home}${/}bin_third_party${/}-", "read, execute";
+
+    permission java.io.FilePermission "<<ALL FILES>>", "execute";
 };
 
 grant {
     // User's home directory
     permission java.io.FilePermission "${user.home}${/}-", "read, write";
+
+    // Schema and Schematron directories
+    permission java.io.FilePermission "${ddf.home}${/}schema${/}-", "read";
+    permission java.io.FilePermission "${ddf.home}${/}schematron${/}-", "read";
 
     // Temporary file storage
     permission java.io.FilePermission "${java.io.tmpdir}", "read, write, execute, delete";

--- a/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
@@ -45,8 +45,18 @@ On system: ensure that not everyone can change ACLs on your object.
 
 |SSH
 |tampering, information disclosure, and denial of service
-a|By default, SSH access is disabled in ${branding}. To turn it on, edit the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg`
-file, uncommenting the `sshPort` property. SSH can also be authenticated and authorized through an external Realm,
+a|By default, SSH access to ${branding} is only enabled to connections originating from the same
+host running ${branding}.
+For remote access to ${branding},
+ first establish an SSH session with the host running
+ ${branding}. From within that session, initiate a new SSH connection (to **localhost**), and use
+ the `sshPort` as configured in the file
+ `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg`.
+
+To allow direct remote access to the ${branding} shell from any host, change the value of the
+`sshHost` property to `0.0.0.0` in the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg` file.
+
+SSH can also be authenticated and authorized through an external Realm,
 such as LDAP. This can be accomplished by editing the `<${branding}_HOME>/etc/org.apache.karaf.shell.cfg` file and setting the
 value for `sshRealm`, e.g. to `ldap`. No restart of ${branding} is necessary after this change.
 

--- a/distribution/docs/src/main/resources/content/_configuring/hardening-user-access.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/hardening-user-access.adoc
@@ -11,6 +11,9 @@
 Once ${branding} is configured to use an external user (such as LDAP), remove the `users.properties` file from the `<INSTALL_HOME>/etc` directory.
 Use of a `users.properties` file should be limited to emergency recovery operations and replaced as soon as effectively possible.
 
+If SSH access to the Karaf shell is to be supported, edit the file `org.apache.karaf.shell.cfg` in the `<INSTALL_HOME>/etc` directory, changing the value
+of the `sshRealm` property from `karaf` to `ldap`.
+
 .Emergency Use of `users.properties` file
 [NOTE]
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,7 @@
                 <version>2.0.0</version>
                 <executions>
                     <execution>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
#### What does this PR do?
Turns on local access to SSH into running DDF.
Also shuts down access to all but a specific subset of Karaf shell commands.

#### Who is reviewing it? 
@tbatie @Lambeaux @vinamartin @paouelle @ricklarsen 

#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@rzwiefel
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Install and SSH into running DDF. It should work from the same host as the instance and not from anywhere else.

Also check that access to Karaf commands is restricted to only the subset now specified in `etc/org.apache.karaf.command.acl.shell.cfg` and that they work correctly. Confirm that necessary/common functionality is not blocked from the shell.

#### Any background context you want to provide?
This is now safe because of the introduction of the Java security manager.

#### What are the relevant tickets?
[DDF-3273](https://codice.atlassian.net/browse/DDF-3273)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
