### PR TITLE
DDF-3366 Added NoNameCoder to CSW Endpoint

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TransactionMessageBodyReader.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/reader/TransactionMessageBodyReader.java
@@ -15,6 +15,7 @@ package org.codice.ddf.spatial.ogc.csw.catalog.endpoint.reader;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.io.naming.NoNameCoder;
 import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.MetacardType;
@@ -64,7 +65,7 @@ public class TransactionMessageBodyReader implements MessageBodyReader<CswTransa
       MultivaluedMap<String, String> multivaluedMap,
       InputStream inputStream)
       throws IOException, WebApplicationException {
-    XStream xStream = new XStream(new Xpp3Driver());
+    XStream xStream = new XStream(new Xpp3Driver(new NoNameCoder()));
     TransactionRequestConverter transactionRequestConverter =
         new TransactionRequestConverter(cswRecordConverter, registry);
     transactionRequestConverter.setCswRecordConverter(new CswRecordConverter(metacardType));


### PR DESCRIPTION
#### What does this PR do?
This PR add a NoNameCoder to the CSW Endpoint so elements with double underscores can be handled appropriately.
#### Who is reviewing it? 
@adimka @mojogitoverhere 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/data 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@millerw8
@rzwiefel
#### How should this be tested? (List steps with links to updated documentation)
A full build should suffice
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3366](https://codice.atlassian.net/browse/DDF-3366)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
