### PR TITLE
[2.11.x] DDF-2824 corrected typo in docs template and jbake.properties file

### DIFF
--- a/distribution/docs/src/main/resources/content/_metadataAttributes/associations-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/associations-attributes-table.adoc
@@ -1,5 +1,5 @@
 ﻿:title: Associations
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group represent associations between products.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/contact-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/contact-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: Contact
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect metadata about different kinds of people/groups/units/organizations that can be associated with a metacard.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/core-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/core-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: Core Attributes
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Core Attributes.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/datetime-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/datetime-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: DateTime
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect temporal aspects about the resource.  

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/history-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/history-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: History
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the history/versioning of the metacard.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/location-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/location-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: Location
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect location aspects about the resource.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/media-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/media-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: Media
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect metadata about media in general.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/metacard-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/metacard-attributes-table.adoc
@@ -1,5 +1,5 @@
 :title: Metacard
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the metacard itself.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/mp4-attributes.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/mp4-attributes.adoc
@@ -1,5 +1,5 @@
 :title: Mp4 Additional Attribute
-:type: subappendix
+:type: subAppendix
 :parent: Metadata Attributes
 :status: published
 :summary: Additional attribute for Mp4 files.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/security-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/security-attributes-table.adoc
@@ -1,5 +1,5 @@
 ﻿:title: Security
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group relate to security of the resource and metadata.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/topic-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/topic-attributes-table.adoc
@@ -1,5 +1,5 @@
 ﻿:title: Topic
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the topic of the resource.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/validation-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/validation-attributes-table.adoc
@@ -1,5 +1,5 @@
 ﻿:title: Validation
-:type: subappendix
+:type: subAppendix
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group identify validation issues with the metacard and/or resource.

--- a/distribution/docs/src/main/resources/jbake.properties
+++ b/distribution/docs/src/main/resources/jbake.properties
@@ -66,4 +66,4 @@ template.applicationReference.file=application-reference.ftl
 template.table.file=application-reference.ftl
 template.appendixIntro.file=appendices.ftl
 template.appendix.file=appendices.ftl
-template.subappendix.file=appendices.ftl
+template.subAppendix.file=appendices.ftl

--- a/distribution/docs/src/main/resources/templates/appendices.ftl
+++ b/distribution/docs/src/main/resources/templates/appendices.ftl
@@ -10,11 +10,11 @@ include::${ai.file}[]
 
 === ${appendix.title}
 include::${appendix.file}[]
-<#list subappendixs as subappendix>
-<#if (subappendix.parent == appendix.children)>
+<#list subAppendixs as subAppendix>
+<#if (subAppendix.parent == appendix.children)>
 
-==== ${subappendix.title}
-include::${subappendix.file}[]
+==== ${subAppendix.title}
+include::${subAppendix.file}[]
 </#if>
 </#list>
 </#if>


### PR DESCRIPTION
#### What does this PR do?

- fixes jbake type declaration that was not following convention. All type names should be camel case.

#### Who is reviewing it? 
@mcalcote @oconnormi 

#### Choose 2 committers to review/merge the PR. 
@clockard
@coyotesqrl
@lessarderic
@pklinef
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

- build logs were showing a null pointer exception. Docs still rendered as expected. Error should be gone now.

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
