### PR TITLE
DDF-3297 Adds escape character for `user.dir` property in system.prop…

### DIFF
--- a/distribution/ddf-common/pom.xml
+++ b/distribution/ddf-common/pom.xml
@@ -92,6 +92,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
                     <includeEmptyDirs>true</includeEmptyDirs>
+                    <escapeString>\</escapeString>
                 </configuration>
                 <executions>
                     <execution>

--- a/distribution/ddf-common/src/main/resources/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources/etc/system.properties
@@ -289,10 +289,10 @@ user.country="US"
 
 #
 # This is the default home location which will work in development and test
-# and, by virtue of being beneath the ${user.home} directory, will not cause
+# and, by virtue of being beneath the \${user.home} directory, will not cause
 # an access exception for being inaccessible.
 #
-org.ops4j.pax.url.mvn.settings=file:${user.home}/.m2/settings.xml
+org.ops4j.pax.url.mvn.settings=file:\${user.home}/.m2/settings.xml
 
 #
 # Disable Hazelcast version check


### PR DESCRIPTION

(cherry picked from commit 824ce08)

#### What does this PR do?
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
