### PR TITLE
[2.11.x] DDF-3317 Fixed TikaInputTransformer parsing wrong metadata

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -381,11 +381,12 @@ public class TikaInputTransformer implements InputTransformer {
                 metadata, id, metadataText, metacardType, useResourceTitleAsTitle);
         if (StringUtils.isNotBlank(bodyText)) {
           metacard.setAttribute(new AttributeImpl(Extracted.EXTRACTED_TEXT, bodyText));
+          processContentMetadataExtractors(bodyText, metacard);
         }
 
-        processContentMetadataExtractors(bodyText, metacard);
-
-        processMetadataExtractors(metadataText, metacard);
+        if (StringUtils.isNotBlank(metadataText)) {
+          processMetadataExtractors(metadataText, metacard);
+        }
 
         if (validationAttribute != null) {
           metacard.setAttribute(validationAttribute);

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -385,7 +385,7 @@ public class TikaInputTransformer implements InputTransformer {
 
         processContentMetadataExtractors(bodyText, metacard);
 
-        processMetadataExtractors(bodyText, metacard);
+        processMetadataExtractors(metadataText, metacard);
 
         if (validationAttribute != null) {
           metacard.setAttribute(validationAttribute);

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -794,6 +795,16 @@ public class TikaInputTransformerTest {
 
     Metacard metacard = transform(new ByteArrayInputStream("something".getBytes()));
     assertThat(metacard.getMetacardType(), equalTo(metacardType));
+  }
+
+  @Test
+  public void testEmptyStringMetadataExtractor() throws Exception {
+    MetadataExtractor metadataExtractor = mock(MetadataExtractor.class);
+    when(metadataExtractor.canProcess(any())).thenReturn(true);
+    addMetadataExtractor(metadataExtractor);
+    tikaInputTransformer.setMetadataMaxLength(0);
+    transform(new ByteArrayInputStream("something".getBytes()));
+    verify(metadataExtractor, times(0)).process(any(), any());
   }
 
   private String convertDate(Date date) {


### PR DESCRIPTION
#### What does this PR do?
Fixes the TikaInputTransformer parsing bodyText instead of metadataText.
#### Who is reviewing it? 
@gordocanchola @emmberk 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
