### PR TITLE
DDF-3297 Update itests to fix ddf.home.policy on Windows (#2453)

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -156,10 +156,10 @@ grant
 //
 // Commons-io includes functionality to monitor directories asynchronously
 //
-//grant
-//  codeBase "file:${ddf.home.policy}system/commons-io/commons-io/-" {
-//    permission java.io.FilePermission "${ddf.home}${/}-", "read";
-//};
+grant
+  codeBase "file:${ddf.home.policy}system/commons-io/commons-io/-" {
+    permission java.io.FilePermission "${ddf.home}${/}-", "read";
+};
 
 grant {
     // User's home directory

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -63,6 +63,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
@@ -593,6 +594,13 @@ public abstract class AbstractIntegrationTest {
   }
 
   protected Option[] configureVmOptions() {
+    String ddfHomePolicyPath;
+    if (SystemUtils.IS_OS_WINDOWS) {
+      ddfHomePolicyPath = "-Dddf.home.policy=/{karaf.home}/";
+    } else {
+      ddfHomePolicyPath = "-Dddf.home.policy={karaf.home}/";
+    }
+
     return options(
         vmOption("-Xmx2048M"),
         // avoid integration tests stealing focus on OS X
@@ -603,7 +611,7 @@ public abstract class AbstractIntegrationTest {
             "-DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"),
         vmOption("-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy"),
         HomeAwareVmOption.homeAwareVmOption("-Dddf.home={karaf.home}"),
-        HomeAwareVmOption.homeAwareVmOption("-Dddf.home.policy={karaf.home}/"),
+        HomeAwareVmOption.homeAwareVmOption(ddfHomePolicyPath),
         when(Boolean.getBoolean("generatePolicyFile")).useOptions(generatorSecurityManager()),
         when(!Boolean.getBoolean("generatePolicyFile")).useOptions(standardSecurityManager()));
   }


### PR DESCRIPTION
#### What does this PR do?
Updated `AbstractIntegrationTest` to add a leading slash for Windows OSs to fix itest permissions issues with the security manager.

#### Who is reviewing it? 
@brianfelix 
@mackncheesiest 
@AzGoalie 
@tbatie 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Run all itests on Windows machine and verify that the tests are able to be run instead of hanging on permissions issues.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
