### PR TITLE
DDF-3359 Fix installer port change issue

### DIFF
--- a/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
+++ b/libs/common-system/src/main/java/org/codice/ddf/configuration/SystemBaseUrl.java
@@ -23,6 +23,10 @@ public final class SystemBaseUrl {
 
   public static final String HTTPS_PORT = "org.codice.ddf.system.httpsPort";
 
+  public static final String INTERNAL_HTTP_PORT = "org.codice.ddf.system.internalHttpPort";
+
+  public static final String INTERNAL_HTTPS_PORT = "org.codice.ddf.system.internalHttpsPort";
+
   public static final String PORT = "org.codice.ddf.system.port";
 
   public static final String HOST = "org.codice.ddf.system.hostname";
@@ -172,6 +176,14 @@ public final class SystemBaseUrl {
 
   public static String getHttpsPort() {
     return System.getProperty(HTTPS_PORT, DEFAULT_HTTPS_PORT);
+  }
+
+  public static String getInternalHttpPort() {
+    return System.getProperty(INTERNAL_HTTP_PORT, DEFAULT_HTTP_PORT);
+  }
+
+  public static String getInternalHttpsPort() {
+    return System.getProperty(INTERNAL_HTTPS_PORT, DEFAULT_HTTPS_PORT);
   }
 
   /**

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
@@ -53,6 +53,8 @@ public class SystemPropertiesAdminTest {
 
   File userAttrsFile = null;
 
+  File paxWebFile = null;
+
   int expectedSystemPropertiesCount = 0;
 
   @Before
@@ -81,6 +83,7 @@ public class SystemPropertiesAdminTest {
     systemPropsFile = new File(etcFolder, "system.properties");
     userPropsFile = new File(etcFolder, "users.properties");
     userAttrsFile = new File(etcFolder, "users.attributes");
+    paxWebFile = new File(etcFolder, "org.ops4j.pax.web.cfg");
   }
 
   @Test
@@ -191,6 +194,50 @@ public class SystemPropertiesAdminTest {
         fail("User attribute file did not get updated.");
       }
     }
+  }
+
+  @Test
+  public void testPaxWebPortUpdate() throws Exception {
+    SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
+    spa.syncPaxWebFilePorts(true, true);
+    Properties paxProps = new Properties();
+    try (FileReader userPropsReader = new FileReader(paxWebFile)) {
+      paxProps.load(userPropsReader);
+      assertThat(paxProps.size(), is(2));
+      assertThat(paxProps.getProperty("org.osgi.service.http.port"), equalTo("4567"));
+      assertThat(paxProps.getProperty("org.osgi.service.http.port.secure"), equalTo("8901"));
+    }
+  }
+
+  @Test
+  public void testPaxWebPortUpdateHttpsOnly() throws Exception {
+    SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
+    spa.syncPaxWebFilePorts(true, false);
+    Properties paxProps = new Properties();
+    try (FileReader userPropsReader = new FileReader(paxWebFile)) {
+      paxProps.load(userPropsReader);
+      assertThat(paxProps.size(), is(1));
+      assertThat(paxProps.getProperty("org.osgi.service.http.port.secure"), equalTo("8901"));
+    }
+  }
+
+  @Test
+  public void testPaxWebPortUpdateHttpOnly() throws Exception {
+    SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
+    spa.syncPaxWebFilePorts(false, true);
+    Properties paxProps = new Properties();
+    try (FileReader userPropsReader = new FileReader(paxWebFile)) {
+      paxProps.load(userPropsReader);
+      assertThat(paxProps.size(), is(1));
+      assertThat(paxProps.getProperty("org.osgi.service.http.port"), equalTo("4567"));
+    }
+  }
+
+  @Test
+  public void testPaxWebPortNoUpdate() throws Exception {
+    SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
+    spa.syncPaxWebFilePorts(false, false);
+    assertThat(paxWebFile.exists(), is(false));
   }
 
   private String getDetailsValue(List<SystemPropertyDetails> props, String key) {


### PR DESCRIPTION
#### What does this PR do?
Update the SystemPropertiesAdmin to update the pax web ports when needed

Also addressed some minor sonarqube findings in some of the files.

#### Who is reviewing it? 
@peterhuffer @emmberk 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and change the ports in the installer to https=9993 http=9181. 
Verify that the system restarts properly and the UIs are accessible.
#### What are the relevant tickets?
[DDF-3359](https://codice.atlassian.net/browse/DDF-3359)
#### Checklist:
- [x] Update / Add Unit Tests