### PR TITLE
[2.11.x] DDF-3327 Fix description overflow in Admin UI Application boxes (#2392)

### DIFF
--- a/platform/admin/ui/src/main/webapp/less/application/app-card.less
+++ b/platform/admin/ui/src/main/webapp/less/application/app-card.less
@@ -25,6 +25,10 @@
   .panel-body {
     padding: 0px @app-card-overlay-width 0px 0px; // reset bootstrap
     height: 100%;
+    display: -ms-flexbox;
+    -ms-flex-direction: column;
+    display: flex;
+    flex-direction: column;
   }
 
   .name {
@@ -33,6 +37,7 @@
   }
 
   .description {
+    -ms-flex: 1;
     height: 150px;
     .divider {
       margin: 1px 0px;

--- a/platform/admin/ui/src/main/webapp/less/utils.less
+++ b/platform/admin/ui/src/main/webapp/less/utils.less
@@ -54,7 +54,7 @@
     -moz-box-sizing: content-box;
     float: right;
     position: relative;
-    top: -25px;
+    top: -15%;
     left: 100%;
     width: 3em; margin-left: -3em;
     padding-right: 5px; // magic number #1


### PR DESCRIPTION
#### What does this PR do?
Fixes a problem where the description of an application would overflow the box it was held in depending on the size of the user's window.
#### Who is reviewing it? 
#### Choose 2 committers to review/merge the PR. 
@clockard
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and navigate to the admin console. Verify that resizing your browser does not cause the description text for applications to overflow the application boxes. This should be tested on IE10, chrome and firefox.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3327](https://codice.atlassian.net/browse/DDF-3327)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
