### PR TITLE
[2.11.x] DDF-3354 CDM verify file size is stable before ingesting

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -326,8 +326,7 @@
                             hazelcast,
                             sardine,
                             httpclient,
-                            httpcore,
-                            commons-io
+                            httpcore
                         </Embed-Dependency>
                         <Import-Package>
                             !org.eclipse.jetty.server.bio,

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
@@ -21,7 +21,6 @@ import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.util.List;
 import javax.validation.constraints.NotNull;
-import org.apache.camel.Component;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -39,11 +38,15 @@ public abstract class AbstractDurableFileConsumer extends GenericFileConsumer<Ev
 
   FileSystemPersistenceProvider fileSystemPersistenceProvider;
 
+  String remaining;
+
   AbstractDurableFileConsumer(
       GenericFileEndpoint<EventfulFileWrapper> endpoint,
+      String remaining,
       Processor processor,
       GenericFileOperations<EventfulFileWrapper> operations) {
     super(endpoint, processor, operations);
+    this.remaining = remaining;
   }
 
   @Override
@@ -58,16 +61,12 @@ public abstract class AbstractDurableFileConsumer extends GenericFileConsumer<Ev
 
   @Override
   protected boolean pollDirectory(String fileName, List list, int depth) {
-    Component component = endpoint.getComponent();
-    String remaining;
-    if (component != null) {
-      remaining = ((DurableFileComponent) component).remaining;
-      if (remaining != null) {
-        String sha1 = DigestUtils.sha1Hex(remaining);
-        initialize(remaining, sha1);
-        return doPoll(sha1);
-      }
+    if (remaining != null) {
+      String sha1 = DigestUtils.sha1Hex(remaining);
+      initialize(remaining, sha1);
+      return doPoll(sha1);
     }
+
     return false;
   }
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DavAlterationObserver.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DavAlterationObserver.java
@@ -305,5 +305,6 @@ public class DavAlterationObserver implements Serializable {
 
   private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
+    listeners = new LinkedHashSet<>();
   }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.content.monitor;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javafx.util.Pair;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DurableFileAlterationListener extends FileAlterationListenerAdaptor {
+
+  public static final long DEFAULT_PERIOD = 5;
+
+  public static final String CDM_FILE_CHECK_PERIOD_PROPERTY = "org.codice.ddf.cdm.fileCheckPeriod";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DurableFileAlterationListener.class);
+
+  private Map<File, Pair<Long, WatchEvent.Kind<Path>>> fileMap = new ConcurrentHashMap<>();
+
+  private ScheduledExecutorService executorService;
+
+  private AbstractDurableFileConsumer consumer;
+
+  public DurableFileAlterationListener(@NotNull AbstractDurableFileConsumer consumer) {
+    this.consumer = consumer;
+    executorService =
+        Executors.newSingleThreadScheduledExecutor(
+            StandardThreadFactoryBuilder.newThreadFactory("directoryMonitorFileChecker"));
+    this.startExecutor();
+  }
+
+  public DurableFileAlterationListener(
+      @NotNull AbstractDurableFileConsumer consumer,
+      @NotNull ScheduledExecutorService executorService) {
+    this.consumer = consumer;
+    this.executorService = executorService;
+    this.startExecutor();
+  }
+
+  private void startExecutor() {
+    long period = DEFAULT_PERIOD;
+    try {
+      period =
+          Long.parseLong(
+              System.getProperty(CDM_FILE_CHECK_PERIOD_PROPERTY, Long.toString(DEFAULT_PERIOD)));
+      if (period < 1) {
+        period = DEFAULT_PERIOD;
+      }
+    } catch (NumberFormatException e) {
+      LOGGER.debug(
+          "Invalid value for system property org.codice.ddf.cdm.fileCheckPeriod. Expected an integer but was {}. Defaulting to {}",
+          System.getProperty(CDM_FILE_CHECK_PERIOD_PROPERTY),
+          period);
+    }
+    executorService.scheduleAtFixedRate(this::checkFiles, 10, period, TimeUnit.SECONDS);
+  }
+
+  public void destroy() {
+    // copied from the Executor javadocs
+    executorService.shutdown();
+    try {
+      if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+        executorService.shutdownNow();
+        if (!executorService.awaitTermination(60, TimeUnit.SECONDS))
+          LOGGER.debug("Error terminating scheduled executor service");
+      }
+    } catch (InterruptedException ie) {
+      executorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public void onFileChange(File file) {
+    if (!fileMap.containsKey(file)) {
+      fileMap.put(file, new Pair<>(-1L, StandardWatchEventKinds.ENTRY_MODIFY));
+    }
+  }
+
+  @Override
+  public void onFileCreate(File file) {
+    fileMap.put(file, new Pair<>(-1L, StandardWatchEventKinds.ENTRY_CREATE));
+  }
+
+  @Override
+  public void onFileDelete(File file) {
+    consumer.createExchangeHelper(file, StandardWatchEventKinds.ENTRY_DELETE);
+  }
+
+  void checkFiles() {
+    List<File> completedFiles = new ArrayList<>();
+    for (Map.Entry<File, Pair<Long, WatchEvent.Kind<Path>>> entry : fileMap.entrySet()) {
+      if (entry.getKey().length() == entry.getValue().getKey()) {
+        completedFiles.add(entry.getKey());
+        consumer.createExchangeHelper(entry.getKey(), entry.getValue().getValue());
+      } else {
+        entry.setValue(new Pair<>(entry.getKey().length(), entry.getValue().getValue()));
+      }
+    }
+    completedFiles.stream().forEach(file -> fileMap.remove(file));
+  }
+}

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileComponent.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileComponent.java
@@ -22,9 +22,6 @@ import org.apache.camel.util.StringHelper;
 import org.apache.commons.lang.StringUtils;
 
 public class DurableFileComponent extends GenericFileComponent<EventfulFileWrapper> {
-  Boolean isDav;
-
-  String remaining;
 
   @Override
   protected GenericFileEndpoint<EventfulFileWrapper> buildFileEndpoint(
@@ -41,9 +38,8 @@ public class DurableFileComponent extends GenericFileComponent<EventfulFileWrapp
       throw new IllegalArgumentException("Location to monitor must be specified");
     }
 
-    this.remaining = remaining;
     String davParam = String.valueOf(parameters.get("isDav"));
-    isDav = Boolean.valueOf(davParam);
+    boolean isDav = Boolean.parseBoolean(davParam);
     parameters.remove("isDav");
 
     GenericFileConfiguration config = new GenericFileConfiguration();
@@ -52,17 +48,15 @@ public class DurableFileComponent extends GenericFileComponent<EventfulFileWrapp
       file = new File("");
     }
     config.setDirectory(file.getCanonicalPath());
-    DurableFileEndpoint result = new DurableFileEndpoint(uri, this);
+    DurableFileEndpoint result = new DurableFileEndpoint(uri, remaining, isDav, this);
     result.setFile(file);
     result.setConfiguration(config);
 
     return result;
   }
 
-  public void setIsDav(String paramDav) {
-    isDav = Boolean.valueOf(paramDav);
-  }
-
   @Override
-  protected void afterPropertiesSet(GenericFileEndpoint endpoint) throws Exception {}
+  protected void afterPropertiesSet(GenericFileEndpoint endpoint) throws Exception {
+    // do nothing
+  }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileEndpoint.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileEndpoint.java
@@ -46,13 +46,17 @@ public class DurableFileEndpoint extends GenericFileEndpoint<EventfulFileWrapper
 
   private final Boolean isDav;
 
+  private String remaining;
+
   @UriPath(name = "directoryName")
   @Metadata(required = "true")
   private File file;
 
-  DurableFileEndpoint(String uri, DurableFileComponent durableFileComponent) {
+  DurableFileEndpoint(
+      String uri, String remaining, boolean isDav, DurableFileComponent durableFileComponent) {
     super(uri, durableFileComponent);
-    this.isDav = durableFileComponent.isDav;
+    this.remaining = remaining;
+    this.isDav = isDav;
   }
 
   @Override
@@ -62,10 +66,10 @@ public class DurableFileEndpoint extends GenericFileEndpoint<EventfulFileWrapper
 
     if (isDav) {
       return new DurableWebDavFileConsumer(
-          this, processor, new EventfulFileWrapperGenericFileOperations());
+          this, remaining, processor, new EventfulFileWrapperGenericFileOperations());
     } else {
       return new DurableFileSystemFileConsumer(
-          this, processor, new EventfulFileWrapperGenericFileOperations());
+          this, remaining, processor, new EventfulFileWrapperGenericFileOperations());
     }
   }
 
@@ -116,7 +120,9 @@ public class DurableFileEndpoint extends GenericFileEndpoint<EventfulFileWrapper
   private static class EventfulFileWrapperGenericFileOperations
       implements GenericFileOperations<EventfulFileWrapper> {
     @Override
-    public void setEndpoint(GenericFileEndpoint<EventfulFileWrapper> endpoint) {}
+    public void setEndpoint(GenericFileEndpoint<EventfulFileWrapper> endpoint) {
+      // do nothing
+    }
 
     @Override
     public boolean deleteFile(String name) throws GenericFileOperationFailedException {
@@ -161,7 +167,9 @@ public class DurableFileEndpoint extends GenericFileEndpoint<EventfulFileWrapper
 
     @Override
     public void releaseRetreivedFileResources(Exchange exchange)
-        throws GenericFileOperationFailedException {}
+        throws GenericFileOperationFailedException {
+      // do nothing
+    }
 
     @Override
     public boolean storeFile(String name, Exchange exchange)
@@ -175,10 +183,14 @@ public class DurableFileEndpoint extends GenericFileEndpoint<EventfulFileWrapper
     }
 
     @Override
-    public void changeCurrentDirectory(String path) throws GenericFileOperationFailedException {}
+    public void changeCurrentDirectory(String path) throws GenericFileOperationFailedException {
+      // do nothing
+    }
 
     @Override
-    public void changeToParentDirectory() throws GenericFileOperationFailedException {}
+    public void changeToParentDirectory() throws GenericFileOperationFailedException {
+      // do nothing
+    }
 
     @Override
     public List<EventfulFileWrapper> listFiles() throws GenericFileOperationFailedException {

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
@@ -26,9 +26,10 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
 
   DurableFileSystemFileConsumer(
       GenericFileEndpoint<EventfulFileWrapper> endpoint,
+      String remaining,
       Processor processor,
       GenericFileOperations<EventfulFileWrapper> operations) {
-    super(endpoint, processor, operations);
+    super(endpoint, remaining, processor, operations);
     listener = new DurableFileAlterationListener(this);
   }
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
@@ -14,15 +14,13 @@
 package org.codice.ddf.catalog.content.monitor;
 
 import java.io.File;
-import java.nio.file.StandardWatchEventKinds;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFileEndpoint;
 import org.apache.camel.component.file.GenericFileOperations;
-import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
 
 public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
-  private DurableFileAlterationListener listener = new DurableFileAlterationListener();
+  private DurableFileAlterationListener listener;
 
   private FileAlterationObserver observer;
 
@@ -31,6 +29,7 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
       Processor processor,
       GenericFileOperations<EventfulFileWrapper> operations) {
     super(endpoint, processor, operations);
+    listener = new DurableFileAlterationListener(this);
   }
 
   @Override
@@ -66,22 +65,6 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
     if (observer != null) {
       observer.destroy();
     }
-  }
-
-  protected class DurableFileAlterationListener extends FileAlterationListenerAdaptor {
-    @Override
-    public void onFileChange(File file) {
-      createExchangeHelper(file, StandardWatchEventKinds.ENTRY_MODIFY);
-    }
-
-    @Override
-    public void onFileCreate(File file) {
-      createExchangeHelper(file, StandardWatchEventKinds.ENTRY_CREATE);
-    }
-
-    @Override
-    public void onFileDelete(File file) {
-      createExchangeHelper(file, StandardWatchEventKinds.ENTRY_DELETE);
-    }
+    listener.destroy();
   }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
@@ -40,9 +40,10 @@ public class DurableWebDavFileConsumer extends AbstractDurableFileConsumer {
 
   DurableWebDavFileConsumer(
       GenericFileEndpoint<EventfulFileWrapper> endpoint,
+      String remaining,
       Processor processor,
       GenericFileOperations<EventfulFileWrapper> operations) {
-    super(endpoint, processor, operations);
+    super(endpoint, remaining, processor, operations);
   }
 
   @Override

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListenerTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListenerTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.content.monitor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.StandardWatchEventKinds;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DurableFileAlterationListenerTest {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  AbstractDurableFileConsumer consumer;
+
+  ScheduledExecutorService executor;
+
+  DurableFileAlterationListener listener;
+
+  File testFile;
+
+  @Before
+  public void setup() throws Exception {
+    consumer = mock(AbstractDurableFileConsumer.class);
+    executor = mock(ScheduledExecutorService.class);
+    listener = new DurableFileAlterationListener(consumer, executor);
+
+    testFile = folder.newFile("testFile.txt");
+  }
+
+  @Test
+  public void testFileCreate() throws Exception {
+    listener.onFileCreate(testFile);
+    runCheck(1, false);
+    verify(consumer).createExchangeHelper(testFile, StandardWatchEventKinds.ENTRY_CREATE);
+  }
+
+  @Test
+  public void testFileCreateSlowFileTransfer() throws Exception {
+    listener.onFileCreate(testFile);
+    runCheck(3, true);
+    verify(consumer).createExchangeHelper(testFile, StandardWatchEventKinds.ENTRY_CREATE);
+  }
+
+  @Test
+  public void testFileUpdate() throws Exception {
+    listener.onFileChange(testFile);
+    runCheck(1, false);
+    verify(consumer).createExchangeHelper(testFile, StandardWatchEventKinds.ENTRY_MODIFY);
+  }
+
+  @Test
+  public void testFileUpdateSlowFileTransfer() throws Exception {
+    listener.onFileChange(testFile);
+    runCheck(3, true);
+    verify(consumer).createExchangeHelper(testFile, StandardWatchEventKinds.ENTRY_MODIFY);
+  }
+
+  @Test
+  public void testCustomPeriod() {
+    System.setProperty(DurableFileAlterationListener.CDM_FILE_CHECK_PERIOD_PROPERTY, "8");
+    executor = mock(ScheduledExecutorService.class);
+    listener = new DurableFileAlterationListener(consumer, executor);
+    verify(executor).scheduleAtFixedRate(any(), anyLong(), eq(8L), any());
+  }
+
+  @Test
+  public void testBadCustomPeriod() {
+    System.setProperty(DurableFileAlterationListener.CDM_FILE_CHECK_PERIOD_PROPERTY, "notanumber");
+    executor = mock(ScheduledExecutorService.class);
+    listener = new DurableFileAlterationListener(consumer, executor);
+    verify(executor)
+        .scheduleAtFixedRate(
+            any(), anyLong(), eq(DurableFileAlterationListener.DEFAULT_PERIOD), any());
+  }
+
+  @Test
+  public void testNegativeCustomPeriod() {
+    System.setProperty(DurableFileAlterationListener.CDM_FILE_CHECK_PERIOD_PROPERTY, "-1");
+    executor = mock(ScheduledExecutorService.class);
+    listener = new DurableFileAlterationListener(consumer, executor);
+    verify(executor)
+        .scheduleAtFixedRate(
+            any(), anyLong(), eq(DurableFileAlterationListener.DEFAULT_PERIOD), any());
+  }
+
+  private void runCheck(int times, boolean sizeChange) throws Exception {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(testFile))) {
+      for (int i = 0; i < times; i++) {
+        if (sizeChange) {
+          writer.write("Test Data\n");
+          writer.flush();
+        }
+        listener.checkFiles();
+        verify(consumer, never()).createExchangeHelper(any(), any());
+      }
+      listener.checkFiles();
+    }
+  }
+}

--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -397,7 +397,10 @@ public class FileSystemStorageProvider implements StorageProvider {
       extension = FilenameUtils.getExtension(FilenameUtils.removeExtension(filename));
       try {
         reference = new URI(new String(Files.readAllBytes(file), Charset.forName("UTF-8")));
-        if (reference.getScheme().equalsIgnoreCase("file")) {
+
+        if (reference.getScheme() == null) {
+          file = Paths.get(reference.toASCIIString());
+        } else if (reference.getScheme().equalsIgnoreCase("file")) {
           file = Paths.get(reference);
         } else {
           file = null;


### PR DESCRIPTION
#### What does this PR do?
Makes sure a file has finished copying before trying to ingest it with the CDM.
Also fixed a potential NPE in FileSystemStorageProvider
Also fix multiple monitored directory issue.

#### Who is reviewing it? 
@brendan-hofmann @emmberk 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and create a CDM for an empty directory.
Copy this script to a file and make it executable and changing 'cdm-dir' to the monitored directory configured for the CDM. The script simulates a slowly copying file. 
```
#!/bin/bash
for i in {1..60}
do
   echo "Line $i" >> cdm-dir/cdm-changing-file.txt
   sleep 1
done
```
Start the script and verify that the cdm-changing-file.txt doesn't show up in the catalog until after the script has finished. 
Run the script again and verify that the cdm-changing-file.txt metacard doesn't get updated until after the script has finished.
Add a second CDM for a different directory and copy a text file into it. Verify that the text file is ingested.
#### What are the relevant tickets?
[DDF-3354](https://codice.atlassian.net/browse/DDF-3354)
#### Checklist:
- [X] Update / Add Unit Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
