### PR TITLE
DDF-3297 Adds thirdparty directory for downstream projects

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -223,6 +223,13 @@
             <fileMode>0644</fileMode>
         </fileSet>
 
+        <!-- DDF Third-party directory -->
+        <fileSet>
+            <directory>${setup.folder}/thirdparty</directory>
+            <outputDirectory>/thirdparty</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
         <fileSet>
             <directory>${setup.folder}/data</directory>
             <outputDirectory>/data</outputDirectory>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -126,11 +126,16 @@ grant
     permission java.util.PropertyPermission "javax.net.ssl.*", "read";
 
     permission java.io.FilePermission "${ddf.home}${/}bin_third_party${/}-", "read, execute";
+
+    permission java.io.FilePermission "<<ALL FILES>>", "execute";
 };
 
 grant {
     // User's home directory
     permission java.io.FilePermission "${user.home}${/}-", "read, write";
+
+    // DDF third-party directory for common resources
+    permission java.io.FilePermission "${ddf.home}${/}thirdparty${/}-", "read";
 
     // Temporary file storage
     permission java.io.FilePermission "${java.io.tmpdir}", "read, write, execute, delete";
@@ -145,7 +150,6 @@ grant {
     permission java.io.FilePermission "/lib", "read";
     permission java.io.FilePermission "/proc/self/exe", "read";
     permission java.io.FilePermission "/usr/lib", "read";
-
 
     // Distribution File Permissions
     permission java.io.FilePermission "${ddf.home}", "read";

--- a/distribution/ddf-common/src/main/resources/thirdparty/README.md
+++ b/distribution/ddf-common/src/main/resources/thirdparty/README.md
@@ -1,0 +1,10 @@
+# DDF Third-party Resources
+This directory is intended as common storage for third-party projects.
+The DDF default security policy allows global read access to this directory
+for its running Java process, thereby providing a centralized location custom
+bundles can look to for resource files.
+
+Depending on the needs of the third-party project, the permissions on this
+directory can be expanded or restricted as needed by managing the
+[`default.policy`](https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/security/default.policy).
+


### PR DESCRIPTION
#### What does this PR do?
Adds thirdparty directory for storing common resources shared across bundles by downstream projects.

Also adds file execute permissions to OSGi library.

#### Who is reviewing it? 
@tbatie @Lambeaux 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Creating a bundle that reads resources from anywhere in the new thirdparty directory and placing those resources there should permit them to be read.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
