### PR TITLE
DDF-3368 [2.11.x] TestSecurity.testCertificateGeneratorService() fails intermittently

### DIFF
--- a/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
+++ b/platform/security/certificate/security-certificate-generator/src/main/java/org/codice/ddf/security/certificate/generator/CertificateGenerator.java
@@ -61,25 +61,27 @@ public class CertificateGenerator implements CertificateGeneratorMBean {
   protected void registerMbean() {
     ObjectName objectName = null;
     MBeanServer mBeanServer = null;
+
     try {
       objectName = new ObjectName(CertificateGenerator.class.getName() + ":service=certgenerator");
       mBeanServer = ManagementFactory.getPlatformMBeanServer();
     } catch (MalformedObjectNameException e) {
-      LOGGER.info("Unable to create Certificate Generator MBean.", e);
+      LOGGER.error("Unable to create Certificate Generator MBean.", e);
     }
+
     if (mBeanServer != null) {
       try {
         try {
           mBeanServer.registerMBean(this, objectName);
-          LOGGER.debug(
+          LOGGER.error(
               "Registered Certificate Generator MBean under object name: {}",
               objectName.toString());
         } catch (InstanceAlreadyExistsException e) {
-          LOGGER.debug("Re-registered Certificate Generator MBean");
+          LOGGER.error("Re-registered Certificate Generator MBean");
         }
       } catch (Exception e) {
         // objectName is not always non-null because new ObjectName(...) can throw an exception
-        LOGGER.info(
+        LOGGER.error(
             "Could not register MBean [{}].",
             objectName != null ? objectName.toString() : CertificateGenerator.class.getName(),
             e);


### PR DESCRIPTION
#### What does this PR do?
Changes the test to wait for the CertificateGenerator service to come up.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@ahoffer 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard

#### How should this be tested? (List steps with links to updated documentation)
CI Build

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3368](https://codice.atlassian.net/browse/DDF-3368)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
